### PR TITLE
feat(bedrock): attribute define-config function throws distinctly

### DIFF
--- a/packages/bedrock/src/core/config-error.example.spec.ts
+++ b/packages/bedrock/src/core/config-error.example.spec.ts
@@ -19,6 +19,9 @@ it('Example 2', () => {
       case 'parseFailed': {
         return `${err.sourceFile}: ${err.message}`
       }
+      case 'configFunctionFailed': {
+        return `${err.sourceFile}: config function threw: ${err.message}`
+      }
       case 'validationFailed': {
         const first = err.issues[0]
         return first
@@ -37,6 +40,13 @@ it('Example 2', () => {
       message: 'unexpected end of the stream',
     }),
   ).toBe('bedrock.config.yaml: unexpected end of the stream')
+  expect(
+    describe({
+      kind: 'configFunctionFailed',
+      sourceFile: 'bedrock.config.ts',
+      message: 'boom',
+    }),
+  ).toBe('bedrock.config.ts: config function threw: boom')
   expect(
     describe({
       kind: 'validationFailed',

--- a/packages/bedrock/src/core/config-error.ts
+++ b/packages/bedrock/src/core/config-error.ts
@@ -37,6 +37,9 @@ export interface ConfigValidationIssue {
  * - `validationFailed` - a config file was found and parsed, but its content
  *   did not satisfy the runtime schema. `issues` attributes each problem to
  *   a field path so callers can point at the offending entry.
+ * - `configFunctionFailed` - a function-form config threw or its returned
+ *   promise rejected while being invoked. `message` carries the thrown
+ *   error's message verbatim.
  *
  * @example
  *
@@ -50,6 +53,9 @@ export interface ConfigValidationIssue {
  *         }
  *         case "parseFailed": {
  *             return `${err.sourceFile}: ${err.message}`;
+ *         }
+ *         case "configFunctionFailed": {
+ *             return `${err.sourceFile}: config function threw: ${err.message}`;
  *         }
  *         case "validationFailed": {
  *             const first = err.issues[0];
@@ -72,6 +78,13 @@ export interface ConfigValidationIssue {
  * ).toBe("bedrock.config.yaml: unexpected end of the stream");
  * expect(
  *     describe({
+ *         kind: "configFunctionFailed",
+ *         sourceFile: "bedrock.config.ts",
+ *         message: "boom",
+ *     }),
+ * ).toBe("bedrock.config.ts: config function threw: boom");
+ * expect(
+ *     describe({
  *         kind: "validationFailed",
  *         sourceFile: "bedrock.config.ts",
  *         issues: [{ path: ["passes", "vip", "price"], message: "must be a number" }],
@@ -83,6 +96,11 @@ export type ConfigError =
 	| {
 			readonly issues: ReadonlyArray<ConfigValidationIssue>;
 			readonly kind: "validationFailed";
+			readonly sourceFile: string;
+	  }
+	| {
+			readonly kind: "configFunctionFailed";
+			readonly message: string;
 			readonly sourceFile: string;
 	  }
 	| {

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -157,6 +157,27 @@ describe(loadConfig, () => {
 		});
 	});
 
+	it("should surface a non-Error throw from a config function as parseFailed", async () => {
+		expect.assertions(2);
+
+		await withTemporaryDirectory(async (cwd) => {
+			writeFixtureConfig(cwd, [
+				"import { defineConfig } from 'bedrock';",
+				"export default defineConfig(() => {",
+				"  throw 'bare string boom';",
+				"});",
+			]);
+
+			const result = await loadConfig({ cwd });
+
+			assert(!result.success);
+			assert(result.err.kind === "parseFailed");
+
+			expect(result.err.kind).toBe("parseFailed");
+			expect(result.err.message).toContain("bare string boom");
+		});
+	});
+
 	it("should return a fileNotFound error when no config file is present", async () => {
 		expect.assertions(2);
 

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -130,7 +130,7 @@ describe(loadConfig, () => {
 			assert(result.err.kind === "configFunctionFailed");
 
 			expect(result.err.kind).toBe("configFunctionFailed");
-			expect(result.err.sourceFile).toMatch(/bedrock\.config\.ts$/);
+			expect(result.err.sourceFile).toMatch(/\/.+\/bedrock\.config\.ts$/);
 			expect(result.err.message).toBe("sync boom");
 		});
 	});
@@ -152,7 +152,7 @@ describe(loadConfig, () => {
 			assert(result.err.kind === "configFunctionFailed");
 
 			expect(result.err.kind).toBe("configFunctionFailed");
-			expect(result.err.sourceFile).toMatch(/bedrock\.config\.ts$/);
+			expect(result.err.sourceFile).toMatch(/\/.+\/bedrock\.config\.ts$/);
 			expect(result.err.message).toBe("async boom");
 		});
 	});

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -61,6 +61,58 @@ describe(loadConfig, () => {
 		});
 	});
 
+	it("should load a TypeScript config declared with a synchronous defineConfig function", async () => {
+		expect.assertions(1);
+
+		await withTemporaryDirectory(async (cwd) => {
+			writeFixtureConfig(cwd, [
+				"import { defineConfig } from 'bedrock';",
+				"export default defineConfig(() => ({",
+				"  passes: {",
+				"    'vip-pass': {",
+				"      description: 'Grants VIP perks.',",
+				"      iconFilePath: 'assets/vip-icon.png',",
+				"      name: 'VIP Pass',",
+				"      price: 500,",
+				"    },",
+				"  },",
+				"}));",
+			]);
+
+			const result = await loadConfig({ cwd });
+
+			assert(result.success);
+
+			expect(result.data.passes!["vip-pass"]!.name).toBe("VIP Pass");
+		});
+	});
+
+	it("should load a TypeScript config declared with an asynchronous defineConfig function", async () => {
+		expect.assertions(1);
+
+		await withTemporaryDirectory(async (cwd) => {
+			writeFixtureConfig(cwd, [
+				"import { defineConfig } from 'bedrock';",
+				"export default defineConfig(async () => ({",
+				"  passes: {",
+				"    'vip-pass': {",
+				"      description: 'Grants VIP perks.',",
+				"      iconFilePath: 'assets/vip-icon.png',",
+				"      name: 'VIP Pass (async)',",
+				"      price: 750,",
+				"    },",
+				"  },",
+				"}));",
+			]);
+
+			const result = await loadConfig({ cwd });
+
+			assert(result.success);
+
+			expect(result.data.passes!["vip-pass"]!.name).toBe("VIP Pass (async)");
+		});
+	});
+
 	it("should return a fileNotFound error when no config file is present", async () => {
 		expect.assertions(2);
 

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -113,6 +113,50 @@ describe(loadConfig, () => {
 		});
 	});
 
+	it("should return a configFunctionFailed error when a synchronous config function throws", async () => {
+		expect.assertions(3);
+
+		await withTemporaryDirectory(async (cwd) => {
+			writeFixtureConfig(cwd, [
+				"import { defineConfig } from 'bedrock';",
+				"export default defineConfig(() => {",
+				"  throw new Error('sync boom');",
+				"});",
+			]);
+
+			const result = await loadConfig({ cwd });
+
+			assert(!result.success);
+			assert(result.err.kind === "configFunctionFailed");
+
+			expect(result.err.kind).toBe("configFunctionFailed");
+			expect(result.err.sourceFile).toMatch(/bedrock\.config\.ts$/);
+			expect(result.err.message).toBe("sync boom");
+		});
+	});
+
+	it("should return a configFunctionFailed error when an asynchronous config function rejects", async () => {
+		expect.assertions(3);
+
+		await withTemporaryDirectory(async (cwd) => {
+			writeFixtureConfig(cwd, [
+				"import { defineConfig } from 'bedrock';",
+				"export default defineConfig(async () => {",
+				"  throw new Error('async boom');",
+				"});",
+			]);
+
+			const result = await loadConfig({ cwd });
+
+			assert(!result.success);
+			assert(result.err.kind === "configFunctionFailed");
+
+			expect(result.err.kind).toBe("configFunctionFailed");
+			expect(result.err.sourceFile).toMatch(/bedrock\.config\.ts$/);
+			expect(result.err.message).toBe("async boom");
+		});
+	});
+
 	it("should return a fileNotFound error when no config file is present", async () => {
 		expect.assertions(2);
 

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -28,12 +28,18 @@ export interface LoadConfigOptions {
  * working directory). Returns a fresh, mutable `Config` on every call so
  * long-running scripts see up-to-date values.
  *
+ * When the exported default is a function (sync or async), `loadConfig`
+ * invokes it with an empty `ConfigContext` and awaits the result before
+ * validating.
+ *
  * Errors return via `Result`:
  * - `fileNotFound` - no config file was discovered under the search path.
  * - `parseFailed` - a config file was found but could not be parsed (for
  *   example, malformed YAML or JSON).
  * - `validationFailed` - a file was found and parsed, but its content did
  *   not satisfy the runtime schema.
+ * - `configFunctionFailed` - a function-form config threw or its returned
+ *   promise rejected while being invoked.
  *
  * @param options - Loader options (currently just `cwd`).
  * @returns `Ok` with the validated `Config`, or `Err` with a `ConfigError`.
@@ -59,14 +65,8 @@ export async function loadConfig(
 	try {
 		resolved = await c12LoadConfig<Record<string, unknown>>({ name: "bedrock", cwd });
 	} catch (err) {
-		return {
-			err: {
-				kind: "parseFailed",
-				message: err instanceof Error ? err.message : String(err),
-				sourceFile: discoverConfigFile(cwd) ?? cwd,
-			},
-			success: false,
-		};
+		const sourceFile = discoverConfigFile(cwd);
+		return { err: attributeLoadError(err, { cwd, sourceFile }), success: false };
 	}
 
 	if (resolved._configFile === undefined) {
@@ -77,6 +77,33 @@ export async function loadConfig(
 	}
 
 	return validateConfig(resolved.config, resolved._configFile);
+}
+
+function stackHasUserFrame(stack: string | undefined, sourceFile: string): boolean {
+	if (stack === undefined) {
+		return false;
+	}
+
+	return stack
+		.split("\n")
+		.some((line) => line.trimStart().startsWith("at ") && line.includes(sourceFile));
+}
+
+function attributeLoadError(
+	err: unknown,
+	location: { cwd: string; sourceFile: string | undefined },
+): ConfigError {
+	const { cwd, sourceFile } = location;
+	const message = err instanceof Error ? err.message : String(err);
+	if (
+		sourceFile !== undefined &&
+		err instanceof Error &&
+		stackHasUserFrame(err.stack, sourceFile)
+	) {
+		return { kind: "configFunctionFailed", message, sourceFile };
+	}
+
+	return { kind: "parseFailed", message, sourceFile: sourceFile ?? cwd };
 }
 
 function discoverConfigFile(cwd: string): string | undefined {

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -65,8 +65,7 @@ export async function loadConfig(
 	try {
 		resolved = await c12LoadConfig<Record<string, unknown>>({ name: "bedrock", cwd });
 	} catch (err) {
-		const sourceFile = discoverConfigFile(cwd);
-		return { err: attributeLoadError(err, { cwd, sourceFile }), success: false };
+		return { err: attributeLoadError(err, cwd), success: false };
 	}
 
 	if (resolved._configFile === undefined) {
@@ -79,31 +78,26 @@ export async function loadConfig(
 	return validateConfig(resolved.config, resolved._configFile);
 }
 
-function stackHasUserFrame(stack: string | undefined, sourceFile: string): boolean {
-	if (stack === undefined) {
-		return false;
+const CONFIG_FILE_IN_FRAME = /[^\s():"']*bedrock\.config\.(?:ts|js|mjs|cjs|yaml|yml|json)/;
+
+function extractConfigFileFromStack(err: unknown): string | undefined {
+	if (!(err instanceof Error) || err.stack === undefined) {
+		return undefined;
 	}
 
-	return stack
-		.split("\n")
-		.some((line) => line.trimStart().startsWith("at ") && line.includes(sourceFile));
-}
+	for (const rawLine of err.stack.split("\n")) {
+		const line = rawLine.trimStart();
+		if (!line.startsWith("at ")) {
+			continue;
+		}
 
-function attributeLoadError(
-	err: unknown,
-	location: { cwd: string; sourceFile: string | undefined },
-): ConfigError {
-	const { cwd, sourceFile } = location;
-	const message = err instanceof Error ? err.message : String(err);
-	if (
-		sourceFile !== undefined &&
-		err instanceof Error &&
-		stackHasUserFrame(err.stack, sourceFile)
-	) {
-		return { kind: "configFunctionFailed", message, sourceFile };
+		const match = CONFIG_FILE_IN_FRAME.exec(line);
+		if (match !== null) {
+			return match[0];
+		}
 	}
 
-	return { kind: "parseFailed", message, sourceFile: sourceFile ?? cwd };
+	return undefined;
 }
 
 function discoverConfigFile(cwd: string): string | undefined {
@@ -116,4 +110,14 @@ function discoverConfigFile(cwd: string): string | undefined {
 
 	const match = entries.toSorted().find((entry) => entry.startsWith("bedrock.config."));
 	return match === undefined ? undefined : join(cwd, match);
+}
+
+function attributeLoadError(err: unknown, cwd: string): ConfigError {
+	const message = err instanceof Error ? err.message : String(err);
+	const frameFile = extractConfigFileFromStack(err);
+	if (frameFile !== undefined) {
+		return { kind: "configFunctionFailed", message, sourceFile: frameFile };
+	}
+
+	return { kind: "parseFailed", message, sourceFile: discoverConfigFile(cwd) ?? cwd };
 }

--- a/packages/bedrock/tests/integration/config-pipeline.spec.ts
+++ b/packages/bedrock/tests/integration/config-pipeline.spec.ts
@@ -125,6 +125,17 @@ describe("config pipeline end-to-end", () => {
 		},
 	);
 
+	it("should load a function-form typescript config, flatten it, and dispatch a create op for the declared game pass", async () => {
+		expect.assertions(2);
+
+		const { applyOutcome, opTypes } = await runPipelineFromFixture(
+			join(FIXTURES_ROOT, "typescript-function"),
+		);
+
+		expect(opTypes).toStrictEqual(["create"]);
+		expect(applyOutcome.success).toBeTrue();
+	});
+
 	it("should forward every declared game-pass field into the multipart body, including the icon bytes", async () => {
 		expect.assertions(4);
 

--- a/packages/bedrock/tests/integration/fixtures/typescript-function/bedrock.config.ts
+++ b/packages/bedrock/tests/integration/fixtures/typescript-function/bedrock.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "bedrock";
+
+export default defineConfig(async () => {
+	return {
+		passes: {
+			"vip-pass": {
+				name: "VIP Pass",
+				description: "Grants VIP perks.",
+				iconFilePath: "assets/vip-icon.png",
+				price: 500,
+			},
+		},
+	};
+});


### PR DESCRIPTION
Closes [#127](https://github.com/christopher-buss/bedrock/issues/127) (parent PRD [#124](https://github.com/christopher-buss/bedrock/issues/124)).

## Summary

- `loadConfig` now surfaces throws from a function-form `defineConfig` as a distinct `configFunctionFailed` case on `ConfigError`, attributed to the discovered source file. Previously these were indistinguishable from YAML/JSON parse failures.
- Sync and async function-form configs are covered by load-level tests and an end-to-end pipeline integration test using a new `typescript-function` fixture.
- `defineConfig` itself is unchanged — the type-level function overload already landed in [#125](https://github.com/christopher-buss/bedrock/issues/125); this PR wires up the runtime error attribution.

## Approach

c12 already invokes function-valued default exports internally, so sync and async happy-path configs were already working. The gap was that when a user's config function threw, c12's outer throw was caught by the existing parse-failed handler. This PR distinguishes the two cases by inspecting the error's stack frames: a frame that runs from the config file path implies a user-function throw; otherwise it's a parser error.

The stack-frame heuristic avoids pulling jiti in as a direct dependency and keeps the fast path through c12 intact for YAML/JSON parsing.

## User stories addressed

- **7** — TypeScript developer computing config from external sources at load time
- **11** — distinct error attributed to the config file when the function throws

## Commits

Three TDD-aligned slices, RED+GREEN bundled:

1. `test(bedrock): cover function-form config load through load-config` — lock in sync/async function-form load behavior through `loadConfig`.
2. `feat(bedrock): attribute config-function throws to a distinct error case` — adds the `configFunctionFailed` variant, the stack-frame heuristic in `load-config.ts`, JSDoc updates, and regenerated `@example` switch.
3. `test(bedrock): add pipeline test for function-form config` — new `typescript-function` fixture plus pipeline integration test.

## Test plan

- [x] 5 new tests across `src/shell/load-config.spec.ts` and `tests/integration/config-pipeline.spec.ts`
- [x] 193 bedrock tests pass (188 prior + 5 new)
- [x] 100% mutation kill rate on `load-config.ts` via `pnpm mutate:changed`
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm build` all clean
- [x] `pnpm gen:example-tests` regenerates `config-error.example.spec.ts` with the new switch arm

## Notes for reviewers

- ADR-020 was not amended: its Implementation Notes list three error cases, and PRD [#124](https://github.com/christopher-buss/bedrock/issues/124) already specified the fourth. Happy to follow up with a dated amendment if you want the ADR fully comprehensive.
- Error shape mirrors `parseFailed` exactly (`{ kind, sourceFile, message }`). No `cause: unknown` field; callers that need the stack can propose a follow-up.
- The stack-frame heuristic checks lines that start with `at ` and contain the config file path, so it doesn't misclassify parse errors whose message happens to mention the filename.