### PR TITLE
ci: run claude-review on same-repo prs

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -14,7 +14,7 @@ jobs:
     if: |
       github.event.pull_request != null &&
       github.event.sender.type != 'Bot' &&
-      github.head_repository.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
## Summary

- The `claude-review` job's `if:` guard referenced `github.head_repository.full_name`, which is not a valid GitHub Actions context property. The expression always evaluated to false, so the job was skipped on every PR (visible in `gh run list --workflow=claude-review.yaml` — every recent run is `skipped` with zero steps executed).
- Replaced it with `github.event.pull_request.head.repo.full_name`, the canonical context for a PR's head repo. This preserves the original intent (only run for same-repo PRs, never forks) while actually evaluating correctly.

## Test plan

- [ ] Once merged, open a follow-up PR and confirm the **Claude Code Review** workflow run reaches the `Wait for triage to complete` step rather than skipping immediately.
- [ ] `gh run view <id> --json jobs` for that run shows steps executing instead of an empty `steps: []` array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)