### PR TITLE
feat(ocale): add rate-limit-queue token bucket

### DIFF
--- a/packages/open-cloud/src/internal/http/rate-limit-queue.spec.ts
+++ b/packages/open-cloud/src/internal/http/rate-limit-queue.spec.ts
@@ -1,0 +1,177 @@
+import type { SleepFunc } from "#src/internal/utils/sleep";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+
+import { RateLimitQueue } from "./rate-limit-queue.ts";
+
+interface FakeClock {
+	readonly advance: (ms: number) => void;
+	readonly sleep: SleepFunc;
+	readonly waits: ReadonlyArray<number>;
+}
+
+/**
+ * A test double where sleeping also advances the mocked `Date.now()` by
+ * `ms`, so production code that drains by wall time sees deterministic
+ * elapsed intervals without real-time drift. The `Date.now` spy is
+ * restored automatically when the current test finishes.
+ *
+ * @returns A clock with a tracking `sleep`, a `waits` log, and `advance`.
+ */
+function createFakeClock(): FakeClock {
+	let time = 0;
+	const waits: Array<number> = [];
+	const spy = vi.spyOn(Date, "now").mockImplementation(() => time);
+	onTestFinished(() => {
+		spy.mockRestore();
+	});
+	return {
+		advance(ms) {
+			time += ms;
+		},
+		async sleep(ms) {
+			waits.push(ms);
+			time += ms;
+		},
+		waits,
+	};
+}
+
+describe(RateLimitQueue, () => {
+	it("should invoke the task immediately when the bucket has tokens", async () => {
+		expect.assertions(3);
+
+		const onRateLimit = vi.fn<(waitMs: number) => void>();
+		const clock = createFakeClock();
+		const queue = new RateLimitQueue(
+			{ maxPerSecond: 5, operationKey: "test.op" },
+			{ onRateLimit },
+			clock.sleep,
+		);
+
+		const result = await queue.acquire(async () => "ok");
+
+		expect(result).toBe("ok");
+		expect(clock.waits).toStrictEqual([]);
+		expect(onRateLimit).not.toHaveBeenCalled();
+	});
+
+	it("should sleep for one refill interval when the bucket is empty", async () => {
+		expect.assertions(2);
+
+		const clock = createFakeClock();
+		const queue = new RateLimitQueue(
+			{ maxPerSecond: 1, operationKey: "test.op" },
+			{},
+			clock.sleep,
+		);
+
+		await queue.acquire(async () => "first");
+		const result = await queue.acquire(async () => "second");
+
+		expect(result).toBe("second");
+		expect(clock.waits).toStrictEqual([1000]);
+	});
+
+	it("should regenerate tokens at the configured rate after exhausting the burst", async () => {
+		expect.assertions(1);
+
+		const clock = createFakeClock();
+		const queue = new RateLimitQueue(
+			{ maxPerSecond: 2, operationKey: "test.op" },
+			{},
+			clock.sleep,
+		);
+
+		await queue.acquire(async () => "a");
+		await queue.acquire(async () => "b");
+		await queue.acquire(async () => "c");
+		await queue.acquire(async () => "d");
+
+		expect(clock.waits).toStrictEqual([500, 500]);
+	});
+
+	it("should fire onRateLimit with the same waitMs passed to sleep", async () => {
+		expect.assertions(2);
+
+		const onRateLimit = vi.fn<(waitMs: number) => void>();
+		const clock = createFakeClock();
+		const queue = new RateLimitQueue(
+			{ maxPerSecond: 4, operationKey: "test.op" },
+			{ onRateLimit },
+			clock.sleep,
+		);
+
+		await queue.acquire(async () => "a");
+		await queue.acquire(async () => "b");
+		await queue.acquire(async () => "c");
+		await queue.acquire(async () => "d");
+		await queue.acquire(async () => "e");
+
+		expect(clock.waits).toStrictEqual([250]);
+		expect(onRateLimit).toHaveBeenCalledExactlyOnceWith(250);
+	});
+
+	it("should serialize concurrent acquires so each waits for the prior token", async () => {
+		expect.assertions(2);
+
+		const clock = createFakeClock();
+		const queue = new RateLimitQueue(
+			{ maxPerSecond: 1, operationKey: "test.op" },
+			{},
+			clock.sleep,
+		);
+
+		const results = await Promise.all([
+			queue.acquire(async () => "a"),
+			queue.acquire(async () => "b"),
+			queue.acquire(async () => "c"),
+		]);
+
+		expect(results).toStrictEqual(["a", "b", "c"]);
+		expect(clock.waits).toStrictEqual([1000, 1000]);
+	});
+
+	it("should drain the bucket in proportion to elapsed wall time", async () => {
+		expect.assertions(1);
+
+		const clock = createFakeClock();
+		const queue = new RateLimitQueue(
+			{ maxPerSecond: 2, operationKey: "test.op" },
+			{},
+			clock.sleep,
+		);
+
+		await queue.acquire(async () => "a");
+		await queue.acquire(async () => "b");
+		clock.advance(500);
+		await queue.acquire(async () => "c");
+
+		expect(clock.waits).toStrictEqual([]);
+	});
+
+	it.for<[maxPerSecond: number, expectedWaitMs: number]>([
+		[1, 1000],
+		[2, 500],
+		[10, 100],
+	])(
+		"should size the refill interval for maxPerSecond=%i to %ims",
+		async ([maxPerSecond, expectedWaitMs]) => {
+			expect.assertions(1);
+
+			const clock = createFakeClock();
+			const queue = new RateLimitQueue(
+				{ maxPerSecond, operationKey: "test.op" },
+				{},
+				clock.sleep,
+			);
+
+			for (let index = 0; index < maxPerSecond; index++) {
+				await queue.acquire(async () => index);
+			}
+
+			await queue.acquire(async () => "overflow");
+
+			expect(clock.waits).toStrictEqual([expectedWaitMs]);
+		},
+	);
+});

--- a/packages/open-cloud/src/internal/http/rate-limit-queue.ts
+++ b/packages/open-cloud/src/internal/http/rate-limit-queue.ts
@@ -1,0 +1,82 @@
+import type { SleepFunc } from "../utils/sleep.ts";
+import type { OpenCloudHooks } from "./types.ts";
+
+/**
+ * Identifies and bounds a single Roblox Open Cloud operation for rate
+ * limiting, e.g. `{ operationKey: "game-passes.create", maxPerSecond: 5 }`.
+ */
+export interface OperationLimit {
+	/** Maximum sustained request rate in requests per second. */
+	readonly maxPerSecond: number;
+	/** Stable identifier for the operation (e.g. "game-passes.create"). */
+	readonly operationKey: string;
+}
+
+/**
+ * Token-bucket rate limiter for a single `(apiKey, operation)` pair. Every
+ * call to `acquire` consumes one token; when the bucket is empty the call
+ * waits until a token regenerates before invoking the task. Burst capacity
+ * equals `maxPerSecond`, refilling at `maxPerSecond` tokens per second.
+ *
+ * Implemented as a leaky bucket tracking drain debt in ms. `#lastCheck`
+ * advances by `waitMs` after every sleep so the algorithm stays correct
+ * whether or not the injected sleep moves `Date.now()` forward.
+ */
+export class RateLimitQueue {
+	readonly #hooks: OpenCloudHooks;
+	readonly #intervalMs: number;
+	readonly #maxBucketLevel: number;
+	readonly #sleep: SleepFunc;
+
+	#bucketLevel = 0;
+	#chain: Promise<void> = Promise.resolve();
+	#lastCheck: number = Date.now();
+
+	/**
+	 * Creates a rate-limit queue bound to a single operation.
+	 *
+	 * @param limit - The operation key and its per-second request ceiling.
+	 * @param hooks - Observability callbacks; `onRateLimit` fires when the
+	 *   bucket is empty and a sleep is about to start.
+	 * @param sleep - Injectable sleep (tests pass a fake).
+	 */
+	constructor(limit: OperationLimit, hooks: OpenCloudHooks, sleep: SleepFunc) {
+		this.#intervalMs = 1000 / limit.maxPerSecond;
+		this.#maxBucketLevel = limit.maxPerSecond * this.#intervalMs;
+		this.#hooks = hooks;
+		this.#sleep = sleep;
+	}
+
+	/**
+	 * Waits for a token — sleeping and firing `hooks.onRateLimit` if the
+	 * bucket is empty — then executes `task`. Concurrent callers are
+	 * serialized at token acquisition; tasks themselves run independently
+	 * once their token is secured.
+	 *
+	 * @param task - The request to run once a token is available.
+	 * @returns The value produced by `task`.
+	 */
+	public async acquire<T>(task: () => Promise<T>): Promise<T> {
+		const myTurn = this.#chain.then(async () => this.#waitForToken());
+		this.#chain = myTurn;
+		await myTurn;
+		return task();
+	}
+
+	async #waitForToken(): Promise<void> {
+		const now = Math.max(Date.now(), this.#lastCheck);
+		const drained = Math.max(0, this.#bucketLevel - (now - this.#lastCheck));
+		this.#lastCheck = now;
+
+		if (drained + this.#intervalMs <= this.#maxBucketLevel) {
+			this.#bucketLevel = drained + this.#intervalMs;
+			return;
+		}
+
+		const waitMs = drained + this.#intervalMs - this.#maxBucketLevel;
+		this.#hooks.onRateLimit?.(waitMs);
+		await this.#sleep(waitMs);
+		this.#bucketLevel = this.#maxBucketLevel;
+		this.#lastCheck = now + waitMs;
+	}
+}

--- a/packages/open-cloud/src/internal/http/rate-limit-queue.ts
+++ b/packages/open-cloud/src/internal/http/rate-limit-queue.ts
@@ -8,7 +8,11 @@ import type { OpenCloudHooks } from "./types.ts";
 export interface OperationLimit {
 	/** Maximum sustained request rate in requests per second. */
 	readonly maxPerSecond: number;
-	/** Stable identifier for the operation (e.g. "game-passes.create"). */
+	/**
+	 * Stable identifier for the operation (e.g. "game-passes.create"). Not
+	 * consumed by the queue itself; callers use it to key per-operation
+	 * queues in a registry (see GamePassesClient).
+	 */
 	readonly operationKey: string;
 }
 


### PR DESCRIPTION
## References

- Closes #19
- PRD: #13

## Summary

Adds `RateLimitQueue`, a token-bucket rate limiter for a single `(apiKey, operation)` pair. Every `acquire()` consumes one token; when the bucket is empty the call sleeps for a refill interval and fires `hooks.onRateLimit(waitMs)` before invoking the task.

- Leaky-bucket tracking drain debt in ms; burst capacity = `maxPerSecond`, refill rate = `maxPerSecond` tokens/sec
- Concurrent callers are serialized at token acquisition via a promise chain; tasks themselves run independently once their token is secured
- `#lastCheck` advances by `waitMs` post-sleep so the algorithm stays correct whether or not the injected sleep moves `Date.now()` forward

Per PRD Q10, retries live outside the queue slot — the queue wraps `send`, each retry inside `executeWithRetry` re-acquires. Wiring the queue into a client is out of scope here.

## Test Plan

- [x] `pnpm exec vp test` passes (131 tests)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm exec stryker run` — 100% mutation score (21/21 killed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)