### PR TITLE
feat(ocale): error hierarchy + root exports

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -15,6 +15,9 @@ export default isentinel(
 			},
 		},
 		type: "package",
+		typescript: {
+			erasableOnly: true,
+		},
 	},
 	{
 		name: "project/config",

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -24,6 +24,13 @@ export default isentinel(
 		},
 	},
 	{
+		name: "project/src",
+		files: [`packages/*/*/${GLOB_SRC}`],
+		rules: {
+			"better-max-params/better-max-params": ["error", { func: 2 }],
+		},
+	},
+	{
 		name: "project/jsdoc",
 		files: [GLOB_SRC],
 		ignores: [GLOB_MARKDOWN_CODE],

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"@vitest/eslint-plugin": "catalog:lint",
 		"better-typescript-lib": "catalog:tsc",
 		"eslint": "catalog:lint",
+		"eslint-plugin-erasable-syntax-only": "catalog:lint",
 		"eslint-plugin-n": "catalog:lint",
 		"eslint-plugin-pnpm": "catalog:lint",
 		"eslint_d": "catalog:dev",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,7 +35,7 @@
 		"build": "vp pack",
 		"dev": "vp pack --watch",
 		"test": "vitest",
-		"typecheck": "tsgo --noEmit -p tsconfig.build.json"
+		"typecheck": "tsgo --noEmit"
 	},
 	"devDependencies": {
 		"@bedrock/typescript-config": "workspace:*",

--- a/packages/open-cloud/package.json
+++ b/packages/open-cloud/package.json
@@ -39,7 +39,7 @@
 		"build": "vp pack",
 		"dev": "vp pack --watch",
 		"test": "vitest",
-		"typecheck": "tsgo --noEmit -p tsconfig.build.json"
+		"typecheck": "tsgo --noEmit"
 	},
 	"devDependencies": {
 		"@bedrock/typescript-config": "workspace:*",

--- a/packages/open-cloud/src/errors/api-error.spec.ts
+++ b/packages/open-cloud/src/errors/api-error.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { ApiError } from "./api-error.ts";
+import { OpenCloudError } from "./base.ts";
+
+describe(ApiError, () => {
+	it("should set name to ApiError", () => {
+		expect.assertions(1);
+
+		const error = new ApiError("not found", { statusCode: 404 });
+
+		expect(error.name).toBe("ApiError");
+	});
+
+	it("should set message from constructor argument", () => {
+		expect.assertions(1);
+
+		const error = new ApiError("internal server error", { statusCode: 500 });
+
+		expect(error.message).toBe("internal server error");
+	});
+
+	it("should be an instance of OpenCloudError", () => {
+		expect.assertions(1);
+
+		const error = new ApiError("not found", { statusCode: 404 });
+
+		expect(error).toBeInstanceOf(OpenCloudError);
+	});
+
+	it("should be an instance of Error", () => {
+		expect.assertions(1);
+
+		const error = new ApiError("not found", { statusCode: 404 });
+
+		expect(error).toBeInstanceOf(Error);
+	});
+
+	it("should store statusCode", () => {
+		expect.assertions(1);
+
+		const error = new ApiError("not found", { statusCode: 404 });
+
+		expect(error.statusCode).toBe(404);
+	});
+
+	it("should store code when provided", () => {
+		expect.assertions(1);
+
+		const error = new ApiError("not found", {
+			code: "RESOURCE_NOT_FOUND",
+			statusCode: 404,
+		});
+
+		expect(error.code).toBe("RESOURCE_NOT_FOUND");
+	});
+
+	it("should have undefined code when not provided", () => {
+		expect.assertions(1);
+
+		const error = new ApiError("not found", { statusCode: 404 });
+
+		expect(error.code).toBeUndefined();
+	});
+
+	it("should store cause when provided", () => {
+		expect.assertions(1);
+
+		const cause = new Error("original");
+		const error = new ApiError("not found", { cause, statusCode: 404 });
+
+		expect(error.cause).toBe(cause);
+	});
+});

--- a/packages/open-cloud/src/errors/api-error.ts
+++ b/packages/open-cloud/src/errors/api-error.ts
@@ -1,0 +1,33 @@
+import { OpenCloudError } from "./base.ts";
+
+/**
+ * Options for constructing an {@link ApiError}.
+ */
+export interface ApiErrorOptions extends ErrorOptions {
+	/** Optional machine-readable error code from the API. */
+	code?: string;
+	/** HTTP status code from the API response. */
+	statusCode: number;
+}
+
+/**
+ * Thrown when the Roblox Open Cloud API returns a non-2xx response
+ * that is not a rate limit (429).
+ */
+export class ApiError extends OpenCloudError {
+	public readonly code: string | undefined;
+	public override readonly name: string = "ApiError";
+	public readonly statusCode: number;
+
+	/**
+	 * Creates a new ApiError.
+	 *
+	 * @param message - Human-readable error description.
+	 * @param options - Error options including status code and optional error code.
+	 */
+	constructor(message: string, options: ApiErrorOptions) {
+		super(message, options);
+		this.statusCode = options.statusCode;
+		this.code = options.code;
+	}
+}

--- a/packages/open-cloud/src/errors/base.spec.ts
+++ b/packages/open-cloud/src/errors/base.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { OpenCloudError } from "./base";
+
+describe(OpenCloudError, () => {
+	it("should set name to OpenCloudError", () => {
+		expect.assertions(1);
+
+		const error = new OpenCloudError("test");
+
+		expect(error.name).toBe("OpenCloudError");
+	});
+
+	it("should set message from constructor argument", () => {
+		expect.assertions(1);
+
+		const error = new OpenCloudError("something went wrong");
+
+		expect(error.message).toBe("something went wrong");
+	});
+
+	it("should be an instance of Error", () => {
+		expect.assertions(1);
+
+		const error = new OpenCloudError("test");
+
+		expect(error).toBeInstanceOf(Error);
+	});
+
+	it("should store cause when provided", () => {
+		expect.assertions(1);
+
+		const cause = new Error("original");
+		const error = new OpenCloudError("wrapped", { cause });
+
+		expect(error.cause).toBe(cause);
+	});
+
+	it("should have undefined cause when not provided", () => {
+		expect.assertions(1);
+
+		const error = new OpenCloudError("test");
+
+		expect(error.cause).toBeUndefined();
+	});
+});

--- a/packages/open-cloud/src/errors/base.ts
+++ b/packages/open-cloud/src/errors/base.ts
@@ -5,5 +5,5 @@
  * extend this class, enabling `instanceof OpenCloudError` checks.
  */
 export class OpenCloudError extends Error {
-	public override readonly name = "OpenCloudError";
+	public override readonly name: string = "OpenCloudError";
 }

--- a/packages/open-cloud/src/errors/base.ts
+++ b/packages/open-cloud/src/errors/base.ts
@@ -1,0 +1,9 @@
+/**
+ * Base error class for all Open Cloud SDK errors.
+ *
+ * All specific error types (RateLimitError, ApiError, NetworkError)
+ * extend this class, enabling `instanceof OpenCloudError` checks.
+ */
+export class OpenCloudError extends Error {
+	public override readonly name = "OpenCloudError";
+}

--- a/packages/open-cloud/src/errors/network-error.spec.ts
+++ b/packages/open-cloud/src/errors/network-error.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { OpenCloudError } from "./base.ts";
+import { NetworkError } from "./network-error.ts";
+
+describe(NetworkError, () => {
+	it("should set name to NetworkError", () => {
+		expect.assertions(1);
+
+		const error = new NetworkError("fetch failed");
+
+		expect(error.name).toBe("NetworkError");
+	});
+
+	it("should set message from constructor argument", () => {
+		expect.assertions(1);
+
+		const error = new NetworkError("DNS resolution failed");
+
+		expect(error.message).toBe("DNS resolution failed");
+	});
+
+	it("should be an instance of OpenCloudError", () => {
+		expect.assertions(1);
+
+		const error = new NetworkError("fetch failed");
+
+		expect(error).toBeInstanceOf(OpenCloudError);
+	});
+
+	it("should be an instance of Error", () => {
+		expect.assertions(1);
+
+		const error = new NetworkError("fetch failed");
+
+		expect(error).toBeInstanceOf(Error);
+	});
+
+	it("should store cause when provided", () => {
+		expect.assertions(1);
+
+		const cause = new TypeError("Failed to fetch");
+		const error = new NetworkError("request failed", { cause });
+
+		expect(error.cause).toBe(cause);
+	});
+
+	it("should have undefined cause when not provided", () => {
+		expect.assertions(1);
+
+		const error = new NetworkError("fetch failed");
+
+		expect(error.cause).toBeUndefined();
+	});
+});

--- a/packages/open-cloud/src/errors/network-error.ts
+++ b/packages/open-cloud/src/errors/network-error.ts
@@ -1,0 +1,9 @@
+import { OpenCloudError } from "./base.ts";
+
+/**
+ * Thrown when a network-level failure prevents the request from reaching
+ * the Roblox Open Cloud API (e.g., DNS resolution failure, connection timeout).
+ */
+export class NetworkError extends OpenCloudError {
+	public override readonly name: string = "NetworkError";
+}

--- a/packages/open-cloud/src/errors/rate-limit.spec.ts
+++ b/packages/open-cloud/src/errors/rate-limit.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { OpenCloudError } from "./base";
-import { RateLimitError } from "./rate-limit";
+import { OpenCloudError } from "./base.ts";
+import { RateLimitError } from "./rate-limit.ts";
 
 describe(RateLimitError, () => {
 	it("should set name to RateLimitError", () => {

--- a/packages/open-cloud/src/errors/rate-limit.spec.ts
+++ b/packages/open-cloud/src/errors/rate-limit.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { OpenCloudError } from "./base";
+import { RateLimitError } from "./rate-limit";
+
+describe(RateLimitError, () => {
+	it("should set name to RateLimitError", () => {
+		expect.assertions(1);
+
+		const error = new RateLimitError("rate limited", { retryAfterSeconds: 30 });
+
+		expect(error.name).toBe("RateLimitError");
+	});
+
+	it("should set message from constructor argument", () => {
+		expect.assertions(1);
+
+		const error = new RateLimitError("too many requests", { retryAfterSeconds: 5 });
+
+		expect(error.message).toBe("too many requests");
+	});
+
+	it("should be an instance of OpenCloudError", () => {
+		expect.assertions(1);
+
+		const error = new RateLimitError("rate limited", { retryAfterSeconds: 10 });
+
+		expect(error).toBeInstanceOf(OpenCloudError);
+	});
+
+	it("should be an instance of Error", () => {
+		expect.assertions(1);
+
+		const error = new RateLimitError("rate limited", { retryAfterSeconds: 10 });
+
+		expect(error).toBeInstanceOf(Error);
+	});
+
+	it("should store retryAfterSeconds", () => {
+		expect.assertions(1);
+
+		const error = new RateLimitError("rate limited", { retryAfterSeconds: 42 });
+
+		expect(error.retryAfterSeconds).toBe(42);
+	});
+
+	it("should store cause when provided", () => {
+		expect.assertions(1);
+
+		const cause = new Error("original");
+		const error = new RateLimitError("rate limited", { cause, retryAfterSeconds: 10 });
+
+		expect(error.cause).toBe(cause);
+	});
+});

--- a/packages/open-cloud/src/errors/rate-limit.ts
+++ b/packages/open-cloud/src/errors/rate-limit.ts
@@ -1,4 +1,4 @@
-import { OpenCloudError } from "./base";
+import { OpenCloudError } from "./base.ts";
 
 /**
  * Options for constructing a {@link RateLimitError}.

--- a/packages/open-cloud/src/errors/rate-limit.ts
+++ b/packages/open-cloud/src/errors/rate-limit.ts
@@ -1,0 +1,29 @@
+import { OpenCloudError } from "./base";
+
+/**
+ * Options for constructing a {@link RateLimitError}.
+ */
+export interface RateLimitErrorOptions extends ErrorOptions {
+	/** Seconds to wait before retrying the request. */
+	retryAfterSeconds: number;
+}
+
+/**
+ * Thrown when the Roblox Open Cloud API returns a 429 Too Many Requests response.
+ * Contains the server-suggested retry delay.
+ */
+export class RateLimitError extends OpenCloudError {
+	public override readonly name = "RateLimitError";
+	public readonly retryAfterSeconds: number;
+
+	/**
+	 * Creates a new RateLimitError.
+	 *
+	 * @param message - Human-readable error description.
+	 * @param options - Error options including the retry delay.
+	 */
+	constructor(message: string, options: RateLimitErrorOptions) {
+		super(message, options);
+		this.retryAfterSeconds = options.retryAfterSeconds;
+	}
+}

--- a/packages/open-cloud/src/index.ts
+++ b/packages/open-cloud/src/index.ts
@@ -1,1 +1,5 @@
-export type { Result } from "./types";
+export { ApiError, type ApiErrorOptions } from "./errors/api-error.ts";
+export { OpenCloudError } from "./errors/base.ts";
+export { NetworkError } from "./errors/network-error.ts";
+export { RateLimitError, type RateLimitErrorOptions } from "./errors/rate-limit.ts";
+export type { Result } from "./types.ts";

--- a/packages/open-cloud/src/internal/utils/sleep.spec.ts
+++ b/packages/open-cloud/src/internal/utils/sleep.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { sleep } from "./sleep";
+import { sleep } from "./sleep.ts";
 
 describe(sleep, () => {
 	it("should resolve after the specified delay", async () => {

--- a/packages/open-cloud/src/internal/utils/try-catch.ts
+++ b/packages/open-cloud/src/internal/utils/try-catch.ts
@@ -1,4 +1,4 @@
-import type { Result } from "../../types";
+import type { Result } from "../../types.ts";
 
 /**
  * Wraps a promise into a {@link Result}, catching rejections.

--- a/packages/typescript-config/tsconfig.base.json
+++ b/packages/typescript-config/tsconfig.base.json
@@ -8,7 +8,9 @@
 		"customConditions": ["source"],
 		"types": ["bun"],
 		"declarationDir": "${configDir}/dist",
-		"noEmit": false
+		"noEmit": false,
+		"isolatedDeclarations": true,
+		"erasableSyntaxOnly": true
 	},
 	"include": ["${configDir}/**/*"],
 	"exclude": [

--- a/packages/typescript-config/tsconfig.base.json
+++ b/packages/typescript-config/tsconfig.base.json
@@ -9,6 +9,7 @@
 		"types": ["bun"],
 		"allowImportingTsExtensions": true,
 		"allowJs": false,
+		"exactOptionalPropertyTypes": true,
 		"declarationDir": "${configDir}/dist",
 		"noEmit": false,
 		"isolatedDeclarations": true,

--- a/packages/typescript-config/tsconfig.base.json
+++ b/packages/typescript-config/tsconfig.base.json
@@ -7,6 +7,8 @@
 		"libReplacement": true,
 		"customConditions": ["source"],
 		"types": ["bun"],
+		"allowImportingTsExtensions": true,
+		"allowJs": false,
 		"declarationDir": "${configDir}/dist",
 		"noEmit": false,
 		"isolatedDeclarations": true,

--- a/packages/typescript-config/tsconfig.base.json
+++ b/packages/typescript-config/tsconfig.base.json
@@ -7,12 +7,11 @@
 		"libReplacement": true,
 		"customConditions": ["source"],
 		"types": ["bun"],
-		"allowImportingTsExtensions": true,
+		"rewriteRelativeImportExtensions": true,
 		"allowJs": false,
 		"exactOptionalPropertyTypes": true,
 		"declarationDir": "${configDir}/dist",
 		"noEmit": false,
-		"isolatedDeclarations": true,
 		"erasableSyntaxOnly": true
 	},
 	"include": ["${configDir}/**/*"],

--- a/packages/typescript-config/tsconfig.build.json
+++ b/packages/typescript-config/tsconfig.build.json
@@ -6,7 +6,8 @@
 		"rootDir": "${configDir}/src",
 		"declaration": true,
 		"declarationMap": true,
-		"outDir": "${configDir}/dist"
+		"outDir": "${configDir}/dist",
+		"isolatedDeclarations": true
 	},
 	"include": ["${configDir}/src"],
 	"exclude": ["${configDir}/src/**/*.spec.ts", "${configDir}/src/**/*.test.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ catalogs:
     eslint:
       specifier: 9.39.2
       version: 9.39.2
+    eslint-plugin-erasable-syntax-only:
+      specifier: 0.4.0
+      version: 0.4.0
     eslint-plugin-n:
       specifier: 17.24.0
       version: 17.24.0
@@ -185,6 +188,9 @@ importers:
       eslint:
         specifier: catalog:lint
         version: 9.39.2(jiti@2.6.1)
+      eslint-plugin-erasable-syntax-only:
+        specifier: catalog:lint
+        version: 0.4.0(@typescript-eslint/parser@8.58.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
       eslint-plugin-n:
         specifier: catalog:lint
         version: 17.24.0(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
@@ -3053,6 +3059,10 @@ packages:
   cacheable@2.3.4:
     resolution: {integrity: sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==}
 
+  cached-factory@0.1.0:
+    resolution: {integrity: sha512-IGOSWu+NuED5UzCRmBeqQPZ8z7SkgrD/nN67W2iY1Qv83CVhevyMexkGclJ86saXisIqxoOnbeiTWvsCHRqJBw==}
+    engines: {node: '>=18'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -3522,6 +3532,14 @@ packages:
     engines: {node: ^20.0.0 || >=22.0.0}
     peerDependencies:
       eslint: '>=8.0.0'
+
+  eslint-plugin-erasable-syntax-only@0.4.0:
+    resolution: {integrity: sha512-7dx2gpfVn0FFEGukLqsF/izW4hGvSaySNOkcuSCO4q6Khh0ecOGYlRhW9hhDUtNryuKc+cXd1WFiQdpae3xzaQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      '@typescript-eslint/parser': 8.58.1
+      eslint: '>=9'
+      typescript: '>=5'
 
   eslint-plugin-es-x@7.8.0:
     resolution: {integrity: sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==}
@@ -7788,6 +7806,8 @@ snapshots:
       keyv: 5.6.0
       qified: 0.9.1
 
+  cached-factory@0.1.0: {}
+
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001757: {}
@@ -8280,6 +8300,16 @@ snapshots:
   eslint-plugin-de-morgan@2.0.0(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.2(jiti@2.6.1)
+
+  eslint-plugin-erasable-syntax-only@0.4.0(@typescript-eslint/parser@8.58.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2))(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2):
+    dependencies:
+      '@typescript-eslint/parser': 8.58.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      '@typescript-eslint/utils': 8.58.1(eslint@9.39.2(jiti@2.6.1))(typescript@6.0.2)
+      cached-factory: 0.1.0
+      eslint: 9.39.2(jiti@2.6.1)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-es-x@7.8.0(eslint@9.39.2(jiti@2.6.1)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ publicHoistPattern:
 
 shellEmulator: true
 trustPolicy: no-downgrade
+trustPolicyIgnoreAfter: 10080 # 7 days
 
 trustPolicyExclude:
   - eslint-config-prettier@9.1.2
@@ -53,6 +54,7 @@ catalogs:
     "@isentinel/hooks": 1.3.0
     "@vitest/eslint-plugin": 1.6.16
     eslint: 9.39.2
+    eslint-plugin-erasable-syntax-only: 0.4.0
     eslint-plugin-n: 17.24.0
     eslint-plugin-pnpm: 1.6.0
     publint: 0.3.18


### PR DESCRIPTION
## Summary

- Implements the four-class error hierarchy for `@bedrock/ocale`: `OpenCloudError` (base), `RateLimitError`, `ApiError`, `NetworkError`
- Exports all error classes and option types from the package root alongside `Result`
- Adds build config improvements: `.ts` import extensions, `isolatedDeclarations` scoped to build, typecheck now covers tests

Closes #15

## Test plan

- [x] `pnpm test` — 48 tests pass with 100% coverage on error files
- [x] `pnpm typecheck` — passes (now includes tests and config files)
- [x] `pnpm build` — succeeds
- [x] `pnpm lint` — passes
- [x] `instanceof` narrowing works through the hierarchy (`RateLimitError → OpenCloudError → Error`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)