### PR TITLE
ci: run mutate:changed in agent pre-commit hook

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -65,6 +65,13 @@ local build = new Step {
     exclusive = true
 }
 
+local mutate = new Step {
+    glob = List("*.ts", "*.tsx")
+    check = "pnpm mutate:changed"
+    shell = bash
+    exclusive = true
+}
+
 hooks {
     ["pre-commit"] {
         stash = "none"
@@ -76,6 +83,7 @@ hooks {
             ["gen-example-tests"] = (genExampleTests) { condition = isAgent }
             ["test"] = (test) { condition = isAgent }
             ["build"] = (build) { condition = isAgent }
+            ["mutate"] = (mutate) { condition = isAgent }
         }
     }
     ["pre-push"] {


### PR DESCRIPTION
## Summary

- Adds a new `mutate` step to `hk.pkl` that runs `pnpm mutate:changed`, gated on `isAgent` so it only fires for agent-driven commits (Claude, Cursor, Codex, etc. — same `std-env` detection used by `test`/`build`).
- Closes the gap between [ADR-015](docs/adr/015-stryker-mutation-testing.md)'s documented "before committing" workflow and what `hk` actually enforces — agent commits with surviving mutants are now blocked locally rather than only at CI.
- Humans are intentionally untouched: the step is not added to `pre-push` or `check`, and runs on demand via `pnpm mutate:changed` for non-agent contexts.

## Caching

No new cache layer. Stryker's existing `--incremental` cache (per ADR-015, written to `reports/stryker-incremental.json`) handles the "agent already ran it" case — a manual `pnpm mutate:changed` warms the cache, and the pre-commit re-run skips mutants whose covering tests haven't changed. Redundant-invocation cost is just bun + Stryker startup (~5–15s).

## Test plan

- [ ] `hk validate` passes (verified locally)
- [ ] Inside an agent shell: edit a `.ts` file in a package with `stryker.config.ts`, then `git commit` — confirm the `mutate` step appears in `hk` output and runs
- [ ] Re-commit without further edits — second run noticeably faster via Stryker `--incremental`
- [ ] Outside an agent shell: confirm `mutate` is skipped (matches `test`/`build` behavior)
- [ ] Edit a `.md`-only file as agent — confirm `glob` skips `mutate` entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)