### PR TITLE
test(bedrock): add type-level tests for config public api

### DIFF
--- a/packages/bedrock/src/index.spec-d.ts
+++ b/packages/bedrock/src/index.spec-d.ts
@@ -8,18 +8,57 @@ import {
 	asRobloxAssetId,
 	asSha256Hex,
 	buildDesired,
+	defineConfig,
 	isResourceKey,
 	isRobloxAssetId,
 	isSha256Hex,
+	loadConfig,
 } from "./index.ts";
 import type {
 	ApplyError,
 	BuildDesiredError,
+	Config,
+	ConfigContext,
+	ConfigError,
+	ConfigInput,
+	ConfigValidationIssue,
+	LoadConfigOptions,
 	ResourceDesiredState,
 	ResourceKey,
 	RobloxAssetId,
 	Sha256Hex,
 } from "./index.ts";
+
+interface ExpectedFileNotFound {
+	readonly kind: "fileNotFound";
+	readonly searchedFrom: string;
+}
+
+interface ExpectedParseFailed {
+	readonly kind: "parseFailed";
+	readonly message: string;
+	readonly sourceFile: string;
+}
+
+interface ExpectedConfigFunctionFailed {
+	readonly kind: "configFunctionFailed";
+	readonly message: string;
+	readonly sourceFile: string;
+}
+
+interface ExpectedValidationFailed {
+	readonly issues: ReadonlyArray<ConfigValidationIssue>;
+	readonly kind: "validationFailed";
+	readonly sourceFile: string;
+}
+
+function syncConfigBuilder(_ctx: ConfigContext): Config {
+	return { passes: {} };
+}
+
+async function asyncConfigBuilder(_ctx: ConfigContext): Promise<Config> {
+	return { passes: {} };
+}
 
 const brandShapeCases: ReadonlyArray<readonly [name: string, assertShape: () => void]> = [
 	[
@@ -120,5 +159,95 @@ describe(applyOps, () => {
 
 	it("should discriminate ApplyError on driverFailure and updateUnsupported kinds", () => {
 		expectTypeOf<ApplyError["kind"]>().toEqualTypeOf<"driverFailure" | "updateUnsupported">();
+	});
+});
+
+describe("Config", () => {
+	it("should expose exactly the four documented root fields", () => {
+		expectTypeOf<keyof Config>().toEqualTypeOf<
+			"environments" | "experience" | "extends" | "passes"
+		>();
+	});
+
+	it("should reserve environments, experience, and extends as unknown", () => {
+		expectTypeOf<Config["environments"]>().toEqualTypeOf<unknown>();
+		expectTypeOf<Config["experience"]>().toEqualTypeOf<unknown>();
+		expectTypeOf<Config["extends"]>().toEqualTypeOf<unknown>();
+	});
+
+	it("should treat every root field as optional so an empty object satisfies Config", () => {
+		expectTypeOf<Record<string, never>>().toExtend<Config>();
+	});
+});
+
+describe(defineConfig, () => {
+	it("should preserve the literal type when given a plain object", () => {
+		const literal = {
+			passes: {
+				"vip-pass": {
+					name: "VIP Pass",
+					description: "Grants VIP perks.",
+					iconFilePath: "assets/vip-icon.png",
+					price: 500,
+				},
+			},
+		};
+		expectTypeOf(defineConfig(literal)).toEqualTypeOf<typeof literal>();
+	});
+
+	it("should preserve the function type when given a sync config function", () => {
+		expectTypeOf(defineConfig(syncConfigBuilder)).toEqualTypeOf<typeof syncConfigBuilder>();
+	});
+
+	it("should preserve the function type when given an async config function", () => {
+		expectTypeOf(defineConfig(asyncConfigBuilder)).toEqualTypeOf<typeof asyncConfigBuilder>();
+	});
+
+	it("should constrain its generic to ConfigInput", () => {
+		expectTypeOf(defineConfig).parameter(0).toEqualTypeOf<ConfigInput>();
+	});
+});
+
+describe(loadConfig, () => {
+	it("should accept an optional LoadConfigOptions argument", () => {
+		expectTypeOf(loadConfig).parameter(0).toEqualTypeOf<LoadConfigOptions | undefined>();
+	});
+
+	it("should resolve to a Result of Config or ConfigError", () => {
+		expectTypeOf<Awaited<ReturnType<typeof loadConfig>>>().toEqualTypeOf<
+			Result<Config, ConfigError>
+		>();
+	});
+});
+
+describe("ConfigError", () => {
+	it("should discriminate on kind across the four documented variants", () => {
+		expectTypeOf<ConfigError["kind"]>().toEqualTypeOf<
+			"configFunctionFailed" | "fileNotFound" | "parseFailed" | "validationFailed"
+		>();
+	});
+
+	it("should narrow fileNotFound to carry only searchedFrom", () => {
+		expectTypeOf<
+			Extract<ConfigError, { kind: "fileNotFound" }>
+		>().toEqualTypeOf<ExpectedFileNotFound>();
+	});
+
+	it("should narrow parseFailed to carry message and sourceFile", () => {
+		expectTypeOf<
+			Extract<ConfigError, { kind: "parseFailed" }>
+		>().toEqualTypeOf<ExpectedParseFailed>();
+	});
+
+	it("should narrow configFunctionFailed to carry message and sourceFile", () => {
+		expectTypeOf<
+			Extract<ConfigError, { kind: "configFunctionFailed" }>
+		>().toEqualTypeOf<ExpectedConfigFunctionFailed>();
+	});
+
+	it("should narrow validationFailed to carry issues and sourceFile", () => {
+		expectTypeOf<
+			Extract<ConfigError, { kind: "validationFailed" }>
+		>().toEqualTypeOf<ExpectedValidationFailed>();
 	});
 });


### PR DESCRIPTION
Closes [#139](https://github.com/christopher-buss/bedrock/issues/139) (parent PRD [#124](https://github.com/christopher-buss/bedrock/issues/124)).

## Summary

- Adds four `describe` blocks to `packages/bedrock/src/index.spec-d.ts` that lock in the inferred and exported shapes of the config public API under vitest's typecheck runner.
- Covers `Config` (keyset of 4 root fields, `environments` / `experience` / `extends` reserved as `unknown`, all fields optional), `defineConfig` (literal-type preservation across plain object, sync function, and async function inputs; parameter constrained to `ConfigInput`), `loadConfig` (return envelope is `Promise<Result<Config, ConfigError>>` with optional `LoadConfigOptions`), and `ConfigError` (discriminator union plus per-variant shape for `fileNotFound`, `parseFailed`, `configFunctionFailed`, and `validationFailed`).
- Lifts helper function declarations and expected-variant-shape interfaces to module scope to satisfy `unicorn/consistent-function-scoping` and keep the describe body under `max-lines-per-function`.

## Why

PRD [#124](https://github.com/christopher-buss/bedrock/issues/124)'s Testing Decisions section calls for type-level tests on the config public API so accidental widening (a lost `readonly`, a widened generic, a dropped variant field) fails the test suite rather than slipping past `typecheck`. Today `index.spec-d.ts` pins branded IDs, `buildDesired`, and `applyOps` but nothing for the config surface. This PR fills that gap.

## Test plan

- [x] `VITEST_TYPECHECK=true pnpm --filter @bedrock/bedrock test src/index.spec-d.ts` — 65 pass, 0 type errors
- [x] `pnpm --filter @bedrock/bedrock test` — 574 pass, 0 type errors (14 new assertions)
- [x] `pnpm lint` — clean
- [x] Pre-push hooks (lint, typecheck, gen-example-tests, unused, build, test) all passed

## Notes for reviewers

- Test-only change; no production code touched. All new lines are exercised by `expectTypeOf` assertions in the same file.
- The "every root field is optional" assertion uses `expectTypeOf<Record<string, never>>().toExtend<Config>()` as the lint-compliant equivalent of `{} extends Config` (ESLint bans the bare `{}` type).
- Out of scope per AC: `ConfigContext` (intentionally empty per ADR), `validateConfig` (its return type is the same `Result<Config, ConfigError>` envelope as `loadConfig` and is covered indirectly).

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>