### PR TITLE
refactor: replace two loop accumulators with array methods

### DIFF
--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -3,7 +3,7 @@ import type { Result } from "@bedrock/ocale";
 import { ArkErrors, type, type Type } from "arktype";
 
 import { RESOURCE_KEY_PATTERN_SOURCE } from "../types/ids.ts";
-import type { ConfigError, ConfigValidationIssue } from "./config-error.ts";
+import type { ConfigError } from "./config-error.ts";
 
 /**
  * Body of a single entry in the `passes` collection. Keys in the parent
@@ -154,13 +154,12 @@ const rootSchema: Type<Config> = type({
 export function validateConfig(input: unknown, sourceFile: string): Result<Config, ConfigError> {
 	const validated = rootSchema(input);
 	if (validated instanceof ArkErrors) {
-		const issues: Array<ConfigValidationIssue> = [];
-		for (const issue of validated) {
-			issues.push({
+		const issues = Array.from(validated, (issue) => {
+			return {
 				message: issue.message,
 				path: [...issue.path].map((segment) => String(segment)),
-			});
-		}
+			};
+		});
 
 		return {
 			err: { issues, kind: "validationFailed", sourceFile },

--- a/packages/open-cloud/src/resources/universes/builders.ts
+++ b/packages/open-cloud/src/resources/universes/builders.ts
@@ -72,14 +72,5 @@ export function buildUpdateRequest(
 }
 
 function extractUpdateFieldKeys(parameters: UpdateUniverseParameters): ReadonlyArray<string> {
-	const keys: Array<string> = [];
-	for (const key of Object.keys(parameters)) {
-		if (key === "universeId") {
-			continue;
-		}
-
-		keys.push(key);
-	}
-
-	return keys;
+	return Object.keys(parameters).filter((key) => key !== "universeId");
 }


### PR DESCRIPTION
## Summary

- Collapse `extractUpdateFieldKeys` in the universes builder to a single `Object.keys(...).filter(...)` call (no more `for...of` + `.push` accumulator).
- Collapse the `validateConfig` issue loop to `Array.from(validated, mapFn)` and drop the now-unused `ConfigValidationIssue` import.

Both changes came out of a functional-programming review pass across `packages/*/src`; the rest of the scan came back clean (`readonly` discipline, ReadonlyArray on type properties, options-object usage, nesting depth, FCIS purity). The remaining `ops.push` loops in `core/diff.ts`, `core/flatten.ts`, `shell/apply-ops.ts`, and `shell/build-desired.ts` are order-sensitive sequential accumulations and were deliberately left alone.

Purely internal refactors — behaviour is unchanged on both sides, no test edits required.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm --filter bedrock test` — 271/271 pass
- [x] `pnpm --filter @bedrock/ocale test -- src/resources/universes/builders.spec.ts` — 11/11 pass

Pre-existing `.example.spec.ts` failures in `@bedrock/ocale` (5 files unable to resolve `@bedrock/ocale/universes`) reproduce on `main` and are unrelated to this change.