### PR TITLE
feat(ocale): support uint8array bodies and per-request headers

### DIFF
--- a/packages/open-cloud/src/client/types.ts
+++ b/packages/open-cloud/src/client/types.ts
@@ -27,6 +27,13 @@ export type HttpRequestBody =
 export interface HttpRequest {
 	/** The request body. */
 	readonly body?: HttpRequestBody;
+	/**
+	 * Caller-supplied request headers. Applied after the transport sets
+	 * `x-api-key` and any body-driven `Content-Type`, so a caller-supplied
+	 * header replaces the transport's default. Keys are treated
+	 * case-insensitively.
+	 */
+	readonly headers?: Readonly<Record<string, string>>;
 	/** The HTTP method. */
 	readonly method: "DELETE" | "GET" | "PATCH" | "POST";
 	/** Relative path, e.g. `/game-passes/v1/universes/123/...`. */

--- a/packages/open-cloud/src/client/types.ts
+++ b/packages/open-cloud/src/client/types.ts
@@ -8,10 +8,18 @@ export type { SleepFunc } from "../internal/utils/sleep.ts";
  * Supported request body types.
  *
  * - `FormData` for multipart uploads (Content-Type set automatically by fetch).
+ * - `Uint8Array<ArrayBuffer>` for raw binary uploads (default Content-Type is
+ *   `application/octet-stream`; override via {@link HttpRequest.headers}).
+ *   `SharedArrayBuffer`-backed views are not accepted by `fetch`; wrap them
+ *   via `new Uint8Array(bytes)` to obtain an `ArrayBuffer`-backed copy.
  * - `Record<string, unknown>` for JSON bodies (serialized with `JSON.stringify`).
  * - `undefined` for requests without a body (GET, DELETE).
  */
-export type HttpRequestBody = FormData | Record<string, unknown> | undefined;
+export type HttpRequestBody =
+	| FormData
+	| Record<string, unknown>
+	| Uint8Array<ArrayBuffer>
+	| undefined;
 
 /**
  * A normalized HTTP request to send to the Roblox Open Cloud API.

--- a/packages/open-cloud/src/client/types.ts
+++ b/packages/open-cloud/src/client/types.ts
@@ -30,8 +30,7 @@ export interface HttpRequest {
 	/**
 	 * Caller-supplied request headers. Applied after the transport sets
 	 * `x-api-key` and any body-driven `Content-Type`, so a caller-supplied
-	 * header replaces the transport's default. Keys are treated
-	 * case-insensitively.
+	 * header replaces the transport's default.
 	 */
 	readonly headers?: Readonly<Record<string, string>>;
 	/** The HTTP method. */

--- a/packages/open-cloud/src/client/types.ts
+++ b/packages/open-cloud/src/client/types.ts
@@ -8,11 +8,11 @@ export type { SleepFunc } from "../internal/utils/sleep.ts";
  * Supported request body types.
  *
  * - `FormData` for multipart uploads (Content-Type set automatically by fetch).
+ * - `Record<string, unknown>` for JSON bodies (serialized with `JSON.stringify`).
  * - `Uint8Array<ArrayBuffer>` for raw binary uploads (default Content-Type is
  *   `application/octet-stream`; override via {@link HttpRequest.headers}).
  *   `SharedArrayBuffer`-backed views are not accepted by `fetch`; wrap them
  *   via `new Uint8Array(bytes)` to obtain an `ArrayBuffer`-backed copy.
- * - `Record<string, unknown>` for JSON bodies (serialized with `JSON.stringify`).
  * - `undefined` for requests without a body (GET, DELETE).
  */
 export type HttpRequestBody =

--- a/packages/open-cloud/src/internal/http/fetch-client.spec.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.spec.ts
@@ -283,23 +283,6 @@ describe(buildFetchOptions, () => {
 		expect(headers.get("content-type")).toBe("application/octet-stream; charset=binary");
 	});
 
-	it("should apply caller-supplied headers case-insensitively", () => {
-		expect.assertions(1);
-
-		const options = buildFetchOptions(
-			{
-				body: { name: "Game Pass" },
-				headers: { "CoNtEnT-TyPe": "application/xml" },
-				method: "POST",
-				url: "/test",
-			},
-			{ apiKey: "key", baseUrl: "https://example.com" },
-		);
-		const headers = new Headers(options.headers);
-
-		expect(headers.get("content-type")).toBe("application/xml");
-	});
-
 	it("should add caller-supplied headers alongside x-api-key when no body-branch header is set", () => {
 		expect.assertions(2);
 

--- a/packages/open-cloud/src/internal/http/fetch-client.spec.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.spec.ts
@@ -299,6 +299,22 @@ describe(buildFetchOptions, () => {
 		expect(headers.get("x-trace-id")).toBe("abc123");
 		expect(headers.get("x-api-key")).toBe("key");
 	});
+
+	it("should preserve x-api-key from config against caller-supplied override", () => {
+		expect.assertions(1);
+
+		const options = buildFetchOptions(
+			{
+				headers: { "X-Api-Key": "caller-key" },
+				method: "GET",
+				url: "/test",
+			},
+			{ apiKey: "config-key", baseUrl: "https://example.com" },
+		);
+		const headers = new Headers(options.headers);
+
+		expect(headers.get("x-api-key")).toBe("config-key");
+	});
 });
 
 describe(createFetchHttpClient, () => {

--- a/packages/open-cloud/src/internal/http/fetch-client.spec.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.spec.ts
@@ -342,6 +342,29 @@ describe(createFetchHttpClient, () => {
 		expect(result.data.headers["content-type"]).toBe("application/json");
 	});
 
+	it("should parse JSON body when response Content-Type is text/plain", async () => {
+		expect.assertions(3);
+
+		async function fakeFetch(): Promise<Response> {
+			return new Response(JSON.stringify({ id: "123" }), {
+				headers: { "content-type": "text/plain" },
+				status: 200,
+			});
+		}
+
+		const client = createFetchHttpClient(fakeFetch);
+		const result = await client.request(
+			{ method: "POST", url: "/publish" },
+			{ apiKey: "key", baseUrl: "https://example.com" },
+		);
+
+		assert(result.success);
+
+		expect(result.data.status).toBe(200);
+		expect(result.data.body).toStrictEqual({ id: "123" });
+		expect(result.data.headers["content-type"]).toBe("text/plain");
+	});
+
 	it("should return RateLimitError for 429 with x-ratelimit-reset header", async () => {
 		expect.assertions(2);
 

--- a/packages/open-cloud/src/internal/http/fetch-client.spec.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.spec.ts
@@ -223,6 +223,31 @@ describe(buildFetchOptions, () => {
 		expect(options.body).toBeUndefined();
 		expect(headers.get("content-type")).toBeNull();
 	});
+
+	it("should set Content-Type application/octet-stream for Uint8Array body", () => {
+		expect.assertions(1);
+
+		const body = new Uint8Array([1, 2, 3]);
+		const options = buildFetchOptions(
+			{ body, method: "POST", url: "/test" },
+			{ apiKey: "key", baseUrl: "https://example.com" },
+		);
+		const headers = new Headers(options.headers);
+
+		expect(headers.get("content-type")).toBe("application/octet-stream");
+	});
+
+	it("should pass Uint8Array body directly without copying or serialization", () => {
+		expect.assertions(1);
+
+		const body = new Uint8Array([1, 2, 3]);
+		const options = buildFetchOptions(
+			{ body, method: "POST", url: "/test" },
+			{ apiKey: "key", baseUrl: "https://example.com" },
+		);
+
+		expect(options.body).toBe(body);
+	});
 });
 
 describe(createFetchHttpClient, () => {

--- a/packages/open-cloud/src/internal/http/fetch-client.spec.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.spec.ts
@@ -248,6 +248,74 @@ describe(buildFetchOptions, () => {
 
 		expect(options.body).toBe(body);
 	});
+
+	it("should apply caller-supplied headers last, overriding body-branch Content-Type", () => {
+		expect.assertions(1);
+
+		const options = buildFetchOptions(
+			{
+				body: { name: "Game Pass" },
+				headers: { "Content-Type": "application/xml" },
+				method: "POST",
+				url: "/test",
+			},
+			{ apiKey: "key", baseUrl: "https://example.com" },
+		);
+		const headers = new Headers(options.headers);
+
+		expect(headers.get("content-type")).toBe("application/xml");
+	});
+
+	it("should override octet-stream default when caller supplies Content-Type for Uint8Array body", () => {
+		expect.assertions(1);
+
+		const options = buildFetchOptions(
+			{
+				body: new Uint8Array([1, 2, 3]),
+				headers: { "content-type": "application/octet-stream; charset=binary" },
+				method: "POST",
+				url: "/test",
+			},
+			{ apiKey: "key", baseUrl: "https://example.com" },
+		);
+		const headers = new Headers(options.headers);
+
+		expect(headers.get("content-type")).toBe("application/octet-stream; charset=binary");
+	});
+
+	it("should apply caller-supplied headers case-insensitively", () => {
+		expect.assertions(1);
+
+		const options = buildFetchOptions(
+			{
+				body: { name: "Game Pass" },
+				headers: { "CoNtEnT-TyPe": "application/xml" },
+				method: "POST",
+				url: "/test",
+			},
+			{ apiKey: "key", baseUrl: "https://example.com" },
+		);
+		const headers = new Headers(options.headers);
+
+		expect(headers.get("content-type")).toBe("application/xml");
+	});
+
+	it("should add caller-supplied headers alongside x-api-key when no body-branch header is set", () => {
+		expect.assertions(2);
+
+		const options = buildFetchOptions(
+			{
+				headers: { "x-trace-id": "abc123" },
+				method: "GET",
+				url: "/test",
+			},
+			{ apiKey: "key", baseUrl: "https://example.com" },
+		);
+		const headers = new Headers(options.headers);
+
+		expect(headers.get("x-trace-id")).toBe("abc123");
+		expect(headers.get("x-api-key")).toBe("key");
+	});
 });
 
 describe(createFetchHttpClient, () => {

--- a/packages/open-cloud/src/internal/http/fetch-client.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.ts
@@ -86,6 +86,12 @@ export function buildFetchOptions(request: HttpRequest, config: RequestConfig): 
 		options.body = JSON.stringify(request.body);
 	}
 
+	if (request.headers !== undefined) {
+		for (const [name, value] of Object.entries(request.headers)) {
+			headers.set(name, value);
+		}
+	}
+
 	if (config.timeout !== undefined) {
 		options.signal = AbortSignal.timeout(config.timeout);
 	}

--- a/packages/open-cloud/src/internal/http/fetch-client.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.ts
@@ -78,6 +78,9 @@ export function buildFetchOptions(request: HttpRequest, config: RequestConfig): 
 
 	if (request.body instanceof FormData) {
 		options.body = request.body;
+	} else if (request.body instanceof Uint8Array) {
+		headers.set("content-type", "application/octet-stream");
+		options.body = request.body;
 	} else if (request.body !== undefined) {
 		headers.set("content-type", "application/json");
 		options.body = JSON.stringify(request.body);

--- a/packages/open-cloud/src/internal/http/fetch-client.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.ts
@@ -88,6 +88,10 @@ export function buildFetchOptions(request: HttpRequest, config: RequestConfig): 
 
 	if (request.headers !== undefined) {
 		for (const [name, value] of Object.entries(request.headers)) {
+			if (name.toLowerCase() === "x-api-key") {
+				continue;
+			}
+
 			headers.set(name, value);
 		}
 	}


### PR DESCRIPTION
## Summary

Widens the `@bedrock/ocale` HTTP transport in two additive, non-breaking ways, and locks a pre-existing `classifyResponse` behaviour under a regression test. Second of three vertical slices under the places-client PRD (#81).

- `HttpRequestBody` gains a `Uint8Array<ArrayBuffer>` variant; `buildFetchOptions` passes raw bytes through unchanged with a default `Content-Type: application/octet-stream`. Needed for `.rbxl` binary uploads.
- `HttpRequest` gains an optional `headers?: Readonly<Record<string, string>>` field; caller-supplied entries are merged onto the internal `Headers` after `x-api-key` and any body-driven `Content-Type`, so a caller-supplied `Content-Type` (e.g. `application/xml` for `.rbxlx`) wins. No other default is exposed to overrides.
- Pins `classifyResponse`'s content-type-agnostic `response.json()` call under a regression test, so the Roblox publish-place endpoint's `text/plain` JSON body keeps flowing through.

### Why narrow `Uint8Array` to `Uint8Array<ArrayBuffer>`

`fetch`'s `BodyInit` only accepts `ArrayBuffer`-backed views per spec; `SharedArrayBuffer`-backed ones are not valid body inputs. Typing the union precisely means TypeScript catches this at the call site rather than surfacing a cryptic assignability error deeper in the transport. The JSDoc points callers at `new Uint8Array(bytes)` for the rare case of needing to normalize.

### Header precedence (tested)

1. `x-api-key` from `config.apiKey`.
2. Body-branch default `Content-Type`: `application/octet-stream` for `Uint8Array`, `application/json` for objects, unset for `FormData`/`undefined`.
3. `request.headers` entries, merged last via `headers.set(name, value)`; `Headers.set` normalizes keys, so any casing on the caller's record wins.

## Commits

1. `feat(ocale): accept uint8array request bodies` - type widen + transport branch + 2 tests
2. `feat(ocale): accept per-request headers on http-request` - interface field + merge loop + 3 tests
3. `test(ocale): lock content-type-agnostic json parsing` - text/plain regression test only
4. `refactor(ocale): drop native-behaviour doc and redundant header test` - post-simplify cleanup: removed a JSDoc sentence and a test that described native `Headers.set` case-insensitivity rather than ocale-specific behaviour

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` - 466 tests pass across 50 files
- [x] `pnpm build`
- [x] `pnpm mutate:changed` - 100% mutation score on touched `fetch-client.ts` lines

Closes #83