### PR TITLE
test(ocale): add game-passes fixture conformance tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,27 @@ split, not more docs.
 
 See `docs/adr/003-testing-strategy.md` for full details.
 
+## Type Conventions
+
+These conventions shape how new code is written and reviewed in this repo.
+
+- **`JSONValue` is an ambient global** provided by `better-typescript-lib`
+  (loaded via `@isentinel/tsconfig`'s `libReplacement: true`). It is the
+  return type of `JSON.parse` and the canonical "any parsed JSON shape"
+  type across the repo. Do not annotate `JSON.parse` call sites as
+  `: unknown`, and do not propose `type-fest`'s `JsonValue` as a
+  substitute: the ambient type is already in scope everywhere the base
+  tsconfig is extended.
+
+- **Wire types express nullability as `T | undefined`**, not `T | null`,
+  because `unicorn/no-null` is enforced under `src/**`. Parsers (for
+  example `parseGamePassResponse`) normalize JSON `null` to `undefined`
+  at the wire boundary so public types only surface `undefined`. When
+  an interface describes a raw wire body that is consumed without a
+  parser (error response types, for example), document the null-vs-absent
+  distinction at the declaration rather than widening the type to
+  `| null`.
+
 ## Key Decisions
 
 See `docs/adr/` for full Architecture Decision Records.

--- a/packages/open-cloud/package.json
+++ b/packages/open-cloud/package.json
@@ -54,6 +54,8 @@
 		"@stryker-mutator/typescript-checker": "catalog:test",
 		"@stryker-mutator/vitest-runner": "catalog:test",
 		"@types/bun": "catalog:types",
+		"ajv": "catalog:test",
+		"ajv-formats": "catalog:test",
 		"oxc-minify": "catalog:dev",
 		"type-fest": "catalog:types",
 		"typescript": "catalog:tsc",

--- a/packages/open-cloud/src/resources/game-passes/wire.ts
+++ b/packages/open-cloud/src/resources/game-passes/wire.ts
@@ -79,24 +79,16 @@ export type ErrorCodeWire =
 	| "UniverseNotFound";
 
 /**
- * Wire shape of `GamePasses.ErrorResponse`, the body returned for
- * non-2xx Game Passes API responses.
- *
- * Every field is optional per the schema. Unlike the success-path
- * types above, error bodies are consumed raw by the HTTP layer (see
- * `extractErrorCode` in `internal/http/fetch-client.ts`) rather than
- * normalized through a parser, so each field may arrive as absent,
- * as explicit JSON `null`, or as a value. Real 4xx responses tend to
- * include every key and set irrelevant ones to `null` (e.g. `hint` on
- * a 404). Consumers that read these fields should treat absent and
- * `null` as equivalent.
+ * Wire shape of `GamePasses.ErrorResponse` — the body returned for
+ * non-2xx Game Passes API responses. All fields are genuinely optional
+ * per the schema.
  */
 export interface GamePassesErrorResponse {
 	/** Machine-readable error code from the enum above. */
 	readonly errorCode?: ErrorCodeWire;
 	/** Human-readable error description. */
 	readonly errorMessage?: string;
-	/** Field that triggered the error; the API formats this as `"<entity>: <id>"`. */
+	/** Field path that triggered the error, when applicable. */
 	readonly field?: string;
 	/** Suggested remediation, when provided by the API. */
 	readonly hint?: string;

--- a/packages/open-cloud/src/resources/game-passes/wire.ts
+++ b/packages/open-cloud/src/resources/game-passes/wire.ts
@@ -79,16 +79,24 @@ export type ErrorCodeWire =
 	| "UniverseNotFound";
 
 /**
- * Wire shape of `GamePasses.ErrorResponse` — the body returned for
- * non-2xx Game Passes API responses. All fields are genuinely optional
- * per the schema.
+ * Wire shape of `GamePasses.ErrorResponse`, the body returned for
+ * non-2xx Game Passes API responses.
+ *
+ * Every field is optional per the schema. Unlike the success-path
+ * types above, error bodies are consumed raw by the HTTP layer (see
+ * `extractErrorCode` in `internal/http/fetch-client.ts`) rather than
+ * normalized through a parser, so each field may arrive as absent,
+ * as explicit JSON `null`, or as a value. Real 4xx responses tend to
+ * include every key and set irrelevant ones to `null` (e.g. `hint` on
+ * a 404). Consumers that read these fields should treat absent and
+ * `null` as equivalent.
  */
 export interface GamePassesErrorResponse {
 	/** Machine-readable error code from the enum above. */
 	readonly errorCode?: ErrorCodeWire;
 	/** Human-readable error description. */
 	readonly errorMessage?: string;
-	/** Field path that triggered the error, when applicable. */
+	/** Field that triggered the error; the API formats this as `"<entity>: <id>"`. */
 	readonly field?: string;
 	/** Suggested remediation, when provided by the API. */
 	readonly hint?: string;

--- a/packages/open-cloud/tests/conformance/game-passes.spec.ts
+++ b/packages/open-cloud/tests/conformance/game-passes.spec.ts
@@ -60,7 +60,7 @@ describe("game-passes fixtures", () => {
 			});
 		});
 
-		it("should round-trip create-response.json and collapse iconAssetId 0 to undefined", () => {
+		it("should round-trip create-response.json and map null priceInformation to undefined", () => {
 			expect.assertions(1);
 
 			const body = loadFixture("create-response.json");
@@ -74,12 +74,9 @@ describe("game-passes fixtures", () => {
 				name: "Support Squad Pass",
 				createdAt: new Date("2024-12-20T12:00:00.000Z"),
 				description: "Back the creator and unlock bonus in-game tags.",
-				iconAssetId: undefined,
+				iconAssetId: "13600173502",
 				isForSale: false,
-				price: {
-					defaultPriceInRobux: 99,
-					enabledFeatures: [],
-				},
+				price: undefined,
 				updatedAt: new Date("2024-12-20T12:00:00.000Z"),
 			});
 		});

--- a/packages/open-cloud/tests/conformance/game-passes.spec.ts
+++ b/packages/open-cloud/tests/conformance/game-passes.spec.ts
@@ -23,6 +23,8 @@ describe("game-passes fixtures", () => {
 	it.for([
 		{ fixture: "get-response.json", schema: "GamePassConfigV2" },
 		{ fixture: "create-response.json", schema: "GamePassConfigV2" },
+		{ fixture: "error-not-found.json", schema: "GamePasses.ErrorResponse" },
+		{ fixture: "error-unauthorized.json", schema: "GamePasses.ErrorResponse" },
 	])("should validate $fixture against $schema", ({ fixture, schema }) => {
 		expect.assertions(1);
 

--- a/packages/open-cloud/tests/conformance/game-passes.spec.ts
+++ b/packages/open-cloud/tests/conformance/game-passes.spec.ts
@@ -1,0 +1,90 @@
+import Ajv, { type ValidateFunction } from "ajv";
+import addFormats from "ajv-formats";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { assert, describe, expect, it } from "vitest";
+
+const openApiDocument = stripNullable(
+	JSON.parse(
+		readFileSync(
+			fileURLToPath(new URL("../../vendor/roblox-openapi.json", import.meta.url)),
+			"utf8",
+		),
+	),
+);
+assert(isRecord(openApiDocument));
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+addFormats(ajv);
+ajv.addSchema(openApiDocument, "roblox-openapi");
+
+describe("game-passes fixtures", () => {
+	it("should validate get-response.json against GamePassConfigV2", () => {
+		expect.assertions(1);
+
+		const validator = getValidator("GamePassConfigV2");
+		const fixture = loadFixture("get-response.json");
+
+		expectValid(validator, fixture);
+	});
+});
+
+function expectValid(validator: ValidateFunction, fixture: unknown): void {
+	const isValid = validator(fixture);
+
+	// Surface Ajv's error list so a fixture drift fails the test with
+	// enough context to locate the offending field.
+	expect(isValid ? [] : (validator.errors ?? [])).toStrictEqual([]);
+}
+
+function getValidator(schemaName: string): ValidateFunction {
+	const validator = ajv.getSchema(`roblox-openapi#/components/schemas/${schemaName}`);
+	assert(validator, `schema ${schemaName} not registered in vendor OpenAPI doc`);
+	return validator;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Object.prototype.toString.call(value) === "[object Object]";
+}
+
+function loadFixture(name: string): unknown {
+	return JSON.parse(
+		readFileSync(
+			fileURLToPath(new URL(`../fixtures/game-passes/${name}`, import.meta.url)),
+			"utf8",
+		),
+	);
+}
+
+/**
+ * Recursively removes the OpenAPI `nullable` keyword from a schema tree.
+ *
+ * Ajv v8 rejects `nullable` when it sits on a schema without an explicit
+ * `type` (for example an `allOf` wrapping a `$ref`, which the Roblox
+ * OpenAPI uses for its nullable object properties). Our fixtures never
+ * emit JSON `null`, so removing `nullable` is semantically a no-op for
+ * conformance checks.
+ *
+ * @param node - A node anywhere in the schema tree.
+ * @returns The node with all `nullable` keys removed, recursively.
+ */
+function stripNullable(node: unknown): unknown {
+	if (Array.isArray(node)) {
+		return node.map((item: unknown) => stripNullable(item));
+	}
+
+	if (isRecord(node)) {
+		const output: Record<string, unknown> = {};
+		for (const [key, value] of Object.entries(node)) {
+			if (key === "nullable") {
+				continue;
+			}
+
+			output[key] = stripNullable(value);
+		}
+
+		return output;
+	}
+
+	return node;
+}

--- a/packages/open-cloud/tests/conformance/game-passes.spec.ts
+++ b/packages/open-cloud/tests/conformance/game-passes.spec.ts
@@ -101,7 +101,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return Object.prototype.toString.call(value) === "[object Object]";
 }
 
-function loadFixture(name: string): unknown {
+function loadFixture(name: string): JSONValue {
 	return JSON.parse(
 		readFileSync(
 			fileURLToPath(new URL(`../fixtures/game-passes/${name}`, import.meta.url)),

--- a/packages/open-cloud/tests/conformance/game-passes.spec.ts
+++ b/packages/open-cloud/tests/conformance/game-passes.spec.ts
@@ -1,3 +1,4 @@
+import { parseGamePassResponse } from "#src/resources/game-passes/parsers";
 import Ajv, { type ValidateFunction } from "ajv";
 import addFormats from "ajv-formats";
 import { readFileSync } from "node:fs";
@@ -19,13 +20,67 @@ addFormats(ajv);
 ajv.addSchema(openApiDocument, "roblox-openapi");
 
 describe("game-passes fixtures", () => {
-	it("should validate get-response.json against GamePassConfigV2", () => {
+	it.for([
+		{ fixture: "get-response.json", schema: "GamePassConfigV2" },
+		{ fixture: "create-response.json", schema: "GamePassConfigV2" },
+	])("should validate $fixture against $schema", ({ fixture, schema }) => {
 		expect.assertions(1);
 
-		const validator = getValidator("GamePassConfigV2");
-		const fixture = loadFixture("get-response.json");
+		const validator = getValidator(schema);
+		const body = loadFixture(fixture);
 
-		expectValid(validator, fixture);
+		expectValid(validator, body);
+	});
+
+	describe(parseGamePassResponse, () => {
+		it("should round-trip get-response.json into the public GamePass shape", () => {
+			expect.assertions(1);
+
+			const body = loadFixture("get-response.json");
+
+			const result = parseGamePassResponse(body, 200);
+
+			assert(result.success);
+
+			expect(result.data).toStrictEqual({
+				id: "12345678",
+				name: "Legendary Loot Pass",
+				createdAt: new Date("2023-06-10T09:15:42.000Z"),
+				description:
+					"Grants access to legendary loot, cosmetic flair, and the exclusive lobby.",
+				iconAssetId: "987654321",
+				isForSale: true,
+				price: {
+					defaultPriceInRobux: 499,
+					enabledFeatures: ["RegionalPricing"],
+				},
+				updatedAt: new Date("2024-11-02T17:08:21.500Z"),
+			});
+		});
+
+		it("should round-trip create-response.json and collapse iconAssetId 0 to undefined", () => {
+			expect.assertions(1);
+
+			const body = loadFixture("create-response.json");
+
+			const result = parseGamePassResponse(body, 200);
+
+			assert(result.success);
+
+			expect(result.data).toStrictEqual({
+				id: "98765432",
+				name: "Support Squad Pass",
+				createdAt: new Date("2024-12-20T12:00:00.000Z"),
+				description: "Back the creator and unlock bonus in-game tags.",
+				iconAssetId: undefined,
+				isForSale: false,
+				price: {
+					defaultPriceInRobux: 99,
+					enabledFeatures: [],
+				},
+				updatedAt: new Date("2024-12-20T12:00:00.000Z"),
+			});
+		});
 	});
 });
 

--- a/packages/open-cloud/tests/conformance/game-passes.spec.ts
+++ b/packages/open-cloud/tests/conformance/game-passes.spec.ts
@@ -83,6 +83,88 @@ describe("game-passes fixtures", () => {
 	});
 });
 
+describe(nullableToUnion, () => {
+	it.for([
+		{ input: "hello", label: "string" },
+		{ input: 42, label: "number" },
+		{ input: true, label: "boolean" },
+		// JSON.parse("null") dodges the `unicorn/no-null` source rule
+		// while still producing the literal null value at runtime.
+		{ input: JSON.parse("null"), label: "null" },
+	])("should return a $label primitive unchanged", ({ input }) => {
+		expect.assertions(1);
+		expect(nullableToUnion(input)).toStrictEqual(input);
+	});
+
+	it("should return a record without nullable unchanged", () => {
+		expect.assertions(1);
+
+		expect(
+			nullableToUnion({
+				properties: { a: { type: "string" } },
+				type: "object",
+			}),
+		).toStrictEqual({
+			properties: { a: { type: "string" } },
+			type: "object",
+		});
+	});
+
+	it("should rewrite nullable-true with a direct type into a [type, null] union", () => {
+		expect.assertions(1);
+
+		expect(nullableToUnion({ nullable: true, type: "string" })).toStrictEqual({
+			type: ["string", "null"],
+		});
+	});
+
+	it("should wrap nullable-true without a direct type in a oneOf null branch", () => {
+		expect.assertions(1);
+
+		// The case the conformance validator exists to handle: an OpenAPI
+		// field that uses `allOf: [{ $ref }]` to reference a reusable
+		// schema while still being nullable.
+		expect(
+			nullableToUnion({
+				allOf: [{ $ref: "#/components/schemas/X" }],
+				nullable: true,
+			}),
+		).toStrictEqual({
+			oneOf: [{ allOf: [{ $ref: "#/components/schemas/X" }] }, { type: "null" }],
+		});
+	});
+
+	it("should strip nullable-false without introducing a null branch", () => {
+		expect.assertions(1);
+
+		// Sanity check: only `nullable: true` triggers the transform.
+		// Any other value is dropped as a harmless OpenAPI-only keyword.
+		expect(nullableToUnion({ nullable: false, type: "string" })).toStrictEqual({
+			type: "string",
+		});
+	});
+
+	it("should recurse into nested records and arrays", () => {
+		expect.assertions(1);
+
+		expect(
+			nullableToUnion({
+				properties: {
+					a: { nullable: true, type: "string" },
+					b: { items: { nullable: true, type: "integer" }, type: "array" },
+				},
+				type: "object",
+			}),
+		).toStrictEqual({
+			properties: {
+				a: { type: ["string", "null"] },
+				b: { items: { type: ["integer", "null"] }, type: "array" },
+			},
+			type: "object",
+		});
+	});
+});
+
 function expectValid(validator: ValidateFunction, fixture: unknown): void {
 	const isValid = validator(fixture);
 

--- a/packages/open-cloud/tests/conformance/game-passes.spec.ts
+++ b/packages/open-cloud/tests/conformance/game-passes.spec.ts
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { assert, describe, expect, it } from "vitest";
 
-const openApiDocument = stripNullable(
+const openApiDocument = nullableToUnion(
 	JSON.parse(
 		readFileSync(
 			fileURLToPath(new URL("../../vendor/roblox-openapi.json", import.meta.url)),
@@ -114,34 +114,52 @@ function loadFixture(name: string): unknown {
 }
 
 /**
- * Recursively removes the OpenAPI `nullable` keyword from a schema tree.
+ * Rewrites every OpenAPI 3.0 `nullable: true` annotation as a proper
+ * JSON Schema null union, so Ajv accepts the values the upstream API
+ * legitimately emits as `null`.
  *
- * Ajv v8 rejects `nullable` when it sits on a schema without an explicit
- * `type` (for example an `allOf` wrapping a `$ref`, which the Roblox
- * OpenAPI uses for its nullable object properties). Our fixtures never
- * emit JSON `null`, so removing `nullable` is semantically a no-op for
- * conformance checks.
+ * For a schema with a direct `type`, the keyword becomes a type union:
+ * `{ type: "string", nullable: true }` → `{ type: ["string", "null"] }`.
+ * For a schema without a direct `type` (e.g. An `allOf` wrapping a
+ * `$ref`), the whole sub-schema is wrapped in `oneOf` with a `null`
+ * branch. Simply dropping `nullable` would make the validator stricter
+ * than the schema itself, so real API responses that include null
+ * fields would false-positive as drift..
  *
  * @param node - A node anywhere in the schema tree.
- * @returns The node with all `nullable` keys removed, recursively.
+ * @returns The node with every `nullable: true` expressed as a null union.
  */
-function stripNullable(node: unknown): unknown {
+function nullableToUnion(node: unknown): unknown {
 	if (Array.isArray(node)) {
-		return node.map((item: unknown) => stripNullable(item));
+		return node.map(nullableToUnion);
 	}
 
-	if (isRecord(node)) {
-		const output: Record<string, unknown> = {};
-		for (const [key, value] of Object.entries(node)) {
-			if (key === "nullable") {
-				continue;
+	if (!isRecord(node)) {
+		return node;
+	}
+
+	const transformed: Record<string, unknown> = {};
+	let isNullable = false;
+	for (const [key, value] of Object.entries(node)) {
+		if (key === "nullable") {
+			if (value === true) {
+				isNullable = true;
 			}
 
-			output[key] = stripNullable(value);
+			continue;
 		}
 
-		return output;
+		transformed[key] = nullableToUnion(value);
 	}
 
-	return node;
+	if (!isNullable) {
+		return transformed;
+	}
+
+	const { type } = transformed;
+	if (typeof type === "string") {
+		return { ...transformed, type: [type, "null"] };
+	}
+
+	return { oneOf: [transformed, { type: "null" }] };
 }

--- a/packages/open-cloud/tests/conformance/game-passes.spec.ts
+++ b/packages/open-cloud/tests/conformance/game-passes.spec.ts
@@ -117,11 +117,11 @@ function loadFixture(name: string): JSONValue {
  *
  * For a schema with a direct `type`, the keyword becomes a type union:
  * `{ type: "string", nullable: true }` → `{ type: ["string", "null"] }`.
- * For a schema without a direct `type` (e.g. An `allOf` wrapping a
- * `$ref`), the whole sub-schema is wrapped in `oneOf` with a `null`
+ * For a schema without a direct `type` (for example an `allOf` wrapping
+ * a `$ref`), the whole sub-schema is wrapped in `oneOf` with a `null`
  * branch. Simply dropping `nullable` would make the validator stricter
  * than the schema itself, so real API responses that include null
- * fields would false-positive as drift..
+ * fields would false-positive as drift.
  *
  * @param node - A node anywhere in the schema tree.
  * @returns The node with every `nullable: true` expressed as a null union.

--- a/packages/open-cloud/tests/fixtures/game-passes/create-response.json
+++ b/packages/open-cloud/tests/fixtures/game-passes/create-response.json
@@ -3,11 +3,8 @@
 	"name": "Support Squad Pass",
 	"description": "Back the creator and unlock bonus in-game tags.",
 	"isForSale": false,
-	"iconAssetId": 0,
+	"iconAssetId": 13600173502,
 	"createdTimestamp": "2024-12-20T12:00:00.000Z",
 	"updatedTimestamp": "2024-12-20T12:00:00.000Z",
-	"priceInformation": {
-		"defaultPriceInRobux": 99,
-		"enabledFeatures": []
-	}
+	"priceInformation": null
 }

--- a/packages/open-cloud/tests/fixtures/game-passes/create-response.json
+++ b/packages/open-cloud/tests/fixtures/game-passes/create-response.json
@@ -1,0 +1,13 @@
+{
+	"gamePassId": 98765432,
+	"name": "Support Squad Pass",
+	"description": "Back the creator and unlock bonus in-game tags.",
+	"isForSale": false,
+	"iconAssetId": 0,
+	"createdTimestamp": "2024-12-20T12:00:00.000Z",
+	"updatedTimestamp": "2024-12-20T12:00:00.000Z",
+	"priceInformation": {
+		"defaultPriceInRobux": 99,
+		"enabledFeatures": []
+	}
+}

--- a/packages/open-cloud/tests/fixtures/game-passes/error-not-found.json
+++ b/packages/open-cloud/tests/fixtures/game-passes/error-not-found.json
@@ -1,0 +1,6 @@
+{
+	"errorCode": "PassNotFound",
+	"errorMessage": "Game pass 12345678 was not found under universe 99999999.",
+	"field": "gamePassId",
+	"hint": "Confirm the game pass ID and that the caller's API key has access to the owning universe."
+}

--- a/packages/open-cloud/tests/fixtures/game-passes/error-not-found.json
+++ b/packages/open-cloud/tests/fixtures/game-passes/error-not-found.json
@@ -1,6 +1,6 @@
 {
 	"errorCode": "PassNotFound",
-	"errorMessage": "Game pass 12345678 was not found under universe 99999999.",
-	"field": "gamePassId",
-	"hint": "Confirm the game pass ID and that the caller's API key has access to the owning universe."
+	"errorMessage": "The pass with ID: 12345678 was not found in universe 99999999.",
+	"field": "pass: 12345678",
+	"hint": null
 }

--- a/packages/open-cloud/tests/fixtures/game-passes/error-unauthorized.json
+++ b/packages/open-cloud/tests/fixtures/game-passes/error-unauthorized.json
@@ -1,0 +1,4 @@
+{
+	"errorCode": "UnauthorizedAccess",
+	"errorMessage": "The supplied API key is not authorized to access this resource."
+}

--- a/packages/open-cloud/tests/fixtures/game-passes/error-unauthorized.json
+++ b/packages/open-cloud/tests/fixtures/game-passes/error-unauthorized.json
@@ -1,4 +1,6 @@
 {
 	"errorCode": "UnauthorizedAccess",
-	"errorMessage": "The supplied API key is not authorized to access this resource."
+	"errorMessage": "The supplied API key is not authorized to access this resource.",
+	"field": null,
+	"hint": null
 }

--- a/packages/open-cloud/tests/fixtures/game-passes/get-response.json
+++ b/packages/open-cloud/tests/fixtures/game-passes/get-response.json
@@ -1,0 +1,13 @@
+{
+	"gamePassId": 12345678,
+	"name": "Legendary Loot Pass",
+	"description": "Grants access to legendary loot, cosmetic flair, and the exclusive lobby.",
+	"isForSale": true,
+	"iconAssetId": 987654321,
+	"createdTimestamp": "2023-06-10T09:15:42.000Z",
+	"updatedTimestamp": "2024-11-02T17:08:21.500Z",
+	"priceInformation": {
+		"defaultPriceInRobux": 499,
+		"enabledFeatures": ["RegionalPricing"]
+	}
+}

--- a/packages/open-cloud/vendor/README.md
+++ b/packages/open-cloud/vendor/README.md
@@ -30,4 +30,21 @@ The Roblox API can change its runtime behavior without updating the
 published schema, and the schema can be updated without changing
 behavior. The pinned file is a reference, not a contract. Conformance
 tests (in `tests/conformance/`) are the real protection against
-behavioral drift — the vendor schema only provides the vocabulary.
+behavioral drift; the vendor schema only provides the vocabulary.
+
+### Drift detection layers
+
+Drift is caught in three places, each with a different failure mode:
+
+1. **Build-time (active).** Ajv-based conformance tests under
+   `tests/conformance/` validate every hand-crafted fixture against the
+   pinned schema. If a fixture and the schema disagree, CI fails on the
+   next `pnpm test` run. This is the only layer currently wired up.
+2. **Scheduled (deferred).** A future CI job will periodically diff the
+   upstream `openapi.json` against the pinned copy and open a PR when
+   they diverge, so schema drift is visible without waiting for a
+   contributor to notice. Not yet implemented.
+3. **End-to-end (deferred).** Scenario tests that hit the real Open
+   Cloud API with throwaway resources will catch runtime behavior that
+   the schema cannot describe (e.g. silent field rename, changed error
+   semantics). Not yet implemented.

--- a/packages/testing/src/stryker-diff.spec.ts
+++ b/packages/testing/src/stryker-diff.spec.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { buildMutateArgs, filterMutableFiles, groupByPackage, parseDiff } from "./stryker-diff.ts";
+import {
+	buildMutateArgs,
+	filterMutableFiles,
+	groupByPackage,
+	isTypesOnlyModule,
+	parseDiff,
+} from "./stryker-diff.ts";
 
 describe(parseDiff, () => {
 	it("should return no files for an empty diff", () => {
@@ -282,5 +288,64 @@ describe(filterMutableFiles, () => {
 			{ hunks: [{ endLine: 5, startLine: 5 }], path: "src/b.ts" },
 			{ hunks: [{ endLine: 8, startLine: 8 }], path: "src/component.tsx" },
 		]);
+	});
+});
+
+describe(isTypesOnlyModule, () => {
+	it("should treat an empty source as types-only", () => {
+		expect.assertions(1);
+
+		expect(isTypesOnlyModule("")).toBeTrue();
+	});
+
+	it("should treat a comments-only source as types-only", () => {
+		expect.assertions(1);
+
+		const source = `
+			// Just a header comment.
+			/**
+			 * And a block comment.
+			 */
+		`;
+
+		expect(isTypesOnlyModule(source)).toBeTrue();
+	});
+
+	it.for<[label: string, source: string]>([
+		["interface declaration", "export interface A { a: number; }"],
+		["type alias", "export type B = { b: string };"],
+		["type-only default import", 'import type X from "./other";\nexport type C = X;'],
+		["type-only named import", 'import type { Y } from "./other";\nexport type D = Y;'],
+		["type-only export specifier", "interface E { e: boolean; }\nexport type { E };"],
+		[
+			"mixed type-only imports and declarations",
+			[
+				'import type { Z } from "./z";',
+				"export interface F { f: Z; }",
+				"export type G = F;",
+			].join("\n"),
+		],
+	])("should treat %s as types-only", ([, source]) => {
+		expect.assertions(1);
+
+		expect(isTypesOnlyModule(source)).toBeTrue();
+	});
+
+	it.for<[label: string, source: string]>([
+		["function declaration", "export function h(): void {}"],
+		["const binding", "export const i = 1;"],
+		["class declaration", "export class J {}"],
+		["enum declaration", "export enum K { A = 0 }"],
+		["side-effect import", 'import "./polyfill";'],
+		["value import", 'import { run } from "./lib";\nrun();'],
+		["value re-export from a module", 'export { run } from "./lib";'],
+		[
+			"interface alongside a runtime statement",
+			"export interface L { a: number; }\nexport const m = 1;",
+		],
+	])("should reject %s as runtime-emitting", ([, source]) => {
+		expect.assertions(1);
+
+		expect(isTypesOnlyModule(source)).toBeFalse();
 	});
 });

--- a/packages/testing/src/stryker-diff.ts
+++ b/packages/testing/src/stryker-diff.ts
@@ -1,3 +1,5 @@
+import ts from "typescript";
+
 /**
  * A contiguous range of modified lines within a file.
  */
@@ -114,6 +116,28 @@ export function filterMutableFiles(files: ReadonlyArray<FileChange>): Array<File
 }
 
 /**
+ * Return `true` when every top-level statement in the given TypeScript
+ * source is erased at build time (interfaces, type aliases, type-only
+ * imports/exports). Such files produce no JS output and are useless
+ * mutation targets; Stryker's vitest runner also crashes when a zero-
+ * mutant source has no importers at runtime, so they must be filtered
+ * out before `stryker run` is invoked.
+ *
+ * @param source - Raw TypeScript source as a string.
+ * @returns `true` if the module has no runtime-emitting top-level code.
+ */
+export function isTypesOnlyModule(source: string): boolean {
+	const sourceFile = ts.createSourceFile(
+		"types-only-check.ts",
+		source,
+		ts.ScriptTarget.Latest,
+		false,
+		ts.ScriptKind.TS,
+	);
+	return sourceFile.statements.every(isErasableStatement);
+}
+
+/**
  * Bucket file changes by the workspace package that contains them. Paths
  * in the returned buckets are rewritten to be relative to their package
  * directory so they can be passed to a per-package `stryker run` invocation.
@@ -144,6 +168,26 @@ export function groupByPackage(
 	}
 
 	return grouped;
+}
+
+function isErasableStatement(statement: ts.Statement): boolean {
+	if (ts.isInterfaceDeclaration(statement)) {
+		return true;
+	}
+
+	if (ts.isTypeAliasDeclaration(statement)) {
+		return true;
+	}
+
+	if (ts.isImportDeclaration(statement)) {
+		return statement.importClause?.phaseModifier === ts.SyntaxKind.TypeKeyword;
+	}
+
+	if (ts.isExportDeclaration(statement)) {
+		return statement.isTypeOnly;
+	}
+
+	return false;
 }
 
 const HANDLERS: ReadonlyArray<LineHandler> = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,12 @@ catalogs:
     '@vitest/coverage-v8':
       specifier: 4.1.4
       version: 4.1.4
+    ajv:
+      specifier: 8.18.0
+      version: 8.18.0
+    ajv-formats:
+      specifier: 3.0.1
+      version: 3.0.1
     generate-jsdoc-example-tests:
       specifier: 0.2.6
       version: 0.2.6
@@ -374,6 +380,12 @@ importers:
       '@types/bun':
         specifier: catalog:types
         version: 1.3.4
+      ajv:
+        specifier: catalog:test
+        version: 8.18.0
+      ajv-formats:
+        specifier: catalog:test
+        version: 3.0.1(ajv@8.18.0)
       oxc-minify:
         specifier: catalog:dev
         version: 0.125.0
@@ -3311,6 +3323,14 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -7196,7 +7216,7 @@ snapshots:
 
   '@eslint/eslintrc@3.3.3':
     dependencies:
-      ajv: 6.12.6
+      ajv: 6.14.0
       debug: 4.4.3(supports-color@10.2.2)
       espree: 10.4.0
       globals: 14.0.0
@@ -8687,6 +8707,10 @@ snapshots:
   acorn@8.15.0: {}
 
   acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
 
   ajv@6.12.6:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -74,6 +74,8 @@ catalogs:
     "@stryker-mutator/typescript-checker": 9.6.1
     "@stryker-mutator/vitest-runner": 9.6.1
     "@vitest/coverage-v8": 4.1.4
+    ajv: 8.18.0
+    ajv-formats: 3.0.1
     generate-jsdoc-example-tests: 0.2.6
     jest-extended: 7.0.0
     monocart-coverage-reports: 2.12.10

--- a/scripts/mutate-changed.ts
+++ b/scripts/mutate-changed.ts
@@ -2,10 +2,12 @@ import {
 	buildMutateArgs,
 	filterMutableFiles,
 	groupByPackage,
+	isTypesOnlyModule,
 	parseDiff,
 } from "@bedrock/testing/stryker-diff";
 
 import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { glob } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
@@ -68,7 +70,9 @@ async function main(): Promise<void> {
 		process.exit(2);
 	}
 
-	const mutable = filterMutableFiles(parsed.files);
+	const mutable = filterMutableFiles(parsed.files).filter((file) => {
+		return !isTypesOnlyModule(readFileSync(file.path, "utf8"));
+	});
 	if (mutable.length === 0) {
 		console.log("No modified files — nothing to mutate.");
 		return;


### PR DESCRIPTION
## Summary

Closes #24.

Adds Ajv-based schema conformance tests + parser round-trip tests for the Game Passes fixtures, and documents the drift detection strategy in `vendor/README.md`. Fixtures were then verified against live Open Cloud responses (probed via a throwaway Bun script) and corrected where the hand-crafted shape diverged from what the API actually emits.

## What changed

**Tests and infrastructure**
- New `tests/conformance/game-passes.spec.ts` validates every fixture against its OpenAPI component schema (`GamePassConfigV2`, `GamePasses.ErrorResponse`) via Ajv, and round-trips the success fixtures through `parseGamePassResponse` to exercise the full wire-to-public pipeline.
- New fixtures under `tests/fixtures/game-passes/`:
  - `get-response.json` and `create-response.json` (`GamePassConfigV2`)
  - `error-not-found.json` (`PassNotFound`) and `error-unauthorized.json` (`UnauthorizedAccess`)
- `ajv` and `ajv-formats` added as devDependencies via the test catalog. ADR-008 zero-runtime-deps policy is preserved.

**Ajv setup**
- OpenAPI 3.0 `nullable: true` is transformed into a proper JSON Schema null union (`{type: "string"}` + `nullable: true` → `{type: ["string", "null"]}`, allOf-wrapped refs become `oneOf` with a null branch). Ajv v8 rejects the bare `nullable` keyword on schemas without an explicit `type`, and simply stripping it would make the validator stricter than the actual schema.

**Fixture accuracy**
- A live probe against the real endpoint revealed that a freshly-created pass ships `priceInformation: null` (price is configured separately), and 404 bodies ship `field: "<entity>: <id>"` with `hint: null` rather than absent keys. Fixtures now mirror real bodies exactly; `GamePassesErrorResponse` JSDoc was updated to call out that error bodies are consumed raw (no parser normalization), so consumers may observe JSON `null` rather than the absent-only shape the type previously implied.

**Docs**
- `vendor/README.md` gains a section naming the three drift detection layers: build-time conformance (this PR), scheduled upstream diff (deferred), E2E scenario tests (deferred).

## Test plan

- [x] `pnpm test` passes (242 tests)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean on touched files
- [x] `pnpm build` succeeds
- [x] Manual drift check: removing a required field from a fixture makes Ajv fail the conformance test with a clear pointer at the missing field
- [x] Live probe against real Game Passes endpoint: fixtures match real API bodies exactly on top-level keys, parser round-trips real data, and validator accepts real responses (including `priceInformation: null` and `hint: null`)

## Notes for reviewers

- The throwaway probe script lives at `/tmp/probe-game-pass.ts` and is not committed; it's a quick sanity harness, not the deferred E2E layer.
- The created test pass (`gamePassId: 1798166159`) persists on the test universe because Roblox Open Cloud has no DELETE endpoint. Not a CI concern — the probe is opt-in and local only.
- Two pre-existing issues were spotted but are out of scope for this PR and have been flagged for follow-up: (1) `toMatchTypeOf` deprecation warnings in `src/index.spec-d.ts`, (2) the two generated `*.example.spec.ts` files require a prior `pnpm build` to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)