### PR TITLE
ci: use valid context to detect same-repo prs in claude-review

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -14,7 +14,7 @@ jobs:
     if: |
       github.event.pull_request != null &&
       github.event.sender.type != 'Bot' &&
-      github.head_repository.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       actions: read
       contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,8 +124,16 @@ lands — drop the flag and this note afterwards.
 
 ### Pull Requests
 
-PR titles must follow conventional commit format (e.g.
-`feat(ocale): add result type`). This is enforced by CI.
+PR titles are linted by commitlint (`.github/workflows/lint-pr-title.yaml`) —
+**verify both rules before `gh pr create` / `gh pr edit --title`:**
+
+1. **Subject lower-case**: kebab-case every uppercase letter after
+   `type(scope):`, including code identifiers (`mergeConfig` → `merge-config`,
+   `GamePassesClient` → `game-passes-client`).
+2. **Scope-enum**: if a scope is present it MUST be one of
+   `bedrock, e2e, global, ocale, testing, tsconfig, vite, website`. `ci`,
+   `chore`, `docs`, `build`, `refactor` are **types, not scopes** — write
+   `ci: …` with no scope, not `fix(ci): …`.
 
 ### Creating Issues
 


### PR DESCRIPTION
## Summary
- `github.head_repository.full_name` is not a valid GitHub Actions context property, so the same-repo guard on the `claude-review` job always evaluated to false and every PR since #40 was skipped before any step ran.
- Switch the guard to `github.event.pull_request.head.repo.full_name`, which is the canonical context for the PR's head repo.
- This fix existed locally on `claude/brave-wing-8eaeb6` as `c6e8120` but was not included in the #40 squash-merge.

## Test plan
- [ ] After merge, open an unrelated PR and confirm `gh run list --workflow=claude-review.yaml` shows `conclusion: success` (or `in_progress` / non-skipped) instead of `skipped`.
- [ ] Confirm the run progresses past the job-level `if:` into the "Wait for triage to complete" step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)