### PR TITLE
fix(ci): use claude_args for allowed tools

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -76,15 +76,8 @@ jobs:
         name: Run Claude Code Review
         uses: anthropics/claude-code-action@f0c8eb29807907de7f5412d04afceb5e24817127 # v1.0.23
         with:
-          # See: https://github.com/anthropics/claude-code-action
-          allowed_tools: |
-            Glob
-            Grep
-            Read
-            mcp__github__add_pull_request_review_comment_to_pending_review
-            mcp__github__create_pending_pull_request_review
-            mcp__github__get_pull_request_diff
-            mcp__github__submit_pending_pull_request_review
+          claude_args: |
+            --allowedTools "Glob,Grep,Read,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__create_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__submit_pending_pull_request_review"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/claude-triage.yaml
+++ b/.github/workflows/claude-triage.yaml
@@ -35,12 +35,9 @@ jobs:
         uses: anthropics/claude-code-action@f0c8eb29807907de7f5412d04afceb5e24817127 # v1.0.23
         with:
           allowed_non_write_users: "*"
-          allowed_tools: |
-            Bash(gh label list:*)
-            Bash(gh issue view:*)
-            Bash(gh issue edit:*)
-            Bash(gh search issues:*)
-          claude_args: --model haiku
+          claude_args: |
+            --model haiku
+            --allowedTools "Bash(gh label list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh search issues:*)"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
@@ -53,12 +50,9 @@ jobs:
         uses: anthropics/claude-code-action@f0c8eb29807907de7f5412d04afceb5e24817127 # v1.0.23
         with:
           allowed_non_write_users: "*"
-          allowed_tools: |
-            Bash(gh label list:*)
-            Bash(gh pr view:*)
-            Bash(gh pr edit:*)
-            Bash(gh pr diff:*)
-          claude_args: --model haiku
+          claude_args: |
+            --model haiku
+            --allowedTools "Bash(gh label list:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(gh pr diff:*)"
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary

The `allowed_tools` input is deprecated in claude-code-action. Use `--allowedTools` flag via `claude_args` instead.

Fixes the warning:
```
##[warning]Unexpected input(s) 'allowed_tools', valid inputs are [...]
```

## Test plan

- [ ] Verify triage workflow runs without warnings
- [ ] Verify review workflow runs without warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)