### PR TITLE
ci: quote all-digit hex colors in labels config

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -2,6 +2,7 @@
 # Source of truth. Synced to the repo by .github/workflows/labels.yaml on
 # pushes to main that touch this file, and on manual workflow_dispatch.
 # Edit this file to add, remove, or recolor labels.
+# Hex color codes must be quoted: YAML parses all-digit values as numbers.
 
 - name: bug
   color: d73a4a
@@ -24,7 +25,7 @@
   description: Good for newcomers
 
 - name: help wanted
-  color: 008672
+  color: "008672"
   description: Extra attention is needed
 
 - name: invalid


### PR DESCRIPTION
## Summary

`help wanted`'s color `008672` was reaching EndBug/label-sync as an integer because YAML parses bare all-digit scalars as numbers. The sync rejected the whole config with:

```
✗ Parsed YAML file is invalid:
.color should be a string (received: number, index: 5)
```

([run 24754699641](https://github.com/christopher-buss/bedrock/actions/runs/24754699641)).

Quotes the all-digit codes (`008672`) and documents the rule at the top of the file so new labels don't repeat the mistake. `666666` was already quoted for the same reason.

## Test plan

- [ ] After merge, the Sync Labels workflow completes successfully (run manually from the Actions tab via `workflow_dispatch` if you don't want to wait for the next organic trigger).
- [ ] `gh label list` shows the 14 configured labels with their expected colors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)