### PR TITLE
ci: trigger claude mention workflow on pr comments

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -1,6 +1,8 @@
 name: Claude Code
 
 on:
+  issue_comment:
+    types: [created]
   pull_request_review:
     types: [submitted]
   pull_request_review_comment:
@@ -15,6 +17,7 @@ jobs:
       issues: read
       pull-requests: read
     if: |
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The `.github/workflows/claude.yaml` workflow listened only for `pull_request_review` and `pull_request_review_comment` events. Top-level PR conversation comments are delivered by GitHub as `issue_comment` events (not review comments — those are inline-on-code), so `@claude` mentions in the main PR thread were acknowledged by the GitHub app (eye reaction) but never actually kicked off a workflow run.

Adds `issue_comment` to the trigger list, with a `github.event.issue.pull_request` guard so it only fires on PR comments and not on issue comments.

## Test plan

- [ ] After merge, leave `@claude ...` as a top-level comment on an open PR and verify the workflow runs.
- [ ] Verify inline review-comment and review-submission paths still work.
- [ ] Note: this PR itself will fail the claude-review/triage workflow-validation check because the workflow file on the PR differs from main. Expected and self-resolving on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)