### PR TITLE
refactor(bedrock): clean up public jsdoc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,17 @@ PR titles are linted by commitlint (`.github/workflows/lint-pr-title.yaml`) —
    `bedrock, e2e, global, ocale, testing, tsconfig, vite, website`. `ci`,
    `chore`, `docs`, `build`, `refactor` are **types, not scopes** — write
    `ci: …` with no scope, not `fix(ci): …`.
+3. **Consumer-useful subject**: PR titles become changelog entries for
+   people installing the published package. Write what *changed in the
+   package from the consumer's perspective*, not how the work was organised.
+   Internal terminology (`slice-1`, `post-merge cleanup`, `finalize`,
+   `wire up`, issue numbers, sub-task names) is meaningless in a
+   changelog. Prefer concrete, outcome-focused phrasing: `add game-passes
+   client` over `slice-1 client implementation`; `clean up public jsdoc`
+   over `post-merge cleanup`. If the change is invisible to consumers
+   (pure internal refactor, docs-only), say what actually changed
+   (`remove internal references from public jsdoc`) rather than labelling
+   the pass.
 
 ### Creating Issues
 

--- a/packages/bedrock/CLAUDE.md
+++ b/packages/bedrock/CLAUDE.md
@@ -70,11 +70,12 @@ cannot fail.
 vocabulary a "driver port" is a PRIMARY port, so the name is the opposite of
 its hexagonal role. The clash is deliberate: "driver" follows the Terraform,
 Pulumi, and Mantle IaC convention for a component that talks to a specific
-resource API, which the target audience recognizes immediately. See
-ADR-018 for the full rationale.
+resource API, which the target audience recognizes immediately.
 
-Code comments on `ResourceDriver<K>` should carry the note:
-`// driven (secondary) port in hexagonal terms; named "driver" per IaC community convention (see ADR-018)`.
+Do not cite ADRs in code comments or JSDoc on `ResourceDriver<K>` (or anywhere
+else in `src/`). Rendered JSDoc ships to the public docs site; ADR numbers are
+internal governance. Keep the rationale here, in this CLAUDE.md, and in the
+ADRs themselves.
 
 ## Testing
 

--- a/packages/bedrock/src/adapters/game-pass-driver.ts
+++ b/packages/bedrock/src/adapters/game-pass-driver.ts
@@ -1,4 +1,4 @@
-import { ApiError, type Result } from "@bedrock/ocale";
+import { ApiError, type OpenCloudError, type Result } from "@bedrock/ocale";
 import type { GamePass, GamePassesClient } from "@bedrock/ocale/game-passes";
 
 import type { GamePassDesiredState, ResourceCurrentState } from "../core/resources.ts";
@@ -146,7 +146,7 @@ export function createGamePassDriver(deps: GamePassDriverDeps): ResourceDriver<"
 function toCurrentState(
 	desired: GamePassDesiredState,
 	data: GamePass,
-): Result<ResourceCurrentState, ApiError> {
+): Result<ResourceCurrentState, OpenCloudError> {
 	const { id, iconAssetId } = data;
 	if (iconAssetId === undefined) {
 		return {

--- a/packages/bedrock/src/core/diff.ts
+++ b/packages/bedrock/src/core/diff.ts
@@ -8,8 +8,7 @@ import type { ResourceCurrentState, ResourceDesiredState } from "./resources.ts"
  * Each entry in `desired` is matched to `current` by `key`. A key present only
  * in `desired` produces a `create` op; a key present in both produces an
  * `update` op if any declared field differs or a `noop` op if every field
- * matches. Keys present only in `current` (orphans) are not emitted in slice 1
- * per ADR-019; the `Operation` union has no `delete` variant yet.
+ * matches.
  *
  * Ops appear in the order their desired entries appear in the input array so
  * callers can rely on declaration order when logging or applying ops.

--- a/packages/bedrock/src/core/operations.ts
+++ b/packages/bedrock/src/core/operations.ts
@@ -70,10 +70,6 @@ export interface CreateOperation extends BaseOperation {
  * its matching `current` entry. Both states are carried so the driver can
  * compute the minimal patch.
  *
- * Defined in slice 1 for type completeness, but not yet handled at apply time:
- * `applyOps` returns an `unsupported` error when it encounters one until a
- * driver wires up update support in a later slice.
- *
  * @example
  *
  * ```ts
@@ -162,10 +158,8 @@ export interface NoopOperation extends BaseOperation {
  * `applyOps` consumes. The `type` field is the discriminator (`kind` is
  * reserved for the resource discriminator in `ResourceDesiredState`).
  *
- * Slice 1 ships three variants. A `delete` variant is intentionally absent:
- * resources removed from config are not reconciled until a future slice
- * introduces orphan handling. The `Operation` union is the canonical
- * statement of that product boundary.
+ * A `delete` variant is intentionally absent: resources present only in
+ * current state (orphans) are ignored, never reconciled.
  *
  * @example
  *

--- a/packages/bedrock/src/core/state.ts
+++ b/packages/bedrock/src/core/state.ts
@@ -3,12 +3,12 @@ import type { ResourceCurrentState } from "./resources.ts";
 /**
  * In-memory state snapshot for one environment.
  *
- * The on-disk JSON wraps this shape with a `$bedrock: { version: N }` envelope
- * (see ADR-019 § State file format). Adapters flatten the envelope on read and
- * re-wrap it on write; nothing outside an adapter sees the `$bedrock` key.
+ * The on-disk JSON wraps this shape with a `$bedrock: { version: N }` envelope.
+ * Adapters flatten the envelope on read and re-wrap it on write; nothing
+ * outside an adapter sees the `$bedrock` key.
  *
- * `version` is the literal `1` so a future breaking schema change is a
- * compile-time type shift rather than a silently accepted runtime value.
+ * `version` is a literal so a breaking schema change is a compile-time type
+ * shift rather than a silently accepted runtime value.
  *
  * @example
  *
@@ -51,7 +51,7 @@ export interface BedrockState {
 	readonly environment: string;
 	/** Current state of every resource Bedrock manages in this environment. */
 	readonly resources: ReadonlyArray<ResourceCurrentState>;
-	/** Schema-version literal; bumped only for breaking changes (ADR-019). */
+	/** Schema-version literal; bumped only for breaking changes to the on-disk format. */
 	readonly version: 1;
 }
 
@@ -59,9 +59,8 @@ export interface BedrockState {
  * Failure surfaced by a `StatePort` when a state file exists but cannot be
  * trusted: corrupt JSON, schema failure, or an unknown `$bedrock.version`.
  *
- * The `kind` literal `"stateError"` is the discriminator for a future error
- * union that will carry sibling ports' failures; narrow on it, don't
- * `instanceof` it.
+ * Narrow on `kind` rather than using `instanceof`: `StateError` is plain data,
+ * not a thrown error subclass.
  *
  * @example
  *
@@ -80,7 +79,7 @@ export interface BedrockState {
 export interface StateError {
 	/** Adapter-specific path or identifier of the file that failed to parse. */
 	readonly file: string;
-	/** Discriminator for the future port-error union. */
+	/** Literal discriminator for narrowing. */
 	readonly kind: "stateError";
 	/** Human-readable explanation of why the file could not be trusted. */
 	readonly reason: string;

--- a/packages/bedrock/src/ports/resource-driver.ts
+++ b/packages/bedrock/src/ports/resource-driver.ts
@@ -13,8 +13,7 @@ import type {
  *
  * `ResourceDriver<K>` is a *driven* (secondary) port in hexagonal terms; the
  * name "driver" follows Terraform, Pulumi, and Mantle IaC convention for a
- * component that talks to a specific resource API. See ADR-018 for the full
- * rationale.
+ * component that talks to a specific resource API.
  *
  * @template K - The {@link ResourceKind} discriminator this driver handles.
  *

--- a/packages/bedrock/src/ports/state-port.ts
+++ b/packages/bedrock/src/ports/state-port.ts
@@ -8,9 +8,7 @@ import type { BedrockState, StateError } from "../core/state.ts";
  * and save its per-environment {@link BedrockState} snapshot.
  *
  * `StatePort` is a *driven* (secondary) port in hexagonal terms, following the
- * same naming convention as {@link "./resource-driver".ResourceDriver}. See
- * ADR-018 for the primary/driven distinction and ADR-019 for the state data
- * model this port operates over.
+ * same naming convention as {@link "./resource-driver".ResourceDriver}.
  *
  * @example
  *

--- a/packages/bedrock/src/shell/apply-ops.example.spec.ts
+++ b/packages/bedrock/src/shell/apply-ops.example.spec.ts
@@ -17,7 +17,7 @@ it('Example 1', () => {
         return `driver failed for ${err.key}: ${err.cause.message}`
       }
       case 'updateUnsupported': {
-        return `update not yet supported for ${err.key}`
+        return `update not supported for ${err.key}`
       }
     }
   }
@@ -25,7 +25,7 @@ it('Example 1', () => {
     key: asResourceKey('vip-pass'),
     kind: 'updateUnsupported',
   }
-  expect(describe(err)).toBe('update not yet supported for vip-pass')
+  expect(describe(err)).toBe('update not supported for vip-pass')
 })
 
 it('Example 2', () => {

--- a/packages/bedrock/src/shell/apply-ops.ts
+++ b/packages/bedrock/src/shell/apply-ops.ts
@@ -58,9 +58,10 @@ export type ApplyError =
  * @param registry - Per-kind driver table; dispatch uses `op.desired.kind` as the index.
  * @returns `Ok(undefined)` when every operation succeeds, or the first failure encountered.
  * @throws Whatever the dispatched driver rejects with outside its `Result`
- *   return — notably, `createGamePassDriver` propagates file-read rejections
- *   from its injected `readFile`. Wrap the call site in a try/catch when the
- *   file reader is not trusted.
+ *   return. A driver whose injected I/O (file reads, network calls, etc.)
+ *   throws will surface that rejection here rather than translating it into
+ *   a `Result` failure; wrap the call site in a try/catch when drivers are
+ *   not trusted to contain their own rejections.
  * @example
  *
  * ```ts

--- a/packages/bedrock/src/shell/apply-ops.ts
+++ b/packages/bedrock/src/shell/apply-ops.ts
@@ -6,8 +6,7 @@ import type { ResourceKey } from "../types/ids.ts";
 
 /**
  * Failure surfaced by `applyOps` when an operation cannot be applied.
- * Plain-data discriminated union following the `StateError` pattern in
- * `core/state.ts`; narrow on `kind`, do not `instanceof` it.
+ * Plain-data discriminated union; narrow on `kind`, do not `instanceof` it.
  *
  * @example
  *
@@ -20,7 +19,7 @@ import type { ResourceKey } from "../types/ids.ts";
  *             return `driver failed for ${err.key}: ${err.cause.message}`;
  *         }
  *         case "updateUnsupported": {
- *             return `update not yet supported for ${err.key}`;
+ *             return `update not supported for ${err.key}`;
  *         }
  *     }
  * }
@@ -30,7 +29,7 @@ import type { ResourceKey } from "../types/ids.ts";
  *     kind: "updateUnsupported",
  * };
  *
- * expect(describe(err)).toBe("update not yet supported for vip-pass");
+ * expect(describe(err)).toBe("update not supported for vip-pass");
  * ```
  */
 export type ApplyError =


### PR DESCRIPTION
## Summary

- Strip internal ADR citations and "future slice" hedges from public JSDoc across `diff.ts`, `state.ts`, `operations.ts`, `apply-ops.ts`, `resource-driver.ts`, and `state-port.ts`. These comments ship to the rendered TypeDoc site; ADR numbers are internal governance and roadmap hedges rot as soon as the missing pieces land.
- Widen the private `toCurrentState` helper's error type from `ApiError` to `OpenCloudError` to match the driver's public return contract. No behavioural change — just a source-level correction so the helper doesn't fight future non-`ApiError` paths.
- Replace the `packages/bedrock/CLAUDE.md` directive instructing contributors to add `(see ADR-018)` comments on `ResourceDriver<K>` with an explicit prohibition, so package guidance agrees with the repo-wide rule.
- Add a rule to the root `CLAUDE.md` requiring PR titles to be consumer-useful since they become changelog entries.

## Why

`grep "ADR-0" packages/bedrock/dist/index.d.mts` returns **0** matches after this PR (5 before). Consumers reading the rendered docs no longer see project-governance numbers or timeline hedges.

## Test plan

- [x] `pnpm gen:example-tests` — regenerates cleanly (one `@example` block in `apply-ops.ts` was touched)
- [x] `pnpm typecheck` — clean across all 4 workspace packages
- [x] `pnpm test` in `packages/bedrock` — 156/156 tests pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — `dist/index.mjs` + `dist/index.d.mts` build; `publint` clean
- [ ] `pnpm mutate:changed` on `packages/bedrock/src/**` (only `toCurrentState` has a semantic diff; low risk)

## Notes

The title was rewritten to match the new CLAUDE.md rule (previously `refactor(bedrock): post-merge cleanup for slice-1 public api`, which failed the "consumer-useful" test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)