### PR TITLE
ci: cache stryker incremental report in mutation job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,9 +75,31 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - id: stryker-hash
+        name: Hash Stryker config inputs
+        run: echo "hash=${{ hashFiles('packages/testing/src/stryker.ts', 'packages/*/stryker.config.ts', 'packages/*/tsconfig.json', 'pnpm-lock.yaml') }}" >> "$GITHUB_OUTPUT"
+
+      - id: stryker-cache
+        name: Restore Stryker incremental cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          key: stryker-${{ runner.os }}-${{ steps.stryker-hash.outputs.hash }}-${{ github.head_ref }}-${{ github.sha }}
+          path: |
+            packages/*/reports/stryker-incremental.json
+          restore-keys: |
+            stryker-${{ runner.os }}-${{ steps.stryker-hash.outputs.hash }}-${{ github.head_ref }}-
+
       - env:
           MUTATE_BASE_REF: origin/${{ github.base_ref }}
           VITEST_TYPECHECK: "false"
         name: Mutation test changed files
         run: pnpm mutate:changed
+
+      - if: always() && steps.stryker-cache.outputs.cache-hit != 'true'
+        name: Save Stryker incremental cache
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          key: ${{ steps.stryker-cache.outputs.cache-primary-key }}
+          path: |
+            packages/*/reports/stryker-incremental.json
     timeout-minutes: 20


### PR DESCRIPTION
## Summary

Persist Stryker's `reports/stryker-incremental.json` between CI runs on the mutation job. Today each PR push starts cold (`INFO ProjectReader No incremental result file found…`) and pays the full dry-run + per-test coverage collection cost. Caching the incremental file lets subsequent pushes on the same PR reuse Stryker's per-mutant state.

## What changed

- `.github/workflows/ci.yaml` — added three steps to the `mutation` job: hash Stryker config inputs, `actions/cache/restore`, `actions/cache/save` (always, skip on exact cache-hit).

Cache key: `stryker-<os>-<config-hash>-<head-ref>-<sha>`, where `<config-hash>` is `hashFiles('packages/testing/src/stryker.ts', 'packages/*/stryker.config.ts', 'packages/*/tsconfig.json', 'pnpm-lock.yaml')`. Restore-key drops the `<sha>` suffix so later commits on the same PR branch hit warm cache. Config/lockfile changes bump the hash and invalidate cleanly.

## Scope

Warm-cache benefit applies to repeat pushes on the **same PR branch**. Cross-PR sharing is out of scope: it would require also running mutation on `push` to `main` (adds full-run cost to every merge). That's a deliberate deferral, not an oversight.

## Test plan

- [ ] First run on this PR: cache miss (expected). `pnpm mutate:changed` runs full.
- [ ] Push a second commit: `Restore Stryker incremental cache` should hit `stryker-<os>-<hash>-<head-ref>-`. `ProjectReader` log no longer says "No incremental result file found".
- [ ] Touch `packages/testing/src/stryker.ts` on a later commit and confirm the computed hash changes, forcing a cold run (drift handling).
- [ ] Fork PR (hypothetical): read-only cache access still works; no regression vs. today.

## ADR context

[ADR-015](docs/adr/015-mutation-testing-stryker.md) explicitly lists CI cache mechanism as an implementation detail, not an architectural exclusion. No ADR amendment needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)