### PR TITLE
feat(core): add universe platform availability toggles

### DIFF
--- a/packages/bedrock/src/adapters/universe-driver.example.spec.ts
+++ b/packages/bedrock/src/adapters/universe-driver.example.spec.ts
@@ -32,10 +32,15 @@ it('Example 1', () => {
   })
   return driver
     .create({
+      consoleEnabled: undefined,
+      desktopEnabled: true,
       key: UNIVERSE_SINGLETON_KEY,
       kind: 'universe',
+      mobileEnabled: undefined,
+      tabletEnabled: undefined,
       universeId: asRobloxAssetId('1234567890'),
       voiceChatEnabled: true,
+      vrEnabled: undefined,
     })
     .then((result) => {
       expect(result.success).toBeTrue()

--- a/packages/bedrock/src/adapters/universe-driver.spec.ts
+++ b/packages/bedrock/src/adapters/universe-driver.spec.ts
@@ -2,7 +2,7 @@ import { ApiError } from "@bedrock/ocale";
 import { createFakeHttpClient, validUniverseBody } from "@bedrock/ocale/testing";
 import { UniversesClient } from "@bedrock/ocale/universes";
 
-import { universeDesired } from "#tests/helpers/resources";
+import { PLATFORM_FLAG_ROWS, universeDesired } from "#tests/helpers/resources";
 import { assert, describe, expect, it } from "vitest";
 
 import { UNIVERSE_SINGLETON_KEY } from "../core/resources.ts";
@@ -48,6 +48,53 @@ describe(createUniverseDriver, () => {
 		await driver.create(universeDesired({ voiceChatEnabled: true }));
 
 		expect(http.requests[0]!.request.body).toStrictEqual({ voiceChatEnabled: true });
+	});
+
+	it.for(PLATFORM_FLAG_ROWS)(
+		"should forward a declared %s in the request body and updateMask",
+		async ([flag]) => {
+			expect.assertions(2);
+
+			const { driver, http } = makeDriver();
+			http.mockResponse({ body: validUniverseBody(), status: 200 });
+
+			await driver.create(universeDesired({ [flag]: false }));
+
+			expect(http.requests[0]!.request.body).toStrictEqual({ [flag]: false });
+			expect(http.requests[0]!.request.url).toBe(
+				`/cloud/v2/universes/${UNIVERSE_ID}?updateMask=${flag}`,
+			);
+		},
+	);
+
+	it("should forward every declared platform flag plus voiceChatEnabled in body and updateMask", async () => {
+		expect.assertions(2);
+
+		const { driver, http } = makeDriver();
+		http.mockResponse({ body: validUniverseBody(), status: 200 });
+
+		await driver.create(
+			universeDesired({
+				consoleEnabled: true,
+				desktopEnabled: true,
+				mobileEnabled: false,
+				tabletEnabled: true,
+				voiceChatEnabled: false,
+				vrEnabled: true,
+			}),
+		);
+
+		expect(http.requests[0]!.request.body).toStrictEqual({
+			consoleEnabled: true,
+			desktopEnabled: true,
+			mobileEnabled: false,
+			tabletEnabled: true,
+			voiceChatEnabled: false,
+			vrEnabled: true,
+		});
+		expect(http.requests[0]!.request.url).toBe(
+			`/cloud/v2/universes/${UNIVERSE_ID}?updateMask=desktopEnabled,mobileEnabled,tabletEnabled,consoleEnabled,vrEnabled,voiceChatEnabled`,
+		);
 	});
 
 	it("should return a current state carrying outputs.rootPlaceId extracted from the response", async () => {

--- a/packages/bedrock/src/adapters/universe-driver.ts
+++ b/packages/bedrock/src/adapters/universe-driver.ts
@@ -1,7 +1,12 @@
 import { ApiError, type OpenCloudError, type Result } from "@bedrock/ocale";
 import type { UniversesClient, UpdateUniverseParameters } from "@bedrock/ocale/universes";
 
-import type { ResourceCurrentState, UniverseDesiredState } from "../core/resources.ts";
+import type {
+	ResourceCurrentState,
+	UniverseDesiredState,
+	UniverseManagedFlag,
+} from "../core/resources.ts";
+import { UNIVERSE_MANAGED_FLAGS } from "../core/resources.ts";
 import type { ResourceDriver } from "../ports/resource-driver.ts";
 import { asRobloxAssetId } from "../types/ids.ts";
 
@@ -67,10 +72,15 @@ export interface UniverseDriverDeps {
  *
  * return driver
  *     .create({
+ *         consoleEnabled: undefined,
+ *         desktopEnabled: true,
  *         key: UNIVERSE_SINGLETON_KEY,
  *         kind: "universe",
+ *         mobileEnabled: undefined,
+ *         tabletEnabled: undefined,
  *         universeId: asRobloxAssetId("1234567890"),
  *         voiceChatEnabled: true,
+ *         vrEnabled: undefined,
  *     })
  *     .then((result) => {
  *         expect(result.success).toBeTrue();
@@ -92,12 +102,15 @@ export function createUniverseDriver(deps: UniverseDriverDeps): ResourceDriver<"
 }
 
 function buildParameters(desired: UniverseDesiredState): UpdateUniverseParameters {
-	return {
-		universeId: desired.universeId,
-		...(desired.voiceChatEnabled !== undefined
-			? { voiceChatEnabled: desired.voiceChatEnabled }
-			: {}),
-	};
+	const flags: Partial<Record<UniverseManagedFlag, boolean>> = {};
+	for (const flag of UNIVERSE_MANAGED_FLAGS) {
+		const isEnabled = desired[flag];
+		if (isEnabled !== undefined) {
+			flags[flag] = isEnabled;
+		}
+	}
+
+	return { universeId: desired.universeId, ...flags };
 }
 
 function wrapUpdateError(err: OpenCloudError, desired: UniverseDesiredState): OpenCloudError {

--- a/packages/bedrock/src/adapters/universe-driver.ts
+++ b/packages/bedrock/src/adapters/universe-driver.ts
@@ -1,11 +1,7 @@
 import { ApiError, type OpenCloudError, type Result } from "@bedrock/ocale";
 import type { UniversesClient, UpdateUniverseParameters } from "@bedrock/ocale/universes";
 
-import type {
-	ResourceCurrentState,
-	UniverseDesiredState,
-	UniverseManagedFlag,
-} from "../core/resources.ts";
+import type { ResourceCurrentState, UniverseDesiredState } from "../core/resources.ts";
 import { UNIVERSE_MANAGED_FLAGS } from "../core/resources.ts";
 import type { ResourceDriver } from "../ports/resource-driver.ts";
 import { asRobloxAssetId } from "../types/ids.ts";
@@ -102,15 +98,13 @@ export function createUniverseDriver(deps: UniverseDriverDeps): ResourceDriver<"
 }
 
 function buildParameters(desired: UniverseDesiredState): UpdateUniverseParameters {
-	const flags: Partial<Record<UniverseManagedFlag, boolean>> = {};
-	for (const flag of UNIVERSE_MANAGED_FLAGS) {
-		const isEnabled = desired[flag];
-		if (isEnabled !== undefined) {
-			flags[flag] = isEnabled;
-		}
-	}
-
-	return { universeId: desired.universeId, ...flags };
+	return UNIVERSE_MANAGED_FLAGS.reduce<UpdateUniverseParameters>(
+		(accumulator, flag) => {
+			const isEnabled = desired[flag];
+			return isEnabled === undefined ? accumulator : { ...accumulator, [flag]: isEnabled };
+		},
+		{ universeId: desired.universeId },
+	);
 }
 
 function wrapUpdateError(err: OpenCloudError, desired: UniverseDesiredState): OpenCloudError {

--- a/packages/bedrock/src/core/diff.spec.ts
+++ b/packages/bedrock/src/core/diff.spec.ts
@@ -12,7 +12,11 @@ import { assert, describe, expect, it } from "vitest";
 import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../types/ids.ts";
 import { diff } from "./diff.ts";
 import { UNIVERSE_SINGLETON_KEY } from "./resources.ts";
-import type { GamePassDesiredState, ResourceCurrentState } from "./resources.ts";
+import type {
+	GamePassDesiredState,
+	ResourceCurrentState,
+	UniverseDesiredState,
+} from "./resources.ts";
 
 const ALT_HASH = asSha256Hex("a3f2c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852e1b0");
 const PLACE_KEY = asResourceKey("start-place");
@@ -387,7 +391,7 @@ describe(diff, () => {
 				tabletEnabled: true,
 				voiceChatEnabled: true,
 				vrEnabled: false,
-			};
+			} satisfies Partial<UniverseDesiredState>;
 			const desiredEntry = universeDesired(allFlags);
 			const currentEntry = universeCurrent(allFlags);
 

--- a/packages/bedrock/src/core/diff.spec.ts
+++ b/packages/bedrock/src/core/diff.spec.ts
@@ -3,6 +3,7 @@ import {
 	gamePassDesired,
 	placeCurrent,
 	placeDesired,
+	PLATFORM_FLAG_ROWS,
 	universeCurrent,
 	universeDesired,
 } from "#tests/helpers/resources";
@@ -326,6 +327,114 @@ describe(diff, () => {
 					desired: desiredEntry,
 					type: "update",
 				},
+			]);
+		});
+
+		it.for(PLATFORM_FLAG_ROWS)(
+			"should emit an update op when a declared %s differs from current",
+			([flag]) => {
+				expect.assertions(1);
+
+				const desiredEntry = universeDesired({ [flag]: true });
+				const currentEntry = universeCurrent({ [flag]: false });
+
+				expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
+					{
+						key: UNIVERSE_SINGLETON_KEY,
+						current: currentEntry,
+						desired: desiredEntry,
+						type: "update",
+					},
+				]);
+			},
+		);
+
+		it.for(PLATFORM_FLAG_ROWS)(
+			"should emit a noop when a declared %s matches current",
+			([flag]) => {
+				expect.assertions(1);
+
+				const desiredEntry = universeDesired({ [flag]: true });
+				const currentEntry = universeCurrent({ [flag]: true });
+
+				expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
+					{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+				]);
+			},
+		);
+
+		it.for(PLATFORM_FLAG_ROWS)(
+			"should not treat a concrete current %s as drift when the flag is undeclared but another is",
+			([flag]) => {
+				expect.assertions(1);
+
+				const desiredEntry = universeDesired({ voiceChatEnabled: true });
+				const currentEntry = universeCurrent({ [flag]: true, voiceChatEnabled: true });
+
+				expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
+					{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+				]);
+			},
+		);
+
+		it("should emit a noop when every platform flag is declared and matches current", () => {
+			expect.assertions(1);
+
+			const allFlags = {
+				consoleEnabled: true,
+				desktopEnabled: true,
+				mobileEnabled: false,
+				tabletEnabled: true,
+				voiceChatEnabled: true,
+				vrEnabled: false,
+			};
+			const desiredEntry = universeDesired(allFlags);
+			const currentEntry = universeCurrent(allFlags);
+
+			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
+				{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+			]);
+		});
+
+		it("should emit an update op when one of several declared flags flips", () => {
+			expect.assertions(1);
+
+			const desiredEntry = universeDesired({
+				desktopEnabled: true,
+				mobileEnabled: false,
+				voiceChatEnabled: true,
+			});
+			const currentEntry = universeCurrent({
+				desktopEnabled: true,
+				mobileEnabled: true,
+				voiceChatEnabled: true,
+			});
+
+			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
+				{
+					key: UNIVERSE_SINGLETON_KEY,
+					current: currentEntry,
+					desired: desiredEntry,
+					type: "update",
+				},
+			]);
+		});
+
+		it("should emit a noop when declared subset matches and other flags hold concrete current values", () => {
+			expect.assertions(1);
+
+			const desiredEntry = universeDesired({ desktopEnabled: true });
+			const currentEntry = universeCurrent({
+				consoleEnabled: false,
+				desktopEnabled: true,
+				mobileEnabled: true,
+				tabletEnabled: false,
+				voiceChatEnabled: true,
+				vrEnabled: true,
+			});
+
+			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
+				{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
 			]);
 		});
 	});

--- a/packages/bedrock/src/core/diff.ts
+++ b/packages/bedrock/src/core/diff.ts
@@ -6,6 +6,7 @@ import type {
 	ResourceDesiredState,
 	UniverseDesiredState,
 } from "./resources.ts";
+import { UNIVERSE_MANAGED_FLAGS } from "./resources.ts";
 
 /**
  * Computes the operations required to reconcile `current` state with `desired`
@@ -144,16 +145,21 @@ function universeFieldsEqual(
 	desired: UniverseDesiredState,
 	current: ResourceCurrentState<"universe">,
 ): boolean {
-	// Reached only when `hasNoManagedFields` has already filtered out the
-	// no-declared-fields case, so every managed field is guaranteed defined
-	// here. When a second optional managed field lands on
-	// `UniverseDesiredState`, re-introduce the per-field `!== undefined`
-	// guard for fields that can still be legitimately unmanaged while others
-	// are declared.
-	return (
-		desired.universeId === current.universeId &&
-		desired.voiceChatEnabled === current.voiceChatEnabled
-	);
+	if (desired.universeId !== current.universeId) {
+		return false;
+	}
+
+	// Only compare flags the user has declared. An undeclared flag stays
+	// owned by whoever else writes to the universe (Creator Hub, another
+	// tool), so a concrete current value for it is not drift.
+	for (const flag of UNIVERSE_MANAGED_FLAGS) {
+		const isDesiredEnabled = desired[flag];
+		if (isDesiredEnabled !== undefined && isDesiredEnabled !== current[flag]) {
+			return false;
+		}
+	}
+
+	return true;
 }
 
 function desiredFieldsEqual(desired: ResourceDesiredState, current: ResourceCurrentState): boolean {

--- a/packages/bedrock/src/core/flatten.example.spec.ts
+++ b/packages/bedrock/src/core/flatten.example.spec.ts
@@ -35,13 +35,19 @@ it('Example 2', () => {
 
 it('Example 3', () => {
   const input: UniverseDesiredInput = {
+    consoleEnabled: undefined,
+    desktopEnabled: true,
     key: UNIVERSE_SINGLETON_KEY,
     kind: 'universe',
+    mobileEnabled: undefined,
+    tabletEnabled: undefined,
     universeId: asRobloxAssetId('1234567890'),
     voiceChatEnabled: true,
+    vrEnabled: undefined,
   }
   expect(input.kind).toBe('universe')
   expect(input.key).toBe('main')
+  expect(input.desktopEnabled).toBeTrue()
 })
 
 it('Example 4', () => {

--- a/packages/bedrock/src/core/flatten.spec.ts
+++ b/packages/bedrock/src/core/flatten.spec.ts
@@ -1,3 +1,4 @@
+import { PLATFORM_FLAG_ROWS } from "#tests/helpers/resources";
 import { assert, describe, expect, it } from "vitest";
 
 import { asResourceKey, asRobloxAssetId } from "../types/ids.ts";
@@ -163,9 +164,14 @@ describe(flattenConfig, () => {
 		expect(flattenConfig(config.data)).toStrictEqual([
 			{
 				key: UNIVERSE_SINGLETON_KEY,
+				consoleEnabled: undefined,
+				desktopEnabled: undefined,
 				kind: "universe",
+				mobileEnabled: undefined,
+				tabletEnabled: undefined,
 				universeId: asRobloxAssetId("1234567890"),
 				voiceChatEnabled: true,
+				vrEnabled: undefined,
 			},
 		]);
 	});
@@ -212,6 +218,42 @@ describe(flattenConfig, () => {
 
 		expect(input.voiceChatEnabled).toBeUndefined();
 	});
+
+	it.for(PLATFORM_FLAG_ROWS)(
+		"should propagate a declared %s through to the universe input",
+		([flag]) => {
+			expect.assertions(1);
+
+			const config = validateConfig(
+				{ universe: { [flag]: true, universeId: "1234567890" } },
+				"bedrock.config.ts",
+			);
+			assert(config.success);
+
+			const input = flattenConfig(config.data)[0]!;
+			assert(input.kind === "universe");
+
+			expect(input[flag]).toBeTrue();
+		},
+	);
+
+	it.for(PLATFORM_FLAG_ROWS)(
+		"should carry %s as undefined when the universe entry omits it",
+		([flag]) => {
+			expect.assertions(1);
+
+			const config = validateConfig(
+				{ universe: { universeId: "1234567890" } },
+				"bedrock.config.ts",
+			);
+			assert(config.success);
+
+			const input = flattenConfig(config.data)[0]!;
+			assert(input.kind === "universe");
+
+			expect(input[flag]).toBeUndefined();
+		},
+	);
 
 	it("should omit the universe block from output when the config has no universe", () => {
 		expect.assertions(1);

--- a/packages/bedrock/src/core/flatten.ts
+++ b/packages/bedrock/src/core/flatten.ts
@@ -81,25 +81,41 @@ export interface PlaceDesiredInput {
  * import { asRobloxAssetId, UNIVERSE_SINGLETON_KEY, type UniverseDesiredInput } from "@bedrock/core";
  *
  * const input: UniverseDesiredInput = {
+ *     consoleEnabled: undefined,
+ *     desktopEnabled: true,
  *     key: UNIVERSE_SINGLETON_KEY,
  *     kind: "universe",
+ *     mobileEnabled: undefined,
+ *     tabletEnabled: undefined,
  *     universeId: asRobloxAssetId("1234567890"),
  *     voiceChatEnabled: true,
+ *     vrEnabled: undefined,
  * };
  *
  * expect(input.kind).toBe("universe");
  * expect(input.key).toBe("main");
+ * expect(input.desktopEnabled).toBeTrue();
  * ```
  */
 export interface UniverseDesiredInput {
 	/** Synthesized singleton key (`"main"`), already validated against the `ResourceKey` brand. */
 	readonly key: ResourceKey;
+	/** Whether console players can join; `undefined` leaves the server value untouched. */
+	readonly consoleEnabled: boolean | undefined;
+	/** Whether desktop players can join; `undefined` leaves the server value untouched. */
+	readonly desktopEnabled: boolean | undefined;
 	/** Discriminator tag for the `ResourceDesiredInput` union. */
 	readonly kind: "universe";
+	/** Whether mobile players can join; `undefined` leaves the server value untouched. */
+	readonly mobileEnabled: boolean | undefined;
+	/** Whether tablet players can join; `undefined` leaves the server value untouched. */
+	readonly tabletEnabled: boolean | undefined;
 	/** Existing Roblox universe ID, validated and branded at flatten time. */
 	readonly universeId: RobloxAssetId;
 	/** Whether voice chat is enabled; `undefined` leaves the server value untouched. */
 	readonly voiceChatEnabled: boolean | undefined;
+	/** Whether VR players can join; `undefined` leaves the server value untouched. */
+	readonly vrEnabled: boolean | undefined;
 }
 
 /**
@@ -168,13 +184,22 @@ export function flattenConfig(config: Config): ReadonlyArray<ResourceDesiredInpu
 	}
 
 	if (config.universe !== undefined) {
-		out.push({
-			key: UNIVERSE_SINGLETON_KEY,
-			kind: "universe",
-			universeId: asRobloxAssetId(config.universe.universeId),
-			voiceChatEnabled: config.universe.voiceChatEnabled,
-		});
+		out.push(universeInput(config.universe));
 	}
 
 	return out;
+}
+
+function universeInput(entry: NonNullable<Config["universe"]>): UniverseDesiredInput {
+	return {
+		key: UNIVERSE_SINGLETON_KEY,
+		consoleEnabled: entry.consoleEnabled,
+		desktopEnabled: entry.desktopEnabled,
+		kind: "universe",
+		mobileEnabled: entry.mobileEnabled,
+		tabletEnabled: entry.tabletEnabled,
+		universeId: asRobloxAssetId(entry.universeId),
+		voiceChatEnabled: entry.voiceChatEnabled,
+		vrEnabled: entry.vrEnabled,
+	};
 }

--- a/packages/bedrock/src/core/resources.example.spec.ts
+++ b/packages/bedrock/src/core/resources.example.spec.ts
@@ -44,13 +44,21 @@ it('Example 2', () => {
 
 it('Example 3', () => {
   const universe: UniverseDesiredState = {
+    consoleEnabled: undefined,
+    desktopEnabled: true,
     key: UNIVERSE_SINGLETON_KEY,
     kind: 'universe',
+    mobileEnabled: false,
+    tabletEnabled: undefined,
     universeId: asRobloxAssetId('1234567890'),
     voiceChatEnabled: true,
+    vrEnabled: undefined,
   }
   expect(universe.kind).toBe('universe')
   expect(universe.key).toBe('main')
+  expect(universe.desktopEnabled).toBeTrue()
+  expect(universe.mobileEnabled).toBeFalse()
+  expect(universe.consoleEnabled).toBeUndefined()
 })
 
 it('Example 4', () => {

--- a/packages/bedrock/src/core/resources.spec-d.ts
+++ b/packages/bedrock/src/core/resources.spec-d.ts
@@ -29,9 +29,14 @@ interface ExpectedPlaceOutputs {
 
 interface ExpectedUniverseDesiredState {
 	readonly key: ResourceKey;
+	readonly consoleEnabled: boolean | undefined;
+	readonly desktopEnabled: boolean | undefined;
 	readonly kind: "universe";
+	readonly mobileEnabled: boolean | undefined;
+	readonly tabletEnabled: boolean | undefined;
 	readonly universeId: RobloxAssetId;
 	readonly voiceChatEnabled: boolean | undefined;
+	readonly vrEnabled: boolean | undefined;
 }
 
 interface ExpectedUniverseOutputs {

--- a/packages/bedrock/src/core/resources.ts
+++ b/packages/bedrock/src/core/resources.ts
@@ -181,8 +181,6 @@ export interface UniverseDesiredState {
  * this list so they cannot drift apart. Order drives `updateMask` sequence in
  * generated requests.
  */
-// Module-init const; perTest coverage can't attribute it to any test.
-// Stryker disable next-line all
 export const UNIVERSE_MANAGED_FLAGS = [
 	"desktopEnabled",
 	"mobileEnabled",

--- a/packages/bedrock/src/core/resources.ts
+++ b/packages/bedrock/src/core/resources.ts
@@ -122,7 +122,7 @@ export interface PlaceOutputs {
  * The universe is adopted rather than provisioned: the user supplies an
  * existing `universeId` (Open Cloud cannot mint universes) and bedrock
  * reconciles the declared managed fields against it. Optional managed fields
- * use `T | undefined` to mean "unmanaged" — the diff treats undefined as
+ * use `T | undefined` to mean "unmanaged" - the diff treats undefined as
  * absent and the driver omits the field from the `updateMask`.
  *
  * @example
@@ -135,26 +135,65 @@ export interface PlaceOutputs {
  * } from "@bedrock/core";
  *
  * const universe: UniverseDesiredState = {
+ *     consoleEnabled: undefined,
+ *     desktopEnabled: true,
  *     key: UNIVERSE_SINGLETON_KEY,
  *     kind: "universe",
+ *     mobileEnabled: false,
+ *     tabletEnabled: undefined,
  *     universeId: asRobloxAssetId("1234567890"),
  *     voiceChatEnabled: true,
+ *     vrEnabled: undefined,
  * };
  *
  * expect(universe.kind).toBe("universe");
  * expect(universe.key).toBe("main");
+ * expect(universe.desktopEnabled).toBeTrue();
+ * expect(universe.mobileEnabled).toBeFalse();
+ * expect(universe.consoleEnabled).toBeUndefined();
  * ```
  */
 export interface UniverseDesiredState {
 	/** Fixed singleton key (`"main"`); bedrock synthesizes it in `flattenConfig`. */
 	readonly key: ResourceKey;
+	/** Whether console players can join; `undefined` leaves the server value untouched. */
+	readonly consoleEnabled: boolean | undefined;
+	/** Whether desktop players can join; `undefined` leaves the server value untouched. */
+	readonly desktopEnabled: boolean | undefined;
 	/** Discriminator tag for the `ResourceDesiredState` union. */
 	readonly kind: "universe";
+	/** Whether mobile players can join; `undefined` leaves the server value untouched. */
+	readonly mobileEnabled: boolean | undefined;
+	/** Whether tablet players can join; `undefined` leaves the server value untouched. */
+	readonly tabletEnabled: boolean | undefined;
 	/** User-supplied Roblox universe ID; the universe must already exist. */
 	readonly universeId: RobloxAssetId;
 	/** Whether voice chat is enabled; `undefined` leaves the server value untouched. */
 	readonly voiceChatEnabled: boolean | undefined;
+	/** Whether VR players can join; `undefined` leaves the server value untouched. */
+	readonly vrEnabled: boolean | undefined;
 }
+
+/**
+ * Ordered list of optional boolean managed fields on {@link UniverseDesiredState}.
+ *
+ * The driver translator and the diff's per-field equality guard both iterate
+ * this list so they cannot drift apart. Order drives `updateMask` sequence in
+ * generated requests.
+ */
+// Module-init const; perTest coverage can't attribute it to any test.
+// Stryker disable next-line all
+export const UNIVERSE_MANAGED_FLAGS = [
+	"desktopEnabled",
+	"mobileEnabled",
+	"tabletEnabled",
+	"consoleEnabled",
+	"vrEnabled",
+	"voiceChatEnabled",
+] as const satisfies ReadonlyArray<keyof UniverseDesiredState>;
+
+/** Key of an optional boolean managed field on {@link UniverseDesiredState}. */
+export type UniverseManagedFlag = (typeof UNIVERSE_MANAGED_FLAGS)[number];
 
 /**
  * Discriminated union of every desired-state shape Bedrock manages.

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -1,3 +1,4 @@
+import { PLATFORM_FLAG_ROWS } from "#tests/helpers/resources";
 import { assert, describe, expect, it } from "vitest";
 
 import { validateConfig } from "./schema.ts";
@@ -271,6 +272,72 @@ describe(validateConfig, () => {
 		assert(result.success);
 
 		expect(result.data.universe!.voiceChatEnabled).toBeTrue();
+	});
+
+	it.for(PLATFORM_FLAG_ROWS)("should accept a universe block with %s declared", ([flag]) => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{ universe: { [flag]: false, universeId: "1234567890" } },
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.universe![flag]).toBeFalse();
+	});
+
+	it.for(PLATFORM_FLAG_ROWS)(
+		"should default %s to undefined when the universe block omits it",
+		([flag]) => {
+			expect.assertions(1);
+
+			const result = validateConfig({ universe: { universeId: "1234567890" } }, SOURCE);
+
+			assert(result.success);
+
+			expect(result.data.universe![flag]).toBeUndefined();
+		},
+	);
+
+	it.for(PLATFORM_FLAG_ROWS)("should reject a non-boolean %s on a universe block", ([flag]) => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{ universe: { [flag]: "oops", universeId: "1234567890" } },
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual(["universe", flag]);
+	});
+
+	it("should accept a universe block with every platform flag declared", () => {
+		expect.assertions(5);
+
+		const result = validateConfig(
+			{
+				universe: {
+					consoleEnabled: false,
+					desktopEnabled: true,
+					mobileEnabled: false,
+					tabletEnabled: true,
+					universeId: "1234567890",
+					vrEnabled: false,
+				},
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.universe!.desktopEnabled).toBeTrue();
+		expect(result.data.universe!.mobileEnabled).toBeFalse();
+		expect(result.data.universe!.tabletEnabled).toBeTrue();
+		expect(result.data.universe!.consoleEnabled).toBeFalse();
+		expect(result.data.universe!.vrEnabled).toBeFalse();
 	});
 
 	it("should reject a universe block missing universeId", () => {

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -47,10 +47,20 @@ export interface PlaceEntry {
  * its configuration.
  */
 export interface UniverseEntry {
+	/** Whether console players can join; omit or set `undefined` to leave unmanaged. */
+	consoleEnabled?: boolean | undefined;
+	/** Whether desktop players can join; omit or set `undefined` to leave unmanaged. */
+	desktopEnabled?: boolean | undefined;
+	/** Whether mobile players can join; omit or set `undefined` to leave unmanaged. */
+	mobileEnabled?: boolean | undefined;
+	/** Whether tablet players can join; omit or set `undefined` to leave unmanaged. */
+	tabletEnabled?: boolean | undefined;
 	/** Existing Roblox universe ID. */
 	universeId: string;
 	/** Whether voice chat is enabled; omit or set `undefined` to leave unmanaged. */
 	voiceChatEnabled?: boolean | undefined;
+	/** Whether VR players can join; omit or set `undefined` to leave unmanaged. */
+	vrEnabled?: boolean | undefined;
 }
 
 /**
@@ -119,9 +129,16 @@ const placesCollection = type({
 	[`[/${RESOURCE_KEY_PATTERN_SOURCE}/]`]: placeEntry,
 }).onUndeclaredKey("reject");
 
+const OPTIONAL_BOOLEAN = "boolean | undefined";
+
 const universeEntry = type({
+	"consoleEnabled?": OPTIONAL_BOOLEAN,
+	"desktopEnabled?": OPTIONAL_BOOLEAN,
+	"mobileEnabled?": OPTIONAL_BOOLEAN,
+	"tabletEnabled?": OPTIONAL_BOOLEAN,
 	"universeId": "string.digits",
-	"voiceChatEnabled?": "boolean | undefined",
+	"voiceChatEnabled?": OPTIONAL_BOOLEAN,
+	"vrEnabled?": OPTIONAL_BOOLEAN,
 }).onUndeclaredKey("reject");
 
 const rootSchema: Type<Config> = type({

--- a/packages/bedrock/src/shell/build-desired.spec.ts
+++ b/packages/bedrock/src/shell/build-desired.spec.ts
@@ -1,3 +1,4 @@
+import { PLATFORM_FLAG_ROWS } from "#tests/helpers/resources";
 import { assert, describe, expect, it, vi } from "vitest";
 
 import type { GamePassDesiredInput } from "../core/flatten.ts";
@@ -217,9 +218,14 @@ describe(buildDesired, () => {
 			[
 				{
 					key: UNIVERSE_SINGLETON_KEY,
+					consoleEnabled: undefined,
+					desktopEnabled: true,
 					kind: "universe",
+					mobileEnabled: undefined,
+					tabletEnabled: undefined,
 					universeId: asRobloxAssetId("1234567890"),
 					voiceChatEnabled: true,
+					vrEnabled: undefined,
 				},
 			],
 			readFile,
@@ -229,9 +235,14 @@ describe(buildDesired, () => {
 			data: [
 				{
 					key: UNIVERSE_SINGLETON_KEY,
+					consoleEnabled: undefined,
+					desktopEnabled: true,
 					kind: "universe",
+					mobileEnabled: undefined,
+					tabletEnabled: undefined,
 					universeId: asRobloxAssetId("1234567890"),
 					voiceChatEnabled: true,
+					vrEnabled: undefined,
 				},
 			],
 			success: true,
@@ -248,9 +259,14 @@ describe(buildDesired, () => {
 			[
 				{
 					key: UNIVERSE_SINGLETON_KEY,
+					consoleEnabled: undefined,
+					desktopEnabled: undefined,
 					kind: "universe",
+					mobileEnabled: undefined,
+					tabletEnabled: undefined,
 					universeId: asRobloxAssetId("1234567890"),
 					voiceChatEnabled: undefined,
+					vrEnabled: undefined,
 				},
 			],
 			readFile,
@@ -261,4 +277,31 @@ describe(buildDesired, () => {
 
 		expect(result.data[0]!.voiceChatEnabled).toBeUndefined();
 	});
+
+	it.for(PLATFORM_FLAG_ROWS)(
+		"should propagate a declared %s through to universe desired state",
+		async ([flag]) => {
+			expect.assertions(1);
+
+			const readFile = vi.fn<(path: string) => Promise<Uint8Array>>();
+
+			const baseInput = {
+				key: UNIVERSE_SINGLETON_KEY,
+				consoleEnabled: undefined,
+				desktopEnabled: undefined,
+				kind: "universe" as const,
+				mobileEnabled: undefined,
+				tabletEnabled: undefined,
+				universeId: asRobloxAssetId("1234567890"),
+				voiceChatEnabled: undefined,
+				vrEnabled: undefined,
+			};
+			const result = await buildDesired([{ ...baseInput, [flag]: true }], readFile);
+
+			assert(result.success);
+			assert(result.data[0]!.kind === "universe");
+
+			expect(result.data[0]![flag]).toBeTrue();
+		},
+	);
 });

--- a/packages/bedrock/src/shell/build-desired.ts
+++ b/packages/bedrock/src/shell/build-desired.ts
@@ -177,9 +177,14 @@ function normalizeUniverse(
 	return {
 		data: {
 			key: input.key,
+			consoleEnabled: input.consoleEnabled,
+			desktopEnabled: input.desktopEnabled,
 			kind: "universe",
+			mobileEnabled: input.mobileEnabled,
+			tabletEnabled: input.tabletEnabled,
 			universeId: input.universeId,
 			voiceChatEnabled: input.voiceChatEnabled,
+			vrEnabled: input.vrEnabled,
 		},
 		success: true,
 	};

--- a/packages/bedrock/tests/helpers/resources.ts
+++ b/packages/bedrock/tests/helpers/resources.ts
@@ -5,22 +5,17 @@ import type {
 	UniverseDesiredState,
 	UniverseManagedFlag,
 } from "#src/core/resources";
-import { UNIVERSE_SINGLETON_KEY } from "#src/core/resources";
+import { UNIVERSE_MANAGED_FLAGS, UNIVERSE_SINGLETON_KEY } from "#src/core/resources";
 import { asResourceKey, asRobloxAssetId, asSha256Hex } from "#src/types/ids";
 
 /**
- * `it.for` rows for every platform-availability flag on the universe kind;
- * drops the repeated `[["desktopEnabled"], ["mobileEnabled"], ...]` literal
- * from each spec file.
+ * `it.for` rows for every platform-availability flag on the universe kind.
+ * Derived from `UNIVERSE_MANAGED_FLAGS` so a newly-added managed flag is
+ * picked up automatically; only `voiceChatEnabled` is filtered out, since
+ * it is covered by its own explicit test cases.
  */
-export const PLATFORM_FLAG_ROWS = (
-	[
-		"desktopEnabled",
-		"mobileEnabled",
-		"tabletEnabled",
-		"consoleEnabled",
-		"vrEnabled",
-	] as const satisfies ReadonlyArray<UniverseManagedFlag>
+export const PLATFORM_FLAG_ROWS = UNIVERSE_MANAGED_FLAGS.filter(
+	(flag): flag is Exclude<UniverseManagedFlag, "voiceChatEnabled"> => flag !== "voiceChatEnabled",
 ).map((flag) => [flag] as const);
 
 const ICON_HASH = asSha256Hex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");

--- a/packages/bedrock/tests/helpers/resources.ts
+++ b/packages/bedrock/tests/helpers/resources.ts
@@ -3,9 +3,25 @@ import type {
 	PlaceDesiredState,
 	ResourceCurrentState,
 	UniverseDesiredState,
+	UniverseManagedFlag,
 } from "#src/core/resources";
 import { UNIVERSE_SINGLETON_KEY } from "#src/core/resources";
 import { asResourceKey, asRobloxAssetId, asSha256Hex } from "#src/types/ids";
+
+/**
+ * `it.for` rows for every platform-availability flag on the universe kind;
+ * drops the repeated `[["desktopEnabled"], ["mobileEnabled"], ...]` literal
+ * from each spec file.
+ */
+export const PLATFORM_FLAG_ROWS = (
+	[
+		"desktopEnabled",
+		"mobileEnabled",
+		"tabletEnabled",
+		"consoleEnabled",
+		"vrEnabled",
+	] as const satisfies ReadonlyArray<UniverseManagedFlag>
+).map((flag) => [flag] as const);
 
 const ICON_HASH = asSha256Hex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
@@ -98,9 +114,14 @@ export function placeCurrent(
 export function universeDesired(overrides?: Partial<UniverseDesiredState>): UniverseDesiredState {
 	return {
 		key: UNIVERSE_SINGLETON_KEY,
+		consoleEnabled: undefined,
+		desktopEnabled: undefined,
 		kind: "universe",
+		mobileEnabled: undefined,
+		tabletEnabled: undefined,
 		universeId: asRobloxAssetId("1234567890"),
 		voiceChatEnabled: undefined,
+		vrEnabled: undefined,
 		...overrides,
 	};
 }

--- a/packages/bedrock/tests/integration/fixtures/universe/bedrock.config.ts
+++ b/packages/bedrock/tests/integration/fixtures/universe/bedrock.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "@bedrock/core";
 
 export default defineConfig({
 	universe: {
+		desktopEnabled: false,
 		universeId: "1234567890",
 		voiceChatEnabled: true,
 	},

--- a/packages/bedrock/tests/integration/universe.spec.ts
+++ b/packages/bedrock/tests/integration/universe.spec.ts
@@ -79,10 +79,15 @@ describe("universe pipeline end-to-end", () => {
 		expect(applyResult.data).toHaveLength(1);
 		expect(applyResult.data[0]).toStrictEqual({
 			key: UNIVERSE_SINGLETON_KEY,
+			consoleEnabled: undefined,
+			desktopEnabled: false,
 			kind: "universe",
+			mobileEnabled: undefined,
 			outputs: { rootPlaceId: ROOT_PLACE_ID },
+			tabletEnabled: undefined,
 			universeId: UNIVERSE_ID,
 			voiceChatEnabled: true,
+			vrEnabled: undefined,
 		});
 
 		expect(httpClient.requests).toHaveLength(1);
@@ -91,7 +96,7 @@ describe("universe pipeline end-to-end", () => {
 		assert(first);
 
 		expect(first.request.url).toBe(
-			`/cloud/v2/universes/${UNIVERSE_ID}?updateMask=voiceChatEnabled`,
+			`/cloud/v2/universes/${UNIVERSE_ID}?updateMask=desktopEnabled,voiceChatEnabled`,
 		);
 	});
 
@@ -107,10 +112,15 @@ describe("universe pipeline end-to-end", () => {
 		const ops = diff(desiredResult.data, [
 			{
 				key: UNIVERSE_SINGLETON_KEY,
+				consoleEnabled: undefined,
+				desktopEnabled: false,
 				kind: "universe",
+				mobileEnabled: undefined,
 				outputs: { rootPlaceId: ROOT_PLACE_ID },
+				tabletEnabled: undefined,
 				universeId: UNIVERSE_ID,
 				voiceChatEnabled: true,
+				vrEnabled: undefined,
 			},
 		]);
 


### PR DESCRIPTION
## Summary

Widen the `universe` resource kind with the five Roblox platform availability flags: `desktopEnabled`, `mobileEnabled`, `tabletEnabled`, `consoleEnabled`, `vrEnabled`. Each flag is independently managed — an undeclared flag stays owned by whoever else writes to the universe (Creator Hub, another tool), so a concrete current value for it is not drift.

Closes #155. Parent PRD #98 (user stories 2 and 14).

## What changed

- `UniverseDesiredState` / `UniverseEntry` / `UniverseDesiredInput` gain five optional `boolean | undefined` fields
- `buildParameters` in the driver forwards only declared flags into `UpdateUniverseParameters`; undeclared flags are omitted from the `updateMask` query string
- `universeFieldsEqual` in the diff now uses a per-field `!== undefined` guard so subset-declared configs don't misreport undeclared flags as drift (the old code carried a TODO anticipating exactly this change)
- Driver translator and diff share a new internal `UNIVERSE_MANAGED_FLAGS` tuple so the set of managed fields cannot drift between the two call sites
- The ocale-layer `UpdateUniverseParameters` already declared these flags; no Open Cloud adapter change was needed

## Tests

- Schema / flatten / diff / driver unit tests, table-driven across the five flags via a shared `PLATFORM_FLAG_ROWS` test helper
- Regression test for the per-field guard: an undeclared flag with a concrete current value must not register as drift
- Integration fixture exercises `desktopEnabled: false` end-to-end through `loadConfig → buildDesired → diff → applyOps`, asserting the flag appears in the PATCH `updateMask`
- Mutation score: 100% on touched `src/**` files (18 killed, 0 survived)

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm test` (879 tests)
- [x] `pnpm gen:example-tests`
- [x] `pnpm mutate:changed` (100%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)