### PR TITLE
ci: run hk check with all flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: eslint-${{ runner.os }}-
 
       - name: Run hk check
-        run: hk check
+        run: hk check --all
 
       - if: always()
         name: Upload coverage

--- a/hk.pkl
+++ b/hk.pkl
@@ -17,7 +17,7 @@ local sharedGuards = new Mapping<String, Step> {
     ["detect-private-key"] = (Builtins.detect_private_key) { shell = bash }
     ["check-added-large-files"] = (Builtins.check_added_large_files) {
         shell = bash
-        exclude = List("pnpm-lock.yaml")
+        exclude = List("pnpm-lock.yaml", "packages/*/vendor/**")
     }
 }
 

--- a/hk.pkl
+++ b/hk.pkl
@@ -91,8 +91,8 @@ hooks {
 			["lint"] = lint
             ["typecheck"] = typecheck
             ["gen-example-tests"] = genExampleTests
-            ["test"] = test
             ["build"] = build
+            ["test"] = test
         }
     }
     ["commit-msg"] {
@@ -123,8 +123,8 @@ hooks {
 			["lint"] = lint
             ["typecheck"] = typecheck
             ["gen-example-tests"] = genExampleTests
-            ["test"] = testCi
             ["build"] = build
+            ["test"] = testCi
         }
     }
 }

--- a/packages/open-cloud/src/index.spec-d.ts
+++ b/packages/open-cloud/src/index.spec-d.ts
@@ -171,7 +171,7 @@ describe("OpenCloudClientOptions", () => {
 	});
 
 	it("should have optional baseUrl, maxRetries, timeout", () => {
-		expectTypeOf<OpenCloudClientOptions>().toMatchTypeOf<{
+		expectTypeOf<OpenCloudClientOptions>().toMatchObjectType<{
 			baseUrl?: string;
 			maxRetries?: number;
 			timeout?: number;
@@ -188,7 +188,7 @@ describe("OpenCloudClientOptions", () => {
 	});
 
 	it("should expose hooks, httpClient, and sleep test seams as optional", () => {
-		expectTypeOf<OpenCloudClientOptions>().toMatchTypeOf<{
+		expectTypeOf<OpenCloudClientOptions>().toMatchObjectType<{
 			hooks?: OpenCloudHooks;
 			httpClient?: HttpClient;
 			sleep?: SleepFunc;

--- a/packages/open-cloud/src/index.spec-d.ts
+++ b/packages/open-cloud/src/index.spec-d.ts
@@ -171,7 +171,7 @@ describe("OpenCloudClientOptions", () => {
 	});
 
 	it("should have optional baseUrl, maxRetries, timeout", () => {
-		expectTypeOf<OpenCloudClientOptions>().toMatchObjectType<{
+		expectTypeOf<OpenCloudClientOptions>().toExtend<{
 			baseUrl?: string;
 			maxRetries?: number;
 			timeout?: number;
@@ -188,7 +188,7 @@ describe("OpenCloudClientOptions", () => {
 	});
 
 	it("should expose hooks, httpClient, and sleep test seams as optional", () => {
-		expectTypeOf<OpenCloudClientOptions>().toMatchObjectType<{
+		expectTypeOf<OpenCloudClientOptions>().toExtend<{
 			hooks?: OpenCloudHooks;
 			httpClient?: HttpClient;
 			sleep?: SleepFunc;


### PR DESCRIPTION
Fixes #51.

## Summary

CI on `main` has been silently skipping lint / typecheck / test / build. `hk check` only ran globbed steps against the "modified files" set, which is empty on a fresh CI checkout — so only `gen-example-tests` (the sole step without a glob) actually executed. Two `ts/no-deprecated` errors (`toMatchTypeOf` in `packages/open-cloud/src/index.spec-d.ts`) had landed on `main` as a result.

Switching to `hk check --all` surfaced two other latent issues that had been hidden since the check hook was broken; both are fixed here so the PR is merge-ready.

## Commits

1. **`ci: run hk check with all flag`** — the primary fix. `--all` makes `hk check` run every step against the whole tree, ignoring the modified-files filter. Local `pre-commit`/`pre-push` hooks unchanged so dev stays fast.
2. **`fix(ocale): replace deprecated to-match-type-of with to-match-object-type`** / **`fix(ocale): use to-extend instead of to-match-object-type`** — resolves the two `ts/no-deprecated` errors at `packages/open-cloud/src/index.spec-d.ts:174` and `:191`. `toExtend` preserves the original assignability semantics of `toMatchTypeOf`.
3. **`ci: exclude vendor dirs from check-added-large-files`** — under `--all` the guard scans every file in the tree, not just new ones. Excludes `packages/*/vendor/**` (3.1M `roblox-openapi.json` vendored deliberately in #26).
4. **`fix(global): run build before test in check and pre-push hooks`** — the `ocale` @example blocks import from `@bedrock/ocale` so readers see a realistic public usage. Under vitest this is a self-referential import and vite-plus doesn't honor the `source` condition on the self-ref, so it only resolves once `dist/` exists. Reordering `build` before `test` in both hooks fixes this. `pre-commit` is unchanged (build there is gated on agent mode).

## Test plan

- [x] CI `Build & Test` job now shows `check-merge-conflict`, `detect-private-key`, `check-added-large-files`, `lint`, `typecheck`, `gen-example-tests`, `build`, `test` blocks (not just `gen-example-tests`).
- [x] All globbed steps pass.
- [x] Any further issues surfaced by genuine CI runs filed as separate issues per the scope in #51 (none remaining after the fixes above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)