### PR TITLE
docs: recalibrate adr trigger bar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,78 +224,62 @@ Use GitHub issue templates for:
 - Feature requests
 - Documentation improvements
 
-### Making Architectural Decisions (MANDATORY)
+### Making Architectural Decisions
 
-**ADRs are mandatory before implementing architectural changes. No exceptions.**
+Bedrock is pre-1.0, unpublished, and solo-maintained. ADRs are for decisions
+a future maintainer could not reconstruct from the commit, PR body, and code.
+Default to no ADR.
 
-An Architecture Decision Record (ADR) must be created BEFORE implementation when
-ANY of these conditions apply:
+**Write an ADR when the decision is one of:**
 
-1. **Technology Choices**: New dependencies, build tools, frameworks, or
-   project-wide patterns
-2. **Architectural Patterns**: New layers, boundaries, abstractions, or
-   communication patterns
-3. **External Integrations**: Third-party services, APIs, authentication, or
-   state storage
-4. **Data Models**: State persistence, serialization, configuration formats, or
-   migrations
-5. **Security & Constraints**: Authentication methods, security requirements, or
-   secret management
-6. **Developer Workflow**: CI/CD changes, testing requirements, or code
-   generation
-7. **Breaking Changes**: Backwards-incompatible API changes, deprecations, or
-   removals
+1. **Package or technology choice.** Selecting between candidates where the
+   tradeoffs mattered (c12 vs cosmiconfig, Stryker vs mutmut, Vite vs tsup),
+   or adopting something that locks the project into a vendor, paradigm, or
+   runtime whose removal would require redesign (Effect-TS, a DI container).
+   A utility with no meaningful alternative considered (nanoid, a type-only
+   package, a test helper) does not qualify.
+2. **New category of integration.** A new auth mechanism, state backend, or
+   API provider. A new endpoint on an existing Open Cloud client does not
+   qualify.
+3. **Cross-package pattern.** A new port, layer, or boundary that other
+   packages must adopt. One more adapter inside an established port does
+   not qualify.
+4. **State or wire contract.** State file shape, serialization format, config
+   schema, or diff algebra changes.
+5. **Security.** Auth flow, secret handling, or trust boundary.
+6. **Mandatory developer policy.** A new required check, test level, or
+   commit gate. CI tweaks and retuning existing tooling do not qualify.
+7. **Breaking change post-publish.** Only once bedrock is published to npm.
+   Before that, downstream consumers do not exist.
 
-**What does NOT require an ADR**:
+**Gray-zone calibration:**
 
-- Bug fixes that don't change architecture
-- Tests for existing code
-- Behavior-preserving refactors
-- Documentation updates (unless changing doc strategy)
-- Performance optimizations without new dependencies
-- Features following existing patterns
+| Scenario                                             | ADR? |
+| ---------------------------------------------------- | ---- |
+| New endpoint on an existing Open Cloud client        | no   |
+| New Open Cloud auth flow                             | yes  |
+| `pnpm add nanoid` (no alternative considered)        | no   |
+| Choosing c12 over cosmiconfig for config loading     | yes  |
+| Adopting Effect-TS or equivalent                     | yes  |
+| Tuning Stryker thresholds                            | no   |
+| Requiring mutation testing on CI                     | yes  |
+| New resource kind following ADR-018/019 pattern      | no   |
+| New resource kind that needs its own diff algebra    | yes  |
 
-**Process**:
+**Never ADR:** bug fixes, tests, behavior-preserving refactors, docs,
+performance tweaks.
 
-1. Identify decision type from list above
-2. Use `adr` agent to create ADR collaboratively
-3. Follow methodological Q&A process (see below)
-4. Get stakeholder approval if needed
-5. Mark ADR as "Accepted" before implementation begins
-6. Implement the change
-7. Update ADR if implementation reveals new information
+**Process when an ADR is warranted:**
 
-**For Claude Code**:
+1. Use the `adr` agent. Brainstorm collaboratively; do not auto-generate.
+2. Walk the Q&A: context, options, criteria, consequences, review. One
+   question at a time; never assume.
+3. Draft incrementally. Mark Accepted before implementation.
+4. After Accepted, evolve via dated amendments, never retroactive rewrites
+   of Decision or Consequences.
 
-When user requests implementation meeting ANY trigger criteria above:
-
-1. STOP before implementing
-2. Inform user an ADR is required
-3. Offer to use `adr` agent to create ADR collaboratively
-4. Wait for approval before proceeding with implementation
-
-**ADR Creation Process (Methodological Q&A)**:
-
-The ADR process must be slow and methodological. No assumptions. The `adr` agent
-guides through:
-
-1. **Context Gathering**: Problem? Constraints? Current state? Who's affected?
-2. **Options Exploration**: Alternatives? Pros/cons each? What if do nothing?
-3. **Decision Criteria**: What matters most? Deal-breakers? Timeline? Risk?
-4. **Consequences Analysis**: Positive outcomes? Trade-offs? Reversible? Future?
-5. **Documentation Review**: Review draft, confirm accuracy, identify gaps
-
-**Rules**:
-
-- Ask questions one at a time for complex decisions
-- Never assume - always confirm
-- Use AskUserQuestion tool liberally
-- Reference existing ADRs for consistency patterns
-- Draft ADR incrementally through conversation, not all at once
-
-**Rule of thumb**: If asking "should this be an ADR?" - it probably should be.
-
-See `docs/adr/006-adr-enforcement.md` for full rationale.
+See `docs/adr/006-adr-enforcement.md` for full rationale and the 2026-04-23
+amendment recalibrating the bar.
 
 ## Constraints
 

--- a/docs/adr/006-adr-enforcement.md
+++ b/docs/adr/006-adr-enforcement.md
@@ -177,3 +177,36 @@ line 51). Explicit, mandatory language like ADR-003.
 - [CLAUDE.md current "Making Decisions" section](../../CLAUDE.md)
 - [ADR template](../templates/adr.md)
 - [.claude/agents/adr.md custom agent](../../.claude/agents/adr.md)
+
+## Amendment: 2026-04-23, recalibrate the trigger bar
+
+The original Decision (Part 1) defines seven mandatory triggers broad enough
+that routine work falls inside them: every `pnpm add`, every new Open Cloud
+endpoint, every CI tweak. In practice this produces ceremony. ADRs 011 and
+012 were written retroactively to catch the log up rather than to decide
+anything, and the "if asking, it probably should be" rule of thumb biases
+toward ADRs for additions where no real alternative was considered.
+
+The seven trigger categories remain. Each tightens to require a real
+decision, not mere category membership:
+
+- A package addition triggers an ADR when alternatives were weighed
+  (c12 vs cosmiconfig, Stryker vs mutmut, hk vs husky). A utility with no
+  meaningful competitor does not qualify.
+- A dependency also triggers an ADR when it locks in a vendor or paradigm
+  whose removal would require redesign (Effect-TS, a DI container).
+- An integration triggers an ADR on a new category (auth flow, state
+  backend, API provider), not a new endpoint inside an existing client.
+- Developer workflow triggers an ADR on mandatory policy changes, not on
+  CI tweaks or retuning existing tooling.
+- "Breaking Changes" is inert until bedrock is published to npm. Before
+  that, downstream consumers do not exist.
+
+The rule of thumb "If asking 'should this be an ADR?' - it probably should
+be" is retired. The new default: no ADR unless a future maintainer could
+not reconstruct the *why* from the commit, PR body, and code. CLAUDE.md's
+"Making Architectural Decisions" section is rewritten with a gray-zone
+table rather than abstract categories.
+
+The Q&A process (Part 2) and the "Accepted before implementation" rule
+(Part 3) remain in effect for decisions that clear the narrower bar.


### PR DESCRIPTION
## Summary
- Rewrite CLAUDE.md's "Making Architectural Decisions" section with a narrower default (no ADR unless a future maintainer could not reconstruct the *why* from commit + PR body + code), tightened triggers that each name what does NOT qualify, and a gray-zone calibration table.
- Preserve package-selection-with-real-alternatives as trigger 1 (c12 vs cosmiconfig, Stryker vs mutmut).
- Gate the "breaking change" trigger on post-npm-publish — bedrock is pre-1.0, so downstream consumers do not exist yet.
- Append a dated 2026-04-23 amendment to ADR-006 rather than rewriting its Decision or Consequences (per the ADR amendment convention).

## Why
The prior bar was stricter than Michael Nygard's original 2011 post, MADR, Martin Fowler's guidance, and even the Kubernetes KEP/Rust RFC thresholds. In practice it produced ceremony: a single GitHub issue could trigger 2+ ADRs before any code could be written. ADRs 011 and 012 were written retroactively to catch the log up, not to decide anything, and the rule-of-thumb *"if asking, it probably should be"* biased Claude toward over-firing on routine work.

InfoQ's warning describes the failure mode directly: *"If every decision is architectural, no decision is architectural."*

## Test plan
- [ ] Read CLAUDE.md's new section end-to-end; confirm it reads as declarative reference, not as a rebuttal to the prior version
- [ ] Confirm ADR-006's Decision and Consequences are unchanged; amendment is appended at the bottom
- [ ] Spot-check the gray-zone table against recent real PRs to see whether the calibration feels right

🤖 Generated with [Claude Code](https://claude.com/claude-code)