### PR TITLE
chore: bump anthropics/claude-code-action from 1.0.99 to 1.0.102

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -104,7 +104,7 @@ jobs:
       - id: claude-review
         if: steps.skip-check.outputs.skip != 'true'
         name: Run Claude Code Review
-        uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           claude_args: |
             --allowedTools "Glob,Grep,Read,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__create_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__submit_pending_pull_request_review"

--- a/.github/workflows/claude-triage.yaml
+++ b/.github/workflows/claude-triage.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - if: github.event_name == 'issues'
         name: Triage Issue
-        uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           allowed_non_write_users: "*"
           claude_args: |
@@ -49,7 +49,7 @@ jobs:
 
       - if: github.event_name == 'pull_request'
         name: Triage Pull Request
-        uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           allowed_non_write_users: "*"
           claude_args: |

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - id: claude
         name: Run Claude Code
-        uses: anthropics/claude-code-action@c3d45e8e941e1b2ad7b278c57482d9c5bf1f35b3 # v1.0.99
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## Summary

Routine action version bump via `npx actions-up`. Updates `anthropics/claude-code-action` from `1.0.99` (c3d45e8) to `1.0.102` (5d5c10a) in the four workflows that use it:

- `.github/workflows/claude-review.yaml`
- `.github/workflows/claude-triage.yaml` (two usages)
- `.github/workflows/claude.yaml`

## Test plan

- [ ] CI passes
- [ ] claude-review/triage may fail on this PR itself due to GitHub's workflow validation rule (the workflow file on the PR differs from main). This resolves itself after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)