### PR TITLE
docs(global): add bedrock cli slice 1 architecture adrs

### DIFF
--- a/docs/adr/017-product-framing-programmatic-iac-with-cli.md
+++ b/docs/adr/017-product-framing-programmatic-iac-with-cli.md
@@ -1,0 +1,267 @@
+# ADR-017: Product Framing -- Programmatic IaC with CLI Convenience (Level 2 Hybrid)
+
+**Date:** 2026-04-17  **Status:** Accepted
+
+Decision Makers: Maintainer  
+Tags: product, api-design, public-api, cli, plugin-system, semver
+
+## Context
+
+Bedrock started as a CLI tool. Its early ADRs (002, 011) reflect that framing:
+FCIS + Ports was justified on "CLI tool, not business domain" grounds; the
+hexagonal architecture was rejected as ceremony not warranted for a CLI. That
+framing is now incomplete.
+
+Bedrock serves two distinct audiences:
+
+- **Standard Luau developers** -- the majority of the Roblox developer
+  population. They write game code in Luau. They configure tooling via YAML,
+  JSON, or minimal JS/TS data files. The CLI + multi-format config (c12) is
+  their primary surface. This is why multi-format config exists: it is full,
+  deliberate support for users who have no interest in TypeScript embedding.
+- **roblox-ts developers** -- a minority who write game code in TypeScript.
+  They have everything the Luau audience has, plus the ability to import Bedrock
+  as a TypeScript library and call its functions directly from scripts, tests,
+  and CI pipelines.
+
+The stakes differ by audience. The Luau audience's deployment experience is
+already well-served by CLI + multi-format config; nothing described here
+changes that. The roblox-ts audience's experience is what's at stake: when a
+roblox-ts developer needs to automate deployment -- scheduled price changes,
+post-deploy Luau constant generation, drift assertions in CI -- the natural
+move is to import Bedrock as a library, not to shell out to its CLI. If that
+programmatic surface is an afterthought (undocumented internals, no stability
+commitment, no examples), the roblox-ts use cases are effectively locked out.
+
+The planned plugin system (ROADMAP v0.3+) makes the stakes concrete: plugins
+will implement `ResourceDriver<K>` and call core functions like `diff` and
+`applyOps`. That plugin contract *is* a public API. Treating it as an escape
+hatch rather than a documented, stable product surface would mean shipping an
+extensibility story on an undocumented, unstable foundation.
+
+Three product framings were available:
+
+- **Level 1** (CLI-first with escape hatch): `bedrock.config.ts` is a data file;
+  `bedrock deploy` is the entry point; programmatic use is an advanced escape
+  hatch, lightly documented if documented at all.
+- **Level 2** (programmatic-first with CLI convenience): Bedrock is a TypeScript
+  library. CLI commands are thin wrappers over the same public functions.
+  Programmatic use is equally documented, equally stable, and equally supported.
+- **Level 3** (constructor-registration, Pulumi/CDK style): `new GamePass(...)`
+  registers resources with an engine at construction time.
+
+## Decision
+
+Bedrock is a **programmatic TypeScript IaC library for Roblox. The CLI is a
+convenience wrapper over the same public API. User scripts that import Bedrock
+are a canonical way to use it, not a side door (Level 2).**
+
+Concretely:
+
+- Users may write a `deploy.ts` that calls `deploy()`, `diff()`, or `applyOps()`
+  directly and run it with `bun run deploy.ts`. This is not an escape hatch --
+  it is the canonical programmatic surface.
+- `bedrock deploy` loads a default-exported config and calls the same underlying
+  functions. CLI and programmatic paths are identical below the entry point.
+- The following surface is the **public API**: `diff`, `applyOps`, `buildDesired`,
+  `ResourceDriver<K>`, `defineConfig`, `deploy`, all associated type contracts,
+  and any symbol exported from `src/index.ts`.
+- The public API is semver-versioned. During 0.x, breaking changes are permitted
+  in minor bumps (0.1 -> 0.2) per standard pre-1.0 semver convention. Strict
+  breaking-change-in-major-only semantics engage at 1.0.
+- Every public export carries a JSDoc `@example` block per ADR-005. No public
+  symbol ships without a tested, rendered example.
+- The TypeDoc docs site (ADR-004) publishes both CLI and programmatic API
+  documentation at v0.1 launch. There is no "API coming soon" placeholder.
+- `ResourceDriver<K>` is a plugin contract, not an internal type. Third-party
+  authors will implement it. Its stability follows the same semver treatment as
+  the rest of the public API.
+
+### Motivating use cases
+
+These use cases drove Level 2 from the roblox-ts audience. The Luau audience
+is served equivalently by multi-format config (YAML/JSON) + CLI; Level 2 does
+not change their experience.
+
+1. **Scheduled price mutations.** A cron-triggered script bypasses the `bedrock`
+   CLI entirely and runs as a plain TypeScript program (e.g.
+   `bun run scripts/black-friday.ts`). The script imports Bedrock's functions
+   directly -- `loadConfig`, `deploy` -- and orchestrates the full
+   mutate-then-deploy flow in user code: load the config, override game-pass
+   prices to 30% off, call `deploy()`. A second cron later restores normal
+   prices. This is meaningfully different from `bedrock deploy`, which loads the
+   default config and deploys it unmodified. The programmatic API makes the
+   "mutate then deploy" flow possible in a single process; the CLI alone cannot
+   express it.
+2. **Post-deploy output plugins.** After a deploy completes, a user-authored
+   plugin writes Luau source files (e.g. `Passes.luau` with game-pass asset IDs
+   as constants) for use in game code. The plugin receives the deployed state as
+   data and writes whatever output the studio needs. Different studios have
+   different output shapes; the plugin system exists to support this without
+   Bedrock prescribing the format.
+3. **Drift assertions in CI.** A test file imports `diff` from Bedrock and calls
+   it against live Roblox state. If the result is non-empty, the test fails --
+   config and live state have diverged without a deploy. This gives studios an
+   automated early-warning signal that runs in CI without any CLI invocation.
+4. **Multi-game monorepo orchestration.** A studio with multiple Roblox
+   experiences writes a single script that iterates over per-game configs and
+   calls `deploy()` for each. Sequencing, error handling, and reporting are
+   expressed in TypeScript; the script does not shell out to `bedrock deploy`
+   in a loop.
+
+## Consequences
+
+### Positive
+
+- Plugin system (ROADMAP v0.3) has a stable, documented foundation to build on.
+  `ResourceDriver<K>` is ready to be implemented by third parties before the
+  plugin runtime ships.
+- Programmatic use cases (scheduled scripts, drift tests, orchestration) are
+  supported without workarounds.
+- TypeScript users get full type inference and IDE support for deployment logic.
+  `defineConfig` returns a typed value; `diff` and `applyOps` have documented
+  signatures.
+- The CLI and programmatic surfaces cannot diverge: they share the same
+  underlying functions.
+- ADR-005's `@example` requirement applies to the entire public API, so the docs
+  site renders complete, tested usage samples at launch.
+
+### Negative
+
+- Public API = product. Every exported symbol in `src/index.ts` is a commitment.
+  Thoughtless exports accumulate semver debt. Contributors must apply the same
+  discipline to API surface that ADR-003 requires for tests.
+- Function signatures must be ergonomic for embedding: named parameter objects,
+  sensible defaults, TS inference. This is additional design work on top of
+  making functions correct.
+- Integration tests are needed to verify the public API works end-to-end, not
+  just that internal units behave correctly. Test surface grows.
+- Semver creates a communication obligation: breaking changes to the public API
+  during 0.x require a CHANGELOG entry with clear labeling. No deprecation
+  notice period is required during 0.x; no release cadence is mandated. Both
+  are deferred to a future 1.0 stability policy ADR.
+- The Open Cloud constraint (ADR-007) applies to Bedrock's own adapters.
+  Third-party plugin authors are responsible for their own API choices within
+  their `ResourceDriver<K>` implementations.
+
+### Neutral
+
+- Package structure (single `bedrock` package vs. split `@bedrock/core` +
+  `@bedrock/cli`) is not resolved by this ADR. Splitting is deferred until
+  concrete demand arises. A future ADR will define the split criteria if needed.
+- ADR-002's FCIS + Ports architecture is unaffected by this decision. Level 2
+  is a product framing, not an architecture-pattern change. ADR-018 (planned)
+  will refine ADR-002 to reflect the primary/driven port distinction that Level
+  2 makes explicit.
+
+### Revisit criteria
+
+This ADR should be reopened if any of the following occur:
+
+- **Package split demand emerges.** Concrete pressure -- bundle-size complaints,
+  versioning divergence between core and CLI, or an external embedder explicitly
+  requesting a standalone `@bedrock/core` -- upgrades the package-structure
+  question from "neutral/deferred" to an active decision.
+- **1.0 planning begins.** The semver obligations deferred here (deprecation
+  notice period, release cadence) must be decided before strict
+  breaking-change-in-major semantics engage. A 1.0 stability policy ADR should
+  supersede the deferred items in this one.
+- **Audience ratio shifts substantially.** If roblox-ts adoption grows to the
+  point where it is no longer a clear minority of Bedrock users, the two-audience
+  framing and the "Level 2 does not change the Luau audience's experience"
+  language may need rebalancing.
+- **Level 3 ergonomic complaints are resolved by new patterns.** If CDK/Pulumi
+  successors demonstrably solve implicit ordering, constructor side-effects, and
+  difficult unit testing -- the four objections listed under Level 3 rejection --
+  the constructor-registration alternative should be re-evaluated.
+
+## Alternatives Considered
+
+### Level 1: CLI-first with programmatic escape hatch
+
+`bedrock.config.ts` is a data file. `bedrock deploy` is the primary entry point.
+Programmatic access exists but is undocumented, unstable, and framed as
+advanced use.
+
+**Rejected.** Level 1 leaves the plugin system without a supported foundation:
+plugins implement `ResourceDriver<K>` and call core functions like `diff` and
+`applyOps`, which Level 1 explicitly treats as undocumented, unstable, advanced
+use. The plugin system's stability becomes an accidental consequence of the
+escape hatch's quality rather than a designed commitment. Beyond plugins, the
+motivating use cases above are mainstream roblox-ts studio workflows -- not edge
+cases. Level 1 makes them harder, not easier, while providing no concrete
+benefit.
+
+### Level 3: Constructor-registration (Pulumi / CDK style)
+
+`new GamePass({ name: "VIP" })` registers the resource with a global engine at
+construction time. `bedrock.deploy()` flushes the registry.
+
+**Rejected** for four specific reasons:
+
+1. **Machinery cost disproportionate to scope.** v1.0 has six resource types.
+   The registration runtime, lifecycle hooks, and dependency graph that
+   constructor-based tools require are significant engineering investment for
+   a small fixed resource set.
+2. **Mantle migration becomes hard.** YAML config maps naturally to a
+   `defineConfig` data structure. It does not map naturally to constructor calls.
+   Maintaining the migration path (CLAUDE.md constraint) requires config-as-data.
+3. **Known ergonomic complaints.** AWS CDK Level-3 constructs carry
+   widely-documented friction: implicit ordering, constructor side-effects,
+   difficult unit testing, surprises when constructs are composed. Bedrock should
+   not import these problems.
+4. **Config-as-data matches both audiences.** Luau developers are already
+   familiar with declarative config files (Mantle YAML, Rojo `project.json`);
+   a `defineConfig` data structure is a natural continuation of that idiom.
+   roblox-ts developers are familiar with typed object literals and Vite-style
+   `defineConfig` helpers; the data-file pattern is equally comfortable for
+   them. Constructor-registration is a larger conceptual step for both groups
+   and benefits neither.
+
+## Implementation Notes
+
+- API surface is gated at `src/index.ts`. Symbols not exported there are
+  internal and carry no stability commitment.
+- `defineConfig` should return its argument typed, so TypeScript infers the
+  config shape without requiring explicit type annotations at call sites.
+- `ResourceDriver<K>` documentation must include a full `@example` implementing
+  a minimal driver, so plugin authors have a concrete starting point.
+- The docs site must present CLI-with-multi-format-config and programmatic-TS
+  as peer entry points, not a hierarchy. Luau users land on CLI + YAML/JSON
+  config; roblox-ts users land on either surface. Neither path is buried or
+  framed as advanced.
+- ADR-018 (planned) refines ADR-002 to name the primary port (CLI entry,
+  programmatic entry) vs. driven ports (state backend, Open Cloud HTTP). That
+  distinction follows from Level 2 but is a separate architectural concern.
+
+## Related Decisions
+
+- **ADR-002**: Monorepo with FCIS + Ports Architecture -- unaffected by this
+  ADR. Level 2 is a product framing; the internal architecture remains FCIS +
+  Ports. Planned ADR-018 will refine ADR-002 on primary/driven port distinction.
+- **ADR-004**: Documentation Site -- the docs site must publish both CLI and
+  programmatic API documentation at v0.1. ADR-004's v0.1 deliverable scope is
+  extended by this decision.
+- **ADR-005**: Tested JSDoc Examples -- `@example` blocks are required on every
+  public export, not just selected ones. ADR-005's scope is broadened to the
+  full `src/index.ts` surface by this decision.
+- **ADR-007**: Open Cloud APIs Only -- unaffected. The constraint applies to
+  Bedrock's own adapters. Third-party plugin authors are not bound by it.
+- **ADR-009**: Result Types Over Exceptions -- public API functions follow the
+  same `Promise<Result<T, E>>` convention established for `@bedrock/open-cloud`.
+- **ADR-011**: Simplified Architecture for Library Packages -- the five-criteria
+  opt-out check applies if a future `@bedrock/core` split is proposed. The CLI
+  package (which contains deployment logic) continues to fail criteria 2, 3, 4,
+  and 5 and must use FCIS + Ports.
+
+## References
+
+- [Mantle](https://github.com/blake-mealey/mantle) -- predecessor; migration
+  path is a CLAUDE.md hard constraint
+- [Pulumi](https://www.pulumi.com/) -- Level 3 reference; ergonomic complaints
+  informed the rejection
+- [AWS CDK Level-3 Constructs](https://docs.aws.amazon.com/cdk/v2/guide/constructs.html) --
+  Level 3 reference; documented friction informed the rejection
+- ROADMAP.md -- plugin system (v0.3+) and state backends (S3, R2) that depend
+  on the public API surface established here
+- ADR-004, ADR-005 -- documentation and example obligations extended by this ADR

--- a/docs/adr/018-fcis-ports-with-primary-driven-distinction.md
+++ b/docs/adr/018-fcis-ports-with-primary-driven-distinction.md
@@ -1,0 +1,296 @@
+# ADR-018: Architecture Refinement -- FCIS + Ports with Explicit Primary/Driven Port Distinction
+
+**Date:** 2026-04-17  **Status:** Accepted
+
+Refines: ADR-002 (FCIS + Ports architecture)
+
+Decision Makers: Maintainer  
+Tags: architecture, fcis, ports, hexagonal, plugin-system, public-api
+
+## Context
+
+ADR-002 established Functional Core, Imperative Shell (FCIS) + Ports as
+Bedrock's architecture. It rejected full hexagonal architecture on the grounds
+that "Bedrock is a CLI tool, not a business domain application." That
+justification is no longer accurate.
+
+ADR-017 established that Bedrock is a programmatic TypeScript IaC library whose
+CLI is one of several entry points -- not the sole entry point. There are now
+multiple ways to invoke Bedrock (CLI, programmatic API, future plugins) and
+multiple things Bedrock reaches out to (Open Cloud via `@bedrock/open-cloud`,
+future state backends, future config sources). This is precisely the topology
+that ports and adapters were designed for. The port structure is genuinely
+needed -- not just for testability, but because the boundaries are real and will
+be crossed by third parties.
+
+What remains unchanged: the rejection of full hexagonal's OOP ceremony. ADR-002
+rejected that ceremony for the wrong stated reason ("we're just a CLI"). The
+correct reason is that Bedrock's domain is naturally functional: its core logic
+is pure data transformations, not stateful business objects. Application-service
+classes, domain models with behavior, and DI containers add ceremony without
+payoff in a codebase where the core is already pure and testable without mocks.
+
+ADR-018 refines ADR-002 by:
+
+1. Replacing the outdated justification with the accurate one.
+2. Making the primary/driven port distinction explicit in vocabulary, folder
+   layout, and documentation.
+3. Formally acknowledging the `ResourceDriver<K>` terminology choice and its
+   deliberate departure from strict hexagonal naming.
+
+ADR-002's structural decision -- FCIS + Ports, not full hexagonal -- stands.
+
+## Vocabulary
+
+These terms are used throughout this ADR and in contributor-facing materials
+(code comments, CLAUDE.md). They are **not** exposed in user-facing docs (the
+TypeDoc API reference, plugin author tutorials): those use plain language.
+
+| Term | Meaning |
+| ---- | ------- |
+| **Primary port** | An interface the core exposes for external actors to invoke. Primary adapters (CLI, programmatic API, future plugins) call through this interface to drive Bedrock's behavior. The core defines the port; the adapter calls it. Current examples: the CLI entrypoint (`packages/cli/src/bin/`), the programmatic public API (`src/index.ts`). Primary ports correspond to "driver ports" in strict hexagonal terminology. |
+| **Driven port** | An interface through which Bedrock reaches out to an external system. Driven adapters implement these. Current example: `ResourceDriver<K>` (Open Cloud resources via `@bedrock/open-cloud`). Future examples: `StatePort` (Gist / S3 / R2), `ConfigPort` (c12). Driven ports correspond to "secondary ports" in strict hexagonal terminology. |
+| **`ResourceDriver<K>`** | Bedrock's generic driven-port interface, indexed by resource kind `K`. Despite containing the word "driver," this is a **driven** (secondary) port -- the opposite of a hexagonal "driver port," which means primary. The name follows the Terraform / Mantle IaC community convention where "driver" means "the component that talks to a specific resource API." This deliberate mismatch with hexagonal vocabulary is explained in Implementation Notes. |
+
+## Decision
+
+Bedrock uses **FCIS + Ports with an explicit primary/driven distinction**.
+
+The structural choice from ADR-002 is preserved: FCIS + Ports, not full
+hexagonal. The rationale is updated:
+
+- **Full hexagonal is rejected because of OOP ceremony, not because we are a
+  CLI.** Full hexagonal prescribes application-service classes, domain models
+  with behavior, and DI container wiring. Bedrock's domain is a set of pure data
+  transformations (diff, desired-state construction, operation planning). There
+  are no stateful domain objects, no aggregates, no repositories in the DDD
+  sense. Imposing OOP ceremony on a naturally functional domain adds indirection
+  without improving testability or flexibility.
+
+- **FCIS + Ports is chosen because the boundaries are real.** Multiple external
+  actors invoke Bedrock (CLI, programmatic API, plugins). Multiple external
+  systems are reached from Bedrock (resource APIs, state storage, config
+  sources). The port-and-adapter structure gives these boundaries names, makes
+  them testable, and lets third parties implement driven ports (e.g. custom
+  `ResourceDriver<K>` implementations) without depending on Bedrock internals.
+
+Concretely, the folder layout under `packages/cli/src/` is:
+
+```text
+packages/cli/src/
+├── index.ts          # Primary API surface (programmatic entry point)
+├── types/            # Branded primitives and shared type definitions
+├── core/             # Pure domain: types, diff, desired-state types and normalization
+├── shell/            # Use-case orchestration: applyOps, buildDesired, deploy
+├── ports/            # Driven port interfaces: resource-driver.ts, future
+│                     #   state-port.ts, config-port.ts
+└── adapters/         # Driven adapter implementations: game-pass-driver.ts,
+                      #   future gist-state-adapter.ts, c12-config-adapter.ts
+
+packages/cli/src/bin/ # CLI primary adapter (slice 2; invokes shell functions)
+```
+
+The `shell/` name is kept from ADR-002 for continuity. "Shell" already connotes
+"I/O orchestration" in the FCIS vocabulary; renaming to `use-cases/` or
+`services/` would add hexagonal vocabulary without adding clarity.
+
+Primary adapters other than the CLI (programmatic `index.ts`, future plugin
+entrypoints) are not co-located in a `primary-adapters/` folder -- the
+programmatic API is the barrel export itself, and plugins are third-party. There
+is no folder to create.
+
+## Consequences
+
+### Positive
+
+- Contributor mental model is accurate. "We use ports and adapters because we
+  have real, multiple-implementation boundaries" is a better explanation than
+  "we use it for testability but we're just a CLI."
+- Third-party plugin authors have a named contract (`ResourceDriver<K>`) with
+  stable semantics. The driven-port vocabulary in code comments and CLAUDE.md
+  gives contributors a precise frame for where new adapters belong.
+- The architecture is forward-compatible with the plugin system (ADR-017 ROADMAP
+  v0.3+) and with new state backends (S3, R2) without any structural change.
+- Full hexagonal's ceremony is explicitly off the table. Contributors arriving
+  from enterprise TypeScript backgrounds cannot introduce application-service
+  classes or DI containers and cite "architecture" as justification.
+
+### Negative
+
+- Two vocabulary layers exist: internal primary/driven terminology vs. plain
+  user-facing language. Contributors must learn when to use which register.
+  Mitigated by the glossary table in this ADR and a note in CLAUDE.md.
+- `ResourceDriver<K>` is a permanent terminology inconsistency: "driver" in our
+  codebase means the opposite of "driver port" in strict hexagonal. Readers who
+  know hexagonal deeply will notice. Mitigated by the glossary and Implementation
+  Notes, but the inconsistency cannot be fully eliminated without renaming.
+
+### Neutral
+
+- ADR-002's FCIS folder vocabulary (`core/`, `shell/`, `ports/`, `adapters/`)
+  is preserved. No migration of existing code is required.
+- ADR-011's simplified-architecture opt-out does not apply to the CLI package.
+  That verdict is unchanged (see Related Decisions).
+
+### Revisit criteria
+
+This ADR should be reopened if any of the following occur:
+
+- **A genuine OOP-ceremony need emerges.** If a future feature genuinely
+  requires an application-services layer, domain models with behavior, or a DI
+  container -- and the functional alternative is materially worse, not just
+  unfamiliar -- the anti-pattern list should be revisited before the feature is
+  implemented.
+- **The primary/driven vocabulary proves unusable in practice.** If contributors
+  consistently confuse primary vs. driven ports despite the glossary and
+  CLAUDE.md note, simpler terminology (e.g. "entry ports" and "exit ports")
+  should be considered.
+- **The `ResourceDriver<K>` terminology clash becomes actively misleading.**
+  Today the mismatch is mildly paradoxical; a reader who knows hexagonal will
+  notice but quickly understand. If a shift in industry vocabulary makes the
+  clash genuinely confusing to the majority of contributors, the rename cost
+  should be re-evaluated.
+
+## Alternatives Considered
+
+### Full hexagonal architecture
+
+Application-services layer as classes, domain models with behavior (aggregates,
+value objects), DI container for dependency injection.
+
+**Rejected** because Bedrock's domain is a set of pure data transformations.
+There are no stateful domain objects that benefit from encapsulation, no
+aggregates with lifecycle, no repositories managing identity. FCIS achieves the
+same testability and flexibility (pure core, swappable adapters) without the
+class hierarchy. The cost -- learning hexagonal's OOP vocabulary -- is not
+justified when the domain does not call for it.
+
+### Rename `ResourceDriver<K>` to `ResourcePort<K>` for hexagonal consistency
+
+Align our driven-port naming with strict hexagonal vocabulary. "Port" for the
+interface, "adapter" for the implementation.
+
+**Rejected.** "Driver" is the established convention in the Terraform, Pulumi,
+and Mantle ecosystems for the component that talks to a specific resource API.
+roblox-ts developers and IaC practitioners already understand this concept under
+that name. Renaming to `ResourcePort<K>` gains hexagonal consistency at the cost
+of IaC-community familiarity. The mismatch is acknowledged in the glossary and
+Implementation Notes; it does not impair contributors once they read the
+definition.
+
+### Introduce a `primary-adapters/` folder alongside `ports/` and `adapters/`
+
+Make the primary/driven distinction visible in the folder structure by housing
+primary adapters (CLI, programmatic API) in an explicit directory.
+
+**Rejected.** The programmatic API is the `index.ts` barrel export -- there is
+no adapter file to place. The CLI adapter lives in `bin/` because it is an
+executable entry point, not because it is an "adapter" in the same sense as a
+driven adapter. A `primary-adapters/` folder would either be empty or contain
+only a single file (`bin/`), making it ceremony rather than structure. The
+primary/driven distinction is documented in vocabulary, not enforced by folder
+layout for primary adapters.
+
+## Implementation Notes
+
+### Functional domain -- the positive statement and anti-pattern list
+
+The domain is naturally functional: pure data structs, pure functions, no
+behavior on types. A `GamePassDesiredState` is a plain data object; `diff` is a
+function from two data objects to a list of operations; `applyOps` is a function
+from operations and a driver registry to a result.
+
+The following patterns are explicitly out of scope for the CLI package:
+
+- **No DI containers.** Dependencies are injected as function arguments or
+  constructor parameters on plain objects. No IoC container, no `@Injectable`,
+  no service locator.
+- **No application-service classes.** Shell functions (`applyOps`, `deploy`,
+  `buildDesired`) are module-level functions, not methods on a class instance.
+- **No domain models with methods.** Types in `core/` and `types/` are plain
+  data structs (TypeScript interfaces and type aliases). Behavior lives in
+  functions, not on types.
+- **No factory classes.** Object construction is done with plain object literals
+  or constructor functions. A factory function (lowercase, no `new`) is
+  acceptable; a `GamePassFactory` class is not.
+
+### `ResourceDriver<K>` and the hexagonal terminology clash
+
+In strict hexagonal architecture, a "driver port" is a PRIMARY port -- the
+interface through which an external actor drives the application. Our
+`ResourceDriver<K>` is the opposite: it is a DRIVEN (secondary) port through
+which Bedrock reaches out to an external resource API.
+
+The name was chosen deliberately, for two reasons:
+
+1. **IaC community convention.** In Terraform's provider model, Pulumi's
+   resource providers, and Mantle's predecessor architecture, the component that
+   talks to a specific cloud resource API is called a "driver." Roblox-ts
+   developers and IaC practitioners arriving at Bedrock's plugin API will
+   recognise this pattern immediately under the familiar name.
+
+2. **No functional gain from renaming.** `ResourcePort<K>` would be hexagonally
+   correct but would cost contributor goodwill on a concept the IaC community
+   already understands. The glossary table in this ADR names the inconsistency
+   explicitly; any contributor who is confused has a single place to look.
+
+The inconsistency is accepted as a deliberate pragmatic choice. It does not
+affect how the interface is implemented or tested; it affects only the label.
+Code comments on `ResourceDriver<K>` should note: "driven (secondary) port in
+hexagonal terms; named 'driver' per IaC community convention -- see ADR-018."
+
+### `DriverRegistry` pattern
+
+The `DriverRegistry` is a plain object (or `Map`) indexed by resource kind `K`,
+mapping each kind to its `ResourceDriver<K>` implementation. `applyOps` receives
+a registry and dispatches each operation to the appropriate driver:
+
+```ts
+// ports/resource-driver.ts
+export interface ResourceDriver<K extends ResourceKind> {
+	create(
+		desired: ResourceDesiredState<K>,
+	): Promise<Result<ResourceCurrentState<K>, OpenCloudError>>;
+	// update and delete are deferred. update ships when @bedrock/ocale's
+	// resource clients gain update capability; delete ships when a
+	// delete-capable resource lands. Slice 1 has create only; applyOps
+	// returns err(unsupported) if it encounters an Update op.
+}
+
+// shell/apply-ops.ts (simplified)
+export async function applyOps(
+	ops: ReadonlyArray<Operation>,
+	registry: DriverRegistry,
+): Promise<Result<void, OpenCloudError>> {
+	/* ... */
+}
+```
+
+This pattern is type-safe (TypeScript infers `K` from the registry key), easily
+extensible (add a new key), and third-party-friendly (implement the interface,
+pass it in). It does not require a DI container.
+
+## Related Decisions
+
+- **ADR-002**: Monorepo with FCIS + Ports Architecture -- this ADR refines
+  ADR-002. The structural decision (FCIS + Ports, not full hexagonal) is
+  preserved. The rationale is updated: we reject hexagonal ceremony because our
+  domain is naturally functional, not because we are "just a CLI." A header line
+  is added to ADR-002 noting this refinement.
+- **ADR-011**: Simplified Architecture for Library Packages -- ADR-018
+  strengthens but does not change ADR-011's verdict for the CLI package. The CLI
+  fails ADR-011's criteria 2, 3, 4, and 5 because it has a pure core separable
+  from I/O (criterion 4), multiple real swappable driven adapters (criteria 3
+  and 5), and substantive deployment logic beyond pass-through (criterion 2).
+  ADR-011 itself is untouched.
+- **ADR-017**: Product Framing -- the product decision that made ADR-002's "CLI
+  tool" justification incomplete. ADR-018 exists because ADR-017 established
+  multiple primary ports; without that, the primary/driven distinction would have
+  been a formalism with only one primary adapter.
+- **ADR-009**: Result Types Over Exceptions -- driven port interfaces return
+  `Promise<Result<T, BedrockError>>` per ADR-009. This applies to
+  `ResourceDriver<K>` and all future driven ports.
+- **ADR-003**: Testing Strategy -- the refined architecture preserves ADR-003's
+  zero-mock testing story. The pure core is tested without mocks; driven adapters
+  are tested against fakes injected at the port boundary; shell functions are
+  integration-tested with fake adapters.

--- a/docs/adr/019-state-data-model-and-diff-algebra.md
+++ b/docs/adr/019-state-data-model-and-diff-algebra.md
@@ -1,0 +1,493 @@
+# ADR-019: State Data Model and Diff Algebra -- Mantle Parity
+
+**Date:** 2026-04-17  **Status:** Accepted
+
+Decision Makers: Maintainer  
+Tags: state, data-model, diff, types, mantle, migration, core
+
+## Context
+
+ADR-017 established that Bedrock's core types are a public API surface. ADR-018
+placed them in `packages/cli/src/core/` as pure data structs with no I/O. This
+ADR specifies what those types are: the data contracts that slice 1 freezes and
+that all future slices, plugin authors, and programmatic users depend on.
+
+Bedrock's primary migration constraint (CLAUDE.md) is maintaining a path from
+Mantle. Mantle's data model therefore anchors the design:
+
+- Mantle uses serde's untagged-enum pattern for its `RobloxInputs` variants --
+  the discriminator is implicit in the nested object key (e.g.
+  `inputs: { pass: {...} }` vs `inputs: { experience: {...} }`). We use an
+  explicit `kind` field at the top level of each resource, following the
+  TypeScript discriminated-union convention. The two representations carry the
+  same information; our mapping is more idiomatic for TS.
+- Mantle persists `{ inputs, outputs }` per resource. We follow the same
+  structure: desired-state inputs are the authoritative description; outputs are
+  Roblox-returned identifiers.
+- Mantle serialises per-environment state in a single combined YAML file. We
+  depart from this in format (JSON) and layout (one file per environment) while
+  preserving the semantic content.
+- Mantle hashes its entire serialised inputs blob for change detection. We reject
+  this: we use field-by-field comparison where file-backed fields (e.g.
+  `iconFileHash`) carry an explicit pre-computed hash. This is simpler to
+  reason about, avoids serialisation-order sensitivity, and allows future
+  partial-update optimisation.
+
+Three design tensions shaped the specific choices:
+
+1. **Mantle parity vs. TypeScript idioms.** Mantle's Rust code uses `snake_case`
+   with `serde(rename_all = "camelCase")`. We use `camelCase` natively, which
+   matches Mantle's serialised output and eases migration comparisons.
+
+2. **Flat vs. nested type shapes.** A `spec`-nested shape
+   (`{ kind, key, spec: { name, price } }`) is common in Kubernetes-style IaC.
+   We use a flat shape (`{ kind, key, name, price }`) because it reduces
+   accessor depth, matches Mantle's flat resource representation, and is simpler
+   to narrow in TypeScript discriminated unions.
+
+3. **Pure core vs. I/O in types.** `buildDesired` must hash icon files (I/O).
+   The hash result is stored as `iconFileHash` on `ResourceDesiredState`, keeping
+   `diff` pure. The hashing step lives in `shell/` (ADR-018); the hash field
+   lives in `core/`.
+
+## Decision
+
+### Core types
+
+The following types are the slice-1 data contracts. They live in
+`packages/cli/src/core/` and are exported from `packages/cli/src/index.ts` as
+public API (ADR-017).
+
+```ts
+import type { Simplify, Tagged } from "type-fest";
+
+// ── Branded primitives ────────────────────────────────────────────────────────
+
+/** User-supplied identifier for a resource within a config (e.g. "vip-pass"). */
+export type ResourceKey = Tagged<string, "ResourceKey">;
+
+/** Roblox-assigned numeric asset ID, represented as a string to avoid int64 loss. */
+export type RobloxAssetId = Tagged<string, "RobloxAssetId">;
+
+/** Lowercase hex-encoded SHA-256 digest of a local file. */
+export type Sha256Hex = Tagged<string, "Sha256Hex">;
+
+// ── Desired state ─────────────────────────────────────────────────────────────
+
+/** Desired state for a game pass, as declared in user config. */
+export interface GamePassDesiredState {
+	/** User-supplied key; stable across deploys; used to correlate desired ↔ current. */
+	readonly key: ResourceKey;
+	readonly name: string;
+	readonly description: string;
+	/** SHA-256 hex digest of the icon file, computed by `buildDesired` in shell. */
+	readonly iconFileHash: Sha256Hex;
+	/** Path to the icon file on disk, relative to the config file. */
+	readonly iconFilePath: string;
+	readonly kind: "gamePass";
+	/**
+	 * Robux price. `null` means off-sale (mirrors Mantle's `Option<u32>`).
+	 * Omit to leave pricing unchanged on update (not valid for create).
+	 */
+	readonly price: null | number;
+}
+
+/**
+ * Discriminated union of all desired-state types.
+ * Extend by adding new members to this union — no other type changes needed.
+ */
+export type ResourceDesiredState = GamePassDesiredState; // | BadgeDesiredState | ...
+
+// ── Outputs ───────────────────────────────────────────────────────────────────
+
+/** Roblox-returned identifiers for a game pass after create or update. */
+export interface GamePassOutputs {
+	readonly assetId: RobloxAssetId;
+	readonly iconAssetId: RobloxAssetId;
+}
+
+// ── Current state ─────────────────────────────────────────────────────────────
+
+/** The string union of all resource kind discriminators. */
+export type ResourceKind = ResourceDesiredState["kind"];
+
+/**
+ * Per-kind output types. Add a new entry for each new resource kind.
+ * Implemented as a mapped interface so adding a `ResourceKind` variant without
+ * a matching entry here is a compile error.
+ */
+export interface ResourceOutputsByKind {
+	gamePass: GamePassOutputs;
+	// Adding a kind without an entry here is a compile error.
+}
+
+/**
+ * Resolved outputs for a specific resource kind `K`.
+ * @template K The resource kind discriminator.
+ */
+export type ResourceOutputs<K extends ResourceKind> = ResourceOutputsByKind[K];
+
+/**
+ * Current (live) state for a resource kind `K`.
+ * Composed as: the matching desired-state shape plus a nested `outputs` object.
+ * The `outputs` sub-object is kept nested (not flattened) to mirror Mantle's
+ * structure and produce clean migration copy.
+ * @template K The resource kind discriminator.
+ */
+export type ResourceCurrentState<K extends ResourceKind = ResourceKind> = Simplify<
+	Extract<ResourceDesiredState, { kind: K }> & { readonly outputs: ResourceOutputs<K> }
+>;
+
+// ── Operations ────────────────────────────────────────────────────────────────
+
+export interface CreateOperation extends BaseOperation {
+	readonly desired: ResourceDesiredState;
+	readonly type: "create";
+}
+
+export interface UpdateOperation extends BaseOperation {
+	readonly current: ResourceCurrentState;
+	readonly desired: ResourceDesiredState;
+	readonly type: "update";
+}
+
+export interface NoopOperation extends BaseOperation {
+	readonly current: ResourceCurrentState;
+	readonly type: "noop";
+}
+
+/**
+ * Discriminated union of all operation types.
+ * A `delete` variant is intentionally absent from slice 1 — see Decision notes.
+ */
+export type Operation = CreateOperation | NoopOperation | UpdateOperation;
+
+interface BaseOperation {
+	/** Resource key; hoisted to op-level for uniform access across all op types. */
+	readonly key: ResourceKey;
+}
+```
+
+### `diff` function
+
+`diff` is a pure, synchronous function in `core/`. It returns a plain array --
+no `Result` wrapper because there is no I/O and no trust boundary.
+
+```ts
+/**
+ * Computes the operations required to reconcile `current` state with `desired`
+ * state. Pure and synchronous: no I/O, no side effects.
+ *
+ * - Each entry in `desired` is matched to `current` by `key`.
+ * - A key present in `desired` but absent in `current` produces a `create` op.
+ * - A key present in both produces an `update` op if any field differs, or a
+ *   `noop` op if all fields match.
+ * - Keys present in `current` but absent in `desired` are NOT emitted as ops
+ *   in slice 1 (delete is deferred; see Decision notes below).
+ * @param desired - The declared desired state from user config.
+ * @param current - The last-known live state from the state file.
+ */
+export function diff(
+	desired: ReadonlyArray<ResourceDesiredState>,
+	current: ReadonlyArray<ResourceCurrentState>,
+): ReadonlyArray<Operation> {
+	/* ... */
+}
+```
+
+### Delete deferral
+
+A `delete` operation variant and "orphan" detection are **explicitly deferred**
+from slice 1. Resources present in `current` state but absent from `desired`
+config are silently ignored by `diff` -- they are not emitted as any operation
+type. Users who remove a resource from config must delete it manually via the
+Roblox dashboard until a future slice ships the `delete` variant.
+
+This is a deliberate product choice, not an oversight. The `Operation` union's
+absence of a `delete` variant documents the intent to any future contributor.
+
+### State file format
+
+Bedrock writes one JSON state file per environment. The file is named
+`state.<environment>.json` (exact storage path is determined by the `StatePort`
+adapter -- e.g. a Gist adapter stores it as a Gist file; a local adapter stores
+it under `.bedrock/`).
+
+**v1 file shape:**
+
+```json
+{
+	"$bedrock": { "version": 1 },
+	"environment": "production",
+	"resources": [
+		{
+			"kind": "gamePass",
+			"key": "vip-pass",
+			"name": "VIP Pass",
+			"description": "Grants VIP perks.",
+			"price": 500,
+			"iconFilePath": "assets/vip-icon.png",
+			"iconFileHash": "a3f2...e1b0",
+			"outputs": {
+				"assetId": "9876543210",
+				"iconAssetId": "1122334455"
+			}
+		}
+	]
+}
+```
+
+Each entry in `resources` is a `ResourceCurrentState` serialised to JSON.
+`camelCase` is used throughout, matching Mantle's serialised output for
+migration-friendly comparison.
+
+### `StatePort` contract
+
+`StatePort` is a driven port (ADR-018) whose `read()` and `write()` methods
+handle state file I/O. The `read()` return type handles two legitimate outcomes:
+
+`BedrockState` is the **in-memory** shape. The **on-disk** shape wraps it with
+a `$bedrock: { version: N }` envelope (shown in the JSON example above).
+Adapters flatten the envelope on read (extracting `version` from `$bedrock`) and
+re-wrap it on write. Nothing outside an adapter ever sees the raw `$bedrock` key.
+
+```ts
+import type { OpenCloudError, Result } from "@bedrock/open-cloud";
+
+export interface BedrockState {
+	readonly environment: string;
+	readonly resources: ReadonlyArray<ResourceCurrentState>;
+	readonly version: 1;
+}
+
+export interface StateError {
+	readonly file: string;
+	readonly kind: "stateError";
+	readonly reason: string;
+}
+
+export interface StatePort {
+	/**
+	 * Reads state for the given environment.
+	 * - Returns `Ok(null)` when no state file exists (legitimate first deploy).
+	 * - Returns `Err(StateError)` when a file exists but cannot be parsed
+	 *   (corrupt JSON, schema failure, unknown `$bedrock.version`).
+	 *   Never silently falls back to empty state.
+	 */
+	read(environment: string): Promise<Result<BedrockState | null, StateError>>;
+
+	/** Writes state for the given environment, overwriting any existing file. */
+	write(state: BedrockState): Promise<Result<void, StateError>>;
+}
+```
+
+Unknown `$bedrock.version` values must produce a `StateError` with a message
+that names the file, the declared version, and the range of supported versions.
+No silent parse. No best-effort handling.
+
+### Mantle migration notes
+
+The `bedrock migrate` command (a future slice) converts a Mantle state file:
+
+1. Reads `.mantle-state.yml` (Mantle's combined `environments:` YAML map).
+2. For each environment, re-computes file hashes from disk (Mantle's hashes are
+   serialisation-dependent and cannot be trusted directly).
+3. Writes one `state.<environment>.json` per environment in Bedrock's v1 format.
+
+The re-hash-on-migration strategy is flagged here as a known requirement but is
+not implemented in slice 1. The migration slice will formalise it.
+
+## Consequences
+
+### Positive
+
+- Type shapes are Mantle-compatible at the semantic level: `kind`, `key`,
+  `inputs`, `outputs` map directly to Mantle's resource fields. Migration tooling
+  has a clear target.
+- `diff` is pure and sync. It can be called from programmatic scripts, tests, and
+  the CLI without any async plumbing (ADR-017 use case: drift assertions).
+- `ResourceCurrentState<K>` is derived from `ResourceDesiredState` via
+  `Simplify<Extract<...> & { outputs }>`. Adding a new desired-state field
+  automatically propagates to current state; no parallel type maintenance.
+- JSON state format is simpler to parse than YAML, produces clean `git diff`
+  output, and requires no additional runtime dependency.
+- One file per environment means a staging deploy does not churn the production
+  state file. `git diff` and PR reviews are scoped to the affected environment.
+- `$bedrock: { version: 1 }` wrapper from day 1 eliminates the schema-migration
+  bootstrapping problem. A future breaking schema change bumps to `version: 2`
+  and can provide a migration path without a rip-and-replace.
+- Hard error on malformed state prevents silent data loss. A corrupt state file
+  that silently collapses to empty state would cause `applyOps` to re-create
+  every resource on Roblox -- potentially destructive.
+
+### Negative
+
+- Flat discriminated union grows linearly with resource types. With six v1.0
+  resource types the union is manageable; with dozens it may warrant a
+  registry-based approach. Revisit criteria below.
+- No `delete` variant in slice 1. Users who remove a resource from config must
+  delete it manually on the Roblox dashboard. Orphaned resources accumulate in
+  Roblox until a future slice ships the `delete` operation.
+- File hashes (`iconFileHash`) must be computed and stored explicitly. If a user
+  moves an icon file without changing its content, the hash stays the same but
+  `iconFilePath` changes -- causing a spurious update on the icon field. This is
+  the correct behaviour (the path changed), but it may surprise users who expect
+  content-addressable diffing.
+- `StatePort.read()` returning `null` for file-not-found requires callers to
+  handle the null case explicitly rather than treating missing state as an empty
+  resource list. This is correct (the distinction between "no file" and "empty
+  resources" may matter for future diagnostics) but adds a branch at every call
+  site.
+- Departing from Mantle's YAML format means the `bedrock migrate` conversion
+  step is required. Users cannot point Bedrock at an existing Mantle state file
+  and expect it to work without migration.
+
+### Neutral
+
+- `ResourceKey` is user-supplied and opaque to Roblox. It is distinct from
+  `RobloxAssetId`. This distinction must be documented clearly in user-facing
+  config docs to avoid confusion ("why does my `key: "vip-pass"` not match the
+  Roblox asset ID `9876543210`?").
+- `price: null` semantics (off-sale) match Mantle's `Option<u32>`. Users
+  migrating from Mantle will find this familiar; new users may find `null`
+  surprising compared to `isForSale: false`. This is a UX decision deferred to
+  the config/docs slice.
+
+### Revisit criteria
+
+This ADR should be reopened if any of the following occur:
+
+- **A second resource type is added.** The flat discriminated union and
+  per-kind output type pattern should be re-evaluated once there are two
+  real resource types. If the per-kind boilerplate is manageable, continue; if
+  it is growing into a maintenance burden, a codegen or registry-based approach
+  should be considered before the pattern solidifies further.
+- **The migration slice ships.** The re-hash-on-migration strategy described
+  here ("re-compute file hashes from disk") becomes concrete implementation.
+  If the strategy turns out to be impractical (e.g. icon files are no longer
+  on disk at migration time), the fallback needs a decision. ADR-019 should be
+  amended or a child ADR created at that point.
+- **The `delete` operation lands.** The `Operation` union gains a `delete`
+  variant and orphan-detection logic enters `diff`. The orphan-accumulation
+  consequence documented above is resolved. ADR-019's Decision section should
+  be updated to reflect the expanded union.
+- **`$bedrock.version` needs a bump.** Any breaking change to the state file
+  schema (adding a required field, renaming a key, changing a type) must
+  increment `version` and provide a documented migration path. The trigger
+  condition is: a v1 file read by a newer Bedrock would produce incorrect
+  behaviour if silently accepted. Non-breaking additions (optional fields) do
+  not require a version bump.
+
+## Alternatives Considered
+
+### YAML state format (Mantle parity)
+
+Write state files as YAML to match Mantle's `.mantle-state.yml` format, enabling
+direct file comparison during migration.
+
+**Rejected.** Migration is a one-time `bedrock migrate` conversion, not an
+ongoing parallel-write requirement. YAML parity during migration does not require
+Bedrock's own format to be YAML. JSON is simpler to parse without a runtime
+dependency, produces cleaner `git diff` output for per-field state changes, and
+is more natural for the programmatic API (JSON.stringify/parse, no serialisation
+library needed in `StatePort` implementations).
+
+### Combined `environments:` map (Mantle's layout)
+
+Store all environments in a single file: `{ environments: { production: [...],
+staging: [...] } }`, matching Mantle's `BTreeMap<String, Vec<RobloxResource>>`.
+
+**Rejected.** A staging deploy would rewrite a file that also contains
+production state, inflating `git diff` noise and widening the blast radius of a
+backend write failure. Bedrock's state backends (Gist, S3, R2) treat each stored
+object as a named blob; one file per environment is a natural fit and makes
+atomic per-environment writes straightforward.
+
+### Mantle-style blob-hash change detection
+
+Hash the entire serialised inputs blob (as Mantle does) to detect changes,
+rather than comparing fields individually.
+
+**Rejected.** Blob hashing is sensitive to serialisation order and format
+changes. A whitespace change in the config file or a field reordering would
+produce a spurious update. Field-by-field comparison is explicit, predictable,
+and allows future partial-update optimisation (e.g. skip the icon upload if only
+`name` changed). File-backed fields carry an explicit hash (`iconFileHash`)
+computed by `buildDesired` in shell; this is the only case where a hash appears
+in the data model, and its meaning is unambiguous.
+
+### Spec-nested desired state (`{ kind, key, spec: { name, price } }`)
+
+Wrap resource-specific fields under a `spec` sub-object, following
+Kubernetes-style IaC conventions.
+
+**Rejected.** Adds accessor depth without benefit at the slice-1 resource count.
+TypeScript discriminated union narrowing works directly on flat fields; a `spec`
+wrapper requires narrowing the outer union and then accessing `spec`, adding a
+level of indirection at every call site. Mantle's flat resource shape is
+migration-friendly and sufficient for the v1.0 resource set.
+
+## Implementation Notes
+
+- `ResourceDesiredState`, `ResourceCurrentState`, `ResourceKey`, `RobloxAssetId`,
+  `Sha256Hex`, `Operation`, and `diff` are exported from
+  `packages/cli/src/index.ts` as public API per ADR-017.
+- `StatePort`, `BedrockState`, and `StateError` are driven-port types
+  (ADR-018). They are exported from `packages/cli/src/ports/state-port.ts`
+  and re-exported from `src/index.ts`.
+- `buildDesired` (shell) reads icon files and produces `iconFileHash` before
+  calling `diff`. `diff` never reads files. This boundary must be preserved
+  as new file-backed resource types are added.
+- The `DriverRegistry` type maps `ResourceKind` to its `ResourceDriver<K>`
+  implementation. `applyOps` (shell) receives a `DriverRegistry` and dispatches
+  each `Operation` to the appropriate driver. The registry type is:
+
+```ts
+export type DriverRegistry = {
+	[K in ResourceKind]: ResourceDriver<K>;
+};
+```
+
+- **Parent-scope identifiers are injected at apply time, not stored on desired
+  state.** Roblox Open Cloud requires a `universeId` on every game-pass
+  operation, yet `GamePassDesiredState` intentionally carries no `universeId`
+  field — matching Mantle's `PassInputs`, which also omits it. Instead, the
+  scope is threaded into the driver at construction: `createGamePassDriver({
+  client, universeId })` captures the universe in a closure. Slice 1 hardcodes
+  the universeId at the test boundary because experience is not yet a managed
+  resource. When experience becomes managed (a future slice shipping
+  configuration-managed experience resources), `applyOps` will topo-sort
+  dependency order and thread the experience's `outputs.assetId` into the
+  game-pass driver at instantiation. Public types do not change during that
+  refactor — only `applyOps` and the driver-construction path evolve.
+
+- The `Tagged` pattern from type-fest produces branded types whose brand is
+  erased at JSON-serialisation boundaries. Adapters that read state from disk or
+  accept user input must therefore re-apply brands via type-level constructor
+  helpers (`asResourceKey(raw: string): ResourceKey`,
+  `asRobloxAssetId(raw: string): RobloxAssetId`,
+  `asSha256Hex(raw: string): Sha256Hex`). These constructors live in `core/`
+  alongside the branded type definitions. They perform runtime validation
+  (e.g. `asSha256Hex` verifies the string is 64 lowercase hex characters)
+  before returning the branded value, ensuring the compile-time guarantees
+  are backed by runtime checks at every deserialization boundary.
+
+## Related Decisions
+
+- **ADR-009**: Result Types Over Exceptions -- `StatePort.read()` and
+  `StatePort.write()` return `Promise<Result<T, StateError>>`. `diff` does not
+  return a `Result` because it is pure and cannot fail.
+- **ADR-011**: Simplified Architecture for Library Packages -- the CLI package
+  fails ADR-011's opt-out criteria (substantive pure core separable from I/O,
+  swappable driven adapters, significant deployment logic). The types defined
+  here are precisely the "pure core separable from I/O" that criterion 4
+  identifies. ADR-011's verdict (CLI uses FCIS + Ports) is confirmed.
+- **ADR-017**: Product Framing -- all types exported from `src/index.ts` are
+  public API with semver stability obligations. Type renames and shape changes
+  are breaking changes that require a CHANGELOG entry during 0.x and a major
+  version bump at 1.0+.
+- **ADR-018**: Architecture Refinement -- core types live in
+  `packages/cli/src/core/`; `StatePort` and `ResourceDriver<K>` live in
+  `packages/cli/src/ports/`; `buildDesired` (which hashes files) lives in
+  `packages/cli/src/shell/`. The I/O boundary established in ADR-018 is
+  enforced by this ADR's type placement.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -26,6 +26,9 @@ things are the way they are.
 | [014](./014-vite-plus-unified-toolchain.md) | Vite+ as Unified Build, Test, and Task Toolchain | Accepted | 2026-04-15 |
 | [015](./015-mutation-testing-stryker.md) | Mutation Testing with StrykerJS | Accepted | 2026-04-16 |
 | [016](./016-knip-unused-code-detection.md) | Knip for Workspace-Level Unused Code Detection | Accepted | 2026-04-17 |
+| [017](./017-product-framing-programmatic-iac-with-cli.md) | Product Framing: Programmatic IaC with CLI Convenience (Level 2 Hybrid) | Accepted | 2026-04-17 |
+| [018](./018-fcis-ports-with-primary-driven-distinction.md) | Architecture Refinement: FCIS + Ports with Explicit Primary/Driven Port Distinction | Accepted | 2026-04-17 |
+| [019](./019-state-data-model-and-diff-algebra.md) | State Data Model and Diff Algebra (Mantle Parity) | Accepted | 2026-04-17 |
 
 ## Creating a New ADR
 


### PR DESCRIPTION
## Summary

Three ADRs formalizing the architectural decisions for Bedrock CLI slice 1, drafted through the `adr` agent with grill-me discipline and accepted individually. Renumbered to 017/018/019 after main's ADR-016 (knip) landed.

- **ADR-017** — Product framing: Bedrock as a programmatic TypeScript IaC library with CLI convenience (Level 2 hybrid). Establishes public API commitment, `@example` obligations, plugin contract first-class status, semver stance during 0.x.
- **ADR-018** — FCIS + Ports refinement with explicit primary/driven port distinction. Refines ADR-002; does not supersede. Clarifies the `ResourceDriver<K>` naming clash against strict hexagonal terminology. Enumerates OOP anti-patterns that are out of scope.
- **ADR-019** — State data model (Mantle-parity) and diff algebra. Pins the `Operation` union, `ResourceDesiredState`/`ResourceCurrentState` shapes, JSON state format, `$bedrock.version` envelope, hard-error semantics on malformed state, delete-deferred + orphan-handling notes.

Associated PRD: #54. Sub-issues for implementation: #56 through #65 (will be updated to reference the new ADR numbers in follow-up).

## Test plan

- [ ] Review ADR-017 for product-framing accuracy (two-audience framing, Luau + roblox-ts)
- [ ] Review ADR-018 for architecture accuracy (primary/driven distinction, no-OOP rule)
- [ ] Review ADR-019 for data-shape correctness (Mantle parity preserved, JSON state shape)
- [ ] Verify docs/adr/README.md index is correctly updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)