### PR TITLE
feat(core): cli scaffolding with --help and --version

### DIFF
--- a/docs/adr/018-fcis-ports-with-primary-driven-distinction.md
+++ b/docs/adr/018-fcis-ports-with-primary-driven-distinction.md
@@ -294,3 +294,17 @@ pass it in). It does not require a DI container.
   zero-mock testing story. The pure core is tested without mocks; driven adapters
   are tested against fakes injected at the port boundary; shell functions are
   integration-tested with fake adapters.
+
+## Amendments
+
+- **2026-04-25:** The CLI primary-adapter folder is `packages/bedrock/src/cli/`.
+  The original Decision text places it at `packages/cli/src/bin/`; both segments
+  changed after this ADR was accepted. The package was renamed to
+  `@bedrock/core` (PR #163), making `packages/bedrock/` its working-tree path.
+  The `bin/` segment was renamed to `cli/` when the scaffolding landed (#184)
+  to align with the Node convention that `bin` names the published executable
+  entry (`dist/cli/run.mjs`, declared in `package.json` `bin`) rather than the
+  source folder. Source under `cli/` covers the program factory (`index.ts`),
+  the executable shim (`run.ts`), output port (`render.ts`), options parser
+  (`parse-options.ts`), and exit-code constants. Future command modules live
+  under `cli/commands/`.

--- a/knip.ts
+++ b/knip.ts
@@ -29,7 +29,12 @@ const config: KnipConfig = {
 		},
 		"apps/website": {},
 		"packages/bedrock": {
-			entry: ["stryker.config.ts", "src/index.ts", "tests/integration/fixtures/**/*.{ts,js}"],
+			entry: [
+				"stryker.config.ts",
+				"src/cli/run.ts",
+				"src/index.ts",
+				"tests/integration/fixtures/**/*.{ts,js}",
+			],
 		},
 		"packages/open-cloud": {
 			entry: [

--- a/packages/bedrock/CLAUDE.md
+++ b/packages/bedrock/CLAUDE.md
@@ -28,8 +28,11 @@ Source layout under `src/`:
 | `adapters/` | Driven adapter implementations (`GamePassDriver` wrapping `@bedrock/ocale`, future state adapters). |
 | `shell/` | Use-case orchestration (`applyOps`, `buildDesired`, future `deploy`). Calls core with data pulled from adapters. |
 
-A `src/bin/` directory will land in a later slice for the CLI primary
-adapter. The programmatic primary surface is `src/index.ts` itself.
+The CLI primary adapter lives under `src/cli/` (program factory, executable
+shim, output port, options parser, exit codes). The folder name diverges
+from ADR-018's original `bin/` plan; the rename is recorded in a dated
+amendment to that ADR. The programmatic primary surface is `src/index.ts`
+itself.
 
 ## Design principles
 

--- a/packages/bedrock/package.json
+++ b/packages/bedrock/package.json
@@ -29,9 +29,16 @@
 			"source": "./src/index.ts",
 			"default": "./dist/index.mjs"
 		},
+		"./cli/run": {
+			"source": "./src/cli/run.ts",
+			"default": "./dist/cli/run.mjs"
+		},
 		"./package.json": "./package.json"
 	},
 	"types": "./dist/index.d.mts",
+	"bin": {
+		"bedrock": "./dist/cli/run.mjs"
+	},
 	"files": [
 		"dist"
 	],
@@ -69,6 +76,7 @@
 	"publishConfig": {
 		"exports": {
 			".": "./dist/index.mjs",
+			"./cli/run": "./dist/cli/run.mjs",
 			"./package.json": "./package.json"
 		}
 	},

--- a/packages/bedrock/package.json
+++ b/packages/bedrock/package.json
@@ -43,8 +43,10 @@
 	},
 	"dependencies": {
 		"@bedrock/ocale": "workspace:*",
+		"@clack/prompts": "catalog:runtime",
 		"arktype": "catalog:runtime",
-		"c12": "catalog:runtime"
+		"c12": "catalog:runtime",
+		"sade": "catalog:runtime"
 	},
 	"devDependencies": {
 		"@bedrock/testing": "workspace:*",

--- a/packages/bedrock/src/cli/exit-codes.spec.ts
+++ b/packages/bedrock/src/cli/exit-codes.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { EXIT_ERROR, EXIT_OK } from "./exit-codes.ts";
+
+describe("exit codes", () => {
+	it("should expose 0 as success and 1 as failure", () => {
+		expect.assertions(2);
+
+		expect(EXIT_OK).toBe(0);
+		expect(EXIT_ERROR).toBe(1);
+	});
+});

--- a/packages/bedrock/src/cli/exit-codes.ts
+++ b/packages/bedrock/src/cli/exit-codes.ts
@@ -1,0 +1,2 @@
+export const EXIT_OK = 0;
+export const EXIT_ERROR = 1;

--- a/packages/bedrock/src/cli/index.spec-d.ts
+++ b/packages/bedrock/src/cli/index.spec-d.ts
@@ -1,0 +1,48 @@
+import type { Sade } from "sade";
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { diff } from "../core/diff.ts";
+import type { deploy } from "../shell/deploy.ts";
+import type { loadConfig } from "../shell/load-config.ts";
+import type { ProgDeps } from "./index.ts";
+import { createProg } from "./index.ts";
+import type { ClackPort } from "./render.ts";
+
+describe("ProgDeps", () => {
+	it("should expose exactly the five injection slots", () => {
+		expectTypeOf<keyof ProgDeps>().toEqualTypeOf<
+			"clack" | "deploy" | "diff" | "exit" | "loadConfig"
+		>();
+	});
+
+	it("should mark every slot as optional so an empty deps object satisfies ProgDeps", () => {
+		expectTypeOf<Record<string, never>>().toExtend<ProgDeps>();
+	});
+
+	it("should accept the real deploy signature in the deploy slot", () => {
+		expectTypeOf<NonNullable<ProgDeps["deploy"]>>().toEqualTypeOf<typeof deploy>();
+	});
+
+	it("should accept the real diff signature in the diff slot", () => {
+		expectTypeOf<NonNullable<ProgDeps["diff"]>>().toEqualTypeOf<typeof diff>();
+	});
+
+	it("should accept the real loadConfig signature in the loadConfig slot", () => {
+		expectTypeOf<NonNullable<ProgDeps["loadConfig"]>>().toEqualTypeOf<typeof loadConfig>();
+	});
+
+	it("should accept the ClackPort interface in the clack slot", () => {
+		expectTypeOf<NonNullable<ProgDeps["clack"]>>().toEqualTypeOf<ClackPort>();
+	});
+
+	it("should accept a never-returning exit handle in the exit slot", () => {
+		expectTypeOf<NonNullable<ProgDeps["exit"]>>().toEqualTypeOf<(code: number) => never>();
+	});
+});
+
+describe(createProg, () => {
+	it("should accept an optional ProgDeps argument and return a sade Sade instance", () => {
+		expectTypeOf(createProg).parameter(0).toEqualTypeOf<ProgDeps | undefined>();
+		expectTypeOf<ReturnType<typeof createProg>>().toEqualTypeOf<Sade>();
+	});
+});

--- a/packages/bedrock/src/cli/index.ts
+++ b/packages/bedrock/src/cli/index.ts
@@ -1,0 +1,47 @@
+import { createRequire } from "node:module";
+import sade from "sade";
+import type { Sade } from "sade";
+
+import type { diff as defaultDiff } from "../core/diff.ts";
+import type { deploy as defaultDeploy } from "../shell/deploy.ts";
+import type { loadConfig as defaultLoadConfig } from "../shell/load-config.ts";
+import type { ClackPort } from "./render.ts";
+
+export { createClackPort } from "./render.ts";
+
+const PROGRAM_NAME = "bedrock";
+const PROGRAM_DESCRIBE = "Infrastructure-as-Code deployment tool for Roblox";
+
+const require = createRequire(import.meta.url);
+const manifest = require("../../package.json") as { readonly version: string };
+
+/**
+ * Dependency seam for the bedrock CLI program. Every slot is optional;
+ * command actions resolve a real default when a slot is omitted.
+ */
+export interface ProgDeps {
+	/** Output port; defaults to a real `@clack/prompts` adapter inside command actions. */
+	readonly clack?: ClackPort;
+	/** Reconciles config to live state; defaults to the public `deploy`. */
+	readonly deploy?: typeof defaultDeploy;
+	/** Pure desired-vs-current operation list builder; defaults to the public `diff`. */
+	readonly diff?: typeof defaultDiff;
+	/** Process exit handle; defaults to `process.exit` so tests can intercept termination. */
+	readonly exit?: (code: number) => never;
+	/** Project config loader; defaults to the public `loadConfig`. */
+	readonly loadConfig?: typeof defaultLoadConfig;
+}
+
+/**
+ * Construct the bedrock CLI program. Pure factory: no `process.argv` parsing,
+ * no clack output, no exits. Callers (the `run.ts` shim, integration tests)
+ * call `.parse()` on the returned sade instance.
+ * @param _deps - Dependency overrides for command actions. Reserved for the
+ *   `bedrock deploy` and `bedrock diff` slices; unused while no commands are
+ *   registered.
+ * @returns A configured sade program with the bedrock name, description, and
+ *   the currently installed `@bedrock/core` version.
+ */
+export function createProg(_deps?: ProgDeps): Sade {
+	return sade(PROGRAM_NAME).describe(PROGRAM_DESCRIBE).version(manifest.version);
+}

--- a/packages/bedrock/src/cli/index.ts
+++ b/packages/bedrock/src/cli/index.ts
@@ -1,7 +1,7 @@
-import { createRequire } from "node:module";
 import sade from "sade";
 import type { Sade } from "sade";
 
+import manifest from "../../package.json" with { type: "json" };
 import type { diff as defaultDiff } from "../core/diff.ts";
 import type { deploy as defaultDeploy } from "../shell/deploy.ts";
 import type { loadConfig as defaultLoadConfig } from "../shell/load-config.ts";
@@ -11,9 +11,6 @@ export { createClackPort } from "./render.ts";
 
 const PROGRAM_NAME = "bedrock";
 const PROGRAM_DESCRIBE = "Infrastructure-as-Code deployment tool for Roblox";
-
-const require = createRequire(import.meta.url);
-const manifest = require("../../package.json") as { readonly version: string };
 
 /**
  * Dependency seam for the bedrock CLI program. Every slot is optional;

--- a/packages/bedrock/src/cli/parse-options.spec-d.ts
+++ b/packages/bedrock/src/cli/parse-options.spec-d.ts
@@ -1,0 +1,41 @@
+import type { Result } from "@bedrock/ocale";
+
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { CommonOptions, ParseOptionsError } from "./parse-options.ts";
+import { parseCommonOptions } from "./parse-options.ts";
+
+describe("CommonOptions", () => {
+	it("should expose exactly the four documented common-flag fields", () => {
+		expectTypeOf<keyof CommonOptions>().toEqualTypeOf<
+			"apiKey" | "configFile" | "environments" | "githubToken"
+		>();
+	});
+
+	it("should require environments and leave the credentials slots optional", () => {
+		expectTypeOf<CommonOptions["environments"]>().toEqualTypeOf<ReadonlyArray<string>>();
+		expectTypeOf<CommonOptions["apiKey"]>().toEqualTypeOf<string | undefined>();
+		expectTypeOf<CommonOptions["configFile"]>().toEqualTypeOf<string | undefined>();
+		expectTypeOf<CommonOptions["githubToken"]>().toEqualTypeOf<string | undefined>();
+	});
+});
+
+describe("ParseOptionsError", () => {
+	it("should discriminate on kind across the missingRequired and unknownFlag variants", () => {
+		expectTypeOf<ParseOptionsError["kind"]>().toEqualTypeOf<
+			"missingRequired" | "unknownFlag"
+		>();
+	});
+
+	it("should attach a flag name to every variant", () => {
+		expectTypeOf<ParseOptionsError["flag"]>().toEqualTypeOf<string>();
+	});
+});
+
+describe(parseCommonOptions, () => {
+	it("should resolve to a Result of CommonOptions or ParseOptionsError", () => {
+		expectTypeOf<ReturnType<typeof parseCommonOptions>>().toEqualTypeOf<
+			Result<CommonOptions, ParseOptionsError>
+		>();
+	});
+});

--- a/packages/bedrock/src/cli/parse-options.spec-d.ts
+++ b/packages/bedrock/src/cli/parse-options.spec-d.ts
@@ -21,9 +21,9 @@ describe("CommonOptions", () => {
 });
 
 describe("ParseOptionsError", () => {
-	it("should discriminate on kind across the missingRequired and unknownFlag variants", () => {
+	it("should discriminate on kind across the three documented variants", () => {
 		expectTypeOf<ParseOptionsError["kind"]>().toEqualTypeOf<
-			"missingRequired" | "unknownFlag"
+			"invalidValue" | "missingRequired" | "unknownFlag"
 		>();
 	});
 

--- a/packages/bedrock/src/cli/parse-options.spec.ts
+++ b/packages/bedrock/src/cli/parse-options.spec.ts
@@ -94,6 +94,26 @@ describe(parseCommonOptions, () => {
 		expect(result.data.githubToken).toBe("ghp-456");
 	});
 
+	it("should fall back to the api-key alternate when only the kebab form is supplied", () => {
+		expect.assertions(1);
+
+		const result = parseCommonOptions({ "api-key": "kebab-key", "env": "production" });
+
+		assert(result.success);
+
+		expect(result.data.apiKey).toBe("kebab-key");
+	});
+
+	it("should fall back to the github-token alternate when only the kebab form is supplied", () => {
+		expect.assertions(1);
+
+		const result = parseCommonOptions({ "env": "production", "github-token": "kebab-token" });
+
+		assert(result.success);
+
+		expect(result.data.githubToken).toBe("kebab-token");
+	});
+
 	it("should ignore the sade-reserved help and version flag aliases", () => {
 		expect.assertions(1);
 

--- a/packages/bedrock/src/cli/parse-options.spec.ts
+++ b/packages/bedrock/src/cli/parse-options.spec.ts
@@ -25,6 +25,28 @@ describe(parseCommonOptions, () => {
 		expect(result.err.flag).toBe("verbose");
 	});
 
+	it("should reject when --env carries a non-string value", () => {
+		expect.assertions(2);
+
+		const result = parseCommonOptions({ env: false });
+
+		assert(!result.success);
+
+		expect(result.err.kind).toBe("invalidValue");
+		expect(result.err.flag).toBe("env");
+	});
+
+	it("should reject when one of multiple --env values is not a string", () => {
+		expect.assertions(2);
+
+		const result = parseCommonOptions({ env: ["staging", true] });
+
+		assert(!result.success);
+
+		expect(result.err.kind).toBe("invalidValue");
+		expect(result.err.flag).toBe("env");
+	});
+
 	it("should normalize a single --env into a one-element environments array", () => {
 		expect.assertions(1);
 

--- a/packages/bedrock/src/cli/parse-options.spec.ts
+++ b/packages/bedrock/src/cli/parse-options.spec.ts
@@ -1,0 +1,110 @@
+import { assert, describe, expect, it } from "vitest";
+
+import { parseCommonOptions } from "./parse-options.ts";
+
+describe(parseCommonOptions, () => {
+	it("should reject when --env is missing", () => {
+		expect.assertions(2);
+
+		const result = parseCommonOptions({ "--": [], "_": [] });
+
+		assert(!result.success);
+
+		expect(result.err.kind).toBe("missingRequired");
+		expect(result.err.flag).toBe("env");
+	});
+
+	it("should reject unknown flags by name", () => {
+		expect.assertions(2);
+
+		const result = parseCommonOptions({ env: "production", verbose: true });
+
+		assert(!result.success);
+
+		expect(result.err.kind).toBe("unknownFlag");
+		expect(result.err.flag).toBe("verbose");
+	});
+
+	it("should normalize a single --env into a one-element environments array", () => {
+		expect.assertions(1);
+
+		const result = parseCommonOptions({ env: "production" });
+
+		assert(result.success);
+
+		expect(result.data.environments).toStrictEqual(["production"]);
+	});
+
+	it("should preserve multiple --env values as a multi-element environments array", () => {
+		expect.assertions(1);
+
+		const result = parseCommonOptions({ env: ["staging", "production"] });
+
+		assert(result.success);
+
+		expect(result.data.environments).toStrictEqual(["staging", "production"]);
+	});
+
+	it("should default optional flags to undefined when omitted", () => {
+		expect.assertions(3);
+
+		const result = parseCommonOptions({ env: "production" });
+
+		assert(result.success);
+
+		expect(result.data.apiKey).toBeUndefined();
+		expect(result.data.configFile).toBeUndefined();
+		expect(result.data.githubToken).toBeUndefined();
+	});
+
+	it("should round-trip every recognized flag value when all are supplied", () => {
+		expect.assertions(4);
+
+		const result = parseCommonOptions({
+			"--": [],
+			"_": [],
+			"apiKey": "key-123",
+			"config": "./bedrock.staging.config.ts",
+			"env": "staging",
+			"githubToken": "ghp-456",
+		});
+
+		assert(result.success);
+
+		expect(result.data.environments).toStrictEqual(["staging"]);
+		expect(result.data.apiKey).toBe("key-123");
+		expect(result.data.configFile).toBe("./bedrock.staging.config.ts");
+		expect(result.data.githubToken).toBe("ghp-456");
+	});
+
+	it("should accept the kebab-case alternates produced by mri alongside their camelCase peers", () => {
+		expect.assertions(2);
+
+		const result = parseCommonOptions({
+			"api-key": "key-123",
+			"apiKey": "key-123",
+			"env": "production",
+			"github-token": "ghp-456",
+			"githubToken": "ghp-456",
+		});
+
+		assert(result.success);
+
+		expect(result.data.apiKey).toBe("key-123");
+		expect(result.data.githubToken).toBe("ghp-456");
+	});
+
+	it("should ignore the sade-reserved help and version flag aliases", () => {
+		expect.assertions(1);
+
+		const result = parseCommonOptions({
+			env: "production",
+			h: false,
+			help: false,
+			v: false,
+			version: false,
+		});
+
+		expect(result.success).toBeTrue();
+	});
+});

--- a/packages/bedrock/src/cli/parse-options.ts
+++ b/packages/bedrock/src/cli/parse-options.ts
@@ -1,0 +1,89 @@
+import type { Result } from "@bedrock/ocale";
+
+/**
+ * Typed shape command actions consume after the raw sade options object has
+ * been validated and normalized.
+ */
+export interface CommonOptions {
+	/** Roblox Open Cloud API key override; falls back to ROBLOX_API_KEY when undefined. */
+	readonly apiKey?: string;
+	/** Explicit config file path; when undefined the loader's discovery rules apply. */
+	readonly configFile?: string;
+	/** Target environment names. Sade collects `--env` repeatedly into this list. */
+	readonly environments: ReadonlyArray<string>;
+	/** GitHub token override; falls back to GITHUB_TOKEN when undefined. */
+	readonly githubToken?: string;
+}
+
+/**
+ * Failure modes surfaced by `parseCommonOptions`. Both variants name the
+ * offending flag so callers can render a precise diagnostic.
+ */
+export type ParseOptionsError =
+	| { readonly flag: string; readonly kind: "missingRequired" }
+	| { readonly flag: string; readonly kind: "unknownFlag" };
+
+const RECOGNIZED_FLAGS: ReadonlySet<string> = new Set([
+	"api-key",
+	"apiKey",
+	"config",
+	"env",
+	"github-token",
+	"githubToken",
+]);
+
+const SADE_RESERVED: ReadonlySet<string> = new Set(["--", "_", "h", "help", "v", "version"]);
+
+/**
+ * Translate the raw sade options POJO into a typed `CommonOptions`. Pure: no
+ * I/O, no clack, no sade types. Reused by `bedrock deploy` and `bedrock diff`.
+ * @param rawOptions - The options object sade hands the action callback.
+ * @returns `Ok(CommonOptions)` on success, or `Err(ParseOptionsError)` when a
+ *   required flag is missing or an unrecognized flag was supplied.
+ */
+export function parseCommonOptions(
+	rawOptions: Readonly<Record<string, unknown>>,
+): Result<CommonOptions, ParseOptionsError> {
+	for (const key of Object.keys(rawOptions)) {
+		if (!RECOGNIZED_FLAGS.has(key) && !SADE_RESERVED.has(key)) {
+			return { err: { flag: key, kind: "unknownFlag" }, success: false };
+		}
+	}
+
+	const environment = rawOptions["env"];
+	if (environment === undefined) {
+		return { err: { flag: "env", kind: "missingRequired" }, success: false };
+	}
+
+	const environments = Array.isArray(environment)
+		? environment.map(String)
+		: [String(environment)];
+
+	const apiKey = pickString(rawOptions, "apiKey", "api-key");
+	const configFile = pickString(rawOptions, "config");
+	const githubToken = pickString(rawOptions, "githubToken", "github-token");
+
+	return {
+		data: {
+			environments,
+			...(apiKey === undefined ? {} : { apiKey }),
+			...(configFile === undefined ? {} : { configFile }),
+			...(githubToken === undefined ? {} : { githubToken }),
+		},
+		success: true,
+	};
+}
+
+function pickString(
+	rawOptions: Readonly<Record<string, unknown>>,
+	...keys: ReadonlyArray<string>
+): string | undefined {
+	for (const key of keys) {
+		const value = rawOptions[key];
+		if (typeof value === "string") {
+			return value;
+		}
+	}
+
+	return undefined;
+}

--- a/packages/bedrock/src/cli/parse-options.ts
+++ b/packages/bedrock/src/cli/parse-options.ts
@@ -16,10 +16,11 @@ export interface CommonOptions {
 }
 
 /**
- * Failure modes surfaced by `parseCommonOptions`. Both variants name the
+ * Failure modes surfaced by `parseCommonOptions`. Every variant names the
  * offending flag so callers can render a precise diagnostic.
  */
 export type ParseOptionsError =
+	| { readonly flag: string; readonly kind: "invalidValue" }
 	| { readonly flag: string; readonly kind: "missingRequired" }
 	| { readonly flag: string; readonly kind: "unknownFlag" };
 
@@ -50,14 +51,10 @@ export function parseCommonOptions(
 		}
 	}
 
-	const environment = rawOptions["env"];
-	if (environment === undefined) {
-		return { err: { flag: "env", kind: "missingRequired" }, success: false };
+	const environments = resolveEnvironments(rawOptions["env"]);
+	if (!environments.success) {
+		return environments;
 	}
-
-	const environments = Array.isArray(environment)
-		? environment.map(String)
-		: [String(environment)];
 
 	const apiKey = pickString(rawOptions, "apiKey", "api-key");
 	const configFile = pickString(rawOptions, "config");
@@ -65,13 +62,31 @@ export function parseCommonOptions(
 
 	return {
 		data: {
-			environments,
+			environments: environments.data,
 			...(apiKey === undefined ? {} : { apiKey }),
 			...(configFile === undefined ? {} : { configFile }),
 			...(githubToken === undefined ? {} : { githubToken }),
 		},
 		success: true,
 	};
+}
+
+function resolveEnvironments(raw: unknown): Result<ReadonlyArray<string>, ParseOptionsError> {
+	if (raw === undefined) {
+		return { err: { flag: "env", kind: "missingRequired" }, success: false };
+	}
+
+	const candidates = Array.isArray(raw) ? raw : [raw];
+	const environments: Array<string> = [];
+	for (const candidate of candidates) {
+		if (typeof candidate !== "string") {
+			return { err: { flag: "env", kind: "invalidValue" }, success: false };
+		}
+
+		environments.push(candidate);
+	}
+
+	return { data: environments, success: true };
 }
 
 function pickString(

--- a/packages/bedrock/src/cli/render.spec-d.ts
+++ b/packages/bedrock/src/cli/render.spec-d.ts
@@ -1,0 +1,27 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { ClackPort } from "./render.ts";
+import { createClackPort } from "./render.ts";
+
+describe("ClackPort", () => {
+	it("should expose exactly the six clack subset methods", () => {
+		expectTypeOf<keyof ClackPort>().toEqualTypeOf<
+			"cancel" | "intro" | "logError" | "logMessage" | "logSuccess" | "outro"
+		>();
+	});
+
+	it("should accept a single string argument on every method and return void", () => {
+		expectTypeOf<ClackPort["cancel"]>().toEqualTypeOf<(message: string) => void>();
+		expectTypeOf<ClackPort["intro"]>().toEqualTypeOf<(message: string) => void>();
+		expectTypeOf<ClackPort["logError"]>().toEqualTypeOf<(message: string) => void>();
+		expectTypeOf<ClackPort["logMessage"]>().toEqualTypeOf<(message: string) => void>();
+		expectTypeOf<ClackPort["logSuccess"]>().toEqualTypeOf<(message: string) => void>();
+		expectTypeOf<ClackPort["outro"]>().toEqualTypeOf<(message: string) => void>();
+	});
+});
+
+describe(createClackPort, () => {
+	it("should return a ClackPort and take no arguments", () => {
+		expectTypeOf(createClackPort).toEqualTypeOf<() => ClackPort>();
+	});
+});

--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -1,0 +1,107 @@
+import { S_BAR, S_BAR_END, S_BAR_START, S_ERROR, S_SUCCESS } from "@clack/prompts";
+
+import { Buffer } from "node:buffer";
+import process from "node:process";
+import { describe, expect, it, vi } from "vitest";
+
+import { type ClackPort, createClackPort } from "./render.ts";
+
+interface CapturedOutput {
+	readonly text: string;
+}
+
+function captureWith(act: (port: ClackPort) => void): CapturedOutput {
+	const chunks: Array<string> = [];
+	const spy = vi
+		.spyOn(process.stdout, "write")
+		.mockImplementation((chunk: string | Uint8Array): boolean => {
+			chunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+			return true;
+		});
+
+	try {
+		act(createClackPort());
+	} finally {
+		spy.mockRestore();
+	}
+
+	return { text: chunks.join("") };
+}
+
+describe(createClackPort, () => {
+	it("should open a frame with the intro corner symbol", () => {
+		expect.assertions(3);
+
+		const { text } = captureWith((port) => {
+			port.intro("intro-title");
+		});
+
+		expect(text).toContain("intro-title");
+		expect(text).toContain(S_BAR_START);
+		expect(text).not.toContain(S_BAR_END);
+	});
+
+	it("should close a frame with the outro corner symbol after a bar continuation", () => {
+		expect.assertions(4);
+
+		const { text } = captureWith((port) => {
+			port.outro("outro-message");
+		});
+
+		expect(text).toContain("outro-message");
+		expect(text).toContain(S_BAR_END);
+		expect(text).toContain(S_BAR);
+		expect(text).not.toContain(S_BAR_START);
+	});
+
+	it("should render a cancel without an active bar continuation", () => {
+		expect.assertions(4);
+
+		const { text } = captureWith((port) => {
+			port.cancel("cancel-message");
+		});
+
+		expect(text).toContain("cancel-message");
+		expect(text).toContain(S_BAR_END);
+		expect(text).not.toContain(S_BAR);
+		expect(text).not.toContain(S_BAR_START);
+	});
+
+	it("should render a success line with the success symbol", () => {
+		expect.assertions(3);
+
+		const { text } = captureWith((port) => {
+			port.logSuccess("success-message");
+		});
+
+		expect(text).toContain("success-message");
+		expect(text).toContain(S_SUCCESS);
+		expect(text).not.toContain(S_ERROR);
+	});
+
+	it("should render an error line with the error symbol", () => {
+		expect.assertions(3);
+
+		const { text } = captureWith((port) => {
+			port.logError("error-message");
+		});
+
+		expect(text).toContain("error-message");
+		expect(text).toContain(S_ERROR);
+		expect(text).not.toContain(S_SUCCESS);
+	});
+
+	it("should render a plain message line without success, error, or frame symbols", () => {
+		expect.assertions(5);
+
+		const { text } = captureWith((port) => {
+			port.logMessage("plain-message");
+		});
+
+		expect(text).toContain("plain-message");
+		expect(text).toContain(S_BAR);
+		expect(text).not.toContain(S_SUCCESS);
+		expect(text).not.toContain(S_ERROR);
+		expect(text).not.toContain(S_BAR_END);
+	});
+});

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -1,0 +1,48 @@
+import { cancel, intro, log, outro } from "@clack/prompts";
+
+/**
+ * Output port the CLI renders through. Mirrors the subset of `@clack/prompts`
+ * the bedrock CLI uses today; tests inject a fake to assert what was rendered.
+ */
+export interface ClackPort {
+	/** End an interactive flow with a cancellation marker. */
+	cancel(message: string): void;
+	/** Open a framed section with a title (used for command intros). */
+	intro(message: string): void;
+	/** Render a single error line inside an open frame. */
+	logError(message: string): void;
+	/** Render a single neutral line inside an open frame. */
+	logMessage(message: string): void;
+	/** Render a single success line inside an open frame. */
+	logSuccess(message: string): void;
+	/** Close the current framed section with a final message. */
+	outro(message: string): void;
+}
+
+/**
+ * Construct a `ClackPort` whose methods delegate to `@clack/prompts`. The
+ * resulting port writes to `process.stdout` via clack's defaults.
+ * @returns A port whose six methods each invoke the matching clack helper.
+ */
+export function createClackPort(): ClackPort {
+	return {
+		cancel: (message) => {
+			cancel(message);
+		},
+		intro: (message) => {
+			intro(message);
+		},
+		logError: (message) => {
+			log.error(message);
+		},
+		logMessage: (message) => {
+			log.message(message);
+		},
+		logSuccess: (message) => {
+			log.success(message);
+		},
+		outro: (message) => {
+			outro(message);
+		},
+	};
+}

--- a/packages/bedrock/src/cli/run.ts
+++ b/packages/bedrock/src/cli/run.ts
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+import process from "node:process";
+
+import { createProg } from "./index.ts";
+
+createProg().parse(process.argv);

--- a/packages/bedrock/tests/integration/cli/index.spec.ts
+++ b/packages/bedrock/tests/integration/cli/index.spec.ts
@@ -37,12 +37,16 @@ function startCapture(): () => CapturedStreams {
 		.mockImplementation((...messages: ReadonlyArray<unknown>) => {
 			stderr.push(`${messages.map((message) => String(message)).join(" ")}\n`);
 		});
+	const exitSpy = vi.spyOn(process, "exit").mockImplementation((code): never => {
+		throw new Error(`unexpected process.exit(${String(code)}) during captured run`);
+	});
 
 	return () => {
 		stdoutSpy.mockRestore();
 		stderrSpy.mockRestore();
 		logSpy.mockRestore();
 		errorSpy.mockRestore();
+		exitSpy.mockRestore();
 		return { stderr, stdout };
 	};
 }

--- a/packages/bedrock/tests/integration/cli/index.spec.ts
+++ b/packages/bedrock/tests/integration/cli/index.spec.ts
@@ -1,0 +1,101 @@
+import { Buffer } from "node:buffer";
+import { createRequire } from "node:module";
+import process from "node:process";
+import { describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const manifest = require("../../../package.json") as { readonly version: string };
+
+interface CapturedStreams {
+	readonly stderr: ReadonlyArray<string>;
+	readonly stdout: ReadonlyArray<string>;
+}
+
+function startCapture(): () => CapturedStreams {
+	const stdout: Array<string> = [];
+	const stderr: Array<string> = [];
+
+	const stdoutSpy = vi
+		.spyOn(process.stdout, "write")
+		.mockImplementation((chunk: string | Uint8Array): boolean => {
+			stdout.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+			return true;
+		});
+	const stderrSpy = vi
+		.spyOn(process.stderr, "write")
+		.mockImplementation((chunk: string | Uint8Array): boolean => {
+			stderr.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+			return true;
+		});
+	const logSpy = vi
+		.spyOn(console, "log")
+		.mockImplementation((...messages: ReadonlyArray<unknown>) => {
+			stdout.push(`${messages.map((message) => String(message)).join(" ")}\n`);
+		});
+	const errorSpy = vi
+		.spyOn(console, "error")
+		.mockImplementation((...messages: ReadonlyArray<unknown>) => {
+			stderr.push(`${messages.map((message) => String(message)).join(" ")}\n`);
+		});
+
+	return () => {
+		stdoutSpy.mockRestore();
+		stderrSpy.mockRestore();
+		logSpy.mockRestore();
+		errorSpy.mockRestore();
+		return { stderr, stdout };
+	};
+}
+
+describe("cli program factory", () => {
+	it("should not produce stdout or stderr writes during module evaluation", async () => {
+		expect.assertions(2);
+
+		vi.resetModules();
+		const collect = startCapture();
+		try {
+			await import("#src/cli/index");
+		} finally {
+			const { stderr, stdout } = collect();
+
+			expect(stdout.join("")).toBe("");
+			expect(stderr.join("")).toBe("");
+		}
+	});
+
+	it("should print 'bedrock, <pkg.version>' when --version is parsed", async () => {
+		expect.assertions(2);
+
+		const { createProg } = await import("#src/cli/index");
+		const prog = createProg();
+
+		const collect = startCapture();
+		try {
+			prog.parse(["node", "bedrock", "--version"]);
+		} finally {
+			const { stdout } = collect();
+			const captured = stdout.join("");
+
+			expect(captured).toContain("bedrock,");
+			expect(captured).toContain(manifest.version);
+		}
+	});
+
+	it("should describe the program in --help output", async () => {
+		expect.assertions(2);
+
+		const { createProg } = await import("#src/cli/index");
+		const prog = createProg();
+
+		const collect = startCapture();
+		try {
+			prog.parse(["node", "bedrock", "--help"]);
+		} finally {
+			const { stdout } = collect();
+			const captured = stdout.join("");
+
+			expect(captured).toContain("bedrock");
+			expect(captured).toContain("Roblox");
+		}
+	});
+});

--- a/packages/bedrock/vite.config.ts
+++ b/packages/bedrock/vite.config.ts
@@ -1,1 +1,14 @@
-export { sharedConfig as default } from "@bedrock/vite-config";
+import { sharedConfig } from "@bedrock/vite-config";
+
+import { mergeConfig } from "vite-plus";
+
+export default mergeConfig(sharedConfig, {
+	pack: {
+		entry: ["src/index.ts", "src/cli/run.ts"],
+	},
+	test: {
+		coverage: {
+			exclude: [...sharedConfig.test.coverage.exclude, "src/cli/run.ts"],
+		},
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,12 +100,18 @@ catalogs:
       specifier: 0.3.18
       version: 0.3.18
   runtime:
+    '@clack/prompts':
+      specifier: 1.2.0
+      version: 1.2.0
     arktype:
       specifier: 2.2.0
       version: 2.2.0
     c12:
       specifier: 3.3.4
       version: 3.3.4
+    sade:
+      specifier: 1.8.1
+      version: 1.8.1
   script:
     jiti:
       specifier: 2.6.1
@@ -366,12 +372,18 @@ importers:
       '@bedrock/ocale':
         specifier: workspace:*
         version: link:../open-cloud
+      '@clack/prompts':
+        specifier: catalog:runtime
+        version: 1.2.0
       arktype:
         specifier: catalog:runtime
         version: 2.2.0
       c12:
         specifier: catalog:runtime
         version: 3.3.4(magicast@0.5.2)
+      sade:
+        specifier: catalog:runtime
+        version: 1.8.1
     devDependencies:
       '@bedrock/testing':
         specifier: workspace:*

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -67,8 +67,10 @@ catalogs:
     knip: 6.4.1
     publint: 0.3.18
   runtime:
+    "@clack/prompts": 1.2.0
     arktype: 2.2.0
     c12: 3.3.4
+    sade: 1.8.1
   script:
     jiti: 2.6.1
     std-env: 4.1.0


### PR DESCRIPTION
## Summary

- Stands up the `bedrock` binary and the shared CLI infrastructure under `packages/bedrock/src/cli/`. After this slice the binary builds, executes, and answers `--help` and `--version` correctly; no commands do real work yet, those are filed separately as `#186` and `#187`.
- Adds `sade` and `@clack/prompts` to the workspace `runtime` catalog and to `@bedrock/core`'s dependencies, declares `"bin": { "bedrock": "./dist/cli/run.mjs" }` in `package.json`, and extends `vite.config.ts` `pack.entry` with `src/cli/run.ts`. tsdown preserves the `#!/usr/bin/env node` shebang and `chmod +x`'s the emitted file. `publint` accepts the bin declaration; both PRD #112 open questions resolve cleanly.
- Resolves the post-rename folder name in a dated 2026-04-25 amendment to `docs/adr/018-fcis-ports-with-primary-driven-distinction.md` (`bin/` → `cli/`, `packages/cli/` → `packages/bedrock/`); the original Decision text and folder-layout diagram are left intact. Also updates `packages/bedrock/CLAUDE.md` to point contributors at `src/cli/`.

The branch is structured as 8 small commits, one per behaviour slice (per the project's TDD cadence): catalog/deps, exit-code constants, ClackPort + clack adapter, common options parser, program factory + bin entry, ADR amendment + CLAUDE.md update, kebab-only fallback test additions, and a knip entry registration plus type-level pin for the parse-options types.

Closes #184. Parent PRD: #112.

## Test plan

- [ ] `pnpm gen:example-tests && pnpm lint && pnpm typecheck && pnpm test && pnpm build` all clean.
- [ ] `MUTATE_BASE_REF=origin/main pnpm mutate:changed` reports 100% mutation score on `src/cli/index.ts`, `src/cli/parse-options.ts`, `src/cli/render.ts`. (Run with the incremental cache cleared if Stryker reuses a stale prior run.)
- [ ] `node packages/bedrock/dist/cli/run.mjs --version` prints `bedrock, 0.0.1`. Direct invocation `./packages/bedrock/dist/cli/run.mjs --version` works (shebang preserved, executable bit set by tsdown).
- [ ] `node packages/bedrock/dist/cli/run.mjs --help` prints the program description and the auto-generated help including `--version` and `--help` flags. No commands listed yet (none registered).
- [ ] `pnpm --filter @bedrock/core exec publint` reports no issues.
- [ ] Integration test `tests/integration/cli/index.spec.ts` confirms `#src/cli/index.ts` imports without observable stdout/stderr writes; type-level tests in `index.spec-d.ts`, `render.spec-d.ts`, `parse-options.spec-d.ts` pin the public-shape contracts.