### PR TITLE
feat(ocale): add http-client fake; rename existing to fake-send

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,7 @@ lands — drop the flag and this note afterwards.
 2. Run `pnpm build` (must succeed)
 3. Run `pnpm test` (must pass)
 4. Run `pnpm typecheck` (must pass)
+5. Run `pnpm mutate:changed` (no surviving mutants on touched `src/**` files)
 
 ### Pull Requests
 

--- a/packages/open-cloud/src/internal/http/execute.spec.ts
+++ b/packages/open-cloud/src/internal/http/execute.spec.ts
@@ -32,7 +32,7 @@ describe(executeWithRetry, () => {
 			config: makeRetryConfig(),
 			hooks,
 			send: fakeHttp.send,
-			sleep: fakeSleep.sleep,
+			sleep: fakeSleep,
 		});
 
 		assert(result.success);
@@ -62,7 +62,7 @@ describe(executeWithRetry, () => {
 			config: makeRetryConfig(),
 			hooks,
 			send: fakeHttp.send,
-			sleep: fakeSleep.sleep,
+			sleep: fakeSleep,
 		});
 
 		assert(result.success);
@@ -94,7 +94,7 @@ describe(executeWithRetry, () => {
 			}),
 			hooks,
 			send: fakeHttp.send,
-			sleep: fakeSleep.sleep,
+			sleep: fakeSleep,
 		});
 
 		assert(result.success);
@@ -121,7 +121,7 @@ describe(executeWithRetry, () => {
 			config: makeRetryConfig(),
 			hooks,
 			send: fakeHttp.send,
-			sleep: fakeSleep.sleep,
+			sleep: fakeSleep,
 		});
 
 		assert(!result.success);
@@ -151,7 +151,7 @@ describe(executeWithRetry, () => {
 			config: makeRetryConfig({ maxRetries: 2 }),
 			hooks,
 			send: fakeHttp.send,
-			sleep: fakeSleep.sleep,
+			sleep: fakeSleep,
 		});
 
 		assert(!result.success);
@@ -180,7 +180,7 @@ describe(executeWithRetry, () => {
 			config: makeRetryConfig(),
 			hooks,
 			send: fakeHttp.send,
-			sleep: fakeSleep.sleep,
+			sleep: fakeSleep,
 		});
 
 		assert(result.success);
@@ -209,7 +209,7 @@ describe(executeWithRetry, () => {
 			config: makeRetryConfig(),
 			hooks,
 			send: fakeHttp.send,
-			sleep: fakeSleep.sleep,
+			sleep: fakeSleep,
 		});
 
 		expect(onRequest).toHaveBeenCalledTimes(3);
@@ -236,7 +236,7 @@ describe(executeWithRetry, () => {
 			config: makeRetryConfig(),
 			hooks,
 			send: fakeHttp.send,
-			sleep: fakeSleep.sleep,
+			sleep: fakeSleep,
 		});
 
 		expect(onRetry).toHaveBeenCalledTimes(2);
@@ -262,7 +262,7 @@ describe(executeWithRetry, () => {
 			config: makeRetryConfig(),
 			hooks,
 			send: fakeHttp.send,
-			sleep: fakeSleep.sleep,
+			sleep: fakeSleep,
 		});
 
 		expect(onRateLimit.mock.calls.map(([waitMs]) => waitMs)).toStrictEqual([2000, 5000]);
@@ -285,7 +285,7 @@ describe(executeWithRetry, () => {
 			config: makeRetryConfig({ retryDelay }),
 			hooks: {},
 			send: fakeHttp.send,
-			sleep: fakeSleep.sleep,
+			sleep: fakeSleep,
 		});
 
 		expect(fakeSleep.waits).toStrictEqual([3000]);
@@ -311,7 +311,7 @@ describe(executeWithRetry, () => {
 			}),
 			hooks: {},
 			send: fakeHttp.send,
-			sleep: fakeSleep.sleep,
+			sleep: fakeSleep,
 		});
 
 		expect(fakeSleep.waits).toStrictEqual([1000, 2000]);
@@ -332,7 +332,7 @@ describe(executeWithRetry, () => {
 			config: makeRetryConfig({ retryableStatuses: [] }),
 			hooks,
 			send: fakeHttp.send,
-			sleep: fakeSleep.sleep,
+			sleep: fakeSleep,
 		});
 
 		assert(!result.success);
@@ -361,7 +361,7 @@ describe(executeWithRetry, () => {
 			config: makeRetryConfig({ maxRetries: 1 }),
 			hooks,
 			send: fakeHttp.send,
-			sleep: fakeSleep.sleep,
+			sleep: fakeSleep,
 		});
 
 		expect(onRetry).toHaveBeenCalledExactlyOnceWith(1, firstError);

--- a/packages/open-cloud/src/internal/http/execute.spec.ts
+++ b/packages/open-cloud/src/internal/http/execute.spec.ts
@@ -1,4 +1,4 @@
-import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
+import { createFakeSend } from "#tests/helpers/fake-send";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
 import { makeRetryConfig } from "#tests/helpers/retry-config";
 import { assert, describe, expect, it, vi } from "vitest";
@@ -23,7 +23,7 @@ describe(executeWithRetry, () => {
 		const onRetry = vi.fn<(attempt: number, error: Error) => void>();
 		const onRateLimit = vi.fn<(waitMs: number) => void>();
 		const hooks: OpenCloudHooks = { onRateLimit, onRequest, onRetry };
-		const fakeHttp = createFakeHttpClient({
+		const fakeSend = createFakeSend({
 			responses: [{ data: okResponse({ id: "1" }), success: true }],
 		});
 		const fakeSleep = createFakeSleep();
@@ -31,14 +31,14 @@ describe(executeWithRetry, () => {
 		const result = await executeWithRetry(request, {
 			config: makeRetryConfig(),
 			hooks,
-			send: fakeHttp.send,
+			send: fakeSend.send,
 			sleep: fakeSleep,
 		});
 
 		assert(result.success);
 
 		expect(result.data.body).toStrictEqual({ id: "1" });
-		expect(fakeHttp.requests).toHaveLength(1);
+		expect(fakeSend.requests).toHaveLength(1);
 		expect(onRetry).not.toHaveBeenCalled();
 		expect(onRateLimit).not.toHaveBeenCalled();
 	});
@@ -50,7 +50,7 @@ describe(executeWithRetry, () => {
 		const onRateLimit = vi.fn<(waitMs: number) => void>();
 		const hooks: OpenCloudHooks = { onRateLimit, onRetry };
 		const rateLimitError = new RateLimitError("slow down", { retryAfterSeconds: 1 });
-		const fakeHttp = createFakeHttpClient({
+		const fakeSend = createFakeSend({
 			responses: [
 				{ err: rateLimitError, success: false },
 				{ data: okResponse({ id: "ok" }), success: true },
@@ -61,14 +61,14 @@ describe(executeWithRetry, () => {
 		const result = await executeWithRetry(request, {
 			config: makeRetryConfig(),
 			hooks,
-			send: fakeHttp.send,
+			send: fakeSend.send,
 			sleep: fakeSleep,
 		});
 
 		assert(result.success);
 
 		expect(result.data.body).toStrictEqual({ id: "ok" });
-		expect(fakeHttp.requests).toHaveLength(2);
+		expect(fakeSend.requests).toHaveLength(2);
 		expect(onRetry).toHaveBeenCalledExactlyOnceWith(1, rateLimitError);
 		expect(onRateLimit).toHaveBeenCalledExactlyOnceWith(1000);
 		expect(fakeSleep.waits).toStrictEqual([1000]);
@@ -80,7 +80,7 @@ describe(executeWithRetry, () => {
 		const onRetry = vi.fn<(attempt: number, error: Error) => void>();
 		const hooks: OpenCloudHooks = { onRetry };
 		const serverError = new ApiError("unavailable", { statusCode: 503 });
-		const fakeHttp = createFakeHttpClient({
+		const fakeSend = createFakeSend({
 			responses: [
 				{ err: serverError, success: false },
 				{ data: okResponse({ id: "ok" }), success: true },
@@ -93,14 +93,14 @@ describe(executeWithRetry, () => {
 				retryableStatuses: IDEMPOTENT_METHOD_DEFAULTS.retryableStatuses,
 			}),
 			hooks,
-			send: fakeHttp.send,
+			send: fakeSend.send,
 			sleep: fakeSleep,
 		});
 
 		assert(result.success);
 
 		expect(result.data.body).toStrictEqual({ id: "ok" });
-		expect(fakeHttp.requests).toHaveLength(2);
+		expect(fakeSend.requests).toHaveLength(2);
 		expect(onRetry).toHaveBeenCalledExactlyOnceWith(1, serverError);
 		expect(fakeSleep.waits).toHaveLength(1);
 	});
@@ -112,7 +112,7 @@ describe(executeWithRetry, () => {
 		const onRateLimit = vi.fn<(waitMs: number) => void>();
 		const hooks: OpenCloudHooks = { onRateLimit, onRetry };
 		const badRequest = new ApiError("bad request", { statusCode: 400 });
-		const fakeHttp = createFakeHttpClient({
+		const fakeSend = createFakeSend({
 			responses: [{ err: badRequest, success: false }],
 		});
 		const fakeSleep = createFakeSleep();
@@ -120,14 +120,14 @@ describe(executeWithRetry, () => {
 		const result = await executeWithRetry(request, {
 			config: makeRetryConfig(),
 			hooks,
-			send: fakeHttp.send,
+			send: fakeSend.send,
 			sleep: fakeSleep,
 		});
 
 		assert(!result.success);
 
 		expect(result.err).toBe(badRequest);
-		expect(fakeHttp.requests).toHaveLength(1);
+		expect(fakeSend.requests).toHaveLength(1);
 		expect(onRetry).not.toHaveBeenCalled();
 		expect(onRateLimit).not.toHaveBeenCalled();
 	});
@@ -138,7 +138,7 @@ describe(executeWithRetry, () => {
 		const onRetry = vi.fn<(attempt: number, error: Error) => void>();
 		const hooks: OpenCloudHooks = { onRetry };
 		const lastError = new RateLimitError("still limited", { retryAfterSeconds: 1 });
-		const fakeHttp = createFakeHttpClient({
+		const fakeSend = createFakeSend({
 			responses: [
 				{ err: new RateLimitError("one", { retryAfterSeconds: 1 }), success: false },
 				{ err: new RateLimitError("two", { retryAfterSeconds: 1 }), success: false },
@@ -150,14 +150,14 @@ describe(executeWithRetry, () => {
 		const result = await executeWithRetry(request, {
 			config: makeRetryConfig({ maxRetries: 2 }),
 			hooks,
-			send: fakeHttp.send,
+			send: fakeSend.send,
 			sleep: fakeSleep,
 		});
 
 		assert(!result.success);
 
 		expect(result.err).toBe(lastError);
-		expect(fakeHttp.requests).toHaveLength(3);
+		expect(fakeSend.requests).toHaveLength(3);
 		expect(onRetry).toHaveBeenCalledTimes(2);
 		expect(fakeSleep.waits).toHaveLength(2);
 	});
@@ -167,7 +167,7 @@ describe(executeWithRetry, () => {
 
 		const onRetry = vi.fn<(attempt: number, error: Error) => void>();
 		const hooks: OpenCloudHooks = { onRetry };
-		const fakeHttp = createFakeHttpClient({
+		const fakeSend = createFakeSend({
 			responses: [
 				{ err: new RateLimitError("1", { retryAfterSeconds: 1 }), success: false },
 				{ err: new RateLimitError("2", { retryAfterSeconds: 1 }), success: false },
@@ -179,14 +179,14 @@ describe(executeWithRetry, () => {
 		const result = await executeWithRetry(request, {
 			config: makeRetryConfig(),
 			hooks,
-			send: fakeHttp.send,
+			send: fakeSend.send,
 			sleep: fakeSleep,
 		});
 
 		assert(result.success);
 
 		expect(result.data.body).toStrictEqual({ id: "ok" });
-		expect(fakeHttp.requests).toHaveLength(3);
+		expect(fakeSend.requests).toHaveLength(3);
 		expect(onRetry).toHaveBeenCalledTimes(2);
 		expect(fakeSleep.waits).toHaveLength(2);
 	});
@@ -196,7 +196,7 @@ describe(executeWithRetry, () => {
 
 		const onRequest = vi.fn<(request: HttpRequest) => void>();
 		const hooks: OpenCloudHooks = { onRequest };
-		const fakeHttp = createFakeHttpClient({
+		const fakeSend = createFakeSend({
 			responses: [
 				{ err: new RateLimitError("1", { retryAfterSeconds: 1 }), success: false },
 				{ err: new RateLimitError("2", { retryAfterSeconds: 1 }), success: false },
@@ -208,7 +208,7 @@ describe(executeWithRetry, () => {
 		await executeWithRetry(request, {
 			config: makeRetryConfig(),
 			hooks,
-			send: fakeHttp.send,
+			send: fakeSend.send,
 			sleep: fakeSleep,
 		});
 
@@ -223,7 +223,7 @@ describe(executeWithRetry, () => {
 		const hooks: OpenCloudHooks = { onRetry };
 		const firstError = new RateLimitError("1", { retryAfterSeconds: 1 });
 		const secondError = new RateLimitError("2", { retryAfterSeconds: 1 });
-		const fakeHttp = createFakeHttpClient({
+		const fakeSend = createFakeSend({
 			responses: [
 				{ err: firstError, success: false },
 				{ err: secondError, success: false },
@@ -235,7 +235,7 @@ describe(executeWithRetry, () => {
 		await executeWithRetry(request, {
 			config: makeRetryConfig(),
 			hooks,
-			send: fakeHttp.send,
+			send: fakeSend.send,
 			sleep: fakeSleep,
 		});
 
@@ -249,7 +249,7 @@ describe(executeWithRetry, () => {
 
 		const onRateLimit = vi.fn<(waitMs: number) => void>();
 		const hooks: OpenCloudHooks = { onRateLimit };
-		const fakeHttp = createFakeHttpClient({
+		const fakeSend = createFakeSend({
 			responses: [
 				{ err: new RateLimitError("1", { retryAfterSeconds: 2 }), success: false },
 				{ err: new RateLimitError("2", { retryAfterSeconds: 5 }), success: false },
@@ -261,7 +261,7 @@ describe(executeWithRetry, () => {
 		await executeWithRetry(request, {
 			config: makeRetryConfig(),
 			hooks,
-			send: fakeHttp.send,
+			send: fakeSend.send,
 			sleep: fakeSleep,
 		});
 
@@ -273,7 +273,7 @@ describe(executeWithRetry, () => {
 		expect.assertions(2);
 
 		const retryDelay = vi.fn<(attempt: number) => number>(() => 99_999);
-		const fakeHttp = createFakeHttpClient({
+		const fakeSend = createFakeSend({
 			responses: [
 				{ err: new RateLimitError("slow", { retryAfterSeconds: 3 }), success: false },
 				{ data: okResponse(), success: true },
@@ -284,7 +284,7 @@ describe(executeWithRetry, () => {
 		await executeWithRetry(request, {
 			config: makeRetryConfig({ retryDelay }),
 			hooks: {},
-			send: fakeHttp.send,
+			send: fakeSend.send,
 			sleep: fakeSleep,
 		});
 
@@ -295,7 +295,7 @@ describe(executeWithRetry, () => {
 	it("should use exponential backoff for 5xx errors with no retry-after hint", async () => {
 		expect.assertions(1);
 
-		const fakeHttp = createFakeHttpClient({
+		const fakeSend = createFakeSend({
 			responses: [
 				{ err: new ApiError("1", { statusCode: 500 }), success: false },
 				{ err: new ApiError("2", { statusCode: 500 }), success: false },
@@ -310,7 +310,7 @@ describe(executeWithRetry, () => {
 				retryDelay: defaultRetryDelay,
 			}),
 			hooks: {},
-			send: fakeHttp.send,
+			send: fakeSend.send,
 			sleep: fakeSleep,
 		});
 
@@ -323,7 +323,7 @@ describe(executeWithRetry, () => {
 		const onRetry = vi.fn<(attempt: number, error: Error) => void>();
 		const hooks: OpenCloudHooks = { onRetry };
 		const rateLimitError = new RateLimitError("no retries", { retryAfterSeconds: 1 });
-		const fakeHttp = createFakeHttpClient({
+		const fakeSend = createFakeSend({
 			responses: [{ err: rateLimitError, success: false }],
 		});
 		const fakeSleep = createFakeSleep();
@@ -331,14 +331,14 @@ describe(executeWithRetry, () => {
 		const result = await executeWithRetry(request, {
 			config: makeRetryConfig({ retryableStatuses: [] }),
 			hooks,
-			send: fakeHttp.send,
+			send: fakeSend.send,
 			sleep: fakeSleep,
 		});
 
 		assert(!result.success);
 
 		expect(result.err).toBe(rateLimitError);
-		expect(fakeHttp.requests).toHaveLength(1);
+		expect(fakeSend.requests).toHaveLength(1);
 		expect(onRetry).not.toHaveBeenCalled();
 	});
 
@@ -349,7 +349,7 @@ describe(executeWithRetry, () => {
 		const hooks: OpenCloudHooks = { onRetry };
 		const firstError = new RateLimitError("1", { retryAfterSeconds: 1 });
 		const finalError = new RateLimitError("2", { retryAfterSeconds: 1 });
-		const fakeHttp = createFakeHttpClient({
+		const fakeSend = createFakeSend({
 			responses: [
 				{ err: firstError, success: false },
 				{ err: finalError, success: false },
@@ -360,7 +360,7 @@ describe(executeWithRetry, () => {
 		await executeWithRetry(request, {
 			config: makeRetryConfig({ maxRetries: 1 }),
 			hooks,
-			send: fakeHttp.send,
+			send: fakeSend.send,
 			sleep: fakeSleep,
 		});
 

--- a/packages/open-cloud/tests/helpers/fake-http-client.spec.ts
+++ b/packages/open-cloud/tests/helpers/fake-http-client.spec.ts
@@ -177,13 +177,13 @@ describe(createFakeHttpClient, () => {
 	});
 
 	it("should throw FakeHttpClientError naming method, url, and consumed count when queue is empty", async () => {
-		expect.assertions(2);
+		expect.assertions(1);
 
 		const fake = createFakeHttpClient().mockResponse({ status: 200 });
 		await fake.request(getRequest, config);
 
-		await expect(fake.request(postRequest, config)).rejects.toThrow(FakeHttpClientError);
-		await expect(fake.request(postRequest, config)).rejects.toThrow(
+		await expect(fake.request(postRequest, config)).rejects.toThrowWithMessage(
+			FakeHttpClientError,
 			"FakeHttpClient: no mock queued for POST /v1/create (consumed 1, pending 0)",
 		);
 	});

--- a/packages/open-cloud/tests/helpers/fake-http-client.spec.ts
+++ b/packages/open-cloud/tests/helpers/fake-http-client.spec.ts
@@ -1,0 +1,199 @@
+import { ApiError } from "#src/errors/api-error";
+import { OpenCloudError } from "#src/errors/base";
+import { NetworkError } from "#src/errors/network-error";
+import { RateLimitError } from "#src/errors/rate-limit";
+import type { HttpRequest, RequestConfig } from "#src/internal/http/types";
+import { assert, describe, expect, it } from "vitest";
+
+import { createFakeHttpClient, FakeHttpClientError } from "./fake-http-client.ts";
+
+const getRequest: HttpRequest = { method: "GET", url: "/v1/ping" };
+const postRequest: HttpRequest = {
+	body: { name: "pass" },
+	method: "POST",
+	url: "/v1/create",
+};
+const config: RequestConfig = { apiKey: "test", baseUrl: "https://apis.roblox.test" };
+const overrideConfig: RequestConfig = {
+	apiKey: "override",
+	baseUrl: "https://override.test",
+};
+
+describe(createFakeHttpClient, () => {
+	it("should record both request and config on each call", async () => {
+		expect.assertions(1);
+
+		const fake = createFakeHttpClient()
+			.mockResponse({ status: 200 })
+			.mockResponse({ status: 201 });
+
+		await fake.request(getRequest, config);
+		await fake.request(postRequest, overrideConfig);
+
+		expect(fake.requests).toStrictEqual([
+			{ config, request: getRequest },
+			{ config: overrideConfig, request: postRequest },
+		]);
+	});
+
+	it("should default mockResponse body and headers when omitted", async () => {
+		expect.assertions(1);
+
+		const fake = createFakeHttpClient().mockResponse({ status: 204 });
+
+		const result = await fake.request(getRequest, config);
+
+		expect(result).toStrictEqual({
+			data: { body: {}, headers: {}, status: 204 },
+			success: true,
+		});
+	});
+
+	it("should replay mockResponse with provided body and headers", async () => {
+		expect.assertions(1);
+
+		const fake = createFakeHttpClient().mockResponse({
+			body: { id: "abc" },
+			headers: { "x-custom": "1" },
+			status: 200,
+		});
+
+		const result = await fake.request(getRequest, config);
+
+		expect(result).toStrictEqual({
+			data: { body: { id: "abc" }, headers: { "x-custom": "1" }, status: 200 },
+			success: true,
+		});
+	});
+
+	it("should replay mockError with the exact error instance", async () => {
+		expect.assertions(1);
+
+		const error = new OpenCloudError("boom");
+		const fake = createFakeHttpClient().mockError(error);
+
+		const result = await fake.request(getRequest, config);
+
+		assert(!result.success);
+
+		expect(result.err).toBe(error);
+	});
+
+	it("should replay mockRateLimit as RateLimitError with retryAfterSeconds", async () => {
+		expect.assertions(2);
+
+		const fake = createFakeHttpClient()
+			.mockRateLimit({ retryAfterSeconds: 2 })
+			.mockRateLimit({ message: "slow down", retryAfterSeconds: 5 });
+
+		const defaultResult = await fake.request(getRequest, config);
+		const customResult = await fake.request(getRequest, config);
+
+		assert(!defaultResult.success);
+		assert(!customResult.success);
+
+		expect(defaultResult.err).toBeInstanceOf(RateLimitError);
+		expect(customResult.err).toStrictEqual(
+			new RateLimitError("slow down", { retryAfterSeconds: 5 }),
+		);
+	});
+
+	it("should replay mockApiError as ApiError with statusCode and optional code", async () => {
+		expect.assertions(3);
+
+		const fake = createFakeHttpClient()
+			.mockApiError({ statusCode: 500 })
+			.mockApiError({ code: "BAD_INPUT", message: "bad input", statusCode: 400 });
+
+		const defaultResult = await fake.request(getRequest, config);
+		const detailedResult = await fake.request(getRequest, config);
+
+		assert(!defaultResult.success);
+		assert(!detailedResult.success);
+		assert(detailedResult.err instanceof ApiError);
+
+		expect(defaultResult.err).toBeInstanceOf(ApiError);
+		expect(detailedResult.err).toStrictEqual(
+			new ApiError("bad input", { code: "BAD_INPUT", statusCode: 400 }),
+		);
+		expect(detailedResult.err.code).toBe("BAD_INPUT");
+	});
+
+	it("should replay mockNetworkError as NetworkError preserving cause when provided", async () => {
+		expect.assertions(3);
+
+		const cause = new Error("ECONNREFUSED");
+		const fake = createFakeHttpClient()
+			.mockNetworkError()
+			.mockNetworkError({ cause, message: "dial failed" });
+
+		const defaultResult = await fake.request(getRequest, config);
+		const detailedResult = await fake.request(getRequest, config);
+
+		assert(!defaultResult.success);
+		assert(!detailedResult.success);
+
+		expect(defaultResult.err).toBeInstanceOf(NetworkError);
+		expect(detailedResult.err.message).toBe("dial failed");
+		expect(detailedResult.err.cause).toBe(cause);
+	});
+
+	it("should consume mocks FIFO across mixed error types", async () => {
+		expect.assertions(3);
+
+		const fake = createFakeHttpClient()
+			.mockResponse({ status: 200 })
+			.mockApiError({ statusCode: 500 })
+			.mockRateLimit({ retryAfterSeconds: 1 })
+			.mockNetworkError();
+
+		const first = await fake.request(getRequest, config);
+		const second = await fake.request(getRequest, config);
+		const third = await fake.request(getRequest, config);
+		const fourth = await fake.request(getRequest, config);
+
+		assert(first.success);
+		assert(!second.success && !third.success && !fourth.success);
+
+		expect(second.err).toBeInstanceOf(ApiError);
+		expect(third.err).toBeInstanceOf(RateLimitError);
+		expect(fourth.err).toBeInstanceOf(NetworkError);
+	});
+
+	it("should reflect queue depth in pendingMocks", async () => {
+		expect.assertions(3);
+
+		const fake = createFakeHttpClient();
+
+		expect(fake.pendingMocks).toBe(0);
+
+		fake.mockResponse({ status: 200 }).mockApiError({ statusCode: 500 });
+
+		expect(fake.pendingMocks).toBe(2);
+
+		await fake.request(getRequest, config);
+
+		expect(fake.pendingMocks).toBe(1);
+	});
+
+	it("should throw FakeHttpClientError naming method, url, and consumed count when queue is empty", async () => {
+		expect.assertions(2);
+
+		const fake = createFakeHttpClient().mockResponse({ status: 200 });
+		await fake.request(getRequest, config);
+
+		await expect(fake.request(postRequest, config)).rejects.toThrow(FakeHttpClientError);
+		await expect(fake.request(postRequest, config)).rejects.toThrow(
+			"FakeHttpClient: no mock queued for POST /v1/create (consumed 1, pending 0)",
+		);
+	});
+
+	it("should expose FakeHttpClientError as an Error subclass", () => {
+		expect.assertions(2);
+
+		const error = new FakeHttpClientError("boom");
+
+		expect(error).toBeInstanceOf(Error);
+		expect(error.name).toBe("FakeHttpClientError");
+	});
+});

--- a/packages/open-cloud/tests/helpers/fake-http-client.ts
+++ b/packages/open-cloud/tests/helpers/fake-http-client.ts
@@ -1,0 +1,165 @@
+import { ApiError } from "#src/errors/api-error";
+import type { OpenCloudError } from "#src/errors/base";
+import { NetworkError } from "#src/errors/network-error";
+import { RateLimitError } from "#src/errors/rate-limit";
+import type {
+	HttpClient,
+	HttpRequest,
+	HttpResponse,
+	RequestConfig,
+} from "#src/internal/http/types";
+import type { Result } from "#src/types";
+
+/**
+ * A request captured by {@link FakeHttpClient} for later assertion.
+ */
+export interface CapturedRequest {
+	/** The per-request config passed alongside the request. */
+	readonly config: RequestConfig;
+	/** The request passed to {@link HttpClient.request}. */
+	readonly request: HttpRequest;
+}
+
+/**
+ * A fluent fake for the {@link HttpClient} boundary. Mocks are queued in
+ * FIFO order and consumed by each `request()` call. Records every
+ * request and config for later assertion. Throws
+ * {@link FakeHttpClientError} if the queue is empty when `request()` is
+ * called — surfaces missing mocks as test setup bugs instead of silently
+ * repeating the last response.
+ */
+export interface FakeHttpClient extends HttpClient {
+	/** Queues an {@link ApiError} with the given status code and optional message/code. */
+	mockApiError(options: { code?: string; message?: string; statusCode: number }): FakeHttpClient;
+	/** Queues an error Result with the given error instance. */
+	mockError(error: OpenCloudError): FakeHttpClient;
+	/** Queues a {@link NetworkError}. Preserves `cause` when provided. */
+	mockNetworkError(options?: { cause?: unknown; message?: string }): FakeHttpClient;
+	/** Queues a {@link RateLimitError} with the given retry hint. */
+	mockRateLimit(options: { message?: string; retryAfterSeconds: number }): FakeHttpClient;
+	/** Queues a successful {@link HttpResponse}. Body defaults to `{}`; headers default to `{}`. */
+	mockResponse(options: {
+		body?: unknown;
+		headers?: Readonly<Record<string, string>>;
+		status: number;
+	}): FakeHttpClient;
+	/** Number of queued mocks that have not yet been consumed. */
+	readonly pendingMocks: number;
+	/** Chronological log of every `(request, config)` pair the fake received. */
+	readonly requests: ReadonlyArray<CapturedRequest>;
+}
+
+type ErrorResult = Result<HttpResponse, OpenCloudError> & { success: false };
+
+interface FakeState {
+	readonly captured: Array<CapturedRequest>;
+	consumed: number;
+	readonly queue: Array<Result<HttpResponse, OpenCloudError>>;
+}
+
+/**
+ * Thrown when {@link FakeHttpClient.request} is called but no mock has
+ * been queued. The message names the method, url, and consumed count to
+ * aid debugging of missing `.mockResponse`/`.mockError` setup.
+ */
+export class FakeHttpClientError extends Error {
+	public override readonly name: string = "FakeHttpClientError";
+}
+
+/**
+ * Creates a fluent {@link FakeHttpClient} that sits at the
+ * {@link HttpClient} seam. Use for integration tests where you need to
+ * assert per-request config (apiKey, baseUrl) flows through to HTTP.
+ *
+ * @returns A fresh fake with an empty mock queue.
+ */
+export function createFakeHttpClient(): FakeHttpClient {
+	const state: FakeState = { captured: [], consumed: 0, queue: [] };
+	function enqueue(result: Result<HttpResponse, OpenCloudError>): FakeHttpClient {
+		state.queue.push(result);
+		return fake;
+	}
+
+	const fake: FakeHttpClient = {
+		mockApiError: (options) => enqueue(errorResult(buildApiError(options))),
+		mockError: (error) => enqueue(errorResult(error)),
+		mockNetworkError: (options) => enqueue(errorResult(buildNetworkError(options))),
+		mockRateLimit: (options) => enqueue(errorResult(buildRateLimitError(options))),
+		mockResponse: (options) => enqueue(successResult(options)),
+		get pendingMocks() {
+			return state.queue.length;
+		},
+		async request(request, config) {
+			state.captured.push({ config, request });
+			return consumeNextMock(state, request);
+		},
+		get requests() {
+			return state.captured;
+		},
+	};
+
+	return fake;
+}
+
+function successResult(options: {
+	body?: unknown;
+	headers?: Readonly<Record<string, string>>;
+	status: number;
+}): Result<HttpResponse, OpenCloudError> {
+	return {
+		data: {
+			body: options.body ?? {},
+			headers: options.headers ?? {},
+			status: options.status,
+		},
+		success: true,
+	};
+}
+
+function errorResult(err: OpenCloudError): ErrorResult {
+	return { err, success: false };
+}
+
+function buildApiError(options: { code?: string; message?: string; statusCode: number }): ApiError {
+	const message = options.message ?? "API error";
+	if (options.code === undefined) {
+		return new ApiError(message, { statusCode: options.statusCode });
+	}
+
+	return new ApiError(message, { code: options.code, statusCode: options.statusCode });
+}
+
+function buildNetworkError(
+	options: undefined | { cause?: unknown; message?: string },
+): NetworkError {
+	const message = options?.message ?? "Network error";
+	if (options?.cause === undefined) {
+		return new NetworkError(message);
+	}
+
+	return new NetworkError(message, { cause: options.cause });
+}
+
+function buildRateLimitError(options: {
+	message?: string;
+	retryAfterSeconds: number;
+}): RateLimitError {
+	return new RateLimitError(options.message ?? "Rate limited", {
+		retryAfterSeconds: options.retryAfterSeconds,
+	});
+}
+
+function consumeNextMock(
+	state: FakeState,
+	request: HttpRequest,
+): Result<HttpResponse, OpenCloudError> {
+	const next = state.queue.shift();
+	if (next === undefined) {
+		throw new FakeHttpClientError(
+			`FakeHttpClient: no mock queued for ${request.method} ${request.url} (consumed ${String(state.consumed)}, pending 0)`,
+		);
+	}
+
+	state.consumed += 1;
+	return next;
+}

--- a/packages/open-cloud/tests/helpers/fake-send.spec.ts
+++ b/packages/open-cloud/tests/helpers/fake-send.spec.ts
@@ -56,7 +56,8 @@ describe(createFakeSend, () => {
 
 		await fakeSend.send(getRequest);
 
-		await expect(fakeSend.send(postRequest)).rejects.toThrow(
+		await expect(fakeSend.send(postRequest)).rejects.toThrowWithMessage(
+			Error,
 			"createFakeSend exhausted: 2 calls made, only 1 responses scripted",
 		);
 	});

--- a/packages/open-cloud/tests/helpers/fake-send.spec.ts
+++ b/packages/open-cloud/tests/helpers/fake-send.spec.ts
@@ -1,0 +1,63 @@
+import { ApiError } from "#src/errors/api-error";
+import type { HttpRequest, HttpResponse } from "#src/internal/http/types";
+import { describe, expect, it } from "vitest";
+
+import { createFakeSend } from "./fake-send.ts";
+
+function okResponse(body: unknown = {}): HttpResponse {
+	return { body, headers: {}, status: 200 };
+}
+
+const getRequest: HttpRequest = { method: "GET", url: "/v1/ping" };
+const postRequest: HttpRequest = { method: "POST", url: "/v1/create" };
+
+describe(createFakeSend, () => {
+	it("should record each request in invocation order", async () => {
+		expect.assertions(1);
+
+		const fakeSend = createFakeSend({
+			responses: [
+				{ data: okResponse(), success: true },
+				{ data: okResponse(), success: true },
+			],
+		});
+
+		await fakeSend.send(getRequest);
+		await fakeSend.send(postRequest);
+
+		expect(fakeSend.requests).toStrictEqual([getRequest, postRequest]);
+	});
+
+	it("should replay queued responses FIFO", async () => {
+		expect.assertions(2);
+
+		const successBody = { id: "first" };
+		const apiError = new ApiError("nope", { statusCode: 404 });
+		const fakeSend = createFakeSend({
+			responses: [
+				{ data: okResponse(successBody), success: true },
+				{ err: apiError, success: false },
+			],
+		});
+
+		const firstResult = await fakeSend.send(getRequest);
+		const secondResult = await fakeSend.send(getRequest);
+
+		expect(firstResult).toStrictEqual({ data: okResponse(successBody), success: true });
+		expect(secondResult).toStrictEqual({ err: apiError, success: false });
+	});
+
+	it("should throw when called after the queue is exhausted", async () => {
+		expect.assertions(1);
+
+		const fakeSend = createFakeSend({
+			responses: [{ data: okResponse(), success: true }],
+		});
+
+		await fakeSend.send(getRequest);
+
+		await expect(fakeSend.send(postRequest)).rejects.toThrow(
+			"createFakeSend exhausted: 2 calls made, only 1 responses scripted",
+		);
+	});
+});

--- a/packages/open-cloud/tests/helpers/fake-send.ts
+++ b/packages/open-cloud/tests/helpers/fake-send.ts
@@ -2,18 +2,21 @@ import type { OpenCloudError } from "#src/errors/base";
 import type { HttpRequest, HttpResponse } from "#src/internal/http/types";
 import type { Result } from "#src/types";
 
-/** A transport callback shaped like the `send` argument of `executeWithRetry`. */
-export type FakeSend = (request: HttpRequest) => Promise<Result<HttpResponse, OpenCloudError>>;
+/**
+ * The `send` callback shape consumed by `executeWithRetry`. A plain
+ * transport function — no `RequestConfig`, no queueing, no retries.
+ */
+export type SendFunc = (request: HttpRequest) => Promise<Result<HttpResponse, OpenCloudError>>;
 
 /**
- * A scripted HTTP send: replays `responses` in order and records every
- * request it receives.
+ * A scripted fake for the `send` callback. Replays responses in order
+ * and records every request it receives.
  */
-export interface FakeHttpClient {
+export interface FakeSend {
 	/** Chronological log of every request the fake received. */
 	readonly requests: ReadonlyArray<HttpRequest>;
 	/** The scripted send callback. */
-	readonly send: FakeSend;
+	readonly send: SendFunc;
 }
 
 /**
@@ -25,9 +28,9 @@ export interface FakeHttpClient {
  * @returns A `send` callback plus a `requests` log.
  * @rejects {Error} When a call is made after all scripted responses are consumed.
  */
-export function createFakeHttpClient(options: {
+export function createFakeSend(options: {
 	readonly responses: ReadonlyArray<Result<HttpResponse, OpenCloudError>>;
-}): FakeHttpClient {
+}): FakeSend {
 	const requests: Array<HttpRequest> = [];
 	let index = 0;
 
@@ -38,7 +41,7 @@ export function createFakeHttpClient(options: {
 
 		if (response === undefined) {
 			throw new Error(
-				`createFakeHttpClient exhausted: ${String(index)} calls made, only ${String(options.responses.length)} responses scripted`,
+				`createFakeSend exhausted: ${String(index)} calls made, only ${String(options.responses.length)} responses scripted`,
 			);
 		}
 

--- a/packages/open-cloud/tests/helpers/fake-sleep.spec.ts
+++ b/packages/open-cloud/tests/helpers/fake-sleep.spec.ts
@@ -42,6 +42,6 @@ describe(createFakeSleep, () => {
 		const fakeSleep = createFakeSleep();
 		const asSleepFunc: SleepFunc = fakeSleep;
 
-		expect(asSleepFunc).toBeInstanceOf(Function);
+		expect(asSleepFunc).toBeFunction();
 	});
 });

--- a/packages/open-cloud/tests/helpers/fake-sleep.spec.ts
+++ b/packages/open-cloud/tests/helpers/fake-sleep.spec.ts
@@ -1,0 +1,47 @@
+import type { SleepFunc } from "#src/internal/utils/sleep";
+import { describe, expect, it } from "vitest";
+
+import { createFakeSleep } from "./fake-sleep.ts";
+
+describe(createFakeSleep, () => {
+	it("should expose an empty waits log before any invocation", () => {
+		expect.assertions(1);
+
+		const fakeSleep = createFakeSleep();
+
+		expect(fakeSleep.waits).toStrictEqual([]);
+	});
+
+	it("should record each invocation in call order", async () => {
+		expect.assertions(1);
+
+		const fakeSleep = createFakeSleep();
+
+		await fakeSleep(100);
+		await fakeSleep(250);
+		await fakeSleep(50);
+
+		expect(fakeSleep.waits).toStrictEqual([100, 250, 50]);
+	});
+
+	it("should resolve immediately without a real delay", async () => {
+		expect.assertions(1);
+
+		const fakeSleep = createFakeSleep();
+
+		const start = Date.now();
+		await fakeSleep(1_000_000);
+		const elapsed = Date.now() - start;
+
+		expect(elapsed).toBeLessThan(50);
+	});
+
+	it("should be assignable to SleepFunc", () => {
+		expect.assertions(1);
+
+		const fakeSleep = createFakeSleep();
+		const asSleepFunc: SleepFunc = fakeSleep;
+
+		expect(asSleepFunc).toBeInstanceOf(Function);
+	});
+});

--- a/packages/open-cloud/tests/helpers/fake-sleep.ts
+++ b/packages/open-cloud/tests/helpers/fake-sleep.ts
@@ -1,18 +1,19 @@
 import type { SleepFunc } from "#src/internal/utils/sleep";
 
-/** A sleep double that records its wait arguments without delaying. */
-export interface FakeSleep {
-	/** A sleep function that records `ms` and resolves immediately. */
-	readonly sleep: SleepFunc;
-	/** Chronological log of every `ms` value `sleep` was called with. */
+/**
+ * A directly-callable sleep double that records its wait arguments without
+ * delaying. Assignable to {@link SleepFunc}.
+ */
+export interface FakeSleep extends SleepFunc {
+	/** Chronological log of every `ms` value the fake was called with. */
 	readonly waits: ReadonlyArray<number>;
 }
 
 /**
- * Creates a {@link SleepFunc} that resolves immediately and records every
+ * Creates a {@link FakeSleep} that resolves immediately and records every
  * `ms` value it was called with.
  *
- * @returns A sleep function and a `waits` log.
+ * @returns A callable sleep function with a `waits` log attached.
  */
 export function createFakeSleep(): FakeSleep {
 	const waits: Array<number> = [];
@@ -21,5 +22,11 @@ export function createFakeSleep(): FakeSleep {
 		waits.push(ms);
 	}
 
-	return { sleep, waits };
+	const fake: FakeSleep = Object.assign(sleep, {
+		get waits(): ReadonlyArray<number> {
+			return waits;
+		},
+	});
+
+	return fake;
 }

--- a/packages/open-cloud/tests/vitest-jest-extended.d.ts
+++ b/packages/open-cloud/tests/vitest-jest-extended.d.ts
@@ -1,0 +1,1 @@
+import "@bedrock/testing/jest-extended";


### PR DESCRIPTION
## Summary

Completes [#20](https://github.com/christopher-buss/bedrock/issues/20) by reshaping test helpers to cover both fake seams introduced by "Wiring A" ([ADR-010](docs/adr/010-sdk-managed-rate-limiting-and-retry.md), grill-me Q10). Unblocks [#23](https://github.com/christopher-buss/bedrock/issues/23) (GamePassesClient) by providing a fake at the `HttpClient.request(req, config)` boundary that captures `(request, config)` pairs — required for integration tests that assert per-request `apiKey`/`baseUrl` flow-through.

### The two fake seams

1. **`send`-callback seam** — consumed by `executeWithRetry`. No `RequestConfig` visible. The pre-existing helper fit this shape.
2. **`HttpClient` seam** — consumed by `GamePassesClient` via `OpenCloudClientOptions.httpClient`. Captures config.

Issue #20's spec was written before Wiring A landed and described the `HttpClient`-seam fake, but the file name `fake-http-client.ts` ended up attached to a `send`-seam fake. This PR splits them:

- Renames the existing `fake-http-client.ts` → `fake-send.ts` with `createFakeSend` (matches what it actually is).
- Adds a new `fake-http-client.ts` implementing the full `HttpClient` interface with the fluent `mock*` API from the issue spec.

### Changes (in order)

1. **`refactor(ocale): make FakeSleep directly callable`** — reshapes `FakeSleep` from `{ sleep, waits }` to a callable function with `waits` attached. Migrates 13 call sites in `execute.spec.ts`.
2. **`refactor(ocale): rename fake-http-client to fake-send`** — file rename + `createFakeHttpClient` → `createFakeSend`, `FakeHttpClient` → `FakeSend`, `FakeSend` type alias → `SendFunc`. No behaviour change.
3. **`feat(ocale): add HttpClient-seam fake for integration tests`** — new `createFakeHttpClient()` with fluent `mockResponse`, `mockError`, `mockRateLimit`, `mockApiError`, `mockNetworkError`; `pendingMocks` getter; throws `FakeHttpClientError` on exhaustion with method/url/consumed count.
4. **`docs: add mutate:changed to pre-commit quality gates`** — adds `pnpm mutate:changed` as step 5 in `CLAUDE.md`'s "Before Committing" checklist.
5. **`test(ocale): wire jest-extended matchers for open-cloud tests`** — adds `tests/vitest-jest-extended.d.ts` importing `@bedrock/testing/jest-extended` (not `jest-extended` directly — pnpm strict isolation blocks that since it's not a declared dep of open-cloud). Applies `toBeFunction()` and `toThrowWithMessage` improvements.
6. **`test(ocale): use toThrowWithMessage in fake-send spec`** — symmetry with the http-client spec.

### Self-tests (100% coverage on helpers)

- `fake-sleep.spec.ts` — empty waits, call-order recording, immediate resolution, `SleepFunc` assignability.
- `fake-send.spec.ts` — request capture, FIFO replay across mixed result types, exhaustion error.
- `fake-http-client.spec.ts` — config capture, all 5 mock builders (default + custom), FIFO across mixed error types, `pendingMocks` accounting, `FakeHttpClientError` message format.

## ⚠️ Conflicts with main

The branch was cut before [#36](https://github.com/christopher-buss/bedrock/pull/36) (rate-limit-queue) merged. Both PRs touched `fake-http-client.ts`, `fake-sleep.ts`, and `execute.spec.ts`. Resolution will need to reconcile:

- `#36` modified the existing `fake-http-client.ts` in-place (presumably for its own needs).
- This PR renames that file to `fake-send.ts` and adds a differently-shaped `fake-http-client.ts`.

Not force-pushing an unprompted rebase per `docs/adr` / project conventions. Happy to rebase on request.

## Test plan

- [x] `pnpm --filter @bedrock/ocale test` — 140/140 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] Helpers self-test at 100% coverage (run `vp test --coverage tests/helpers`)
- [x] `execute.spec.ts` migrated without behaviour change (still 122/122 pass)
- [ ] Manual review: reconcile with PR #36's changes to `fake-http-client.ts`

Closes #20 

🤖 Generated with [Claude Code](https://claude.com/claude-code)