### PR TITLE
test(bedrock): consolidate resource fixture builders into shared helpers

### DIFF
--- a/packages/bedrock/src/adapters/game-pass-driver.spec.ts
+++ b/packages/bedrock/src/adapters/game-pass-driver.spec.ts
@@ -2,11 +2,11 @@ import { ApiError } from "@bedrock/ocale";
 import { GamePassesClient } from "@bedrock/ocale/game-passes";
 import { createFakeHttpClient, validGamePassBody } from "@bedrock/ocale/testing";
 
+import { gamePassDesired } from "#tests/helpers/resources";
 import type { Except } from "type-fest";
 import { assert, describe, expect, it } from "vitest";
 
-import type { GamePassDesiredState } from "../core/resources.ts";
-import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../types/ids.ts";
+import { asRobloxAssetId } from "../types/ids.ts";
 import { createGamePassDriver, type GamePassDriverDeps } from "./game-pass-driver.ts";
 
 const UNIVERSE_ID = asRobloxAssetId("1234567890");
@@ -19,21 +19,6 @@ const WIRE_BODY = validGamePassBody({
 	iconAssetId: 1_122_334_455,
 	priceInformation: { defaultPriceInRobux: 500, enabledFeatures: [] },
 });
-
-function makeDesired(overrides?: Partial<GamePassDesiredState>): GamePassDesiredState {
-	return {
-		key: asResourceKey("vip-pass"),
-		name: "VIP Pass",
-		description: "Grants VIP perks.",
-		iconFileHash: asSha256Hex(
-			"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-		),
-		iconFilePath: "assets/vip-icon.png",
-		kind: "gamePass",
-		price: 500,
-		...overrides,
-	};
-}
 
 function makeDriver(overrides?: Partial<Except<GamePassDriverDeps, "client">>) {
 	const http = createFakeHttpClient();
@@ -71,7 +56,7 @@ describe(createGamePassDriver, () => {
 		const { driver, http } = makeDriver();
 		http.mockResponse({ body: WIRE_BODY, status: 200 });
 
-		const desired = makeDesired();
+		const desired = gamePassDesired();
 		const result = await driver.create(desired);
 
 		assert(result.success);
@@ -91,7 +76,7 @@ describe(createGamePassDriver, () => {
 		const { driver, http } = makeDriver();
 		http.mockResponse({ body: WIRE_BODY, status: 200 });
 
-		await driver.create(makeDesired());
+		await driver.create(gamePassDesired());
 
 		const captured = http.requests[0]!;
 
@@ -105,7 +90,7 @@ describe(createGamePassDriver, () => {
 		const { driver, http } = makeDriver();
 		http.mockResponse({ body: WIRE_BODY, status: 200 });
 
-		await driver.create(makeDesired());
+		await driver.create(gamePassDesired());
 
 		const captured = http.requests[0]!;
 
@@ -123,7 +108,7 @@ describe(createGamePassDriver, () => {
 		const { driver, http } = makeDriver();
 		http.mockResponse({ body: WIRE_BODY, status: 200 });
 
-		await driver.create(makeDesired({ price: undefined }));
+		await driver.create(gamePassDesired({ price: undefined }));
 
 		const captured = http.requests[0]!;
 		assert(captured.request.body instanceof FormData);
@@ -137,7 +122,7 @@ describe(createGamePassDriver, () => {
 		const { driver, http } = makeDriver();
 		http.mockApiError({ message: "boom", statusCode: 500 });
 
-		const result = await driver.create(makeDesired());
+		const result = await driver.create(gamePassDesired());
 
 		assert(!result.success);
 		assert(result.err instanceof ApiError);
@@ -155,7 +140,7 @@ describe(createGamePassDriver, () => {
 			status: 200,
 		});
 
-		const result = await driver.create(makeDesired());
+		const result = await driver.create(gamePassDesired());
 
 		assert(!result.success);
 
@@ -182,7 +167,7 @@ describe(createGamePassDriver, () => {
 			universeId: UNIVERSE_ID,
 		});
 
-		await expect(driver.create(makeDesired())).rejects.toBe(fsError);
+		await expect(driver.create(gamePassDesired())).rejects.toBe(fsError);
 		expect(http.requests).toBeEmpty();
 	});
 });

--- a/packages/bedrock/src/adapters/place-driver.spec.ts
+++ b/packages/bedrock/src/adapters/place-driver.spec.ts
@@ -2,32 +2,19 @@ import { ApiError } from "@bedrock/ocale";
 import { PlacesClient } from "@bedrock/ocale/places";
 import { createFakeHttpClient } from "@bedrock/ocale/testing";
 
+import { placeCurrent, placeDesired } from "#tests/helpers/resources";
 import type { Except } from "type-fest";
 import { assert, describe, expect, it } from "vitest";
 
-import type { PlaceDesiredState, ResourceCurrentState } from "../core/resources.ts";
-import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../types/ids.ts";
+import { asRobloxAssetId } from "../types/ids.ts";
 import { createPlaceDriver, type PlaceDriverDeps } from "./place-driver.ts";
 
 const UNIVERSE_ID = asRobloxAssetId("1234567890");
 const PLACE_ID = asRobloxAssetId("4711");
-const PLACE_KEY = asResourceKey("start-place");
-const PLACE_HASH = asSha256Hex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 const RBXL_SIGNATURE = new Uint8Array([
 	0x3c, 0x72, 0x6f, 0x62, 0x6c, 0x6f, 0x78, 0x21, 0x89, 0xff, 0x0d, 0x0a, 0x1a, 0x0a,
 ]);
 const RBXLX_SIGNATURE = new Uint8Array([0x3c, 0x72, 0x6f, 0x62, 0x6c, 0x6f, 0x78, 0x20]);
-
-function makeDesired(overrides?: Partial<PlaceDesiredState>): PlaceDesiredState {
-	return {
-		key: PLACE_KEY,
-		fileHash: PLACE_HASH,
-		filePath: "places/start.rbxl",
-		kind: "place",
-		placeId: PLACE_ID,
-		...overrides,
-	};
-}
 
 function makeDriver(overrides?: Partial<Except<PlaceDriverDeps, "client">>) {
 	const http = createFakeHttpClient();
@@ -44,10 +31,6 @@ function makeDriver(overrides?: Partial<Except<PlaceDriverDeps, "client">>) {
 	return { driver, http };
 }
 
-function currentFrom(desired: PlaceDesiredState): ResourceCurrentState<"place"> {
-	return { ...desired, outputs: { versionNumber: 1 } };
-}
-
 describe(createPlaceDriver, () => {
 	it("should publish an rbxl place and return a PlaceOutputs-shaped current state", async () => {
 		expect.assertions(1);
@@ -55,7 +38,7 @@ describe(createPlaceDriver, () => {
 		const { driver, http } = makeDriver();
 		http.mockResponse({ body: { versionNumber: 3 }, status: 200 });
 
-		const desired = makeDesired();
+		const desired = placeDesired();
 		const result = await driver.create(desired);
 
 		assert(result.success);
@@ -72,7 +55,7 @@ describe(createPlaceDriver, () => {
 		const { driver, http } = makeDriver();
 		http.mockResponse({ body: { versionNumber: 1 }, status: 200 });
 
-		await driver.create(makeDesired());
+		await driver.create(placeDesired());
 
 		const captured = http.requests[0]!;
 
@@ -89,7 +72,7 @@ describe(createPlaceDriver, () => {
 		const { driver, http } = makeDriver({ readFile: async () => RBXLX_SIGNATURE });
 		http.mockResponse({ body: { versionNumber: 1 }, status: 200 });
 
-		await driver.create(makeDesired({ filePath: "places/start.rbxlx" }));
+		await driver.create(placeDesired({ filePath: "places/start.rbxlx" }));
 
 		expect(http.requests[0]!.request.headers?.["content-type"]).toBe("application/xml");
 	});
@@ -99,7 +82,7 @@ describe(createPlaceDriver, () => {
 
 		const { driver, http } = makeDriver();
 
-		const result = await driver.create(makeDesired({ filePath: "places/start.txt" }));
+		const result = await driver.create(placeDesired({ filePath: "places/start.txt" }));
 
 		assert(!result.success);
 
@@ -114,7 +97,7 @@ describe(createPlaceDriver, () => {
 		const { driver, http } = makeDriver();
 		http.mockApiError({ message: "boom", statusCode: 500 });
 
-		const result = await driver.create(makeDesired());
+		const result = await driver.create(placeDesired());
 
 		assert(!result.success);
 		assert(result.err instanceof ApiError);
@@ -133,7 +116,7 @@ describe(createPlaceDriver, () => {
 			},
 		});
 
-		await expect(driver.create(makeDesired())).rejects.toBe(fsError);
+		await expect(driver.create(placeDesired())).rejects.toBe(fsError);
 		expect(http.requests).toBeEmpty();
 	});
 
@@ -145,8 +128,8 @@ describe(createPlaceDriver, () => {
 
 		assert(driver.update !== undefined);
 
-		const desired = makeDesired();
-		const result = await driver.update(currentFrom(desired), desired);
+		const desired = placeDesired();
+		const result = await driver.update(placeCurrent({ ...desired }), desired);
 
 		assert(result.success);
 

--- a/packages/bedrock/src/core/diff.spec.ts
+++ b/packages/bedrock/src/core/diff.spec.ts
@@ -1,69 +1,17 @@
+import {
+	gamePassCurrent,
+	gamePassDesired,
+	placeCurrent,
+	placeDesired,
+} from "#tests/helpers/resources";
 import { assert, describe, expect, it } from "vitest";
 
 import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../types/ids.ts";
 import { diff } from "./diff.ts";
-import type { GamePassDesiredState, PlaceDesiredState, ResourceCurrentState } from "./resources.ts";
+import type { GamePassDesiredState, ResourceCurrentState } from "./resources.ts";
 
-const DEFAULT_HASH = asSha256Hex(
-	"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-);
 const ALT_HASH = asSha256Hex("a3f2c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852e1b0");
 const PLACE_KEY = asResourceKey("start-place");
-const PLACE_ID = asRobloxAssetId("4711");
-const PLACE_HASH = asSha256Hex("039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81");
-
-function placeDesired(overrides?: Partial<PlaceDesiredState>): PlaceDesiredState {
-	return {
-		key: PLACE_KEY,
-		fileHash: PLACE_HASH,
-		filePath: "places/start.rbxl",
-		kind: "place",
-		placeId: PLACE_ID,
-		...overrides,
-	};
-}
-
-function placeCurrent(
-	overrides?: Partial<ResourceCurrentState<"place">>,
-): ResourceCurrentState<"place"> {
-	return {
-		...placeDesired(),
-		outputs: { versionNumber: 1 },
-		...overrides,
-	};
-}
-
-function gamePassDesired(overrides?: Partial<GamePassDesiredState>): GamePassDesiredState {
-	return {
-		key: asResourceKey("vip-pass"),
-		name: "VIP Pass",
-		description: "Grants VIP perks.",
-		iconFileHash: DEFAULT_HASH,
-		iconFilePath: "assets/vip-icon.png",
-		kind: "gamePass",
-		price: 500,
-		...overrides,
-	};
-}
-
-function gamePassCurrent(
-	overrides?: Partial<ResourceCurrentState<"gamePass">>,
-): ResourceCurrentState<"gamePass"> {
-	return {
-		key: asResourceKey("vip-pass"),
-		name: "VIP Pass",
-		description: "Grants VIP perks.",
-		iconFileHash: DEFAULT_HASH,
-		iconFilePath: "assets/vip-icon.png",
-		kind: "gamePass",
-		outputs: {
-			assetId: asRobloxAssetId("9876543210"),
-			iconAssetId: asRobloxAssetId("1122334455"),
-		},
-		price: 500,
-		...overrides,
-	};
-}
 
 describe(diff, () => {
 	it("should return an empty list when both snapshots are empty", () => {

--- a/packages/bedrock/src/shell/apply-ops.spec.ts
+++ b/packages/bedrock/src/shell/apply-ops.spec.ts
@@ -1,63 +1,23 @@
 import { OpenCloudError } from "@bedrock/ocale";
 
+import {
+	gamePassCurrent,
+	gamePassDesired,
+	placeCurrent,
+	placeDesired,
+} from "#tests/helpers/resources";
 import { assert, describe, expect, it, vi } from "vitest";
 
 import type { CreateOperation, UpdateOperation } from "../core/operations.ts";
-import type {
-	GamePassDesiredState,
-	PlaceDesiredState,
-	ResourceCurrentState,
-} from "../core/resources.ts";
 import type { DriverRegistry, ResourceDriver } from "../ports/resource-driver.ts";
-import { asResourceKey, asRobloxAssetId, asSha256Hex, type ResourceKey } from "../types/ids.ts";
+import { asResourceKey, type ResourceKey } from "../types/ids.ts";
 import { applyOps } from "./apply-ops.ts";
-
-const ICON_HASH = asSha256Hex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
-const PLACE_HASH = asSha256Hex("039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81");
-
-function gamePassDesired(overrides?: Partial<GamePassDesiredState>): GamePassDesiredState {
-	return {
-		key: asResourceKey("vip-pass"),
-		name: "VIP Pass",
-		description: "Grants VIP perks.",
-		iconFileHash: ICON_HASH,
-		iconFilePath: "assets/vip-icon.png",
-		kind: "gamePass",
-		price: 500,
-		...overrides,
-	};
-}
-
-function currentFrom(desired: GamePassDesiredState): ResourceCurrentState<"gamePass"> {
-	return {
-		...desired,
-		outputs: {
-			assetId: asRobloxAssetId("9876543210"),
-			iconAssetId: asRobloxAssetId("1122334455"),
-		},
-	};
-}
 
 const placeStub: ResourceDriver<"place"> = {
 	async create() {
 		return { err: new OpenCloudError("place stub"), success: false };
 	},
 };
-
-function placeDesired(overrides?: Partial<PlaceDesiredState>): PlaceDesiredState {
-	return {
-		key: asResourceKey("start-place"),
-		fileHash: PLACE_HASH,
-		filePath: "places/start.rbxl",
-		kind: "place",
-		placeId: asRobloxAssetId("4711"),
-		...overrides,
-	};
-}
-
-function placeCurrentFrom(desired: PlaceDesiredState): ResourceCurrentState<"place"> {
-	return { ...desired, outputs: { versionNumber: 1 } };
-}
 
 function createOp(key: ResourceKey) {
 	const desired = gamePassDesired({ key });
@@ -68,7 +28,7 @@ function updateOp(key: ResourceKey) {
 	const desired = gamePassDesired({ key });
 	return {
 		key,
-		current: currentFrom(desired),
+		current: gamePassCurrent({ ...desired }),
 		desired,
 		type: "update",
 	} as const satisfies UpdateOperation;
@@ -102,7 +62,7 @@ describe(applyOps, () => {
 		const op = createOp(asResourceKey("vip-pass"));
 		const create = vi
 			.fn<ResourceDriver<"gamePass">["create"]>()
-			.mockResolvedValue({ data: currentFrom(op.desired), success: true });
+			.mockResolvedValue({ data: gamePassCurrent({ ...op.desired }), success: true });
 
 		const result = await applyOps([op], registryWith(create));
 
@@ -117,7 +77,7 @@ describe(applyOps, () => {
 		const op = createOp(asResourceKey("vip-pass"));
 		const create = vi
 			.fn<ResourceDriver<"gamePass">["create"]>()
-			.mockResolvedValue({ data: currentFrom(op.desired), success: true });
+			.mockResolvedValue({ data: gamePassCurrent({ ...op.desired }), success: true });
 
 		const result = await applyOps(
 			[op, { key: asResourceKey("sync-pass"), type: "noop" }],
@@ -138,7 +98,9 @@ describe(applyOps, () => {
 		];
 		const create = vi
 			.fn<ResourceDriver<"gamePass">["create"]>()
-			.mockImplementation(async (desired) => ({ data: currentFrom(desired), success: true }));
+			.mockImplementation(async (desired) => {
+				return { data: gamePassCurrent({ ...desired }), success: true };
+			});
 
 		const result = await applyOps(ops, registryWith(create));
 
@@ -159,7 +121,7 @@ describe(applyOps, () => {
 		const cause = new OpenCloudError("boom");
 		const create = vi
 			.fn<ResourceDriver<"gamePass">["create"]>()
-			.mockResolvedValueOnce({ data: currentFrom(first.desired), success: true })
+			.mockResolvedValueOnce({ data: gamePassCurrent({ ...first.desired }), success: true })
 			.mockResolvedValueOnce({ err: cause, success: false });
 
 		const result = await applyOps([first, second, third], registryWith(create));
@@ -200,7 +162,7 @@ describe(applyOps, () => {
 		const create = vi.fn<ResourceDriver<"gamePass">["create"]>();
 		const update = vi
 			.fn<NonNullable<ResourceDriver<"gamePass">["update"]>>()
-			.mockResolvedValue({ data: currentFrom(op.desired), success: true });
+			.mockResolvedValue({ data: gamePassCurrent({ ...op.desired }), success: true });
 
 		const result = await applyOps([op], registryWith(create, update));
 
@@ -254,7 +216,7 @@ describe(applyOps, () => {
 			const desired = placeDesired({ key });
 			return {
 				key,
-				current: placeCurrentFrom(desired),
+				current: placeCurrent({ ...desired }),
 				desired,
 				type: "update",
 			} as const satisfies UpdateOperation;
@@ -266,7 +228,7 @@ describe(applyOps, () => {
 			const op = placeCreateOp(asResourceKey("start-place"));
 			const create = vi
 				.fn<ResourceDriver<"place">["create"]>()
-				.mockResolvedValue({ data: placeCurrentFrom(op.desired), success: true });
+				.mockResolvedValue({ data: placeCurrent({ ...op.desired }), success: true });
 
 			const result = await applyOps([op], placeRegistry(create));
 
@@ -313,7 +275,7 @@ describe(applyOps, () => {
 			const create = vi.fn<ResourceDriver<"place">["create"]>();
 			const update = vi
 				.fn<NonNullable<ResourceDriver<"place">["update"]>>()
-				.mockResolvedValue({ data: placeCurrentFrom(op.desired), success: true });
+				.mockResolvedValue({ data: placeCurrent({ ...op.desired }), success: true });
 
 			const result = await applyOps([op], placeRegistry(create, update));
 
@@ -344,10 +306,10 @@ describe(applyOps, () => {
 			expect.assertions(4);
 
 			const placeDesiredState = placeDesired();
-			const gamePassCurrent = currentFrom(gamePassDesired({ key: placeDesiredState.key }));
+			const crossKindCurrent = gamePassCurrent({ key: placeDesiredState.key });
 			const op: UpdateOperation = {
 				key: placeDesiredState.key,
-				current: gamePassCurrent,
+				current: crossKindCurrent,
 				desired: placeDesiredState,
 				type: "update",
 			};
@@ -370,20 +332,11 @@ describe(applyOps, () => {
 		it("should return driverFailure with a kind-mismatch message when op.current.kind does not match gamePass", async () => {
 			expect.assertions(4);
 
-			const placeCurrent: ResourceCurrentState<"place"> = {
-				key: asResourceKey("vip-pass"),
-				fileHash: asSha256Hex(
-					"039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
-				),
-				filePath: "places/start.rbxl",
-				kind: "place",
-				outputs: { versionNumber: 1 },
-				placeId: asRobloxAssetId("4711"),
-			};
+			const crossKindCurrent = placeCurrent({ key: asResourceKey("vip-pass") });
 			const op: UpdateOperation = {
-				key: placeCurrent.key,
-				current: placeCurrent,
-				desired: gamePassDesired({ key: placeCurrent.key }),
+				key: crossKindCurrent.key,
+				current: crossKindCurrent,
+				desired: gamePassDesired({ key: crossKindCurrent.key }),
 				type: "update",
 			};
 			const create = vi.fn<ResourceDriver<"gamePass">["create"]>();

--- a/packages/bedrock/tests/helpers/resources.ts
+++ b/packages/bedrock/tests/helpers/resources.ts
@@ -1,0 +1,87 @@
+import type {
+	GamePassDesiredState,
+	PlaceDesiredState,
+	ResourceCurrentState,
+} from "#src/core/resources";
+import { asResourceKey, asRobloxAssetId, asSha256Hex } from "#src/types/ids";
+
+const ICON_HASH = asSha256Hex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+
+const PLACE_HASH = asSha256Hex("039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81");
+
+/**
+ * Builds a default {@link GamePassDesiredState} fixture. Pass an `overrides`
+ * object to tweak individual fields without re-stating the defaults.
+ *
+ * @param overrides - Fields to override on the default fixture.
+ * @returns A desired-state fixture with the overrides applied.
+ */
+export function gamePassDesired(overrides?: Partial<GamePassDesiredState>): GamePassDesiredState {
+	return {
+		key: asResourceKey("vip-pass"),
+		name: "VIP Pass",
+		description: "Grants VIP perks.",
+		iconFileHash: ICON_HASH,
+		iconFilePath: "assets/vip-icon.png",
+		kind: "gamePass",
+		price: 500,
+		...overrides,
+	};
+}
+
+/**
+ * Builds a default {@link ResourceCurrentState} fixture for the `gamePass`
+ * kind. Pass an `overrides` object to tweak individual fields without
+ * re-stating the defaults.
+ *
+ * @param overrides - Fields to override on the default fixture.
+ * @returns A current-state fixture with the overrides applied.
+ */
+export function gamePassCurrent(
+	overrides?: Partial<ResourceCurrentState<"gamePass">>,
+): ResourceCurrentState<"gamePass"> {
+	return {
+		...gamePassDesired(),
+		outputs: {
+			assetId: asRobloxAssetId("9876543210"),
+			iconAssetId: asRobloxAssetId("1122334455"),
+		},
+		...overrides,
+	};
+}
+
+/**
+ * Builds a default {@link PlaceDesiredState} fixture. Pass an `overrides`
+ * object to tweak individual fields without re-stating the defaults.
+ *
+ * @param overrides - Fields to override on the default fixture.
+ * @returns A desired-state fixture with the overrides applied.
+ */
+export function placeDesired(overrides?: Partial<PlaceDesiredState>): PlaceDesiredState {
+	return {
+		key: asResourceKey("start-place"),
+		fileHash: PLACE_HASH,
+		filePath: "places/start.rbxl",
+		kind: "place",
+		placeId: asRobloxAssetId("4711"),
+		...overrides,
+	};
+}
+
+/**
+ * Builds a default {@link ResourceCurrentState} fixture for the `place` kind.
+ * Pass an `overrides` object to tweak individual fields without re-stating
+ * the defaults.
+ *
+ * @param overrides - Fields to override on the default fixture.
+ * @returns A current-state fixture with the overrides applied.
+ */
+export function placeCurrent(
+	overrides?: Partial<ResourceCurrentState<"place">>,
+): ResourceCurrentState<"place"> {
+	return {
+		...placeDesired(),
+		outputs: { versionNumber: 1 },
+		...overrides,
+	};
+}


### PR DESCRIPTION
## Summary

- Lift duplicated `gamePassDesired`, `gamePassCurrent`, `placeDesired`, and `placeCurrent` fixture builders (plus the `ICON_HASH`/`PLACE_HASH` constants) out of four spec files into a single [packages/bedrock/tests/helpers/resources.ts](packages/bedrock/tests/helpers/resources.ts), mirroring the `@bedrock/ocale` `tests/helpers/` pattern.
- Update [diff.spec.ts](packages/bedrock/src/core/diff.spec.ts), [apply-ops.spec.ts](packages/bedrock/src/shell/apply-ops.spec.ts), [game-pass-driver.spec.ts](packages/bedrock/src/adapters/game-pass-driver.spec.ts), and [place-driver.spec.ts](packages/bedrock/src/adapters/place-driver.spec.ts) to import from `#tests/helpers/resources` instead of re-defining the same fixtures locally.

## Notes for reviewers

- `place-driver.spec.ts` previously used the `ICON_HASH` literal (`e3b0…`) as its local `PLACE_HASH`; aligned onto the canonical `0390…` literal used in the other specs. No behavioural effect — the hash is only propagated through `...desired` spreads and never asserted on directly.
- The `registryWith`/`placeRegistry` helpers in `apply-ops.spec.ts` were intentionally left file-local; only `applyOps` consumes `DriverRegistry`.
- Two local variables in `apply-ops.spec.ts` (`gamePassCurrent`, `placeCurrent`) were renamed to `crossKindCurrent` where they would have shadowed the new imports.

## Test plan

- [x] `pnpm --filter bedrock test` (257/257 pass, typecheck clean)
- [x] `pnpm lint`
- [x] Pre-push hook (lint, typecheck, build, test, knip) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)