### PR TITLE
feat(ocale): add game-pass request builders

### DIFF
--- a/packages/open-cloud/src/resources/game-passes/builders.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.spec.ts
@@ -7,12 +7,12 @@ describe(buildGetRequest, () => {
 	it("should use the GET method", () => {
 		expect.assertions(1);
 
-		const params = {
+		const parameters = {
 			gamePassId: "12345",
 			universeId: "67890",
 		} satisfies GetGamePassParameters;
 
-		const request = buildGetRequest(params);
+		const request = buildGetRequest(parameters);
 
 		expect(request.method).toBe("GET");
 	});
@@ -20,27 +20,25 @@ describe(buildGetRequest, () => {
 	it("should interpolate universeId and gamePassId into the creator URL", () => {
 		expect.assertions(1);
 
-		const params = {
+		const parameters = {
 			gamePassId: "12345",
 			universeId: "67890",
 		} satisfies GetGamePassParameters;
 
-		const request = buildGetRequest(params);
+		const request = buildGetRequest(parameters);
 
-		expect(request.url).toBe(
-			"/game-passes/v1/universes/67890/game-passes/12345/creator",
-		);
+		expect(request.url).toBe("/game-passes/v1/universes/67890/game-passes/12345/creator");
 	});
 
 	it("should not set a body", () => {
 		expect.assertions(1);
 
-		const params = {
+		const parameters = {
 			gamePassId: "12345",
 			universeId: "67890",
 		} satisfies GetGamePassParameters;
 
-		const request = buildGetRequest(params);
+		const request = buildGetRequest(parameters);
 
 		expect(request.body).toBeUndefined();
 	});
@@ -50,12 +48,12 @@ describe(buildCreateRequest, () => {
 	it("should use the POST method", () => {
 		expect.assertions(1);
 
-		const params = {
+		const parameters = {
 			name: "Epic Pass",
 			universeId: "67890",
 		} satisfies CreateGamePassParameters;
 
-		const request = buildCreateRequest(params);
+		const request = buildCreateRequest(parameters);
 
 		expect(request.method).toBe("POST");
 	});
@@ -63,12 +61,12 @@ describe(buildCreateRequest, () => {
 	it("should interpolate universeId into the create URL", () => {
 		expect.assertions(1);
 
-		const params = {
+		const parameters = {
 			name: "Epic Pass",
 			universeId: "67890",
 		} satisfies CreateGamePassParameters;
 
-		const request = buildCreateRequest(params);
+		const request = buildCreateRequest(parameters);
 
 		expect(request.url).toBe("/game-passes/v1/universes/67890/game-passes");
 	});
@@ -76,136 +74,142 @@ describe(buildCreateRequest, () => {
 	it("should append name to a FormData body", () => {
 		expect.assertions(1);
 
-		const params = {
+		const parameters = {
 			name: "Epic Pass",
 			universeId: "67890",
 		} satisfies CreateGamePassParameters;
 
-		const request = buildCreateRequest(params);
+		const request = buildCreateRequest(parameters);
 
 		assert(request.body instanceof FormData);
+
 		expect(request.body.get("name")).toBe("Epic Pass");
 	});
 
 	it("should append description when provided", () => {
 		expect.assertions(1);
 
-		const params = {
-			description: "Unlocks epic stuff",
+		const parameters = {
 			name: "Epic Pass",
+			description: "Unlocks epic stuff",
 			universeId: "67890",
 		} satisfies CreateGamePassParameters;
 
-		const request = buildCreateRequest(params);
+		const request = buildCreateRequest(parameters);
 
 		assert(request.body instanceof FormData);
+
 		expect(request.body.get("description")).toBe("Unlocks epic stuff");
 	});
 
 	it("should omit description when not provided", () => {
 		expect.assertions(1);
 
-		const params = {
+		const parameters = {
 			name: "Epic Pass",
 			universeId: "67890",
 		} satisfies CreateGamePassParameters;
 
-		const request = buildCreateRequest(params);
+		const request = buildCreateRequest(parameters);
 
 		assert(request.body instanceof FormData);
+
 		expect(request.body.has("description")).toBeFalse();
 	});
 
 	it.for<[isForSale: boolean, expected: string]>([
 		[true, "true"],
 		[false, "false"],
-	])(
-		"should stringify isForSale=%s into the form body as %j",
-		([isForSale, expected]) => {
-			expect.assertions(1);
+	])("should stringify isForSale=%s into the form body as %j", ([isForSale, expected]) => {
+		expect.assertions(1);
 
-			const params = {
-				isForSale,
-				name: "Epic Pass",
-				universeId: "67890",
-			} satisfies CreateGamePassParameters;
+		const parameters = {
+			name: "Epic Pass",
+			isForSale,
+			universeId: "67890",
+		} satisfies CreateGamePassParameters;
 
-			const request = buildCreateRequest(params);
+		const request = buildCreateRequest(parameters);
 
-			assert(request.body instanceof FormData);
-			expect(request.body.get("isForSale")).toBe(expected);
-		},
-	);
+		assert(request.body instanceof FormData);
+
+		expect(request.body.get("isForSale")).toBe(expected);
+	});
 
 	it("should omit isForSale when not provided", () => {
 		expect.assertions(1);
 
-		const params = {
+		const parameters = {
 			name: "Epic Pass",
 			universeId: "67890",
 		} satisfies CreateGamePassParameters;
 
-		const request = buildCreateRequest(params);
+		const request = buildCreateRequest(parameters);
 
 		assert(request.body instanceof FormData);
+
 		expect(request.body.has("isForSale")).toBeFalse();
 	});
 
 	it("should stringify price into the form body when provided", () => {
 		expect.assertions(1);
 
-		const params = {
+		const parameters = {
 			name: "Epic Pass",
 			price: 100,
 			universeId: "67890",
 		} satisfies CreateGamePassParameters;
 
-		const request = buildCreateRequest(params);
+		const request = buildCreateRequest(parameters);
 
 		assert(request.body instanceof FormData);
+
 		expect(request.body.get("price")).toBe("100");
 	});
 
 	it("should omit price when not provided", () => {
 		expect.assertions(1);
 
-		const params = {
+		const parameters = {
 			name: "Epic Pass",
 			universeId: "67890",
 		} satisfies CreateGamePassParameters;
 
-		const request = buildCreateRequest(params);
+		const request = buildCreateRequest(parameters);
 
 		assert(request.body instanceof FormData);
+
 		expect(request.body.has("price")).toBeFalse();
 	});
 
 	it("should stringify isRegionalPricingEnabled when provided", () => {
 		expect.assertions(1);
 
-		const params = {
-			isRegionalPricingEnabled: true,
+		const parameters = {
 			name: "Epic Pass",
+			isRegionalPricingEnabled: true,
 			universeId: "67890",
 		} satisfies CreateGamePassParameters;
 
-		const request = buildCreateRequest(params);
+		const request = buildCreateRequest(parameters);
 
 		assert(request.body instanceof FormData);
+
 		expect(request.body.get("isRegionalPricingEnabled")).toBe("true");
 	});
 
 	it("should omit isRegionalPricingEnabled when not provided", () => {
 		expect.assertions(1);
 
-		const params = {
+		const parameters = {
 			name: "Epic Pass",
 			universeId: "67890",
 		} satisfies CreateGamePassParameters;
 
-		const request = buildCreateRequest(params);
+		const request = buildCreateRequest(parameters);
 
 		assert(request.body instanceof FormData);
+
 		expect(request.body.has("isRegionalPricingEnabled")).toBeFalse();
 	});
 
@@ -213,15 +217,16 @@ describe(buildCreateRequest, () => {
 		expect.assertions(1);
 
 		const imageFile = new Uint8Array([1, 2, 3, 4]);
-		const params = {
-			imageFile,
+		const parameters = {
 			name: "Epic Pass",
+			imageFile,
 			universeId: "67890",
 		} satisfies CreateGamePassParameters;
 
-		const request = buildCreateRequest(params);
+		const request = buildCreateRequest(parameters);
 
 		assert(request.body instanceof FormData);
+
 		expect(request.body.get("imageFile")).toBeInstanceOf(Blob);
 	});
 
@@ -231,17 +236,18 @@ describe(buildCreateRequest, () => {
 		const imageFile = new Blob([new Uint8Array([1, 2, 3, 4])], {
 			type: "image/png",
 		});
-		const params = {
-			imageFile,
+		const parameters = {
 			name: "Epic Pass",
+			imageFile,
 			universeId: "67890",
 		} satisfies CreateGamePassParameters;
 
-		const request = buildCreateRequest(params);
+		const request = buildCreateRequest(parameters);
 
 		assert(request.body instanceof FormData);
 		const appended = request.body.get("imageFile");
 		assert(appended instanceof Blob);
+
 		expect(appended).toBeInstanceOf(Blob);
 		expect(appended.type).toBe("image/png");
 	});
@@ -249,14 +255,15 @@ describe(buildCreateRequest, () => {
 	it("should omit imageFile when not provided", () => {
 		expect.assertions(1);
 
-		const params = {
+		const parameters = {
 			name: "Epic Pass",
 			universeId: "67890",
 		} satisfies CreateGamePassParameters;
 
-		const request = buildCreateRequest(params);
+		const request = buildCreateRequest(parameters);
 
 		assert(request.body instanceof FormData);
+
 		expect(request.body.has("imageFile")).toBeFalse();
 	});
 });

--- a/packages/open-cloud/src/resources/game-passes/builders.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.spec.ts
@@ -150,4 +150,33 @@ describe(buildCreateRequest, () => {
 		assert(request.body instanceof FormData);
 		expect(request.body.has("isForSale")).toBeFalse();
 	});
+
+	it("should stringify price into the form body when provided", () => {
+		expect.assertions(1);
+
+		const params = {
+			name: "Epic Pass",
+			price: 100,
+			universeId: "67890",
+		} satisfies CreateGamePassParameters;
+
+		const request = buildCreateRequest(params);
+
+		assert(request.body instanceof FormData);
+		expect(request.body.get("price")).toBe("100");
+	});
+
+	it("should omit price when not provided", () => {
+		expect.assertions(1);
+
+		const params = {
+			name: "Epic Pass",
+			universeId: "67890",
+		} satisfies CreateGamePassParameters;
+
+		const request = buildCreateRequest(params);
+
+		assert(request.body instanceof FormData);
+		expect(request.body.has("price")).toBeFalse();
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/builders.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.spec.ts
@@ -16,4 +16,19 @@ describe(buildGetRequest, () => {
 
 		expect(request.method).toBe("GET");
 	});
+
+	it("should interpolate universeId and gamePassId into the creator URL", () => {
+		expect.assertions(1);
+
+		const params = {
+			gamePassId: "12345",
+			universeId: "67890",
+		} satisfies GetGamePassParameters;
+
+		const request = buildGetRequest(params);
+
+		expect(request.url).toBe(
+			"/game-passes/v1/universes/67890/game-passes/12345/creator",
+		);
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/builders.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { buildGetRequest } from "./builders.ts";
-import type { GetGamePassParameters } from "./types.ts";
+import { buildCreateRequest, buildGetRequest } from "./builders.ts";
+import type { CreateGamePassParameters, GetGamePassParameters } from "./types.ts";
 
 describe(buildGetRequest, () => {
 	it("should use the GET method", () => {
@@ -43,5 +43,20 @@ describe(buildGetRequest, () => {
 		const request = buildGetRequest(params);
 
 		expect(request.body).toBeUndefined();
+	});
+});
+
+describe(buildCreateRequest, () => {
+	it("should use the POST method", () => {
+		expect.assertions(1);
+
+		const params = {
+			name: "Epic Pass",
+			universeId: "67890",
+		} satisfies CreateGamePassParameters;
+
+		const request = buildCreateRequest(params);
+
+		expect(request.method).toBe("POST");
 	});
 });

--- a/packages/open-cloud/src/resources/game-passes/builders.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.spec.ts
@@ -224,4 +224,25 @@ describe(buildCreateRequest, () => {
 		assert(request.body instanceof FormData);
 		expect(request.body.get("imageFile")).toBeInstanceOf(Blob);
 	});
+
+	it("should preserve the MIME type of a Blob imageFile", () => {
+		expect.assertions(2);
+
+		const imageFile = new Blob([new Uint8Array([1, 2, 3, 4])], {
+			type: "image/png",
+		});
+		const params = {
+			imageFile,
+			name: "Epic Pass",
+			universeId: "67890",
+		} satisfies CreateGamePassParameters;
+
+		const request = buildCreateRequest(params);
+
+		assert(request.body instanceof FormData);
+		const appended = request.body.get("imageFile");
+		assert(appended instanceof Blob);
+		expect(appended).toBeInstanceOf(Blob);
+		expect(appended.type).toBe("image/png");
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/builders.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.spec.ts
@@ -115,4 +115,39 @@ describe(buildCreateRequest, () => {
 		assert(request.body instanceof FormData);
 		expect(request.body.has("description")).toBeFalse();
 	});
+
+	it.for<[isForSale: boolean, expected: string]>([
+		[true, "true"],
+		[false, "false"],
+	])(
+		"should stringify isForSale=%s into the form body as %j",
+		([isForSale, expected]) => {
+			expect.assertions(1);
+
+			const params = {
+				isForSale,
+				name: "Epic Pass",
+				universeId: "67890",
+			} satisfies CreateGamePassParameters;
+
+			const request = buildCreateRequest(params);
+
+			assert(request.body instanceof FormData);
+			expect(request.body.get("isForSale")).toBe(expected);
+		},
+	);
+
+	it("should omit isForSale when not provided", () => {
+		expect.assertions(1);
+
+		const params = {
+			name: "Epic Pass",
+			universeId: "67890",
+		} satisfies CreateGamePassParameters;
+
+		const request = buildCreateRequest(params);
+
+		assert(request.body instanceof FormData);
+		expect(request.body.has("isForSale")).toBeFalse();
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/builders.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { buildGetRequest } from "./builders.ts";
+import type { GetGamePassParameters } from "./types.ts";
+
+describe(buildGetRequest, () => {
+	it("should use the GET method", () => {
+		expect.assertions(1);
+
+		const params = {
+			gamePassId: "12345",
+			universeId: "67890",
+		} satisfies GetGamePassParameters;
+
+		const request = buildGetRequest(params);
+
+		expect(request.method).toBe("GET");
+	});
+});

--- a/packages/open-cloud/src/resources/game-passes/builders.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { assert, describe, expect, it } from "vitest";
 
 import { buildCreateRequest, buildGetRequest } from "./builders.ts";
 import type { CreateGamePassParameters, GetGamePassParameters } from "./types.ts";
@@ -71,5 +71,19 @@ describe(buildCreateRequest, () => {
 		const request = buildCreateRequest(params);
 
 		expect(request.url).toBe("/game-passes/v1/universes/67890/game-passes");
+	});
+
+	it("should append name to a FormData body", () => {
+		expect.assertions(1);
+
+		const params = {
+			name: "Epic Pass",
+			universeId: "67890",
+		} satisfies CreateGamePassParameters;
+
+		const request = buildCreateRequest(params);
+
+		assert(request.body instanceof FormData);
+		expect(request.body.get("name")).toBe("Epic Pass");
 	});
 });

--- a/packages/open-cloud/src/resources/game-passes/builders.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.spec.ts
@@ -245,4 +245,18 @@ describe(buildCreateRequest, () => {
 		expect(appended).toBeInstanceOf(Blob);
 		expect(appended.type).toBe("image/png");
 	});
+
+	it("should omit imageFile when not provided", () => {
+		expect.assertions(1);
+
+		const params = {
+			name: "Epic Pass",
+			universeId: "67890",
+		} satisfies CreateGamePassParameters;
+
+		const request = buildCreateRequest(params);
+
+		assert(request.body instanceof FormData);
+		expect(request.body.has("imageFile")).toBeFalse();
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/builders.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.spec.ts
@@ -86,4 +86,33 @@ describe(buildCreateRequest, () => {
 		assert(request.body instanceof FormData);
 		expect(request.body.get("name")).toBe("Epic Pass");
 	});
+
+	it("should append description when provided", () => {
+		expect.assertions(1);
+
+		const params = {
+			description: "Unlocks epic stuff",
+			name: "Epic Pass",
+			universeId: "67890",
+		} satisfies CreateGamePassParameters;
+
+		const request = buildCreateRequest(params);
+
+		assert(request.body instanceof FormData);
+		expect(request.body.get("description")).toBe("Unlocks epic stuff");
+	});
+
+	it("should omit description when not provided", () => {
+		expect.assertions(1);
+
+		const params = {
+			name: "Epic Pass",
+			universeId: "67890",
+		} satisfies CreateGamePassParameters;
+
+		const request = buildCreateRequest(params);
+
+		assert(request.body instanceof FormData);
+		expect(request.body.has("description")).toBeFalse();
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/builders.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.spec.ts
@@ -179,4 +179,33 @@ describe(buildCreateRequest, () => {
 		assert(request.body instanceof FormData);
 		expect(request.body.has("price")).toBeFalse();
 	});
+
+	it("should stringify isRegionalPricingEnabled when provided", () => {
+		expect.assertions(1);
+
+		const params = {
+			isRegionalPricingEnabled: true,
+			name: "Epic Pass",
+			universeId: "67890",
+		} satisfies CreateGamePassParameters;
+
+		const request = buildCreateRequest(params);
+
+		assert(request.body instanceof FormData);
+		expect(request.body.get("isRegionalPricingEnabled")).toBe("true");
+	});
+
+	it("should omit isRegionalPricingEnabled when not provided", () => {
+		expect.assertions(1);
+
+		const params = {
+			name: "Epic Pass",
+			universeId: "67890",
+		} satisfies CreateGamePassParameters;
+
+		const request = buildCreateRequest(params);
+
+		assert(request.body instanceof FormData);
+		expect(request.body.has("isRegionalPricingEnabled")).toBeFalse();
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/builders.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.spec.ts
@@ -31,4 +31,17 @@ describe(buildGetRequest, () => {
 			"/game-passes/v1/universes/67890/game-passes/12345/creator",
 		);
 	});
+
+	it("should not set a body", () => {
+		expect.assertions(1);
+
+		const params = {
+			gamePassId: "12345",
+			universeId: "67890",
+		} satisfies GetGamePassParameters;
+
+		const request = buildGetRequest(params);
+
+		expect(request.body).toBeUndefined();
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/builders.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.spec.ts
@@ -213,8 +213,8 @@ describe(buildCreateRequest, () => {
 		expect(request.body.has("isRegionalPricingEnabled")).toBeFalse();
 	});
 
-	it("should wrap a Uint8Array imageFile into a Blob before appending", () => {
-		expect.assertions(1);
+	it("should wrap a Uint8Array imageFile into a Blob preserving its bytes", () => {
+		expect.assertions(2);
 
 		const imageFile = new Uint8Array([1, 2, 3, 4]);
 		const parameters = {
@@ -226,8 +226,11 @@ describe(buildCreateRequest, () => {
 		const request = buildCreateRequest(parameters);
 
 		assert(request.body instanceof FormData);
+		const appended = request.body.get("imageFile");
+		assert(appended instanceof Blob);
 
-		expect(request.body.get("imageFile")).toBeInstanceOf(Blob);
+		expect(appended).toBeInstanceOf(Blob);
+		expect(appended.size).toBe(imageFile.byteLength);
 	});
 
 	it("should preserve the MIME type of a Blob imageFile", () => {

--- a/packages/open-cloud/src/resources/game-passes/builders.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.spec.ts
@@ -59,4 +59,17 @@ describe(buildCreateRequest, () => {
 
 		expect(request.method).toBe("POST");
 	});
+
+	it("should interpolate universeId into the create URL", () => {
+		expect.assertions(1);
+
+		const params = {
+			name: "Epic Pass",
+			universeId: "67890",
+		} satisfies CreateGamePassParameters;
+
+		const request = buildCreateRequest(params);
+
+		expect(request.url).toBe("/game-passes/v1/universes/67890/game-passes");
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/builders.spec.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.spec.ts
@@ -208,4 +208,20 @@ describe(buildCreateRequest, () => {
 		assert(request.body instanceof FormData);
 		expect(request.body.has("isRegionalPricingEnabled")).toBeFalse();
 	});
+
+	it("should wrap a Uint8Array imageFile into a Blob before appending", () => {
+		expect.assertions(1);
+
+		const imageFile = new Uint8Array([1, 2, 3, 4]);
+		const params = {
+			imageFile,
+			name: "Epic Pass",
+			universeId: "67890",
+		} satisfies CreateGamePassParameters;
+
+		const request = buildCreateRequest(params);
+
+		assert(request.body instanceof FormData);
+		expect(request.body.get("imageFile")).toBeInstanceOf(Blob);
+	});
 });

--- a/packages/open-cloud/src/resources/game-passes/builders.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.ts
@@ -4,13 +4,13 @@ import type { GetGamePassParameters } from "./types.ts";
 /**
  * Builds a `GET` request for the Open Cloud "read game pass" endpoint.
  *
- * @param _params - Universe and game pass identifiers to interpolate into the
+ * @param params - Universe and game pass identifiers to interpolate into the
  *   URL.
  * @returns A pure {@link HttpRequest} describing the read call.
  */
-export function buildGetRequest(_params: GetGamePassParameters): HttpRequest {
+export function buildGetRequest(params: GetGamePassParameters): HttpRequest {
 	return {
 		method: "GET",
-		url: "",
+		url: `/game-passes/v1/universes/${params.universeId}/game-passes/${params.gamePassId}/creator`,
 	};
 }

--- a/packages/open-cloud/src/resources/game-passes/builders.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.ts
@@ -32,6 +32,9 @@ export function buildCreateRequest(
 	if (params.isForSale !== undefined) {
 		body.append("isForSale", String(params.isForSale));
 	}
+	if (params.price !== undefined) {
+		body.append("price", String(params.price));
+	}
 
 	return {
 		body,

--- a/packages/open-cloud/src/resources/game-passes/builders.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.ts
@@ -35,6 +35,12 @@ export function buildCreateRequest(
 	if (params.price !== undefined) {
 		body.append("price", String(params.price));
 	}
+	if (params.isRegionalPricingEnabled !== undefined) {
+		body.append(
+			"isRegionalPricingEnabled",
+			String(params.isRegionalPricingEnabled),
+		);
+	}
 
 	return {
 		body,

--- a/packages/open-cloud/src/resources/game-passes/builders.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.ts
@@ -1,0 +1,16 @@
+import type { HttpRequest } from "../../internal/http/types.ts";
+import type { GetGamePassParameters } from "./types.ts";
+
+/**
+ * Builds a `GET` request for the Open Cloud "read game pass" endpoint.
+ *
+ * @param _params - Universe and game pass identifiers to interpolate into the
+ *   URL.
+ * @returns A pure {@link HttpRequest} describing the read call.
+ */
+export function buildGetRequest(_params: GetGamePassParameters): HttpRequest {
+	return {
+		method: "GET",
+		url: "",
+	};
+}

--- a/packages/open-cloud/src/resources/game-passes/builders.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.ts
@@ -4,63 +4,58 @@ import type { CreateGamePassParameters, GetGamePassParameters } from "./types.ts
 /**
  * Builds a `GET` request for the Open Cloud "read game pass" endpoint.
  *
- * @param params - Universe and game pass identifiers to interpolate into the
- *   URL.
+ * @param parameters - Universe and game pass identifiers to interpolate into
+ *   the URL.
  * @returns A pure {@link HttpRequest} describing the read call.
  */
-export function buildGetRequest(params: GetGamePassParameters): HttpRequest {
+export function buildGetRequest(parameters: GetGamePassParameters): HttpRequest {
 	return {
 		method: "GET",
-		url: `/game-passes/v1/universes/${params.universeId}/game-passes/${params.gamePassId}/creator`,
+		url: `/game-passes/v1/universes/${parameters.universeId}/game-passes/${parameters.gamePassId}/creator`,
 	};
 }
 
 /**
  * Builds a `POST` request for the Open Cloud "create game pass" endpoint.
  *
- * @param params - Parameters describing the new game pass.
+ * @param parameters - Fields describing the new game pass; optional values
+ *   omitted here are left off the multipart payload entirely.
  * @returns A pure {@link HttpRequest} describing the create call.
  */
-export function buildCreateRequest(
-	params: CreateGamePassParameters,
-): HttpRequest {
+export function buildCreateRequest(parameters: CreateGamePassParameters): HttpRequest {
 	const body = new FormData();
-	body.append("name", params.name);
-	appendIfDefined(body, "description", params.description);
-	appendIfDefined(body, "isForSale", params.isForSale);
-	appendIfDefined(body, "price", params.price);
-	appendIfDefined(
-		body,
-		"isRegionalPricingEnabled",
-		params.isRegionalPricingEnabled,
-	);
-	if (params.imageFile !== undefined) {
-		body.append(
-			"imageFile",
-			params.imageFile instanceof Blob
-				? params.imageFile
-				: new Blob([params.imageFile]),
-		);
+	body.append("name", parameters.name);
+	if (parameters.description !== undefined) {
+		body.append("description", parameters.description);
+	}
+
+	if (parameters.isForSale !== undefined) {
+		body.append("isForSale", String(parameters.isForSale));
+	}
+
+	if (parameters.price !== undefined) {
+		body.append("price", String(parameters.price));
+	}
+
+	if (parameters.isRegionalPricingEnabled !== undefined) {
+		body.append("isRegionalPricingEnabled", String(parameters.isRegionalPricingEnabled));
+	}
+
+	if (parameters.imageFile !== undefined) {
+		body.append("imageFile", toBlob(parameters.imageFile));
 	}
 
 	return {
 		body,
 		method: "POST",
-		url: `/game-passes/v1/universes/${params.universeId}/game-passes`,
+		url: `/game-passes/v1/universes/${parameters.universeId}/game-passes`,
 	};
 }
 
-/**
- * Appends a value to `body` under `name` when it is defined, coercing
- * non-string scalars via `String()`. Undefined values are skipped so that
- * `"undefined"` never leaks into the multipart payload.
- */
-function appendIfDefined(
-	body: FormData,
-	name: string,
-	value: boolean | number | string | undefined,
-): void {
-	if (value !== undefined) {
-		body.append(name, String(value));
+function toBlob(value: Blob | Uint8Array): Blob {
+	if (value instanceof Blob) {
+		return value;
 	}
+
+	return new Blob([new Uint8Array(value)]);
 }

--- a/packages/open-cloud/src/resources/game-passes/builders.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.ts
@@ -22,10 +22,10 @@ export function buildGetRequest(params: GetGamePassParameters): HttpRequest {
  * @returns A pure {@link HttpRequest} describing the create call.
  */
 export function buildCreateRequest(
-	_params: CreateGamePassParameters,
+	params: CreateGamePassParameters,
 ): HttpRequest {
 	return {
 		method: "POST",
-		url: "",
+		url: `/game-passes/v1/universes/${params.universeId}/game-passes`,
 	};
 }

--- a/packages/open-cloud/src/resources/game-passes/builders.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.ts
@@ -26,6 +26,9 @@ export function buildCreateRequest(
 ): HttpRequest {
 	const body = new FormData();
 	body.append("name", params.name);
+	if (params.description !== undefined) {
+		body.append("description", params.description);
+	}
 
 	return {
 		body,

--- a/packages/open-cloud/src/resources/game-passes/builders.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.ts
@@ -1,5 +1,5 @@
 import type { HttpRequest } from "../../internal/http/types.ts";
-import type { GetGamePassParameters } from "./types.ts";
+import type { CreateGamePassParameters, GetGamePassParameters } from "./types.ts";
 
 /**
  * Builds a `GET` request for the Open Cloud "read game pass" endpoint.
@@ -12,5 +12,20 @@ export function buildGetRequest(params: GetGamePassParameters): HttpRequest {
 	return {
 		method: "GET",
 		url: `/game-passes/v1/universes/${params.universeId}/game-passes/${params.gamePassId}/creator`,
+	};
+}
+
+/**
+ * Builds a `POST` request for the Open Cloud "create game pass" endpoint.
+ *
+ * @param _params - Parameters describing the new game pass.
+ * @returns A pure {@link HttpRequest} describing the create call.
+ */
+export function buildCreateRequest(
+	_params: CreateGamePassParameters,
+): HttpRequest {
+	return {
+		method: "POST",
+		url: "",
 	};
 }

--- a/packages/open-cloud/src/resources/game-passes/builders.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.ts
@@ -29,6 +29,9 @@ export function buildCreateRequest(
 	if (params.description !== undefined) {
 		body.append("description", params.description);
 	}
+	if (params.isForSale !== undefined) {
+		body.append("isForSale", String(params.isForSale));
+	}
 
 	return {
 		body,

--- a/packages/open-cloud/src/resources/game-passes/builders.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.ts
@@ -34,6 +34,14 @@ export function buildCreateRequest(
 		"isRegionalPricingEnabled",
 		params.isRegionalPricingEnabled,
 	);
+	if (params.imageFile !== undefined) {
+		body.append(
+			"imageFile",
+			params.imageFile instanceof Blob
+				? params.imageFile
+				: new Blob([params.imageFile]),
+		);
+	}
 
 	return {
 		body,

--- a/packages/open-cloud/src/resources/game-passes/builders.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.ts
@@ -18,7 +18,7 @@ export function buildGetRequest(params: GetGamePassParameters): HttpRequest {
 /**
  * Builds a `POST` request for the Open Cloud "create game pass" endpoint.
  *
- * @param _params - Parameters describing the new game pass.
+ * @param params - Parameters describing the new game pass.
  * @returns A pure {@link HttpRequest} describing the create call.
  */
 export function buildCreateRequest(
@@ -26,25 +26,33 @@ export function buildCreateRequest(
 ): HttpRequest {
 	const body = new FormData();
 	body.append("name", params.name);
-	if (params.description !== undefined) {
-		body.append("description", params.description);
-	}
-	if (params.isForSale !== undefined) {
-		body.append("isForSale", String(params.isForSale));
-	}
-	if (params.price !== undefined) {
-		body.append("price", String(params.price));
-	}
-	if (params.isRegionalPricingEnabled !== undefined) {
-		body.append(
-			"isRegionalPricingEnabled",
-			String(params.isRegionalPricingEnabled),
-		);
-	}
+	appendIfDefined(body, "description", params.description);
+	appendIfDefined(body, "isForSale", params.isForSale);
+	appendIfDefined(body, "price", params.price);
+	appendIfDefined(
+		body,
+		"isRegionalPricingEnabled",
+		params.isRegionalPricingEnabled,
+	);
 
 	return {
 		body,
 		method: "POST",
 		url: `/game-passes/v1/universes/${params.universeId}/game-passes`,
 	};
+}
+
+/**
+ * Appends a value to `body` under `name` when it is defined, coercing
+ * non-string scalars via `String()`. Undefined values are skipped so that
+ * `"undefined"` never leaks into the multipart payload.
+ */
+function appendIfDefined(
+	body: FormData,
+	name: string,
+	value: boolean | number | string | undefined,
+): void {
+	if (value !== undefined) {
+		body.append(name, String(value));
+	}
 }

--- a/packages/open-cloud/src/resources/game-passes/builders.ts
+++ b/packages/open-cloud/src/resources/game-passes/builders.ts
@@ -24,7 +24,11 @@ export function buildGetRequest(params: GetGamePassParameters): HttpRequest {
 export function buildCreateRequest(
 	params: CreateGamePassParameters,
 ): HttpRequest {
+	const body = new FormData();
+	body.append("name", params.name);
+
 	return {
+		body,
 		method: "POST",
 		url: `/game-passes/v1/universes/${params.universeId}/game-passes`,
 	};


### PR DESCRIPTION
Closes #22.

## Summary

- Adds pure `buildGetRequest` and `buildCreateRequest` functions under `@bedrock/ocale/game-passes`. Both take typed parameters and return an `HttpRequest`; neither performs I/O or returns a `Result` — builders can't fail under the tracer bullet.
- `buildGetRequest` targets `/game-passes/v1/universes/{universeId}/game-passes/{gamePassId}/creator` with `method: "GET"` and no body (the `/creator` suffix matches the Open Cloud creator-view endpoint).
- `buildCreateRequest` targets `/game-passes/v1/universes/{universeId}/game-passes` with a `FormData` body. `name` is always appended; `description`, `isForSale`, `price`, and `isRegionalPricingEnabled` are appended only when defined and coerced to strings via `String()` so `price: 0` / `isForSale: false` round-trip correctly. `imageFile` is appended as a `Blob`, with `Uint8Array` inputs wrapped via a `toBlob` helper.

## Implementation notes

- Builders stay internal to the `game-passes` module — the subpath barrel continues to export only public types, matching the precedent set in #38. A future `GamePassesClient` issue will import them directly from `./builders.ts`.
- `toBlob` performs a defensive copy for `Uint8Array` inputs via `new Uint8Array(value)` so the payload always satisfies `BlobPart` (which requires `Uint8Array<ArrayBuffer>`). This keeps the public `CreateGamePassParameters.imageFile` type flexible without requiring consumers to care about `SharedArrayBuffer`.
- The optional-field guards are unrolled inline rather than tucked behind an `appendIfDefined` helper: the project's lint rules (`better-max-params: 2` + `func-style: declaration`) combine to disallow both a 3-arg declaration and an arrow-function-to-const form. Commit history shows the attempted refactor and its reversal.
- Each commit pairs RED+GREEN for one observable behaviour slice, per the `hk` hook cadence documented in `packages/open-cloud/CLAUDE.md`.

## Test plan

- [x] `pnpm --filter @bedrock/ocale test` — 192/192 tests green (18 new in `builders.spec.ts`).
- [x] `pnpm --filter @bedrock/ocale typecheck` — clean.
- [x] `pnpm lint` — clean on touched files.
- [x] `MUTATE_BASE_REF=origin/main pnpm mutate:changed` — 39/39 mutants killed on `builders.ts` (100% mutation score).