### PR TITLE
docs(website): auto-generate api sidebar from typedoc navigation

### DIFF
--- a/apps/website/.vitepress/build-sidebar.spec.ts
+++ b/apps/website/.vitepress/build-sidebar.spec.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSidebarFromNavigation, type NavigationItem } from "./build-sidebar.ts";
+
+describe(buildSidebarFromNavigation, () => {
+	it("should return an empty array for empty navigation", () => {
+		expect.assertions(1);
+
+		expect(buildSidebarFromNavigation([], "/bedrock/api/")).toStrictEqual([]);
+	});
+
+	it("should map a leaf item to a sidebar link with the base path and without the .md suffix", () => {
+		expect.assertions(1);
+
+		const nav: ReadonlyArray<NavigationItem> = [
+			{ path: "interfaces/UniverseEntry.md", title: "UniverseEntry" },
+		];
+
+		expect(buildSidebarFromNavigation(nav, "/bedrock/api/")).toStrictEqual([
+			{ link: "/bedrock/api/interfaces/UniverseEntry", text: "UniverseEntry" },
+		]);
+	});
+
+	it("should represent a branch with children as a collapsed group of its items", () => {
+		expect.assertions(1);
+
+		const nav: ReadonlyArray<NavigationItem> = [
+			{
+				children: [
+					{ path: "interfaces/PlaceEntry.md", title: "PlaceEntry" },
+					{ path: "interfaces/UniverseEntry.md", title: "UniverseEntry" },
+				],
+				title: "Interfaces",
+			},
+		];
+
+		expect(buildSidebarFromNavigation(nav, "/bedrock/api/")).toStrictEqual([
+			{
+				collapsed: true,
+				items: [
+					{ link: "/bedrock/api/interfaces/PlaceEntry", text: "PlaceEntry" },
+					{ link: "/bedrock/api/interfaces/UniverseEntry", text: "UniverseEntry" },
+				],
+				text: "Interfaces",
+			},
+		]);
+	});
+
+	it("should emit both link and items when a branch carries its own path", () => {
+		expect.assertions(1);
+
+		const nav: ReadonlyArray<NavigationItem> = [
+			{
+				children: [{ path: "interfaces/GamePass.md", title: "GamePass" }],
+				path: "resources/game-passes/readme.md",
+				title: "Game Passes",
+			},
+		];
+
+		expect(buildSidebarFromNavigation(nav, "/ocale/api/")).toStrictEqual([
+			{
+				collapsed: true,
+				items: [{ link: "/ocale/api/interfaces/GamePass", text: "GamePass" }],
+				link: "/ocale/api/resources/game-passes/readme",
+				text: "Game Passes",
+			},
+		]);
+	});
+
+	it("should recurse into grandchild branches", () => {
+		expect.assertions(1);
+
+		const nav: ReadonlyArray<NavigationItem> = [
+			{
+				children: [
+					{
+						children: [
+							{
+								path: "resources/game-passes/classes/GamePassesClient.md",
+								title: "GamePassesClient",
+							},
+						],
+						title: "Classes",
+					},
+				],
+				title: "Game Passes",
+			},
+		];
+
+		expect(buildSidebarFromNavigation(nav, "/ocale/api/")).toStrictEqual([
+			{
+				collapsed: true,
+				items: [
+					{
+						collapsed: true,
+						items: [
+							{
+								link: "/ocale/api/resources/game-passes/classes/GamePassesClient",
+								text: "GamePassesClient",
+							},
+						],
+						text: "Classes",
+					},
+				],
+				text: "Game Passes",
+			},
+		]);
+	});
+
+	it("should skip items that have neither a path nor children", () => {
+		expect.assertions(1);
+
+		const nav: ReadonlyArray<NavigationItem> = [
+			{ title: "Orphan" },
+			{ path: "interfaces/Universe.md", title: "Universe" },
+		];
+
+		expect(buildSidebarFromNavigation(nav, "/bedrock/api/")).toStrictEqual([
+			{ link: "/bedrock/api/interfaces/Universe", text: "Universe" },
+		]);
+	});
+
+	it("should leave a leading slash in the base path alone when the item path has no leading slash", () => {
+		expect.assertions(1);
+
+		const nav: ReadonlyArray<NavigationItem> = [
+			{ path: "functions/deploy.md", title: "deploy" },
+		];
+
+		expect(buildSidebarFromNavigation(nav, "/bedrock/api/")).toStrictEqual([
+			{ link: "/bedrock/api/functions/deploy", text: "deploy" },
+		]);
+	});
+});

--- a/apps/website/.vitepress/build-sidebar.ts
+++ b/apps/website/.vitepress/build-sidebar.ts
@@ -1,0 +1,60 @@
+import type { DefaultTheme } from "vitepress";
+
+/**
+ * Shape of a single entry in the `navigation.json` file emitted by
+ * `typedoc-plugin-markdown`'s `navigationJson` option. Mirrored locally so the
+ * sidebar builder does not depend on a deep import from the plugin.
+ */
+export interface NavigationItem {
+	/** Nested entries when this item represents a group (kind, category, or module). */
+	readonly children?: ReadonlyArray<NavigationItem>;
+	/** Relative markdown path (e.g. `"interfaces/UniverseEntry.md"`) when the item has its own page. */
+	readonly path?: null | string;
+	/** Display title rendered in the sidebar. */
+	readonly title: string;
+}
+
+/**
+ * Transforms a TypeDoc navigation tree into a VitePress sidebar group. Leaves
+ * become links, branches become collapsed groups, and items with neither path
+ * nor children are dropped.
+ * @param nav - Parsed `navigation.json` contents from a TypeDoc run.
+ * @param basePath - Prefix prepended to every generated link (e.g. `"/bedrock/api/"`).
+ * @returns Sidebar items ready to plug into `themeConfig.sidebar`.
+ */
+export function buildSidebarFromNavigation(
+	nav: ReadonlyArray<NavigationItem>,
+	basePath: string,
+): Array<DefaultTheme.SidebarItem> {
+	return nav.flatMap((item) => toSidebarItem(item, basePath) ?? []);
+}
+
+function toLink(path: string, basePath: string): string {
+	return basePath + path.replace(/\.(?:md|html)$/u, "");
+}
+
+function toSidebarItem(
+	item: NavigationItem,
+	basePath: string,
+): DefaultTheme.SidebarItem | undefined {
+	const children = item.children ?? [];
+	const items = children
+		.map((child) => toSidebarItem(child, basePath))
+		.filter((child): child is DefaultTheme.SidebarItem => child !== undefined);
+	const link =
+		typeof item.path === "string" && item.path.length > 0
+			? toLink(item.path, basePath)
+			: undefined;
+
+	if (items.length > 0) {
+		return link === undefined
+			? { collapsed: true, items, text: item.title }
+			: { collapsed: true, items, link, text: item.title };
+	}
+
+	if (link !== undefined) {
+		return { link, text: item.title };
+	}
+
+	return undefined;
+}

--- a/apps/website/.vitepress/config.ts
+++ b/apps/website/.vitepress/config.ts
@@ -1,5 +1,11 @@
+import { readFileSync } from "node:fs";
 import { defineConfig } from "vitepress";
 import { tabsMarkdownPlugin } from "vitepress-plugin-tabs";
+
+import { buildSidebarFromNavigation, type NavigationItem } from "./build-sidebar.ts";
+
+const navigationBedrock = loadNavigation("./docs/bedrock/api/navigation.json");
+const navigationOcale = loadNavigation("./docs/ocale/api/navigation.json");
 
 export default defineConfig({
 	cleanUrls: true,
@@ -20,11 +26,6 @@ export default defineConfig({
 			{ link: "/bedrock/guide/getting-started", text: "Bedrock" },
 			{ link: "/ocale/guide/getting-started", text: "Ocale" },
 		],
-		// Links into /ocale/api/** and /bedrock/api/** point at paths that
-		// typedoc-plugin-markdown generates from each package's public API. If
-		// typedoc or the plugin is upgraded and changes its output layout,
-		// these links must be updated manually — there's no compile-time check
-		// that they resolve.
 		sidebar: {
 			"/bedrock/": [
 				{
@@ -32,63 +33,23 @@ export default defineConfig({
 					text: "Bedrock",
 				},
 				{
-					items: [
-						{ link: "/bedrock/api/functions/diff", text: "diff" },
-						{ link: "/bedrock/api/type-aliases/Operation", text: "Operation" },
-						{
-							link: "/bedrock/api/type-aliases/ResourceDesiredState",
-							text: "ResourceDesiredState",
-						},
-						{
-							link: "/bedrock/api/type-aliases/ResourceCurrentState",
-							text: "ResourceCurrentState",
-						},
-					],
-					text: "Core",
-				},
-				{
-					items: [
-						{
-							link: "/bedrock/api/interfaces/ResourceDriver",
-							text: "ResourceDriver",
-						},
-						{
-							link: "/bedrock/api/type-aliases/DriverRegistry",
-							text: "DriverRegistry",
-						},
-					],
-					text: "Ports",
-				},
-				{
-					items: [
-						{
-							link: "/bedrock/api/type-aliases/ResourceKey",
-							text: "Branded IDs",
-						},
-					],
-					text: "Types",
+					collapsed: false,
+					items: buildSidebarFromNavigation(navigationBedrock, "/bedrock/api/"),
+					text: "API",
 				},
 			],
 			"/ocale/": [
 				{
-					items: [{ link: "/ocale/guide/getting-started", text: "Getting Started" }],
+					items: [
+						{ link: "/ocale/guide/getting-started", text: "Getting Started" },
+						{ link: "/ocale/guide/errors", text: "Errors" },
+					],
 					text: "Ocale",
 				},
 				{
-					items: [
-						{ link: "/ocale/guide/errors", text: "Errors" },
-						{ link: "/ocale/api/index/type-aliases/Result", text: "Result" },
-					],
-					text: "Core",
-				},
-				{
-					items: [
-						{
-							link: "/ocale/api/resources/game-passes/classes/GamePassesClient",
-							text: "Game Passes",
-						},
-					],
-					text: "Resources",
+					collapsed: false,
+					items: buildSidebarFromNavigation(navigationOcale, "/ocale/api/"),
+					text: "API",
 				},
 			],
 		},
@@ -96,3 +57,31 @@ export default defineConfig({
 	},
 	title: "Bedrock",
 });
+
+function toNavigationItem(value: JSONValue): NavigationItem | undefined {
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return undefined;
+	}
+
+	const { children, path, title } = value;
+	if (typeof title !== "string") {
+		return undefined;
+	}
+
+	return {
+		...(Array.isArray(children) && {
+			children: children.flatMap((child) => toNavigationItem(child) ?? []),
+		}),
+		...(typeof path === "string" && { path }),
+		title,
+	};
+}
+
+function loadNavigation(path: string): Array<NavigationItem> {
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf8"));
+		return Array.isArray(parsed) ? parsed.flatMap((item) => toNavigationItem(item) ?? []) : [];
+	} catch {
+		return [];
+	}
+}

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -12,17 +12,24 @@
 	"type": "module",
 	"scripts": {
 		"docs:build": "typedoc --options ./typedoc.json && typedoc --options ./typedoc.bedrock.json && vitepress build",
-		"docs:dev": "concurrently -k -n ocale,bedrock,vitepress -c magenta,blue,cyan \"typedoc --options ./typedoc.json --watch\" \"typedoc --options ./typedoc.bedrock.json --watch\" \"vitepress dev\"",
+		"docs:dev": "typedoc --options ./typedoc.json && typedoc --options ./typedoc.bedrock.json && concurrently -k -n ocale,bedrock,vitepress -c magenta,blue,cyan \"typedoc --options ./typedoc.json --watch\" \"typedoc --options ./typedoc.bedrock.json --watch\" \"vitepress dev\"",
 		"lint": "eslint --cache .",
-		"preview": "vitepress preview"
+		"preview": "vitepress preview",
+		"test": "vp test",
+		"typecheck": "tsgo --noEmit"
 	},
 	"devDependencies": {
+		"@bedrock/testing": "workspace:*",
+		"@bedrock/typescript-config": "workspace:*",
+		"@bedrock/vite-config": "workspace:*",
 		"concurrently": "catalog:dev",
 		"typedoc": "catalog:build",
 		"typedoc-plugin-markdown": "catalog:build",
 		"typedoc-plugin-replace-text": "catalog:build",
+		"typescript": "catalog:tsc",
 		"vitepress": "catalog:docs",
-		"vitepress-plugin-tabs": "catalog:docs"
+		"vitepress-plugin-tabs": "catalog:docs",
+		"vitest": "catalog:test"
 	},
 	"engines": {
 		"bun": ">=1.0.0"

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -1,5 +1,5 @@
 {
 	"extends": "@bedrock/typescript-config/tsconfig.base.json",
-	"include": [".vitepress/**/*", "docs/**/*"],
+	"include": [".vitepress/**/*", "docs/**/*", "vite.config.ts"],
 	"exclude": ["node_modules", ".vitepress/cache", ".vitepress/dist"]
 }

--- a/apps/website/typedoc.bedrock.json
+++ b/apps/website/typedoc.bedrock.json
@@ -5,6 +5,8 @@
 	"exclude": ["**/*.spec.ts", "**/*.spec-d.ts", "**/*.example.spec.ts", "**/*.example.test.ts"],
 	"tsconfig": "../../packages/bedrock/tsconfig.json",
 	"out": "./docs/bedrock/api",
+	"navigationJson": "./docs/bedrock/api/navigation.json",
+	"pretty": true,
 	"plugin": ["typedoc-plugin-markdown", "typedoc-plugin-replace-text"],
 	"readme": "none",
 	"githubPages": false,

--- a/apps/website/typedoc.json
+++ b/apps/website/typedoc.json
@@ -2,7 +2,9 @@
 	"$schema": "https://typedoc.org/schema.json",
 	"entryPoints": [
 		"../../packages/open-cloud/src/index.ts",
-		"../../packages/open-cloud/src/resources/game-passes/index.ts"
+		"../../packages/open-cloud/src/resources/game-passes/index.ts",
+		"../../packages/open-cloud/src/resources/places/index.ts",
+		"../../packages/open-cloud/src/resources/universes/index.ts"
 	],
 	"entryPointStrategy": "resolve",
 	"exclude": ["**/*.spec.ts", "**/*.spec-d.ts", "**/*.example.spec.ts", "**/*.example.test.ts"],

--- a/apps/website/typedoc.json
+++ b/apps/website/typedoc.json
@@ -8,6 +8,8 @@
 	"exclude": ["**/*.spec.ts", "**/*.spec-d.ts", "**/*.example.spec.ts", "**/*.example.test.ts"],
 	"tsconfig": "../../packages/open-cloud/tsconfig.json",
 	"out": "./docs/ocale/api",
+	"navigationJson": "./docs/ocale/api/navigation.json",
+	"pretty": true,
 	"plugin": ["typedoc-plugin-markdown", "typedoc-plugin-replace-text"],
 	"readme": "none",
 	"githubPages": false,

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -1,0 +1,11 @@
+import { sharedConfig } from "@bedrock/vite-config";
+
+import { mergeConfig } from "vite-plus";
+
+export default mergeConfig(sharedConfig, {
+	test: {
+		coverage: {
+			include: [".vitepress/**/*.{ts,tsx}"],
+		},
+	},
+});

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
 	},
 	"devDependencies": {
 		"@bedrock/testing": "workspace:*",
-		"@bedrock/typescript-config": "workspace:*",
 		"@bedrock/vite-config": "workspace:*",
 		"@commitlint/cli": "catalog:lint",
 		"@commitlint/config-conventional": "catalog:lint",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,24 +330,39 @@ importers:
 
   apps/website:
     devDependencies:
+      '@bedrock/testing':
+        specifier: workspace:*
+        version: link:../../packages/testing
+      '@bedrock/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      '@bedrock/vite-config':
+        specifier: workspace:*
+        version: link:../../packages/vite-config
       concurrently:
         specifier: catalog:dev
         version: 9.1.0
       typedoc:
         specifier: catalog:build
-        version: 0.28.19(typescript@6.0.2)
+        version: 0.28.19(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
       typedoc-plugin-markdown:
         specifier: catalog:build
-        version: 4.11.0(typedoc@0.28.19(typescript@6.0.2))
+        version: 4.11.0(typedoc@0.28.19(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)))
       typedoc-plugin-replace-text:
         specifier: catalog:build
-        version: 4.2.0(typedoc@0.28.19(typescript@6.0.2))
+        version: 4.2.0(typedoc@0.28.19(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)))
+      typescript:
+        specifier: catalog:tsc
+        version: '@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)'
       vitepress:
         specifier: catalog:docs
-        version: 2.0.0-alpha.17(@types/node@24.10.1)(change-case@5.4.4)(esbuild@0.27.7)(jiti@2.6.1)(oxc-minify@0.125.0)(postcss@8.5.9)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.2)(unplugin-unused@0.5.7)(yaml@2.8.3)
+        version: 2.0.0-alpha.17(@types/node@24.10.1)(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))(change-case@5.4.4)(esbuild@0.27.7)(jiti@2.6.1)(oxc-minify@0.125.0)(postcss@8.5.9)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3)
       vitepress-plugin-tabs:
         specifier: catalog:docs
-        version: 0.8.0(vitepress@2.0.0-alpha.17(@types/node@24.10.1)(change-case@5.4.4)(esbuild@0.27.7)(jiti@2.6.1)(oxc-minify@0.125.0)(postcss@8.5.9)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.2)(unplugin-unused@0.5.7)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))
+        version: 0.8.0(vitepress@2.0.0-alpha.17(@types/node@24.10.1)(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))(change-case@5.4.4)(esbuild@0.27.7)(jiti@2.6.1)(oxc-minify@0.125.0)(postcss@8.5.9)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3))(vue@3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)))
+      vitest:
+        specifier: npm:@voidzero-dev/vite-plus-test@0.1.19
+        version: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))(@vitest/coverage-v8@4.1.4)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
 
   packages/bedrock:
     dependencies:
@@ -8808,11 +8823,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-vue@6.0.6(@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.2)(unplugin-unused@0.5.7)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))':
+  '@vitejs/plugin-vue@6.0.6(@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3))(vue@3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
-      vite: '@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.2)(unplugin-unused@0.5.7)(yaml@2.8.3)'
-      vue: 3.5.32(typescript@6.0.2)
+      vite: '@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3)'
+      vue: 3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
 
   '@vitest/coverage-v8@4.1.4(@voidzero-dev/vite-plus-test@0.1.19)':
     dependencies:
@@ -8864,23 +8879,6 @@ snapshots:
       publint: 0.3.18
       tsx: 4.21.0
       typescript: '@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)'
-      unplugin-unused: 0.5.7
-      yaml: 2.8.3
-
-  '@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.2)(unplugin-unused@0.5.7)(yaml@2.8.3)':
-    dependencies:
-      '@oxc-project/runtime': 0.126.0
-      '@oxc-project/types': 0.126.0
-      lightningcss: 1.32.0
-      postcss: 8.5.9
-    optionalDependencies:
-      '@types/node': 24.10.1
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      publint: 0.3.18
-      tsx: 4.21.0
-      typescript: 6.0.2
       unplugin-unused: 0.5.7
       yaml: 2.8.3
 
@@ -9012,35 +9010,35 @@ snapshots:
       '@vue/shared': 3.5.32
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.32(vue@3.5.32(typescript@6.0.2))':
+  '@vue/server-renderer@3.5.32(vue@3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)))':
     dependencies:
       '@vue/compiler-ssr': 3.5.32
       '@vue/shared': 3.5.32
-      vue: 3.5.32(typescript@6.0.2)
+      vue: 3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
 
   '@vue/shared@3.5.32': {}
 
-  '@vueuse/core@14.2.1(vue@3.5.32(typescript@6.0.2))':
+  '@vueuse/core@14.2.1(vue@3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 14.2.1
-      '@vueuse/shared': 14.2.1(vue@3.5.32(typescript@6.0.2))
-      vue: 3.5.32(typescript@6.0.2)
+      '@vueuse/shared': 14.2.1(vue@3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)))
+      vue: 3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
 
-  '@vueuse/integrations@14.2.1(change-case@5.4.4)(focus-trap@8.0.1)(vue@3.5.32(typescript@6.0.2))':
+  '@vueuse/integrations@14.2.1(change-case@5.4.4)(focus-trap@8.0.1)(vue@3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)))':
     dependencies:
-      '@vueuse/core': 14.2.1(vue@3.5.32(typescript@6.0.2))
-      '@vueuse/shared': 14.2.1(vue@3.5.32(typescript@6.0.2))
-      vue: 3.5.32(typescript@6.0.2)
+      '@vueuse/core': 14.2.1(vue@3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)))
+      '@vueuse/shared': 14.2.1(vue@3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)))
+      vue: 3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
     optionalDependencies:
       change-case: 5.4.4
       focus-trap: 8.0.1
 
   '@vueuse/metadata@14.2.1': {}
 
-  '@vueuse/shared@14.2.1(vue@3.5.32(typescript@6.0.2))':
+  '@vueuse/shared@14.2.1(vue@3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)))':
     dependencies:
-      vue: 3.5.32(typescript@6.0.2)
+      vue: 3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -12194,21 +12192,21 @@ snapshots:
       tunnel: 0.0.6
       underscore: 1.13.8
 
-  typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@6.0.2)):
+  typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))):
     dependencies:
-      typedoc: 0.28.19(typescript@6.0.2)
+      typedoc: 0.28.19(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
 
-  typedoc-plugin-replace-text@4.2.0(typedoc@0.28.19(typescript@6.0.2)):
+  typedoc-plugin-replace-text@4.2.0(typedoc@0.28.19(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))):
     dependencies:
-      typedoc: 0.28.19(typescript@6.0.2)
+      typedoc: 0.28.19(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
 
-  typedoc@0.28.19(typescript@6.0.2):
+  typedoc@0.28.19(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)):
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
       markdown-it: 14.1.1
       minimatch: 10.2.5
-      typescript: 6.0.2
+      typescript: '@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)'
       yaml: 2.8.3
 
   typescript@5.9.3: {}
@@ -12370,12 +12368,12 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitepress-plugin-tabs@0.8.0(vitepress@2.0.0-alpha.17(@types/node@24.10.1)(change-case@5.4.4)(esbuild@0.27.7)(jiti@2.6.1)(oxc-minify@0.125.0)(postcss@8.5.9)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.2)(unplugin-unused@0.5.7)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2)):
+  vitepress-plugin-tabs@0.8.0(vitepress@2.0.0-alpha.17(@types/node@24.10.1)(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))(change-case@5.4.4)(esbuild@0.27.7)(jiti@2.6.1)(oxc-minify@0.125.0)(postcss@8.5.9)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3))(vue@3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))):
     dependencies:
-      vitepress: 2.0.0-alpha.17(@types/node@24.10.1)(change-case@5.4.4)(esbuild@0.27.7)(jiti@2.6.1)(oxc-minify@0.125.0)(postcss@8.5.9)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.2)(unplugin-unused@0.5.7)(yaml@2.8.3)
-      vue: 3.5.32(typescript@6.0.2)
+      vitepress: 2.0.0-alpha.17(@types/node@24.10.1)(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))(change-case@5.4.4)(esbuild@0.27.7)(jiti@2.6.1)(oxc-minify@0.125.0)(postcss@8.5.9)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3)
+      vue: 3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
 
-  vitepress@2.0.0-alpha.17(@types/node@24.10.1)(change-case@5.4.4)(esbuild@0.27.7)(jiti@2.6.1)(oxc-minify@0.125.0)(postcss@8.5.9)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.2)(unplugin-unused@0.5.7)(yaml@2.8.3):
+  vitepress@2.0.0-alpha.17(@types/node@24.10.1)(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))(change-case@5.4.4)(esbuild@0.27.7)(jiti@2.6.1)(oxc-minify@0.125.0)(postcss@8.5.9)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3):
     dependencies:
       '@docsearch/css': 4.6.2
       '@docsearch/js': 4.6.2
@@ -12385,17 +12383,17 @@ snapshots:
       '@shikijs/transformers': 3.23.0
       '@shikijs/types': 3.23.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 6.0.6(@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.2)(unplugin-unused@0.5.7)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))
+      '@vitejs/plugin-vue': 6.0.6(@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3))(vue@3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)))
       '@vue/devtools-api': 8.0.5
       '@vue/shared': 3.5.32
-      '@vueuse/core': 14.2.1(vue@3.5.32(typescript@6.0.2))
-      '@vueuse/integrations': 14.2.1(change-case@5.4.4)(focus-trap@8.0.1)(vue@3.5.32(typescript@6.0.2))
+      '@vueuse/core': 14.2.1(vue@3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)))
+      '@vueuse/integrations': 14.2.1(change-case@5.4.4)(focus-trap@8.0.1)(vue@3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)))
       focus-trap: 8.0.1
       mark.js: 8.11.1
       minisearch: 7.2.0
       shiki: 3.23.0
-      vite: '@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.10.1)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(typescript@6.0.2)(unplugin-unused@0.5.7)(yaml@2.8.3)'
-      vue: 3.5.32(typescript@6.0.2)
+      vite: '@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3)'
+      vue: 3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
     optionalDependencies:
       oxc-minify: 0.125.0
       postcss: 8.5.9
@@ -12434,15 +12432,15 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue@3.5.32(typescript@6.0.2):
+  vue@3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)):
     dependencies:
       '@vue/compiler-dom': 3.5.32
       '@vue/compiler-sfc': 3.5.32
       '@vue/runtime-dom': 3.5.32
-      '@vue/server-renderer': 3.5.32(vue@3.5.32(typescript@6.0.2))
+      '@vue/server-renderer': 3.5.32(vue@3.5.32(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)))
       '@vue/shared': 3.5.32
     optionalDependencies:
-      typescript: 6.0.2
+      typescript: '@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)'
 
   walk-up-path@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,9 +191,6 @@ importers:
       '@bedrock/testing':
         specifier: workspace:*
         version: link:packages/testing
-      '@bedrock/typescript-config':
-        specifier: workspace:*
-        version: link:packages/typescript-config
       '@bedrock/vite-config':
         specifier: workspace:*
         version: link:packages/vite-config


### PR DESCRIPTION
## Summary

- The VitePress sidebar was hand-maintained and drifted: every resource driver landed since the initial scaffold (universe, place, game-pass) was missing from the left-hand navigation even though TypeDoc had rendered its markdown.
- Enable `typedoc-plugin-markdown`'s `navigationJson` output, map the resulting tree into `themeConfig.sidebar` at build time via a new pure `buildSidebarFromNavigation` helper, and delete the stale hardcoded API sections.
- Drop a now-unused `@bedrock/typescript-config` entry from the root `package.json` (each workspace that extends the shared tsconfig now declares the dep for itself).

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean (all workspaces, including the newly-covered `apps/website`)
- [x] `pnpm --filter @bedrock/website test` — 7 new unit tests for `buildSidebarFromNavigation`
- [x] `pnpm --filter @bedrock/website run docs:build` — TypeDoc + VitePress succeed
- [x] `pnpm lint:unused` (knip) clean
- [x] Built `apps/website/.vitepress/dist/index.html` hash map contains `UniverseEntry`, `PlaceEntry`, `createGamePassDriver`, `createPlaceDriver`, `createUniverseDriver`, `defineConfig`, `deploy`, `loadConfig` — all previously absent from the sidebar
- [ ] Vercel preview URL shows universe + place resources in the sidebar on `/bedrock/api/*` pages
- [ ] Vercel preview sidebar on `/ocale/api/*` lists both `universes` and `game-passes` resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)