### PR TITLE
fix(global): post-#76 knip and stryker-diff follow-ups

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -30,6 +30,7 @@ const config: KnipConfig = {
 		"apps/website": {},
 		"packages/bedrock": {
 			entry: ["stryker.config.ts", "src/index.ts"],
+			ignoreDependencies: ["@bedrock/ocale"],
 		},
 		"packages/open-cloud": {
 			entry: [

--- a/packages/testing/src/stryker-diff.ts
+++ b/packages/testing/src/stryker-diff.ts
@@ -1,6 +1,21 @@
 import ts from "typescript";
 
 /**
+ * A file change the wrapper cannot translate into a mutation range.
+ * Currently only binary blobs; pure renames are dropped as zero-hunk
+ * entries and rename-with-modifications flows collapse to a normal
+ * change at the new path. New files are handled normally — their
+ * `@@ -0,0 +1,N @@` hunk already covers the full added range, which
+ * Stryker accepts as the mutation window.
+ */
+interface DiffReject {
+	/** Discriminator for the future reject union. */
+	kind: "binary";
+	/** Repo-relative path of the rejected file. */
+	path: string;
+}
+
+/**
  * A contiguous range of modified lines within a file.
  */
 interface Hunk {
@@ -17,21 +32,6 @@ interface FileChange {
 	/** Per-hunk line ranges touched in this file. */
 	hunks: Array<Hunk>;
 	/** Repo-relative path to the file. */
-	path: string;
-}
-
-/**
- * A file change the wrapper cannot translate into a mutation range.
- * Currently only binary blobs; pure renames are dropped as zero-hunk
- * entries and rename-with-modifications flows collapse to a normal
- * change at the new path. New files are handled normally — their
- * `@@ -0,0 +1,N @@` hunk already covers the full added range, which
- * Stryker accepts as the mutation window.
- */
-interface DiffReject {
-	/** Discriminator for the future reject union. */
-	kind: "binary";
-	/** Repo-relative path of the rejected file. */
 	path: string;
 }
 


### PR DESCRIPTION
Stragglers that didn't land in the squash-merge of #76. Branch was rebased onto current `main`; net diff is two small changes.

## Summary

- [knip.ts](knip.ts): add `ignoreDependencies: ["@bedrock/ocale"]` to the `packages/bedrock` workspace so the internal workspace dep doesn't trip `pnpm lint:unused` now that the workspace has been registered with a `src/index.ts` entry.
- [packages/testing/src/stryker-diff.ts](packages/testing/src/stryker-diff.ts): move the `DiffReject` interface to the top of the file to satisfy the declaration-ordering lint rule. No semantic change.

## Test plan

- [ ] `pnpm lint` clean
- [ ] `pnpm lint:unused` clean
- [ ] `pnpm typecheck` clean
- [ ] `pnpm test` green
- [ ] CI `hk check` passes

Refs #66.

Generated with [Claude Code](https://claude.com/claude-code)