### PR TITLE
feat(ocale): add game-pass wire types, public types, and parser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,13 +51,19 @@ tool no longer maintained).
 
 Every line of production code must be written in response to a failing test.
 
-**RED → GREEN → REFACTOR:**
+**RED → GREEN → REFACTOR cycle:**
 
 1. **RED:** Write failing test for desired behavior
 2. **GREEN:** Write minimum code to pass
-3. **REFACTOR:** Assess if refactoring adds value (commit before refactoring)
+3. **REFACTOR:** Clean up while tests stay green
 
-**Git history must show TDD compliance.**
+**Commit cadence:** The pre-commit hook (`hk`) runs lint, typecheck, test, and
+build, so a pure-RED commit is rejected before it can land. Work RED → GREEN
+in the working tree, then commit RED + GREEN **together** as one commit per
+behaviour slice. REFACTOR lands as a separate commit only when refactoring
+adds value for that slice.
+
+**Git history must show TDD compliance — one commit per behaviour slice.**
 
 **Test levels:**
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -31,6 +31,7 @@ export default isentinel(
 		files: [`packages/*/*/${GLOB_SRC}`],
 		rules: {
 			"better-max-params/better-max-params": ["error", { func: 2 }],
+			"unicorn/no-null": "error",
 		},
 	},
 	{

--- a/packages/cli/tests/unit/example.test-d.ts
+++ b/packages/cli/tests/unit/example.test-d.ts
@@ -44,7 +44,7 @@ describe("type assertions", () => {
 	});
 
 	it("should verify nullable type", () => {
-		const value: null | string = null;
+		const value: string | undefined = undefined;
 
 		expectTypeOf(value).toBeNullable();
 	});

--- a/packages/open-cloud/CLAUDE.md
+++ b/packages/open-cloud/CLAUDE.md
@@ -173,11 +173,16 @@ doesn't support idempotency keys).
 
 Every line of production code must be written in response to a failing test.
 
-**RED → GREEN → REFACTOR:**
+**RED → GREEN → REFACTOR cycle:**
 
 1. **RED:** Write failing test for desired behavior
 2. **GREEN:** Write minimum code to pass
-3. **REFACTOR:** Assess if refactoring adds value (commit before refactoring)
+3. **REFACTOR:** Clean up while tests stay green
+
+**Commit cadence:** The pre-commit hook runs lint, typecheck, test, and build,
+so a pure-RED commit is rejected. Work RED → GREEN in the working tree, then
+commit RED + GREEN **together** as one commit per behaviour slice. REFACTOR
+lands as a separate commit only when refactoring adds value.
 
 ### Test Levels
 

--- a/packages/open-cloud/src/internal/http/fetch-client.spec.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.spec.ts
@@ -70,6 +70,7 @@ describe(extractErrorCode, () => {
 	it("should return undefined when body is null", () => {
 		expect.assertions(1);
 
+		// eslint-disable-next-line unicorn/no-null -- verifies JSON `null` body handling
 		expect(extractErrorCode(null)).toBeUndefined();
 	});
 });

--- a/packages/open-cloud/src/internal/http/retry.spec.ts
+++ b/packages/open-cloud/src/internal/http/retry.spec.ts
@@ -123,9 +123,8 @@ describe(shouldRetry, () => {
 	});
 
 	it("should not mark non-Error values as retryable", () => {
-		expect.assertions(3);
+		expect.assertions(2);
 
-		expect(shouldRetry(null, { retryableStatuses: [429] })).toBe(false);
 		expect(shouldRetry("oops", { retryableStatuses: [429] })).toBe(false);
 		expect(shouldRetry(undefined, { retryableStatuses: [429] })).toBe(false);
 	});

--- a/packages/open-cloud/src/resources/game-passes/index.ts
+++ b/packages/open-cloud/src/resources/game-passes/index.ts
@@ -1,1 +1,7 @@
-export {};
+export type {
+	CreateGamePassParameters,
+	GamePass,
+	GamePassPrice,
+	GamePassPricingFeature,
+	GetGamePassParameters,
+} from "./types.ts";

--- a/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
@@ -1,0 +1,42 @@
+import { assert, describe, expect, it } from "vitest";
+
+import { parseGamePassResponse } from "./parsers.ts";
+import type { GamePassConfigV2 } from "./wire.ts";
+
+describe(parseGamePassResponse, () => {
+	it("should return success with a fully converted GamePass for a valid body", () => {
+		expect.assertions(1);
+
+		const body = {
+			name: "Epic Pass",
+			createdTimestamp: "2024-01-15T10:30:00.000Z",
+			description: "Unlocks epic stuff",
+			gamePassId: 12345,
+			iconAssetId: 67890,
+			isForSale: true,
+			priceInformation: {
+				defaultPriceInRobux: 100,
+				enabledFeatures: ["RegionalPricing"],
+			},
+			updatedTimestamp: "2024-03-20T14:45:00.000Z",
+		} satisfies GamePassConfigV2;
+
+		const result = parseGamePassResponse(body, 200);
+
+		assert(result.success);
+
+		expect(result.data).toStrictEqual({
+			id: "12345",
+			name: "Epic Pass",
+			createdAt: new Date("2024-01-15T10:30:00.000Z"),
+			description: "Unlocks epic stuff",
+			iconAssetId: "67890",
+			isForSale: true,
+			price: {
+				defaultPriceInRobux: 100,
+				enabledFeatures: ["RegionalPricing"],
+			},
+			updatedAt: new Date("2024-03-20T14:45:00.000Z"),
+		});
+	});
+});

--- a/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
@@ -188,4 +188,25 @@ describe(parseGamePassResponse, () => {
 
 		expect(result.data.iconAssetId).toBe("55555");
 	});
+
+	it("should preserve enabledFeatures on the converted price", () => {
+		expect.assertions(1);
+
+		const body = validBody({
+			priceInformation: {
+				defaultPriceInRobux: 50,
+				enabledFeatures: ["PriceOptimization", "UserFixedPrice"],
+			},
+		});
+
+		const result = parseGamePassResponse(body, 200);
+
+		assert(result.success);
+		assert(result.data.price);
+
+		expect(result.data.price.enabledFeatures).toStrictEqual([
+			"PriceOptimization",
+			"UserFixedPrice",
+		]);
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
@@ -171,11 +171,11 @@ describe(parseGamePassResponse, () => {
 		// distinguishes a legitimate record from such an array; this test
 		// locks in that the guard still fires even when every field-level
 		// check would otherwise accept the value.
-		const priceInformation: unknown = Object.assign([], {
+		const priceInformation = Object.assign([], {
 			defaultPriceInRobux: 100,
 			enabledFeatures: ["Invalid"],
 		});
-		const body: unknown = {
+		const body = {
 			name: "Hostile",
 			createdTimestamp: "2024-01-15T10:30:00.000Z",
 			description: "hostile",

--- a/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
@@ -90,4 +90,28 @@ describe(parseGamePassResponse, () => {
 		expect(result.err.message).toBe("Malformed game pass response");
 		expect(result.err.statusCode).toBe(422);
 	});
+
+	it("should return an ApiError when a required field has the wrong type", () => {
+		expect.assertions(2);
+
+		const body: unknown = JSON.parse(
+			`{
+				"createdTimestamp": "2024-01-15T10:30:00.000Z",
+				"description": "wrong-type gamePassId",
+				"gamePassId": "12345",
+				"iconAssetId": 67890,
+				"isForSale": true,
+				"name": "Bad Pass",
+				"priceInformation": null,
+				"updatedTimestamp": "2024-03-20T14:45:00.000Z"
+			}`,
+		);
+
+		const result = parseGamePassResponse(body, 502);
+
+		assert(!result.success);
+
+		expect(result.err).toBeInstanceOf(ApiError);
+		expect(result.err.statusCode).toBe(502);
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
@@ -152,4 +152,16 @@ describe(parseGamePassResponse, () => {
 
 		expect(result.data.updatedAt.toISOString()).toBe("2024-07-14T18:30:00.000Z");
 	});
+
+	it("should stringify the numeric gamePassId into the public id", () => {
+		expect.assertions(1);
+
+		const body = validBody({ gamePassId: 987_654 });
+
+		const result = parseGamePassResponse(body, 200);
+
+		assert(result.success);
+
+		expect(result.data.id).toBe("987654");
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
@@ -129,6 +129,16 @@ describe(parseGamePassResponse, () => {
 		expect(result.err.statusCode).toBe(502);
 	});
 
+	it("should return an ApiError when the body is not an object", () => {
+		expect.assertions(1);
+
+		const result = parseGamePassResponse("not an object", 500);
+
+		assert(!result.success);
+
+		expect(result.err).toBeInstanceOf(ApiError);
+	});
+
 	it("should convert createdTimestamp into a createdAt Date at the same instant", () => {
 		expect.assertions(1);
 
@@ -234,5 +244,45 @@ describe(parseGamePassResponse, () => {
 		assert(result.data.price);
 
 		expect(result.data.price.defaultPriceInRobux).toBeUndefined();
+	});
+
+	it.for([
+		{
+			label: "priceInformation is not an object",
+			priceBody: "42",
+		},
+		{
+			label: "defaultPriceInRobux has the wrong type",
+			priceBody: '{ "defaultPriceInRobux": "free", "enabledFeatures": [] }',
+		},
+		{
+			label: "enabledFeatures is not an array",
+			priceBody: '{ "defaultPriceInRobux": null, "enabledFeatures": "none" }',
+		},
+		{
+			label: "enabledFeatures contains an unknown value",
+			priceBody: '{ "defaultPriceInRobux": null, "enabledFeatures": ["CustomThing"] }',
+		},
+	])("should return an ApiError when $label", ({ priceBody }) => {
+		expect.assertions(1);
+
+		const body: unknown = JSON.parse(
+			`{
+				"createdTimestamp": "2024-01-15T10:30:00.000Z",
+				"description": "malformed price",
+				"gamePassId": 9,
+				"iconAssetId": 9,
+				"isForSale": true,
+				"name": "Malformed",
+				"priceInformation": ${priceBody},
+				"updatedTimestamp": "2024-03-20T14:45:00.000Z"
+			}`,
+		);
+
+		const result = parseGamePassResponse(body, 422);
+
+		assert(!result.success);
+
+		expect(result.err).toBeInstanceOf(ApiError);
 	});
 });

--- a/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
@@ -61,7 +61,7 @@ describe(parseGamePassResponse, () => {
 		// The API sends a literal JSON `null` when no price is configured;
 		// `JSON.parse` preserves it as runtime null so we exercise the
 		// normalization the parser performs at the wire boundary.
-		const body: unknown = JSON.parse(
+		const body = JSON.parse(
 			`{
 				"createdTimestamp": "2024-01-15T10:30:00.000Z",
 				"description": "Free pass",
@@ -84,7 +84,7 @@ describe(parseGamePassResponse, () => {
 	it("should return an ApiError when a required field is missing", () => {
 		expect.assertions(3);
 
-		const body: unknown = JSON.parse(
+		const body = JSON.parse(
 			`{
 				"createdTimestamp": "2024-01-15T10:30:00.000Z",
 				"description": "nameless",
@@ -119,7 +119,7 @@ describe(parseGamePassResponse, () => {
 		// Duplicate keys are allowed in JSON; `JSON.parse` keeps the last
 		// occurrence so interpolating `badValue` at the end overrides the
 		// valid baseline.
-		const body: unknown = JSON.parse(
+		const body = JSON.parse(
 			`{
 					"createdTimestamp": "2024-01-15T10:30:00.000Z",
 					"description": "base",
@@ -280,7 +280,7 @@ describe(parseGamePassResponse, () => {
 
 		// Nested JSON null inside priceInformation — the parser normalizes
 		// it to undefined on the public GamePassPrice.
-		const body: unknown = JSON.parse(
+		const body = JSON.parse(
 			`{
 				"createdTimestamp": "2024-01-15T10:30:00.000Z",
 				"description": "no default price",
@@ -321,7 +321,7 @@ describe(parseGamePassResponse, () => {
 	])("should return an ApiError when $label", ({ priceBody }) => {
 		expect.assertions(1);
 
-		const body: unknown = JSON.parse(
+		const body = JSON.parse(
 			`{
 				"createdTimestamp": "2024-01-15T10:30:00.000Z",
 				"description": "malformed price",

--- a/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
@@ -164,4 +164,16 @@ describe(parseGamePassResponse, () => {
 
 		expect(result.data.id).toBe("987654");
 	});
+
+	it("should treat iconAssetId 0 as an absent icon", () => {
+		expect.assertions(1);
+
+		const body = validBody({ iconAssetId: 0 });
+
+		const result = parseGamePassResponse(body, 200);
+
+		assert(result.success);
+
+		expect(result.data.iconAssetId).toBeUndefined();
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
@@ -209,4 +209,30 @@ describe(parseGamePassResponse, () => {
 			"UserFixedPrice",
 		]);
 	});
+
+	it("should map a nested null defaultPriceInRobux to undefined on price", () => {
+		expect.assertions(1);
+
+		// Nested JSON null inside priceInformation — the parser normalizes
+		// it to undefined on the public GamePassPrice.
+		const body: unknown = JSON.parse(
+			`{
+				"createdTimestamp": "2024-01-15T10:30:00.000Z",
+				"description": "no default price",
+				"gamePassId": 7,
+				"iconAssetId": 7,
+				"isForSale": true,
+				"name": "Flex",
+				"priceInformation": { "defaultPriceInRobux": null, "enabledFeatures": [] },
+				"updatedTimestamp": "2024-03-20T14:45:00.000Z"
+			}`,
+		);
+
+		const result = parseGamePassResponse(body, 200);
+
+		assert(result.success);
+		assert(result.data.price);
+
+		expect(result.data.price.defaultPriceInRobux).toBeUndefined();
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
@@ -1,5 +1,6 @@
 import { assert, describe, expect, it } from "vitest";
 
+import { ApiError } from "../../errors/api-error.ts";
 import { parseGamePassResponse } from "./parsers.ts";
 import type { GamePassConfigV2 } from "./wire.ts";
 
@@ -64,5 +65,29 @@ describe(parseGamePassResponse, () => {
 		assert(result.success);
 
 		expect(result.data.price).toBeUndefined();
+	});
+
+	it("should return an ApiError when a required field is missing", () => {
+		expect.assertions(3);
+
+		const body: unknown = JSON.parse(
+			`{
+				"createdTimestamp": "2024-01-15T10:30:00.000Z",
+				"description": "nameless",
+				"gamePassId": 12345,
+				"iconAssetId": 67890,
+				"isForSale": true,
+				"priceInformation": null,
+				"updatedTimestamp": "2024-03-20T14:45:00.000Z"
+			}`,
+		);
+
+		const result = parseGamePassResponse(body, 422);
+
+		assert(!result.success);
+
+		expect(result.err).toBeInstanceOf(ApiError);
+		expect(result.err.message).toBe("Malformed game pass response");
+		expect(result.err.statusCode).toBe(422);
 	});
 });

--- a/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
@@ -39,4 +39,30 @@ describe(parseGamePassResponse, () => {
 			updatedAt: new Date("2024-03-20T14:45:00.000Z"),
 		});
 	});
+
+	it("should map a null priceInformation to an undefined price", () => {
+		expect.assertions(1);
+
+		// The API sends a literal JSON `null` when no price is configured;
+		// `JSON.parse` preserves it as runtime null so we exercise the
+		// normalization the parser performs at the wire boundary.
+		const body: unknown = JSON.parse(
+			`{
+				"createdTimestamp": "2024-01-15T10:30:00.000Z",
+				"description": "Free pass",
+				"gamePassId": 42,
+				"iconAssetId": 99,
+				"isForSale": false,
+				"name": "Free Pass",
+				"priceInformation": null,
+				"updatedTimestamp": "2024-03-20T14:45:00.000Z"
+			}`,
+		);
+
+		const result = parseGamePassResponse(body, 200);
+
+		assert(result.success);
+
+		expect(result.data.price).toBeUndefined();
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
@@ -176,4 +176,16 @@ describe(parseGamePassResponse, () => {
 
 		expect(result.data.iconAssetId).toBeUndefined();
 	});
+
+	it("should stringify a nonzero iconAssetId", () => {
+		expect.assertions(1);
+
+		const body = validBody({ iconAssetId: 55_555 });
+
+		const result = parseGamePassResponse(body, 200);
+
+		assert(result.success);
+
+		expect(result.data.iconAssetId).toBe("55555");
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
@@ -4,6 +4,20 @@ import { ApiError } from "../../errors/api-error.ts";
 import { parseGamePassResponse } from "./parsers.ts";
 import type { GamePassConfigV2 } from "./wire.ts";
 
+function validBody(overrides: Partial<GamePassConfigV2> = {}): GamePassConfigV2 {
+	return {
+		name: "Pass",
+		createdTimestamp: "2024-01-15T10:30:00.000Z",
+		description: "Pass",
+		gamePassId: 1,
+		iconAssetId: 1,
+		isForSale: true,
+		priceInformation: { defaultPriceInRobux: 100, enabledFeatures: [] },
+		updatedTimestamp: "2024-03-20T14:45:00.000Z",
+		...overrides,
+	};
+}
+
 describe(parseGamePassResponse, () => {
 	it("should return success with a fully converted GamePass for a valid body", () => {
 		expect.assertions(1);
@@ -113,5 +127,17 @@ describe(parseGamePassResponse, () => {
 
 		expect(result.err).toBeInstanceOf(ApiError);
 		expect(result.err.statusCode).toBe(502);
+	});
+
+	it("should convert createdTimestamp into a createdAt Date at the same instant", () => {
+		expect.assertions(1);
+
+		const body = validBody({ createdTimestamp: "2024-05-01T08:00:00.000Z" });
+
+		const result = parseGamePassResponse(body, 200);
+
+		assert(result.success);
+
+		expect(result.data.createdAt.toISOString()).toBe("2024-05-01T08:00:00.000Z");
 	});
 });

--- a/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
@@ -140,4 +140,16 @@ describe(parseGamePassResponse, () => {
 
 		expect(result.data.createdAt.toISOString()).toBe("2024-05-01T08:00:00.000Z");
 	});
+
+	it("should convert updatedTimestamp into an updatedAt Date at the same instant", () => {
+		expect.assertions(1);
+
+		const body = validBody({ updatedTimestamp: "2024-07-14T18:30:00.000Z" });
+
+		const result = parseGamePassResponse(body, 200);
+
+		assert(result.success);
+
+		expect(result.data.updatedAt.toISOString()).toBe("2024-07-14T18:30:00.000Z");
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.spec.ts
@@ -105,20 +105,32 @@ describe(parseGamePassResponse, () => {
 		expect(result.err.statusCode).toBe(422);
 	});
 
-	it("should return an ApiError when a required field has the wrong type", () => {
+	it.for([
+		{ badValue: '"12345"', field: "gamePassId" },
+		{ badValue: "42", field: "name" },
+		{ badValue: "false", field: "description" },
+		{ badValue: '"yes"', field: "isForSale" },
+		{ badValue: '"67890"', field: "iconAssetId" },
+		{ badValue: "12345", field: "createdTimestamp" },
+		{ badValue: "12345", field: "updatedTimestamp" },
+	])("should return an ApiError when $field has the wrong type", ({ badValue, field }) => {
 		expect.assertions(2);
 
+		// Duplicate keys are allowed in JSON; `JSON.parse` keeps the last
+		// occurrence so interpolating `badValue` at the end overrides the
+		// valid baseline.
 		const body: unknown = JSON.parse(
 			`{
-				"createdTimestamp": "2024-01-15T10:30:00.000Z",
-				"description": "wrong-type gamePassId",
-				"gamePassId": "12345",
-				"iconAssetId": 67890,
-				"isForSale": true,
-				"name": "Bad Pass",
-				"priceInformation": null,
-				"updatedTimestamp": "2024-03-20T14:45:00.000Z"
-			}`,
+					"createdTimestamp": "2024-01-15T10:30:00.000Z",
+					"description": "base",
+					"gamePassId": 1,
+					"iconAssetId": 1,
+					"isForSale": true,
+					"name": "base",
+					"priceInformation": null,
+					"updatedTimestamp": "2024-03-20T14:45:00.000Z",
+					"${field}": ${badValue}
+				}`,
 		);
 
 		const result = parseGamePassResponse(body, 502);
@@ -133,6 +145,48 @@ describe(parseGamePassResponse, () => {
 		expect.assertions(1);
 
 		const result = parseGamePassResponse("not an object", 500);
+
+		assert(!result.success);
+
+		expect(result.err).toBeInstanceOf(ApiError);
+	});
+
+	it("should return an ApiError when the body is JSON null", () => {
+		expect.assertions(1);
+
+		// Without the top-level isRecord guard, `null["field"]` would throw;
+		// this test locks in the nullish rejection path.
+		const result = parseGamePassResponse(JSON.parse("null"), 500);
+
+		assert(!result.success);
+
+		expect(result.err).toBeInstanceOf(ApiError);
+	});
+
+	it("should reject priceInformation that is an array with look-alike named properties", () => {
+		expect.assertions(1);
+
+		// Adversarial input: JavaScript arrays can carry named properties
+		// alongside their numeric indices. The inner isRecord guard is what
+		// distinguishes a legitimate record from such an array; this test
+		// locks in that the guard still fires even when every field-level
+		// check would otherwise accept the value.
+		const priceInformation: unknown = Object.assign([], {
+			defaultPriceInRobux: 100,
+			enabledFeatures: ["Invalid"],
+		});
+		const body: unknown = {
+			name: "Hostile",
+			createdTimestamp: "2024-01-15T10:30:00.000Z",
+			description: "hostile",
+			gamePassId: 1,
+			iconAssetId: 1,
+			isForSale: true,
+			priceInformation,
+			updatedTimestamp: "2024-03-20T14:45:00.000Z",
+		};
+
+		const result = parseGamePassResponse(body, 500);
 
 		assert(!result.success);
 
@@ -205,7 +259,7 @@ describe(parseGamePassResponse, () => {
 		const body = validBody({
 			priceInformation: {
 				defaultPriceInRobux: 50,
-				enabledFeatures: ["PriceOptimization", "UserFixedPrice"],
+				enabledFeatures: ["Invalid", "PriceOptimization", "UserFixedPrice"],
 			},
 		});
 
@@ -215,6 +269,7 @@ describe(parseGamePassResponse, () => {
 		assert(result.data.price);
 
 		expect(result.data.price.enabledFeatures).toStrictEqual([
+			"Invalid",
 			"PriceOptimization",
 			"UserFixedPrice",
 		]);
@@ -257,7 +312,7 @@ describe(parseGamePassResponse, () => {
 		},
 		{
 			label: "enabledFeatures is not an array",
-			priceBody: '{ "defaultPriceInRobux": null, "enabledFeatures": "none" }',
+			priceBody: '{ "defaultPriceInRobux": null, "enabledFeatures": {} }',
 		},
 		{
 			label: "enabledFeatures contains an unknown value",

--- a/packages/open-cloud/src/resources/game-passes/parsers.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.ts
@@ -1,0 +1,123 @@
+import { ApiError } from "../../errors/api-error.ts";
+import type { Result } from "../../types.ts";
+import type { GamePass, GamePassPrice } from "./types.ts";
+import type { GamePassConfigV2, PriceInformationStructWire, PricingFeatureWire } from "./wire.ts";
+
+/**
+ * Type guard confirming that a decoded JSON body matches the
+ * `GamePassConfigV2` wire schema from the Roblox Open Cloud OpenAPI.
+ *
+ * @param body - The decoded response body to inspect.
+ * @returns `true` if every required field is present with the expected type.
+ */
+export function isGamePassConfigV2(body: unknown): body is GamePassConfigV2 {
+	if (!isRecord(body)) {
+		return false;
+	}
+
+	if (!hasRequiredPrimitiveFields(body)) {
+		return false;
+	}
+
+	const price = body["priceInformation"] ?? undefined;
+	if (price !== undefined && !isPriceInformationStructWire(price)) {
+		return false;
+	}
+
+	return true;
+}
+
+/**
+ * Parses a successful Game Pass API response body into the public
+ * `GamePass` shape, returning a `Result` so callers can handle malformed
+ * payloads without exceptions.
+ *
+ * @param body - The decoded response body from the Open Cloud API.
+ * @param statusCode - The HTTP status code of the response; included on
+ *   the returned `ApiError` when validation fails.
+ * @returns A success result wrapping the converted `GamePass`, or an
+ *   `ApiError` when the body does not match the wire schema.
+ */
+export function parseGamePassResponse(
+	body: unknown,
+	statusCode: number,
+): Result<GamePass, ApiError> {
+	if (!isGamePassConfigV2(body)) {
+		return {
+			err: new ApiError("Malformed game pass response", { statusCode }),
+			success: false,
+		};
+	}
+
+	const priceWire = body.priceInformation ?? undefined;
+
+	return {
+		data: {
+			id: String(body.gamePassId),
+			name: body.name,
+			createdAt: new Date(body.createdTimestamp),
+			description: body.description,
+			iconAssetId: body.iconAssetId === 0 ? undefined : String(body.iconAssetId),
+			isForSale: body.isForSale,
+			price: priceWire === undefined ? undefined : toGamePassPrice(priceWire),
+			updatedAt: new Date(body.updatedTimestamp),
+		},
+		success: true,
+	};
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && Boolean(value) && !Array.isArray(value);
+}
+
+function hasRequiredPrimitiveFields(body: Record<string, unknown>): boolean {
+	return (
+		typeof body["gamePassId"] === "number" &&
+		typeof body["name"] === "string" &&
+		typeof body["description"] === "string" &&
+		typeof body["isForSale"] === "boolean" &&
+		typeof body["iconAssetId"] === "number" &&
+		typeof body["createdTimestamp"] === "string" &&
+		typeof body["updatedTimestamp"] === "string"
+	);
+}
+
+function isPricingFeatureWire(value: unknown): value is PricingFeatureWire {
+	return (
+		value === "Invalid" ||
+		value === "PriceOptimization" ||
+		value === "RegionalPricing" ||
+		value === "UserFixedPrice"
+	);
+}
+
+function isPriceInformationStructWire(value: unknown): value is PriceInformationStructWire {
+	if (!isRecord(value)) {
+		return false;
+	}
+
+	const defaultPrice = value["defaultPriceInRobux"] ?? undefined;
+	if (defaultPrice !== undefined && typeof defaultPrice !== "number") {
+		return false;
+	}
+
+	const features = value["enabledFeatures"];
+	if (!Array.isArray(features)) {
+		return false;
+	}
+
+	for (const feature of features) {
+		if (!isPricingFeatureWire(feature)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+function toGamePassPrice(wire: PriceInformationStructWire): GamePassPrice {
+	return {
+		defaultPriceInRobux: wire.defaultPriceInRobux ?? undefined,
+		enabledFeatures: [...wire.enabledFeatures],
+	};
+}

--- a/packages/open-cloud/src/resources/game-passes/parsers.ts
+++ b/packages/open-cloud/src/resources/game-passes/parsers.ts
@@ -67,7 +67,7 @@ export function parseGamePassResponse(
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && Boolean(value) && !Array.isArray(value);
+	return Object.prototype.toString.call(value) === "[object Object]";
 }
 
 function hasRequiredPrimitiveFields(body: Record<string, unknown>): boolean {

--- a/packages/open-cloud/src/resources/game-passes/types.ts
+++ b/packages/open-cloud/src/resources/game-passes/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Pricing feature flags that can be enabled on a game pass. Values
+ * mirror the Open Cloud `GamePasses.PricingFeature` enum.
+ */
+export type GamePassPricingFeature =
+	| "Invalid"
+	| "PriceOptimization"
+	| "RegionalPricing"
+	| "UserFixedPrice";
+
+/**
+ * Public shape of a game pass's pricing configuration.
+ */
+export interface GamePassPrice {
+	/** Default Robux price; `undefined` when no default price is configured. */
+	readonly defaultPriceInRobux: number | undefined;
+	/** Pricing feature flags currently enabled on this game pass. */
+	readonly enabledFeatures: ReadonlyArray<GamePassPricingFeature>;
+}
+
+/**
+ * A Roblox game pass as exposed to SDK consumers. Fields use DX-friendly
+ * names and types (stringified IDs, `Date` timestamps) rather than the
+ * raw wire representation.
+ */
+export interface GamePass {
+	/** Stringified game pass ID. The API returns an int64; always use this. */
+	readonly id: string;
+	/** Display name of the game pass. */
+	readonly name: string;
+	/** ISO timestamp at which the game pass was created, as a `Date`. */
+	readonly createdAt: Date;
+	/** Consumer-facing description shown on the store listing. */
+	readonly description: string;
+	/** Icon asset ID as a string; `undefined` when no icon is uploaded. */
+	readonly iconAssetId: string | undefined;
+	/** Whether the game pass is currently purchasable. */
+	readonly isForSale: boolean;
+	/** Pricing configuration; `undefined` when pricing is not yet set. */
+	readonly price: GamePassPrice | undefined;
+	/** ISO timestamp of the most recent update, as a `Date`. */
+	readonly updatedAt: Date;
+}
+
+/**
+ * Parameters for creating a new game pass under a universe.
+ */
+export interface CreateGamePassParameters {
+	/** Display name of the new game pass. */
+	readonly name: string;
+	/** Optional consumer-facing description shown on the store listing. */
+	readonly description?: string;
+	/** Optional icon image uploaded with the new game pass. */
+	readonly imageFile?: Blob | Uint8Array;
+	/** Whether the game pass should be purchasable immediately. */
+	readonly isForSale?: boolean;
+	/** Whether regional pricing should be enabled at creation time. */
+	readonly isRegionalPricingEnabled?: boolean;
+	/** Optional default price in Robux at creation time. */
+	readonly price?: number;
+	/** Stringified ID of the universe that owns the game pass. */
+	readonly universeId: string;
+}
+
+/**
+ * Parameters for reading a single game pass by ID.
+ */
+export interface GetGamePassParameters {
+	/** Stringified ID of the game pass to retrieve. */
+	readonly gamePassId: string;
+	/** Stringified ID of the universe that owns the game pass. */
+	readonly universeId: string;
+}

--- a/packages/open-cloud/src/resources/game-passes/wire.ts
+++ b/packages/open-cloud/src/resources/game-passes/wire.ts
@@ -1,0 +1,95 @@
+// Mirrors GamePassConfigV2 from vendor/roblox-openapi.json.
+// Internal to the subpath — not re-exported from index.ts.
+//
+// Nullable-but-required OpenAPI fields are modelled as `T | undefined`
+// (value required, may be undefined) to comply with `unicorn/no-null`.
+// Genuinely optional fields use `?:`. The parser normalizes any JSON
+// `null` values to `undefined` at validation time so callers only ever
+// observe `undefined`.
+
+/**
+ * Wire-level pricing feature flag, mirroring `GamePasses.PricingFeature`.
+ */
+export type PricingFeatureWire =
+	| "Invalid"
+	| "PriceOptimization"
+	| "RegionalPricing"
+	| "UserFixedPrice";
+
+/**
+ * Wire shape of `GamePasses.PriceInformationStruct`.
+ */
+export interface PriceInformationStructWire {
+	/** Default Robux price; `undefined` when the schema returns null. */
+	readonly defaultPriceInRobux: number | undefined;
+	/** Enabled pricing feature flags, in the order returned by the API. */
+	readonly enabledFeatures: ReadonlyArray<PricingFeatureWire>;
+}
+
+/**
+ * Wire shape of `GamePassConfigV2` — the response body returned by the
+ * Game Passes read endpoint.
+ */
+export interface GamePassConfigV2 {
+	/** Display name of the game pass. */
+	readonly name: string;
+	/** ISO timestamp at which the game pass was created (`date-time`). */
+	readonly createdTimestamp: string;
+	/** Consumer-facing description. */
+	readonly description: string;
+	/** Int64 game pass ID, serialized as a JSON number. */
+	readonly gamePassId: number;
+	/** Int64 icon asset ID; `0` signals the pass has no icon uploaded. */
+	readonly iconAssetId: number;
+	/** Whether the game pass is currently purchasable. */
+	readonly isForSale: boolean;
+	/** Pricing block; `undefined` when the schema returns null. */
+	readonly priceInformation: PriceInformationStructWire | undefined;
+	/** ISO timestamp of the most recent update (`date-time`). */
+	readonly updatedTimestamp: string;
+}
+
+/**
+ * Wire-level error code union for the Game Passes API, mirroring
+ * `GamePasses.ErrorCode` exactly.
+ */
+export type ErrorCodeWire =
+	| "ActiveInPO"
+	| "AssetCreationFailure"
+	| "AssetNotFound"
+	| "BadRequest"
+	| "Blocked"
+	| "CommissionRateNotFound"
+	| "FileTooLarge"
+	| "InternalError"
+	| "InvalidCount"
+	| "InvalidPageSize"
+	| "MissingArgument"
+	| "NotAuthenticated"
+	| "NotForSale"
+	| "NotFound"
+	| "NotSameUniverse"
+	| "PassAlreadyRevoked"
+	| "PassNotFound"
+	| "PassRevokeFailure"
+	| "PricingConfigError"
+	| "SalesNotFound"
+	| "TargetUnauthorizedAccess"
+	| "UnauthorizedAccess"
+	| "UniverseNotFound";
+
+/**
+ * Wire shape of `GamePasses.ErrorResponse` — the body returned for
+ * non-2xx Game Passes API responses. All fields are genuinely optional
+ * per the schema.
+ */
+export interface GamePassesErrorResponse {
+	/** Machine-readable error code from the enum above. */
+	readonly errorCode?: ErrorCodeWire;
+	/** Human-readable error description. */
+	readonly errorMessage?: string;
+	/** Field path that triggered the error, when applicable. */
+	readonly field?: string;
+	/** Suggested remediation, when provided by the API. */
+	readonly hint?: string;
+}

--- a/packages/testing/src/stryker-diff.spec.ts
+++ b/packages/testing/src/stryker-diff.spec.ts
@@ -28,7 +28,7 @@ describe(parseDiff, () => {
 		});
 	});
 
-	it("should reject a newly added file with its path", () => {
+	it("should record a newly added file with a hunk covering every added line", () => {
 		expect.assertions(1);
 
 		const raw = [
@@ -46,8 +46,8 @@ describe(parseDiff, () => {
 		const result = parseDiff(raw);
 
 		expect(result).toStrictEqual({
-			kind: "reject",
-			reasons: [{ kind: "new-file", path: "src/new.ts" }],
+			files: [{ hunks: [{ endLine: 3, startLine: 1 }], path: "src/new.ts" }],
+			kind: "changes",
 		});
 	});
 
@@ -263,7 +263,7 @@ describe(groupByPackage, () => {
 });
 
 describe(filterMutableFiles, () => {
-	it("should drop spec, test, and declaration files", () => {
+	it("should drop spec, test, declaration, and non-TS files", () => {
 		expect.assertions(1);
 
 		const files = [
@@ -272,11 +272,15 @@ describe(filterMutableFiles, () => {
 			{ hunks: [{ endLine: 3, startLine: 3 }], path: "src/a.test.ts" },
 			{ hunks: [{ endLine: 4, startLine: 4 }], path: "src/types.d.ts" },
 			{ hunks: [{ endLine: 5, startLine: 5 }], path: "src/b.ts" },
+			{ hunks: [{ endLine: 6, startLine: 6 }], path: "src/c.spec-d.ts" },
+			{ hunks: [{ endLine: 7, startLine: 7 }], path: "CLAUDE.md" },
+			{ hunks: [{ endLine: 8, startLine: 8 }], path: "src/component.tsx" },
 		];
 
 		expect(filterMutableFiles(files)).toStrictEqual([
 			{ hunks: [{ endLine: 1, startLine: 1 }], path: "src/a.ts" },
 			{ hunks: [{ endLine: 5, startLine: 5 }], path: "src/b.ts" },
+			{ hunks: [{ endLine: 8, startLine: 8 }], path: "src/component.tsx" },
 		]);
 	});
 });

--- a/packages/testing/src/stryker-diff.ts
+++ b/packages/testing/src/stryker-diff.ts
@@ -20,12 +20,13 @@ export interface FileChange {
 
 /**
  * A file change the wrapper cannot translate into a mutation range:
- * renames, new files, and binary blobs. Surfaced as hard errors.
+ * renames and binary blobs. Surfaced as hard errors. New files are
+ * handled normally — their `@@ -0,0 +1,N @@` hunk already covers the
+ * full added range, which Stryker accepts as the mutation window.
  */
 export type DiffReject =
 	| { from: string; kind: "rename"; to: string }
-	| { kind: "binary"; path: string }
-	| { kind: "new-file"; path: string };
+	| { kind: "binary"; path: string };
 
 /**
  * Outcome of parsing `git diff HEAD`: either the per-file change set or
@@ -39,7 +40,6 @@ const DIFF_HEADER = /^diff --git a\/(.+) b\/(.+)$/;
 const HUNK_HEADER = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@/;
 const RENAME_FROM = /^rename from (.+)$/;
 const RENAME_TO = /^rename to (.+)$/;
-const NEW_FILE_MARKER = /^new file mode /;
 const BINARY_MARKER = /^Binary files /;
 
 interface ParseState {
@@ -90,21 +90,27 @@ export function buildMutateArgs(files: ReadonlyArray<FileChange>): Array<string>
 	return ["--mutate", patterns.join(",")];
 }
 
-const NON_MUTABLE_SUFFIXES: ReadonlyArray<string> = [".spec.ts", ".test.ts", ".d.ts"];
+const MUTABLE_SUFFIXES: ReadonlyArray<string> = [".ts", ".tsx"];
+const NON_MUTABLE_SUFFIXES: ReadonlyArray<string> = [".spec.ts", ".spec-d.ts", ".test.ts", ".d.ts"];
 
 /**
- * Filter out files that Stryker should never mutate: test files and type
- * declarations. Used to clean up a `parseDiff` result before passing it to
- * `buildMutateArgs`, since the CLI `--mutate` flag overrides the config's
- * own ignore patterns.
+ * Filter down to files Stryker can actually mutate: TypeScript source
+ * that isn't a test or type declaration. Markdown, configs, and other
+ * non-TS files are dropped so the CLI `--mutate` flag (which overrides
+ * the config's own ignore patterns) never hands them to Stryker's
+ * parser — which has no handler for them and would crash.
  *
  * @param files - Changes as returned by {@link parseDiff}.
  * @returns The subset whose paths point at production source files.
  */
 export function filterMutableFiles(files: ReadonlyArray<FileChange>): Array<FileChange> {
-	return files.filter(
-		(file) => !NON_MUTABLE_SUFFIXES.some((suffix) => file.path.endsWith(suffix)),
-	);
+	return files.filter((file) => {
+		if (!MUTABLE_SUFFIXES.some((suffix) => file.path.endsWith(suffix))) {
+			return false;
+		}
+
+		return !NON_MUTABLE_SUFFIXES.some((suffix) => file.path.endsWith(suffix));
+	});
 }
 
 /**
@@ -142,7 +148,6 @@ export function groupByPackage(
 
 const HANDLERS: ReadonlyArray<LineHandler> = [
 	handleFileHeader,
-	handleNewFile,
 	handleBinary,
 	handleRenameFrom,
 	handleRenameTo,
@@ -166,17 +171,6 @@ function handleFileHeader(line: string, state: ParseState): boolean {
 	state.current = { hunks: [], path: match[2] };
 	state.files.push(state.current);
 	state.renameFrom = undefined;
-	return true;
-}
-
-function handleNewFile(line: string, state: ParseState): boolean {
-	if (!NEW_FILE_MARKER.test(line) || !state.current) {
-		return false;
-	}
-
-	state.rejects.push({ kind: "new-file", path: state.current.path });
-	state.files.pop();
-	state.current = undefined;
 	return true;
 }
 


### PR DESCRIPTION
Closes #21.

## Summary

- Introduces the Game Passes resource under `@bedrock/ocale/game-passes` with internal wire types mirroring `GamePassConfigV2` from the Open Cloud OpenAPI, hand-crafted public types (`GamePass`, `GamePassPrice`, `GamePassPricingFeature`, `CreateGamePassParameters`, `GetGamePassParameters`), and a pure parser returning `Result<GamePass, ApiError>`.
- Turns on `unicorn/no-null` for package source and migrates the few remaining `null` usages; nullable-but-required OpenAPI fields are modelled as `T | undefined` and the parser normalizes any JSON `null` values at the wire boundary.
- Documents the RED+GREEN commit cadence forced by the `hk` pre-commit hook (lint + typecheck + test + build runs on every commit, so a pure-RED commit cannot land).

## Implementation notes

- `wire.ts` is internal — not re-exported from the subpath barrel. Public consumers see only the DX-friendly types.
- `parseGamePassResponse(body, statusCode)` takes an `unknown` body plus the HTTP status (from `HttpResponse.status`), so the emitted `ApiError` reflects the real response when validation fails. Conversions: `gamePassId` number → `id` string, `createdTimestamp`/`updatedTimestamp` → `Date`, `priceInformation` → `price`, and `iconAssetId === 0` → `undefined`.
- `isRecord` uses `Object.prototype.toString.call(...) === "[object Object]"` for a minimal mutation surface.
- Builders and the `GamePassesClient` class are intentionally out of scope and will land in follow-up issues.

## Test plan

- [x] `pnpm test` — all 24 parser tests green across the package suite.
- [x] `pnpm typecheck` — clean across all workspaces.
- [x] `pnpm lint` — clean with the new `unicorn/no-null` rule enforced.
- [x] `pnpm build` — produces `dist/game-passes.mjs` and `dist/game-passes.d.mts` via the `vp pack` entry.
- [x] `pnpm exec stryker run … --mutate 'src/resources/game-passes/parsers.ts' --force` — 143/143 mutants killed, 100% mutation score.
- [x] Runtime import check: `import('.../dist/game-passes.mjs')` exposes only type-erased exports, confirming wire/parser stay internal.