### PR TITLE
ci: grant contents read to label sync checkout

### DIFF
--- a/.github/workflows/labels.yaml
+++ b/.github/workflows/labels.yaml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   issues: write
 
 concurrency:


### PR DESCRIPTION
## Summary

The Sync Labels workflow (added in #129) scopes `permissions:` explicitly to `issues: write`. When the permissions block is explicit, every scope not listed defaults to `none`, including `contents: read`. `actions/checkout` had no access to clone the repo and failed the first post-merge run with a `repository-not-found` error ([run 24754362600](https://github.com/christopher-buss/bedrock/actions/runs/24754362600)).

Adds `contents: read` so the checkout step has the minimum access it needs. No other scopes are granted.

## Test plan

- [ ] After merge, the Sync Labels workflow runs successfully on `workflow_dispatch` from the Actions tab.
- [ ] Next push to `main` that touches `labels.yaml` triggers a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)