### PR TITLE
chore: prep repo for open-source launch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repo.
+# See https://docs.github.com/articles/about-code-owners
+*       @christopher-buss

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,8 +1,11 @@
 blank_issues_enabled: false
 
 contact_links:
+  - name: Questions, ideas, bug reports, prompt requests
+    about: Please open a Discussion. Issues are maintainer-only; see CONTRIBUTING.md for the prompt-request workflow.
+    url: https://github.com/christopher-buss/bedrock/discussions
   - name: Documentation
-    about: Check the README for usage information
+    about: Check the README for usage information.
     url: https://github.com/christopher-buss/bedrock#readme
   - name: Report a security vulnerability
     about: Do not file public issues for security reports. Use a private advisory.

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -4,3 +4,6 @@ contact_links:
   - name: Documentation
     about: Check the README for usage information
     url: https://github.com/christopher-buss/bedrock#readme
+  - name: Report a security vulnerability
+    about: Do not file public issues for security reports. Use a private advisory.
+    url: https://github.com/christopher-buss/bedrock/security/advisories/new

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,73 @@
+# GitHub issue / PR labels for bedrock.
+# Source of truth. Synced to the repo by .github/workflows/labels.yaml on
+# pushes to main that touch this file, and on manual workflow_dispatch.
+# Edit this file to add, remove, or recolor labels.
+
+# ---------------------------------------------------------------------------
+# Default labels (GitHub creates these on new repos; keep them here so the
+# sync does not prune them).
+# ---------------------------------------------------------------------------
+
+- name: bug
+  color: d73a4a
+  description: Something isn't working
+
+- name: documentation
+  color: 0075ca
+  description: Improvements or additions to documentation
+
+- name: duplicate
+  color: cfd3d7
+  description: This issue or pull request already exists
+
+- name: enhancement
+  color: a2eeef
+  description: New feature or request
+
+- name: good first issue
+  color: 7057ff
+  description: Good for newcomers
+
+- name: help wanted
+  color: 008672
+  description: Extra attention is needed
+
+- name: invalid
+  color: e4e669
+  description: This doesn't seem right
+
+- name: question
+  color: d876e3
+  description: Further information is requested
+
+- name: wontfix
+  color: ffffff
+  description: This will not be worked on
+
+# ---------------------------------------------------------------------------
+# Package scope labels. Mirror the commitlint scope-enum.
+# ---------------------------------------------------------------------------
+
+- name: pkg:bedrock
+  color: 1d76db
+  description: "Scope: @bedrock/bedrock package"
+
+- name: pkg:ocale
+  color: 1d76db
+  description: "Scope: @bedrock/ocale package"
+
+- name: pkg:testing
+  color: 1d76db
+  description: "Scope: @bedrock/testing package"
+
+- name: pkg:website
+  color: 1d76db
+  description: "Scope: docs website"
+
+# ---------------------------------------------------------------------------
+# Workflow labels.
+# ---------------------------------------------------------------------------
+
+- name: skip-review
+  color: "666666"
+  description: Skip Claude Code review for trivial changes

--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -3,11 +3,6 @@
 # pushes to main that touch this file, and on manual workflow_dispatch.
 # Edit this file to add, remove, or recolor labels.
 
-# ---------------------------------------------------------------------------
-# Default labels (GitHub creates these on new repos; keep them here so the
-# sync does not prune them).
-# ---------------------------------------------------------------------------
-
 - name: bug
   color: d73a4a
   description: Something isn't working
@@ -44,10 +39,6 @@
   color: ffffff
   description: This will not be worked on
 
-# ---------------------------------------------------------------------------
-# Package scope labels. Mirror the commitlint scope-enum.
-# ---------------------------------------------------------------------------
-
 - name: pkg:bedrock
   color: 1d76db
   description: "Scope: @bedrock/bedrock package"
@@ -63,10 +54,6 @@
 - name: pkg:website
   color: 1d76db
   description: "Scope: docs website"
-
-# ---------------------------------------------------------------------------
-# Workflow labels.
-# ---------------------------------------------------------------------------
 
 - name: skip-review
   color: "666666"

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -1,0 +1,33 @@
+name: Sync Labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yaml
+      - .github/workflows/labels.yaml
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    name: Sync labels from .github/labels.yaml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Sync labels
+        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
+        with:
+          config-file: .github/labels.yaml
+          # Flip to true once .github/labels.yaml is the accepted source of
+          # truth. This deletes any label not listed in the config.
+          delete-other-labels: false
+    timeout-minutes: 5

--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -27,7 +27,5 @@ jobs:
         uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
         with:
           config-file: .github/labels.yaml
-          # Flip to true once .github/labels.yaml is the accepted source of
-          # truth. This deletes any label not listed in the config.
-          delete-other-labels: false
+          delete-other-labels: true
     timeout-minutes: 5

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at christopher.buss@pm.me. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -37,7 +37,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at christopher.buss@pm.me. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <christopher.buss@pm.me>. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing to Bedrock
+
+Thanks for the interest. Bedrock is a small project in active development,
+and outside contributions are welcome for bug fixes, docs improvements, and
+features that fit the direction laid out in the [ADRs](./docs/adr/).
+
+This document covers the essentials. The [root `CLAUDE.md`](./CLAUDE.md) is
+the fuller reference; anything here supersedes it for human contributors.
+
+## Ground rules
+
+- **Test-driven.** Every line of production code must be written in response
+  to a failing test (RED → GREEN → REFACTOR). See
+  [ADR-003](./docs/adr/003-testing-strategy.md).
+- **100% coverage** across statements, branches, functions, and lines on
+  `src/**`. CI enforces this.
+- **Be kind.** See the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Getting set up
+
+Prerequisites: [Bun](https://bun.sh) >= 1.3, [pnpm](https://pnpm.io) >= 10,
+Node >= 24.12 (for consumers of published packages; Bun is the dev runtime).
+
+```bash
+git clone https://github.com/christopher-buss/bedrock.git
+cd bedrock
+pnpm install
+```
+
+Useful scripts:
+
+| Command                     | Purpose                                     |
+| --------------------------- | ------------------------------------------- |
+| `pnpm test`                 | Run the Vitest suite.                       |
+| `pnpm lint`                 | ESLint check (auto-fix on).                 |
+| `pnpm typecheck`            | TypeScript validation across the workspace. |
+| `pnpm build`                | Build all packages.                         |
+| `pnpm gen:example-tests`    | Regenerate tests from `@example` JSDoc.     |
+| `pnpm mutate:changed`       | Stryker mutation tests on changed files.    |
+
+The pre-commit hook (managed by [hk](./docs/adr/013-hk-git-hook-manager-with-differentiated-gating.md))
+runs lint, typecheck, test, and build. A red commit is rejected before it
+lands.
+
+## Workflow
+
+1. **Open or pick up an issue.** For anything larger than a bug fix, please
+   open an issue first so we can align on scope before code is written. The
+   [project board](https://github.com/christopher-buss/bedrock/projects)
+   lists work that is ready to pick up.
+2. **Branch from `main`.** Use a descriptive branch name.
+3. **Write the test first.** Commit RED and GREEN together as one commit
+   per behaviour slice (the pre-commit hook rejects a pure-RED commit).
+   REFACTOR lands as a separate commit only when it adds value.
+4. **Keep commits small.** One commit per behaviour slice; the history is
+   expected to show TDD compliance.
+5. **Open a pull request.** The PR template will guide you through what to
+   include. CI must be green before review.
+
+## Architectural changes need an ADR
+
+If your change falls into any of these buckets, an Architecture Decision
+Record is required **before** implementation:
+
+- New dependencies, build tools, or cross-cutting patterns
+- New architectural layers, boundaries, or abstractions
+- External integrations (APIs, auth, storage backends)
+- Data model or configuration format changes
+- Breaking API changes
+
+See [ADR-006: ADR Enforcement](./docs/adr/006-adr-enforcement.md) for the
+full list and the collaborative Q&A process for drafting one.
+
+## Commit and PR title format
+
+Titles are linted by commitlint. Two rules trip people up most often:
+
+1. **Subject must be lowercase kebab-case**, including identifiers.
+   `mergeConfig` becomes `merge-config`, `GamePassesClient` becomes
+   `game-passes-client`.
+2. **Scope must be one of**: `bedrock`, `e2e`, `global`, `ocale`, `testing`,
+   `tsconfig`, `vite`, `website`. `ci`, `chore`, `docs`, `build`, `refactor`
+   are **types**, not scopes. Write `ci: …` with no scope rather than
+   `fix(ci): …`.
+
+Prefer outcome-focused subjects that read well in a changelog: `add
+game-passes client` over `slice-1 client implementation`.
+
+## Public API examples
+
+Every symbol exported from a package's `src/index.ts` should carry a JSDoc
+`@example` block when the usage is non-trivial. Examples are dual-purpose:
+compiled into tests by `pnpm gen:example-tests` and rendered into the docs
+site by TypeDoc. See [ADR-005](./docs/adr/005-jsdoc-example-testing.md) for
+the full contract.
+
+## Reporting security vulnerabilities
+
+Do **not** open a public issue for security reports. Use GitHub's private
+vulnerability reporting or see [SECURITY.md](./SECURITY.md).
+
+## Questions
+
+Open a [discussion](https://github.com/christopher-buss/bedrock/discussions)
+or file an issue using the question template. Response times are
+best-effort.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,6 +105,7 @@ sharing it):
 git clone https://github.com/christopher-buss/bedrock.git
 cd bedrock
 pnpm install
+pnpm build
 pnpm test
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,106 +1,126 @@
 # Contributing to Bedrock
 
-Thanks for the interest. Bedrock is a small project in active development,
-and outside contributions are welcome for bug fixes, docs improvements, and
-features that fit the direction laid out in the [ADRs](./docs/adr/).
+Bedrock is a solo-maintainer project built in the open. Contributions are
+welcome, but the workflow is inverted from a typical OSS repo. This page
+describes the model first, then the mechanics.
 
-This document covers the essentials. The [root `CLAUDE.md`](./CLAUDE.md) is
-the fuller reference; anything here supersedes it for human contributors.
+## Prompt requests, not pull requests
 
-## Ground rules
+This project is organized around prompt requests, a framing borrowed from
+Peter Steinberger:
 
-- **Test-driven.** Every line of production code must be written in response
-  to a failing test (RED → GREEN → REFACTOR). See
+> I don't like pull requests (PRs) any more. A large chunk code change
+> doesn't tell me much about the intent or why it was done.
+>
+> I now prefer prompt requests. Just share the prompt you ran / want to
+> run. If I think it's good, I'll run it myself and merge it.
+
+The default path for an external contribution:
+
+1. Open a [Discussion](https://github.com/christopher-buss/bedrock/discussions)
+   describing the change you want.
+2. Share the prompt you would run to make it happen. Not the diff, the
+   prompt.
+3. If the idea lands, I run the prompt, review the output, and merge.
+
+Intent is the scarce thing. A prompt captures it directly; a diff hides it
+behind output. Adjusting scope before the model runs is cheaper than
+adjusting it after.
+
+## When a pull request is fine
+
+Trivial or mechanical changes (typo, docs fix, one-line bug fix) can come
+in as a normal PR. Anything larger should start in Discussions so scope is
+aligned before code is written. PRs that should have been prompt requests
+will be closed with a pointer here.
+
+## Issues are maintainer-only
+
+Please do not open issues directly. External input goes through
+[Discussions](https://github.com/christopher-buss/bedrock/discussions):
+
+- **Q&A** for usage questions
+- **Ideas** for feature proposals and prompt requests
+- **Bug reports** as a Discussion with reproduction steps
+
+I convert matured Discussions into tracked issues when work is ready to
+start.
+
+For security vulnerabilities, see [SECURITY.md](./SECURITY.md). Never
+report those publicly.
+
+## Writing a good prompt request
+
+A good prompt is specific enough to produce the change you want, loose
+enough that the model has room to pick a reasonable implementation.
+
+Include:
+
+- **Goal.** One sentence about the outcome.
+- **Context.** File paths, relevant conventions, ADRs the change touches.
+- **Constraints.** Public API stability, TDD discipline, dependency
+  policy, anything that must or must not change.
+- **Done looks like.** Which tests pass? What is manually verifiable?
+
+Reference the rules in the [rules section below](#rules-the-generated-code-still-has-to-meet)
+directly in your prompt so the model does not need a second pass.
+
+## ADR-gated changes
+
+Proposals in any of these buckets need an Architecture Decision Record
+before any code runs:
+
+- New dependencies, build tools, or cross-cutting patterns
+- New architectural layers, boundaries, or abstractions
+- External integrations (APIs, auth, storage backends)
+- Data-model or configuration-format changes
+- Breaking API changes
+
+See [ADR-006](./docs/adr/006-adr-enforcement.md) for the full list and the
+collaborative Q&A process. Start the ADR in a Discussion; I will shape it
+into the repo format once the decision is clear.
+
+## Rules the generated code still has to meet
+
+The bar is the same whether a human or an agent writes the diff:
+
+- **Test-driven.** Every line of production code is written in response to
+  a failing test (RED -> GREEN -> REFACTOR). See
   [ADR-003](./docs/adr/003-testing-strategy.md).
 - **100% coverage** across statements, branches, functions, and lines on
   `src/**`. CI enforces this.
-- **Be kind.** See the [Code of Conduct](./CODE_OF_CONDUCT.md).
+- **Commit style.** `type(scope): kebab-case subject`. Scope-enum:
+  `bedrock`, `e2e`, `global`, `ocale`, `testing`, `tsconfig`, `vite`,
+  `website`. `ci`, `chore`, `docs`, `build`, `refactor` are types, not
+  scopes.
+- **Public API examples.** Exported symbols carry JSDoc `@example` blocks
+  ([ADR-005](./docs/adr/005-jsdoc-example-testing.md)).
 
-## Getting set up
+## Local setup
 
-Prerequisites: [Bun](https://bun.sh) >= 1.3, [pnpm](https://pnpm.io) >= 10,
-Node >= 24.12 (for consumers of published packages; Bun is the dev runtime).
+If you want to run things locally (or to run the prompt yourself before
+sharing it):
 
 ```bash
 git clone https://github.com/christopher-buss/bedrock.git
 cd bedrock
 pnpm install
+pnpm test
 ```
 
-Useful scripts:
-
-| Command                     | Purpose                                     |
-| --------------------------- | ------------------------------------------- |
-| `pnpm test`                 | Run the Vitest suite.                       |
-| `pnpm lint`                 | ESLint check (auto-fix on).                 |
-| `pnpm typecheck`            | TypeScript validation across the workspace. |
-| `pnpm build`                | Build all packages.                         |
-| `pnpm gen:example-tests`    | Regenerate tests from `@example` JSDoc.     |
-| `pnpm mutate:changed`       | Stryker mutation tests on changed files.    |
+| Command                  | Purpose                                     |
+| ------------------------ | ------------------------------------------- |
+| `pnpm test`              | Vitest                                      |
+| `pnpm lint`              | ESLint (auto-fix on)                        |
+| `pnpm typecheck`         | TypeScript check across the workspace       |
+| `pnpm build`             | Build all packages                          |
+| `pnpm gen:example-tests` | Regenerate tests from `@example` JSDoc      |
+| `pnpm mutate:changed`    | Stryker mutation tests on changed files     |
 
 The pre-commit hook (managed by [hk](./docs/adr/013-hk-git-hook-manager-with-differentiated-gating.md))
-runs lint, typecheck, test, and build. A red commit is rejected before it
-lands.
+runs lint, typecheck, test, and build.
 
-## Workflow
+## Code of conduct
 
-1. **Open or pick up an issue.** For anything larger than a bug fix, please
-   open an issue first so we can align on scope before code is written. The
-   [project board](https://github.com/christopher-buss/bedrock/projects)
-   lists work that is ready to pick up.
-2. **Branch from `main`.** Use a descriptive branch name.
-3. **Write the test first.** Commit RED and GREEN together as one commit
-   per behaviour slice (the pre-commit hook rejects a pure-RED commit).
-   REFACTOR lands as a separate commit only when it adds value.
-4. **Keep commits small.** One commit per behaviour slice; the history is
-   expected to show TDD compliance.
-5. **Open a pull request.** The PR template will guide you through what to
-   include. CI must be green before review.
-
-## Architectural changes need an ADR
-
-If your change falls into any of these buckets, an Architecture Decision
-Record is required **before** implementation:
-
-- New dependencies, build tools, or cross-cutting patterns
-- New architectural layers, boundaries, or abstractions
-- External integrations (APIs, auth, storage backends)
-- Data model or configuration format changes
-- Breaking API changes
-
-See [ADR-006: ADR Enforcement](./docs/adr/006-adr-enforcement.md) for the
-full list and the collaborative Q&A process for drafting one.
-
-## Commit and PR title format
-
-Titles are linted by commitlint. Two rules trip people up most often:
-
-1. **Subject must be lowercase kebab-case**, including identifiers.
-   `mergeConfig` becomes `merge-config`, `GamePassesClient` becomes
-   `game-passes-client`.
-2. **Scope must be one of**: `bedrock`, `e2e`, `global`, `ocale`, `testing`,
-   `tsconfig`, `vite`, `website`. `ci`, `chore`, `docs`, `build`, `refactor`
-   are **types**, not scopes. Write `ci: …` with no scope rather than
-   `fix(ci): …`.
-
-Prefer outcome-focused subjects that read well in a changelog: `add
-game-passes client` over `slice-1 client implementation`.
-
-## Public API examples
-
-Every symbol exported from a package's `src/index.ts` should carry a JSDoc
-`@example` block when the usage is non-trivial. Examples are dual-purpose:
-compiled into tests by `pnpm gen:example-tests` and rendered into the docs
-site by TypeDoc. See [ADR-005](./docs/adr/005-jsdoc-example-testing.md) for
-the full contract.
-
-## Reporting security vulnerabilities
-
-Do **not** open a public issue for security reports. Use GitHub's private
-vulnerability reporting or see [SECURITY.md](./SECURITY.md).
-
-## Questions
-
-Open a [discussion](https://github.com/christopher-buss/bedrock/discussions)
-or file an issue using the question template. Response times are
-best-effort.
+By participating in Discussions, issues, or PRs, you agree to the
+[Code of Conduct](./CODE_OF_CONDUCT.md).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
 # Bedrock
+
+Infrastructure-as-Code deployment for Roblox, written in TypeScript.
+
+[![CI](https://github.com/christopher-buss/bedrock/actions/workflows/ci.yaml/badge.svg)](https://github.com/christopher-buss/bedrock/actions/workflows/ci.yaml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
+
+> **Pre-release.** APIs are unstable and nothing is published to npm yet.
+> Follow the repository or the [project board](https://github.com/christopher-buss/bedrock/projects)
+> for progress.
+
+## What is Bedrock?
+
+Bedrock declaratively manages Roblox experiences the way Terraform manages
+cloud resources. Describe the places, game passes, badges, and other
+resources an experience should have in a config file; Bedrock figures out
+what to create, update, or delete to match.
+
+It is a spiritual successor to [Mantle](https://github.com/blake-mealey/mantle)
+(no longer maintained), rebuilt in TypeScript on top of Roblox Open Cloud.
+
+## Why
+
+- **Open Cloud only.** No `ROBLOSECURITY` cookies or legacy endpoints.
+  Authenticate with API keys, the way Roblox now recommends.
+- **Programmatic first, CLI second.** Consume Bedrock as a library from
+  your own tooling, or reach for the CLI for day-to-day deploys. See
+  [ADR-017](./docs/adr/017-product-framing-programmatic-iac-with-cli.md).
+- **State in a GitHub Gist.** Zero external services to stand up; a
+  `GITHUB_TOKEN` is enough. Extensible to other backends.
+- **Multi-format config.** TypeScript, JavaScript, YAML, or JSON via c12.
+
+## Packages
+
+| Package                                               | Description                                      |
+| ----------------------------------------------------- | ------------------------------------------------ |
+| [`bedrock`](./packages/bedrock)                       | The deployment library and CLI.                  |
+| [`@bedrock/ocale`](./packages/open-cloud)             | Standalone HTTP client for Roblox Open Cloud.    |
+
+## Status
+
+Bedrock is in active development ahead of a first public release. Core
+pieces in place today:
+
+- Open Cloud client (`@bedrock/ocale`) with game-pass and place resources,
+  built-in rate limiting, retries, and 100% test coverage.
+- State data model and diff algebra ([ADR-019](./docs/adr/019-state-data-model-and-diff-algebra.md)).
+- FCIS + Ports architecture with explicit primary/driven port distinction
+  ([ADR-018](./docs/adr/018-fcis-ports-with-primary-driven-distinction.md)).
+
+The CLI surface and higher-level `deploy` workflow are next. Track progress
+on the [project board](https://github.com/christopher-buss/bedrock/projects).
+
+## Getting started
+
+There is nothing to install from npm yet. To poke at the code locally:
+
+```bash
+git clone https://github.com/christopher-buss/bedrock.git
+cd bedrock
+pnpm install
+pnpm build
+pnpm test
+```
+
+The repository uses [pnpm](https://pnpm.io) workspaces and [Bun](https://bun.sh)
+(>= 1.3) as the runtime. TypeScript builds, tests, and task orchestration run
+through [Vite+](./docs/adr/014-vite-plus-unified-toolchain.md).
+
+## Documentation
+
+- [Documentation site](https://bedrock-livid.vercel.app/) (work in progress)
+- [Architecture Decision Records](./docs/adr/) covering every significant
+  design choice
+
+## Contributing
+
+Contributions are welcome. Please read [CONTRIBUTING.md](./CONTRIBUTING.md)
+before opening a pull request; in particular, Bedrock is test-driven and
+every line of production code is written in response to a failing test.
+
+By participating, you agree to abide by the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+To report a security vulnerability, follow [SECURITY.md](./SECURITY.md).
+
+## License
+
+[MIT](./LICENSE) (c) Christopher Buss.

--- a/README.md
+++ b/README.md
@@ -75,9 +75,12 @@ through [Vite+](./docs/adr/014-vite-plus-unified-toolchain.md).
 
 ## Contributing
 
-Contributions are welcome. Please read [CONTRIBUTING.md](./CONTRIBUTING.md)
-before opening a pull request; in particular, Bedrock is test-driven and
-every line of production code is written in response to a failing test.
+This is a solo-maintainer project with an inverted contribution model.
+External input runs through
+[Discussions](https://github.com/christopher-buss/bedrock/discussions) as
+**prompt requests**: share the prompt you would run rather than opening a
+PR, and I will run it myself if the idea lands. Issues are maintainer-only.
+Read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening anything.
 
 By participating, you agree to abide by the [Code of Conduct](./CODE_OF_CONDUCT.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+## Supported versions
+
+Bedrock is pre-1.0 and under active development. Only the latest release
+is supported; fixes are not backported to older versions.
+
+| Version       | Supported |
+| ------------- | --------- |
+| Latest `main` | Yes       |
+| Everything else | No      |
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security reports.**
+
+Please use GitHub's [private vulnerability reporting](https://github.com/christopher-buss/bedrock/security/advisories/new)
+to submit a report. This creates a private advisory visible only to the
+maintainer and you.
+
+If private reporting is not available for any reason, email
+`christopher.buss@pm.me` instead.
+
+Please include:
+
+- A description of the issue and its impact.
+- Steps to reproduce or a proof-of-concept.
+- The affected package(s) and version(s).
+- Any suggested remediation you have in mind.
+
+## What to expect
+
+- **Acknowledgement** within 3 business days.
+- **Initial assessment** (severity, scope) within 7 business days.
+- **Fix target**: critical issues patched and released within 30 days;
+  lower-severity issues handled on the next regular release cycle.
+- **Credit** in the release notes and advisory once a fix ships, unless
+  you prefer to remain anonymous.
+
+## Scope
+
+The following are in scope:
+
+- Vulnerabilities in published packages (`bedrock`, `@bedrock/ocale`).
+- Vulnerabilities in the deployment flow that could leak secrets, corrupt
+  state, or cause unauthorized access to a Roblox experience the user
+  controls.
+- Supply-chain issues in our own build and release pipeline.
+
+The following are out of scope:
+
+- Vulnerabilities in Roblox Open Cloud itself. Report those to Roblox via
+  their [HackerOne program](https://hackerone.com/roblox).
+- Misuse of a valid API key that the user themselves exposed.
+- Issues in third-party dependencies that have already been disclosed
+  upstream; please follow the upstream project's process instead.
+
+## Threat model notes
+
+- Bedrock authenticates to Roblox via Open Cloud API keys only. The legacy
+  `ROBLOSECURITY` cookie is never used (see
+  [ADR-007](./docs/adr/007-open-cloud-only.md)).
+- State files are stored in GitHub Gists and contain only resource IDs
+  (public data). Secrets are never written to state.
+- `@bedrock/ocale` has zero runtime dependencies (see
+  [ADR-008](./docs/adr/008-zero-runtime-dependencies.md)) to minimise
+  supply-chain surface area.


### PR DESCRIPTION
## Summary

Governance and repo-hygiene layer for flipping Bedrock from private to public, plus a reframe of the contribution model.

- **Governance docs:** `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1), `SECURITY.md`, `.github/CODEOWNERS`.
- **Contribution model:** reframed `CONTRIBUTING.md` around *prompt requests* (after [Peter Steinberger](https://newsletter.pragmaticengineer.com/p/the-creator-of-clawd-i-ship-code)). External contributors open a Discussion and share the prompt they'd run rather than a PR. Issue-template picker now leads with a Discussions link. README contribution paragraph matches.
- **Labels as code:** `.github/labels.yaml` declares the 14 current labels; `.github/workflows/labels.yaml` syncs on push to main via [EndBug/label-sync](https://github.com/EndBug/label-sync). Prune mode is on (`delete-other-labels: true`) since the config is authoritative from day one.
- **Action versions:** bumped `anthropics/claude-code-action` from 1.0.99 to 1.0.102 across the four workflows that use it (via `npx actions-up`).
- **Enforcement (applied out-of-band via `gh api` before merge):**
  - `pull_request_creation_policy: collaborators_only` — external PRs blocked at the platform layer (new [Feb 2026 GitHub setting](https://github.blog/changelog/2026-02-13-new-repository-settings-for-configuring-pull-request-access/)).
  - `has_discussions: true` — Discussions enabled so the links in the docs resolve.

## Test plan

- [ ] CI (`pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`) green on this branch
- [ ] GitHub renders README, CONTRIBUTING, CODE_OF_CONDUCT, SECURITY correctly
- [ ] Issue template picker shows Discussions as the first option
- [ ] Labels workflow runs successfully on first push to `main` after merge (watch Actions tab)
- [ ] External user navigating to the Pull Requests tab sees the "restricted to collaborators" UX after merge
- [ ] Manual: prune default Discussions categories down to Q&A / Ideas / Announcements to match CONTRIBUTING.md framing

## Follow-ups (out of scope for this PR)

- Flip repo visibility to public (and immediately enable Private Vulnerability Reporting, Dependabot, secret scanning + push protection)
- Social preview image, About/topics/homepage in repo Settings
- `bedrock` name on npm is taken by `digitalbazaar/bedrock` — pick a published name before 0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)