### PR TITLE
chore: install hk hooks on every worktree setup

### DIFF
--- a/.claude/hooks/post-worktree-setup.ts
+++ b/.claude/hooks/post-worktree-setup.ts
@@ -113,6 +113,7 @@ function runSetup(worktree: string): number {
 	const steps: Array<[string, Array<string>]> = [
 		["mise", ["trust"]],
 		["mise", ["install"]],
+		["hk", ["install", "--mise"]],
 		["pnpm", ["install"]],
 	];
 	for (const [command, args] of steps) {


### PR DESCRIPTION
## Summary

- Add `hk install --mise` to `.claude/hooks/post-worktree-setup.ts` so every new worktree wires up the pre-commit/pre-push/commit-msg/post-merge hooks that `hk check` gates on.

## Context

`mise.toml` pins an `hk` postinstall of `hk install --mise`, but mise runs it **once**, at the moment `hk` is first cached into `~/.local/share/mise/installs/hk/<version>/`. That cwd is not a git repo, so the install silently no-ops. Subsequent `mise install` runs inside the repo skip the postinstall (tool is cached), leaving `.git/hooks/` with only `.sample` files and letting `git push` bypass the local gates.

Observed on [#88](https://github.com/christopher-buss/bedrock/pull/88): CI's `hk check` caught an unused-export that a local `pre-push` would have caught if installed.

Fixes [#89](https://github.com/christopher-buss/bedrock/issues/89).

## Why this placement

- Runs in a guaranteed-git-repo context (the new worktree).
- Comes after `mise install`, so `hk` is already on PATH via mise shims.
- `hk install --mise` is idempotent — safe to run when hooks are already wired, so no guard is needed.
- Git worktrees share `.git/hooks/` with the primary gitdir, so installing from any worktree wires them up for the main checkout too.

## Test plan

- [ ] `bun .claude/hooks/post-worktree-setup.ts < /dev/null` exits 0 and streams an `hk install --mise` step
- [ ] `ls .git/hooks/` shows non-`.sample` `pre-commit`, `pre-push`, `commit-msg`, `post-merge`
- [ ] Staging a change that trips `hk check` (e.g. an unused export under `src/**`) is rejected by the local `pre-commit`
- [ ] Rerunning the hook in the same worktree stays at exit 0 (idempotent)