### PR TITLE
fix(ocale): use vp test in package test script

### DIFF
--- a/packages/open-cloud/package.json
+++ b/packages/open-cloud/package.json
@@ -42,7 +42,7 @@
 	"scripts": {
 		"build": "vp pack",
 		"dev": "vp pack --watch",
-		"test": "vitest",
+		"test": "vp test",
 		"typecheck": "tsgo --noEmit"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

- `packages/open-cloud/package.json` `"test"` script invoked `vitest` directly, but the package uses `@voidzero-dev/vite-plus-test` whose binary is `vp`, so `pnpm --filter @bedrock/ocale test` failed with `command not found: vitest`.
- Updated the script to `vp test`, matching the sibling `@bedrock/testing` convention.

## Test plan

- [x] `pnpm --filter @bedrock/ocale test --run` — 122 tests pass (same count as main)
- [x] `pnpm test` at repo root — 145 tests pass (pre-existing `stryker.config.ts` `TypeCheckError` unchanged from main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)