### PR TITLE
ci: split pr title lint into separate workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,22 +63,4 @@ jobs:
             apps/*/dist/
             **/*.log
           retention-days: 7
-
     timeout-minutes: 15
-  commitlint:
-    name: Lint PR title
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup
-        uses: ./.github/actions/setup
-
-      - env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        name: Lint PR title
-        run: echo "$PR_TITLE" | pnpm commitlint --verbose
-
-    timeout-minutes: 5

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -1,0 +1,29 @@
+name: Lint PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  commitlint:
+    name: Lint PR title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        name: Lint PR title
+        run: echo "$PR_TITLE" | pnpm commitlint --verbose
+    timeout-minutes: 5


### PR DESCRIPTION
## Summary

- Extracts the `commitlint` job from `ci.yaml` into a dedicated `lint-pr-title.yaml` workflow
- Adds `edited` to the trigger types so PR title fixes fire fresh workflow runs with updated payloads

## Why

The commitlint job reads `github.event.pull_request.title` from the event payload. On a workflow rerun, GitHub replays the original payload — so editing a PR title and rerunning the check revalidates the stale title. Previously the only way to revalidate was to push a new commit, which is ceremony that doesn't match the actual change (metadata, not code).

Splitting the workflow means the `edited` trigger can fire only for title-lint, without re-running the full Build & Test suite on every PR body edit.

## Test plan

- [ ] This PR's own title lint runs against the new workflow (since the workflow is defined in this PR)
- [ ] After merge, editing a PR title on a subsequent PR triggers a fresh `Lint PR Title` run with the updated title

🤖 Generated with [Claude Code](https://claude.com/claude-code)