### PR TITLE
fix(ci): use pull_request trigger for track_progress support

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Wait for triage to complete
-        env:
+      - env:
           GH_TOKEN: ${{ github.token }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REPO: ${{ github.repository }}
+        name: Wait for triage to complete
         run: |
           # Wait for triage workflow to complete (max 5 minutes)
           for i in {1..30}; do

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -1,23 +1,20 @@
 name: Claude Code Review
 
 on:
-  workflow_run:
-    workflows: [Claude Triage]
-    types: [completed]
+  pull_request:
+    types: [opened]
 
 concurrency:
-  group: claude-review-${{ github.event.workflow_run.pull_requests[0].number || 'skipped' }}
+  group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   claude-review:
-    # Only run if triage succeeded and it's a PR (not issue)
+    # Only run if it's a PR from the same repo and not from a bot
     if: |
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.pull_requests[0] != null &&
-      github.event.workflow_run.actor.type != 'Bot' &&
-      github.event.workflow_run.head_repository.full_name == github.repository
+      github.event.pull_request != null &&
+      github.event.sender.type != 'Bot' &&
+      github.head_repository.full_name == github.repository
     permissions:
       actions: read
       contents: read
@@ -27,9 +24,39 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Wait for triage to complete
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Wait for triage workflow to complete (max 5 minutes)
+          for i in {1..30}; do
+            # Get the latest triage run for this PR commit
+            TRIAGE_STATUS=$(gh run list --workflow=claude-triage.yaml \
+              --repo "$REPO" \
+              --json conclusion,status,headSha \
+              --jq ".[] | select(.headSha == \"$PR_HEAD_SHA\") | .conclusion" \
+              --limit 1)
+
+            if [ "$TRIAGE_STATUS" = "success" ]; then
+              echo "Triage completed successfully"
+              exit 0
+            elif [ "$TRIAGE_STATUS" = "failure" ] || [ "$TRIAGE_STATUS" = "cancelled" ]; then
+              echo "Triage did not succeed (status: $TRIAGE_STATUS), skipping review"
+              exit 1
+            fi
+
+            echo "Waiting for triage to complete... (attempt $i/30)"
+            sleep 10
+          done
+
+          echo "Triage did not complete in time, skipping review"
+          exit 1
+
       - env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         id: skip-check
         name: Check if should skip
@@ -59,7 +86,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 1
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - id: read-prompt
         if: steps.skip-check.outputs.skip != 'true'
@@ -81,7 +108,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
             # Bedrock Code Review
 


### PR DESCRIPTION
## Summary

Fixes the `claude-review` workflow to support the `track_progress` feature by changing from `workflow_run` to `pull_request` trigger.

## Problem

The `claude-review` workflow was using `workflow_run` trigger to run after `claude-triage` completed. However, `track_progress` only works with direct GitHub events (pull_request, issues, etc.), not synthetic workflow_run events.

**Error encountered:**
```
track_progress is only supported for events: pull_request, issues, issue_comment,
pull_request_review_comment, pull_request_review. Current event: workflow_run
```

## Solution

- Changed trigger from `workflow_run` to `pull_request: types: [opened]`
- Added wait step that polls for triage workflow completion (max 5 minutes)
- Updated all event context references from `workflow_run` to `pull_request`
- Review workflow now properly waits for triage to succeed before running

## Changes

- `.github/workflows/claude-review.yaml`:
  - Trigger: `workflow_run` → `pull_request`
  - Added "Wait for triage to complete" step
  - Updated job conditions and all PR number/SHA references

## Testing

This PR will test the new workflow behavior:
1. Both triage and review should trigger on PR open
2. Review should wait for triage to complete
3. Review should proceed only if triage succeeds
4. `track_progress` should work without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)