### PR TITLE
chore: add github sponsors funding config

### DIFF
--- a/.github/FUNDING.yaml
+++ b/.github/FUNDING.yaml
@@ -1,0 +1,1 @@
+github: christopher-buss

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -27,6 +27,13 @@ export default isentinel(
 		},
 	},
 	{
+		name: "project/github-required-filenames",
+		files: [".github/FUNDING.{yml,yaml}"],
+		rules: {
+			"unicorn/filename-case": "off",
+		},
+	},
+	{
 		name: "project/src",
 		files: [`packages/*/*/${GLOB_SRC}`],
 		rules: {


### PR DESCRIPTION
## Summary
- Add `.github/FUNDING.yaml` pointing at `christopher-buss` so GitHub renders a Sponsor button on the repo page and releases.
- Scope an eslint override that turns off `unicorn/filename-case` for the FUNDING file, since GitHub mandates the uppercase filename.

## Notes
- File path must be `.github/FUNDING.yaml` (uppercase) for GitHub to pick it up — that's the whole reason the lint override exists.
- The override is narrowly scoped to `.github/FUNDING.{yml,yaml}`; no other file is affected by it.

## Test plan
- [x] `pnpm lint` passes locally
- [x] Pre-commit hook (lint + typecheck + build + test) green
- [ ] After merge to `main`, verify the "Sponsor" button renders on the repo page and links to `https://github.com/sponsors/christopher-buss`

🤖 Generated with [Claude Code](https://claude.com/claude-code)