### PR TITLE
feat(core)!: per-environment resource overlays

### DIFF
--- a/packages/bedrock/src/core/environment.ts
+++ b/packages/bedrock/src/core/environment.ts
@@ -8,16 +8,20 @@ import type { StateError } from "./state.ts";
 // caps length at 64 so adapter-stored filenames can't exceed filesystem
 // limits. If one alphabet changes, update the other deliberately.
 /**
- * Source pattern for environment names. Letters, digits, `-`, `_`, length 1-64.
+ * Source pattern for environment names, including `^` and `$` anchors.
+ * Letters, digits, `-`, `_`, length 1-64.
  *
  * Exported so the config schema can validate `environments` keys against
  * the same alphabet and length cap that adapters enforce on storage
  * identifiers. Single source of truth: changing the alphabet here changes
  * both the runtime check and the schema-level key constraint.
+ *
+ * Anchors are embedded so callers do not have to re-add them, matching
+ * the `RESOURCE_KEY_PATTERN_SOURCE` convention in `types/ids.ts`.
  */
-export const ENV_NAME_PATTERN_SOURCE = "[A-Za-z0-9_-]{1,64}";
+export const ENV_NAME_PATTERN_SOURCE = "^[A-Za-z0-9_-]{1,64}$";
 
-const ENVIRONMENT_NAME_PATTERN = new RegExp(`^${ENV_NAME_PATTERN_SOURCE}$`);
+const ENVIRONMENT_NAME_PATTERN = new RegExp(ENV_NAME_PATTERN_SOURCE);
 
 /**
  * Validate an environment name at a state-adapter boundary.

--- a/packages/bedrock/src/core/environment.ts
+++ b/packages/bedrock/src/core/environment.ts
@@ -7,7 +7,17 @@ import type { StateError } from "./state.ts";
 // because the contracts are distinct: ResourceKey is unbounded, this one
 // caps length at 64 so adapter-stored filenames can't exceed filesystem
 // limits. If one alphabet changes, update the other deliberately.
-const ENVIRONMENT_NAME_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+/**
+ * Source pattern for environment names. Letters, digits, `-`, `_`, length 1-64.
+ *
+ * Exported so the config schema can validate `environments` keys against
+ * the same alphabet and length cap that adapters enforce on storage
+ * identifiers. Single source of truth: changing the alphabet here changes
+ * both the runtime check and the schema-level key constraint.
+ */
+export const ENV_NAME_PATTERN_SOURCE = "[A-Za-z0-9_-]{1,64}";
+
+const ENVIRONMENT_NAME_PATTERN = new RegExp(`^${ENV_NAME_PATTERN_SOURCE}$`);
 
 /**
  * Validate an environment name at a state-adapter boundary.

--- a/packages/bedrock/src/core/flatten.example.spec.ts
+++ b/packages/bedrock/src/core/flatten.example.spec.ts
@@ -54,6 +54,7 @@ it('Example 3', () => {
 
 it('Example 4', () => {
   const config: Config = {
+    environments: { production: {} },
     passes: {
       'vip-pass': {
         description: 'Grants VIP perks.',

--- a/packages/bedrock/src/core/flatten.spec.ts
+++ b/packages/bedrock/src/core/flatten.spec.ts
@@ -6,11 +6,13 @@ import { flattenConfig } from "./flatten.ts";
 import { SOCIAL_LINK_FIELDS, UNIVERSE_SINGLETON_KEY } from "./resources.ts";
 import { validateConfig } from "./schema.ts";
 
+const MinimumEnvironments = { production: {} } as const;
+
 describe(flattenConfig, () => {
 	it("should return an empty array for a config without resource collections", () => {
 		expect.assertions(1);
 
-		const config = validateConfig({}, "bedrock.config.ts");
+		const config = validateConfig({ environments: MinimumEnvironments }, "bedrock.config.ts");
 		assert(config.success);
 
 		expect(flattenConfig(config.data)).toStrictEqual([]);
@@ -21,6 +23,7 @@ describe(flattenConfig, () => {
 
 		const config = validateConfig(
 			{
+				environments: MinimumEnvironments,
 				passes: {
 					"vip-pass": {
 						name: "VIP Pass",
@@ -51,6 +54,7 @@ describe(flattenConfig, () => {
 
 		const config = validateConfig(
 			{
+				environments: MinimumEnvironments,
 				passes: {
 					"free-pass": {
 						name: "Free",
@@ -74,6 +78,7 @@ describe(flattenConfig, () => {
 
 		const config = validateConfig(
 			{
+				environments: MinimumEnvironments,
 				passes: {
 					alpha: {
 						name: "A",
@@ -108,6 +113,7 @@ describe(flattenConfig, () => {
 
 		const config = validateConfig(
 			{
+				environments: MinimumEnvironments,
 				places: {
 					"start-place": { filePath: "places/start.rbxl", placeId: "4711" },
 				},
@@ -131,6 +137,7 @@ describe(flattenConfig, () => {
 
 		const config = validateConfig(
 			{
+				environments: MinimumEnvironments,
 				passes: {
 					"vip-pass": {
 						name: "VIP Pass",
@@ -156,7 +163,10 @@ describe(flattenConfig, () => {
 		expect.assertions(1);
 
 		const config = validateConfig(
-			{ universe: { universeId: "1234567890", voiceChatEnabled: true } },
+			{
+				environments: MinimumEnvironments,
+				universe: { universeId: "1234567890", voiceChatEnabled: true },
+			},
 			"bedrock.config.ts",
 		);
 		assert(config.success);
@@ -183,6 +193,7 @@ describe(flattenConfig, () => {
 
 		const config = validateConfig(
 			{
+				environments: MinimumEnvironments,
 				passes: {
 					"vip-pass": {
 						name: "VIP Pass",
@@ -210,7 +221,7 @@ describe(flattenConfig, () => {
 		expect.assertions(1);
 
 		const config = validateConfig(
-			{ universe: { universeId: "1234567890" } },
+			{ environments: MinimumEnvironments, universe: { universeId: "1234567890" } },
 			"bedrock.config.ts",
 		);
 		assert(config.success);
@@ -227,7 +238,10 @@ describe(flattenConfig, () => {
 			expect.assertions(1);
 
 			const config = validateConfig(
-				{ universe: { [flag]: true, universeId: "1234567890" } },
+				{
+					environments: MinimumEnvironments,
+					universe: { [flag]: true, universeId: "1234567890" },
+				},
 				"bedrock.config.ts",
 			);
 			assert(config.success);
@@ -245,7 +259,7 @@ describe(flattenConfig, () => {
 			expect.assertions(1);
 
 			const config = validateConfig(
-				{ universe: { universeId: "1234567890" } },
+				{ environments: MinimumEnvironments, universe: { universeId: "1234567890" } },
 				"bedrock.config.ts",
 			);
 			assert(config.success);
@@ -262,6 +276,7 @@ describe(flattenConfig, () => {
 
 		const config = validateConfig(
 			{
+				environments: MinimumEnvironments,
 				universe: {
 					displayName: "Fun Universe",
 					privateServerPriceRobux: 250,
@@ -289,6 +304,7 @@ describe(flattenConfig, () => {
 
 		const config = validateConfig(
 			{
+				environments: MinimumEnvironments,
 				universe: {
 					privateServerPriceRobux: undefined,
 					universeId: "1234567890",
@@ -309,7 +325,7 @@ describe(flattenConfig, () => {
 		expect.assertions(1);
 
 		const config = validateConfig(
-			{ universe: { universeId: "1234567890" } },
+			{ environments: MinimumEnvironments, universe: { universeId: "1234567890" } },
 			"bedrock.config.ts",
 		);
 		assert(config.success);
@@ -323,7 +339,7 @@ describe(flattenConfig, () => {
 	it("should omit the universe block from output when the config has no universe", () => {
 		expect.assertions(1);
 
-		const config = validateConfig({}, "bedrock.config.ts");
+		const config = validateConfig({ environments: MinimumEnvironments }, "bedrock.config.ts");
 		assert(config.success);
 
 		expect(flattenConfig(config.data).some((input) => input.kind === "universe")).toBeFalse();
@@ -336,7 +352,10 @@ describe(flattenConfig, () => {
 
 			const value = { title: `t-${field}`, uri: `https://example.com/${field}` };
 			const config = validateConfig(
-				{ universe: { [field]: value, universeId: "1234567890" } },
+				{
+					environments: MinimumEnvironments,
+					universe: { [field]: value, universeId: "1234567890" },
+				},
 				"bedrock.config.ts",
 			);
 			assert(config.success);
@@ -355,7 +374,10 @@ describe(flattenConfig, () => {
 			expect.assertions(2);
 
 			const config = validateConfig(
-				{ universe: { [field]: undefined, universeId: "1234567890" } },
+				{
+					environments: MinimumEnvironments,
+					universe: { [field]: undefined, universeId: "1234567890" },
+				},
 				"bedrock.config.ts",
 			);
 			assert(config.success);
@@ -374,7 +396,7 @@ describe(flattenConfig, () => {
 			expect.assertions(1);
 
 			const config = validateConfig(
-				{ universe: { universeId: "1234567890" } },
+				{ environments: MinimumEnvironments, universe: { universeId: "1234567890" } },
 				"bedrock.config.ts",
 			);
 			assert(config.success);
@@ -392,6 +414,7 @@ describe(flattenConfig, () => {
 		const discord = { title: "Discord", uri: "https://discord.gg/example" };
 		const config = validateConfig(
 			{
+				environments: MinimumEnvironments,
 				universe: {
 					discordSocialLink: discord,
 					twitterSocialLink: undefined,

--- a/packages/bedrock/src/core/flatten.ts
+++ b/packages/bedrock/src/core/flatten.ts
@@ -174,6 +174,7 @@ export type ResourceDesiredInput = GamePassDesiredInput | PlaceDesiredInput | Un
  * import { flattenConfig, type Config } from "@bedrock/core";
  *
  * const config: Config = {
+ *     environments: { production: {} },
  *     passes: {
  *         "vip-pass": {
  *             description: "Grants VIP perks.",

--- a/packages/bedrock/src/core/kinds/game-pass.spec.ts
+++ b/packages/bedrock/src/core/kinds/game-pass.spec.ts
@@ -19,6 +19,7 @@ describe("gamePassKind", () => {
 
 			expect(
 				gamePassKind.flatten({
+					environments: { production: {} },
 					passes: {
 						"vip-pass": {
 							name: "VIP",
@@ -43,13 +44,14 @@ describe("gamePassKind", () => {
 		it("should emit an empty list when the config has no passes", () => {
 			expect.assertions(1);
 
-			expect(gamePassKind.flatten({})).toBeEmpty();
+			expect(gamePassKind.flatten({ environments: { production: {} } })).toBeEmpty();
 		});
 
 		it("should preserve the insertion order of config.passes entries", () => {
 			expect.assertions(1);
 
 			const inputs = gamePassKind.flatten({
+				environments: { production: {} },
 				passes: {
 					"alpha-pass": { name: "Alpha", description: "a", iconFilePath: "a.png" },
 					"beta-pass": { name: "Beta", description: "b", iconFilePath: "b.png" },

--- a/packages/bedrock/src/core/kinds/place.spec.ts
+++ b/packages/bedrock/src/core/kinds/place.spec.ts
@@ -19,6 +19,7 @@ describe("placeKind", () => {
 
 			expect(
 				placeKind.flatten({
+					environments: { production: {} },
 					places: {
 						"start-place": { filePath: "places/start.rbxl", placeId: "4711" },
 					},
@@ -36,7 +37,7 @@ describe("placeKind", () => {
 		it("should emit an empty list when the config has no places", () => {
 			expect.assertions(1);
 
-			expect(placeKind.flatten({})).toBeEmpty();
+			expect(placeKind.flatten({ environments: { production: {} } })).toBeEmpty();
 		});
 	});
 

--- a/packages/bedrock/src/core/kinds/universe.spec.ts
+++ b/packages/bedrock/src/core/kinds/universe.spec.ts
@@ -28,6 +28,7 @@ describe("universeKind", () => {
 
 			expect(
 				universeKind.flatten({
+					environments: { production: {} },
 					universe: { universeId: "1234567890", voiceChatEnabled: true },
 				}),
 			).toStrictEqual([
@@ -44,13 +45,16 @@ describe("universeKind", () => {
 		it("should emit an empty list when the config has no universe block", () => {
 			expect.assertions(1);
 
-			expect(universeKind.flatten({})).toBeEmpty();
+			expect(universeKind.flatten({ environments: { production: {} } })).toBeEmpty();
 		});
 
 		it("should pass voiceChatEnabled through as undefined when omitted", () => {
 			expect.assertions(1);
 
-			const inputs = universeKind.flatten({ universe: { universeId: "1234567890" } });
+			const inputs = universeKind.flatten({
+				environments: { production: {} },
+				universe: { universeId: "1234567890" },
+			});
 
 			expect(inputs[0]?.voiceChatEnabled).toBeUndefined();
 		});

--- a/packages/bedrock/src/core/resolve-state-config.spec.ts
+++ b/packages/bedrock/src/core/resolve-state-config.spec.ts
@@ -10,7 +10,10 @@ describe(resolveStateConfig, () => {
 	it("should return the root state when no per-environment override exists", () => {
 		expect.assertions(1);
 
-		const config: Config = { state: ROOT_STATE };
+		const config: Config = {
+			environments: { production: {} },
+			state: ROOT_STATE,
+		};
 
 		const result = resolveStateConfig(config, "production");
 
@@ -81,7 +84,9 @@ describe(resolveStateConfig, () => {
 	it("should return Err(stateNotConfigured) when neither root nor environment provides state", () => {
 		expect.assertions(2);
 
-		const result = resolveStateConfig({}, "production");
+		const config: Config = { environments: { production: {} } };
+
+		const result = resolveStateConfig(config, "production");
 
 		assert(!result.success);
 

--- a/packages/bedrock/src/core/resolve-state-config.spec.ts
+++ b/packages/bedrock/src/core/resolve-state-config.spec.ts
@@ -93,19 +93,4 @@ describe(resolveStateConfig, () => {
 		expect(result.err.kind).toBe("stateNotConfigured");
 		expect(result.err.environment).toBe("production");
 	});
-
-	it("should return Err(stateNotConfigured) when the matching environment lacks state and no root state exists", () => {
-		expect.assertions(2);
-
-		const config: Config = {
-			environments: { production: {} },
-		};
-
-		const result = resolveStateConfig(config, "production");
-
-		assert(!result.success);
-
-		expect(result.err.kind).toBe("stateNotConfigured");
-		expect(result.err.environment).toBe("production");
-	});
 });

--- a/packages/bedrock/src/core/resolve-state-config.ts
+++ b/packages/bedrock/src/core/resolve-state-config.ts
@@ -50,7 +50,7 @@ export function resolveStateConfig(
 	config: Config,
 	environment: string,
 ): Result<StateConfig, StateNotConfiguredError> {
-	const override = config.environments?.[environment]?.state;
+	const override = config.environments[environment]?.state;
 	if (override !== undefined) {
 		return { data: override, success: true };
 	}

--- a/packages/bedrock/src/core/schema.example.spec.ts
+++ b/packages/bedrock/src/core/schema.example.spec.ts
@@ -20,6 +20,7 @@ it('Example 1', () => {
 
 it('Example 2', () => {
   const config: Config = {
+    environments: { production: {} },
     state: { backend: 'gist', gistId: 'abc123def456' },
     passes: {
       'vip-pass': {
@@ -44,6 +45,7 @@ it('Example 3', () => {
 it('Example 4', () => {
   const ok = validateConfig(
     {
+      environments: { production: {} },
       passes: {
         'vip-pass': {
           description: 'VIP perks.',
@@ -57,7 +59,10 @@ it('Example 4', () => {
   )
   expect(ok.success).toBeTrue()
   const err = validateConfig(
-    { passes: { 'vip-pass': { name: 'VIP' } } },
+    {
+      environments: { production: {} },
+      passes: { 'vip-pass': { name: 'VIP' } },
+    },
     'bedrock.config.ts',
   )
   expect(err.success).toBeFalse()

--- a/packages/bedrock/src/core/schema.spec-d.ts
+++ b/packages/bedrock/src/core/schema.spec-d.ts
@@ -91,3 +91,36 @@ describe("EnvironmentEntry overlay derivation", () => {
 		expectTypeOf<keyof UniverseOverlayEntry>().toEqualTypeOf<keyof UniverseEntry>();
 	});
 });
+
+// Two Config keys are deliberately not environment-overridable. Adding to or
+// removing from this union is the explicit way to opt new fields out of the
+// per-environment overlay surface.
+type NonOverridableConfigKey = "environments" | "extends";
+type OverridableConfigKey = Exclude<keyof Config, NonOverridableConfigKey>;
+type EnvironmentEntryKey = keyof Required<EnvironmentEntry>;
+
+type MissingOverlayKeys = Exclude<OverridableConfigKey, EnvironmentEntryKey>;
+type ExtraOverlayKeys = Exclude<EnvironmentEntryKey, OverridableConfigKey>;
+
+// Compile-time assertions surface as descriptive string-literal types when
+// they fail. `MissingOverlayKeys` and `ExtraOverlayKeys` should both be
+// `never`; if a contributor adds a Config field without declaring an
+// overlay for it (or vice versa), the assertion's failed type names the
+// offending key directly in the error message.
+type AssertNoMissingOverlay = [MissingOverlayKeys] extends [never]
+	? true
+	: `EnvironmentEntry is missing an overlay field for Config keys: ${Extract<MissingOverlayKeys, string>}. Add the field with the correct overlay shape, or add the key name to NonOverridableConfigKey if it should be deliberately excluded.`;
+
+type AssertNoExtraOverlay = [ExtraOverlayKeys] extends [never]
+	? true
+	: `EnvironmentEntry declares overlay fields for keys not present in Config's overridable set: ${Extract<ExtraOverlayKeys, string>}. Either remove the field, add the corresponding Config field, or move the key out of NonOverridableConfigKey.`;
+
+describe("EnvironmentEntry exhaustiveness", () => {
+	it("should declare an overlay field for every overridable Config key", () => {
+		expectTypeOf<AssertNoMissingOverlay>().toEqualTypeOf<true>();
+	});
+
+	it("should not declare overlay fields for keys outside Config's overridable set", () => {
+		expectTypeOf<AssertNoExtraOverlay>().toEqualTypeOf<true>();
+	});
+});

--- a/packages/bedrock/src/core/schema.spec-d.ts
+++ b/packages/bedrock/src/core/schema.spec-d.ts
@@ -5,8 +5,13 @@ import type { Config, StateConfig } from "./schema.ts";
 const STATE: StateConfig = { backend: "gist", gistId: "test" };
 
 describe("Config", () => {
-	it("should accept Config with only root state and no environments", () => {
-		const config = { state: STATE } as const satisfies Config;
+	it("should require environments to be a Record of EnvironmentEntry rather than optional", () => {
+		expectTypeOf<Config["environments"]>().not.toBeUndefined();
+	});
+
+	it("should reject Config that omits the required environments field", () => {
+		// @ts-expect-error environments is required and must be present.
+		const config: Config = { state: STATE };
 		expectTypeOf(config).toExtend<Config>();
 	});
 

--- a/packages/bedrock/src/core/schema.spec-d.ts
+++ b/packages/bedrock/src/core/schema.spec-d.ts
@@ -1,6 +1,13 @@
 import { describe, expectTypeOf, it } from "vitest";
 
-import type { Config, StateConfig } from "./schema.ts";
+import type {
+	Config,
+	EnvironmentEntry,
+	GamePassEntry,
+	PlaceEntry,
+	StateConfig,
+	UniverseEntry,
+} from "./schema.ts";
 
 const STATE: StateConfig = { backend: "gist", gistId: "test" };
 
@@ -35,5 +42,52 @@ describe("Config", () => {
 
 	it("should narrow state on Config to StateConfig | undefined so the deploy boundary handles the missing case", () => {
 		expectTypeOf<Config["state"]>().toEqualTypeOf<StateConfig | undefined>();
+	});
+});
+
+type PlaceOverlayEntry = NonNullable<EnvironmentEntry["places"]>[string];
+type UniverseOverlayEntry = NonNullable<EnvironmentEntry["universe"]>;
+type PassesOverlayEntry = NonNullable<EnvironmentEntry["passes"]>[string];
+
+describe("EnvironmentEntry overlay shapes", () => {
+	it("should require placeId on a places overlay entry while making other fields optional", () => {
+		const overlay = { placeId: "1234" } as const satisfies PlaceOverlayEntry;
+		expectTypeOf(overlay).toExtend<PlaceOverlayEntry>();
+	});
+
+	it("should reject a places overlay entry that omits placeId", () => {
+		// @ts-expect-error placeId is required on every places overlay entry.
+		const overlay: PlaceOverlayEntry = { filePath: "places/staging.rbxl" };
+		expectTypeOf(overlay).toExtend<PlaceOverlayEntry>();
+	});
+
+	it("should require universeId on a universe overlay while making other fields optional", () => {
+		const overlay = { universeId: "9999999999" } as const satisfies UniverseOverlayEntry;
+		expectTypeOf(overlay).toExtend<UniverseOverlayEntry>();
+	});
+
+	it("should reject a universe overlay that omits universeId", () => {
+		// @ts-expect-error universeId is required on a universe overlay.
+		const overlay: UniverseOverlayEntry = { voiceChatEnabled: true };
+		expectTypeOf(overlay).toExtend<UniverseOverlayEntry>();
+	});
+
+	it("should keep every passes overlay field optional", () => {
+		const overlay = {} as const satisfies PassesOverlayEntry;
+		expectTypeOf(overlay).toExtend<PassesOverlayEntry>();
+	});
+});
+
+describe("EnvironmentEntry overlay derivation", () => {
+	it("should match the keys of GamePassEntry on a passes overlay entry", () => {
+		expectTypeOf<keyof PassesOverlayEntry>().toEqualTypeOf<keyof GamePassEntry>();
+	});
+
+	it("should match the keys of PlaceEntry on a places overlay entry", () => {
+		expectTypeOf<keyof PlaceOverlayEntry>().toEqualTypeOf<keyof PlaceEntry>();
+	});
+
+	it("should match the keys of UniverseEntry on a universe overlay", () => {
+		expectTypeOf<keyof UniverseOverlayEntry>().toEqualTypeOf<keyof UniverseEntry>();
 	});
 });

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -6,24 +6,48 @@ import { validateConfig } from "./schema.ts";
 
 const SOURCE = "bedrock.config.ts";
 
+const MinEnvironments = { production: {} } as const;
+
 describe(validateConfig, () => {
-	it("should accept an empty config", () => {
+	it("should reject a config missing the required environments collection", () => {
 		expect.assertions(1);
 
 		const result = validateConfig({}, SOURCE);
 
-		assert(result.success);
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
 
-		expect(result.data).toStrictEqual({});
+		expect(result.err.issues[0]!.path).toStrictEqual(["environments"]);
 	});
 
-	it.for([
-		["environments", { environments: { production: {} } }],
-		["extends", { extends: "./base.config.ts" }],
-	] as const)("should accept the reserved %s key at the root", ([, input]) => {
+	it("should reject a config whose environments collection is empty", () => {
 		expect.assertions(1);
 
-		const result = validateConfig(input, SOURCE);
+		const result = validateConfig({ environments: {} }, SOURCE);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual(["environments"]);
+	});
+
+	it("should accept a minimal config that declares only environments", () => {
+		expect.assertions(1);
+
+		const result = validateConfig({ environments: MinEnvironments }, SOURCE);
+
+		assert(result.success);
+
+		expect(result.data.environments).toContainKey("production");
+	});
+
+	it("should accept the reserved extends key at the root", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{ environments: MinEnvironments, extends: "./base.config.ts" },
+			SOURCE,
+		);
 
 		expect(result.success).toBeTrue();
 	});
@@ -31,7 +55,7 @@ describe(validateConfig, () => {
 	it("should reject unknown top-level keys and point the issue path at the offending key", () => {
 		expect.assertions(3);
 
-		const result = validateConfig({ unexpected: {} }, SOURCE);
+		const result = validateConfig({ environments: MinEnvironments, unexpected: {} }, SOURCE);
 
 		assert(!result.success);
 		assert(result.err.kind === "validationFailed");
@@ -46,6 +70,7 @@ describe(validateConfig, () => {
 
 		const result = validateConfig(
 			{
+				environments: MinEnvironments,
 				passes: {
 					"vip-pass": {
 						name: "VIP Pass",
@@ -68,6 +93,7 @@ describe(validateConfig, () => {
 
 		const result = validateConfig(
 			{
+				environments: MinEnvironments,
 				passes: {
 					"free-pass": {
 						name: "Free Pass",
@@ -89,6 +115,7 @@ describe(validateConfig, () => {
 
 		const result = validateConfig(
 			{
+				environments: MinEnvironments,
 				passes: {
 					"bad key!": {
 						name: "Bad",
@@ -111,6 +138,7 @@ describe(validateConfig, () => {
 
 		const result = validateConfig(
 			{
+				environments: MinEnvironments,
 				passes: {
 					"vip-pass": {
 						name: "VIP",
@@ -132,6 +160,7 @@ describe(validateConfig, () => {
 
 		const result = validateConfig(
 			{
+				environments: MinEnvironments,
 				passes: {
 					"vip-pass": {
 						name: "VIP",
@@ -155,6 +184,7 @@ describe(validateConfig, () => {
 
 		const result = validateConfig(
 			{
+				environments: MinEnvironments,
 				places: {
 					"start-place": {
 						filePath: "places/start.rbxl",
@@ -176,6 +206,7 @@ describe(validateConfig, () => {
 
 		const result = validateConfig(
 			{
+				environments: MinEnvironments,
 				places: {
 					"start-place": { filePath: "places/start.rbxl" },
 				},
@@ -194,6 +225,7 @@ describe(validateConfig, () => {
 
 		const result = validateConfig(
 			{
+				environments: MinEnvironments,
 				places: {
 					"start-place": {
 						filePath: "places/start.rbxl",
@@ -220,6 +252,7 @@ describe(validateConfig, () => {
 
 		const result = validateConfig(
 			{
+				environments: MinEnvironments,
 				places: {
 					"start-place": { filePath: "places/start.rbxl", placeId },
 				},
@@ -238,6 +271,7 @@ describe(validateConfig, () => {
 
 		const result = validateConfig(
 			{
+				environments: MinEnvironments,
 				places: {
 					"bad key!": { filePath: "places/start.rbxl", placeId: "4711" },
 				},
@@ -254,7 +288,10 @@ describe(validateConfig, () => {
 	it("should accept a universe block declaring only universeId", () => {
 		expect.assertions(2);
 
-		const result = validateConfig({ universe: { universeId: "1234567890" } }, SOURCE);
+		const result = validateConfig(
+			{ environments: MinEnvironments, universe: { universeId: "1234567890" } },
+			SOURCE,
+		);
 
 		assert(result.success);
 
@@ -266,7 +303,10 @@ describe(validateConfig, () => {
 		expect.assertions(1);
 
 		const result = validateConfig(
-			{ universe: { universeId: "1234567890", voiceChatEnabled: true } },
+			{
+				environments: MinEnvironments,
+				universe: { universeId: "1234567890", voiceChatEnabled: true },
+			},
 			SOURCE,
 		);
 
@@ -279,7 +319,10 @@ describe(validateConfig, () => {
 		expect.assertions(1);
 
 		const result = validateConfig(
-			{ universe: { [flag]: false, universeId: "1234567890" } },
+			{
+				environments: MinEnvironments,
+				universe: { [flag]: false, universeId: "1234567890" },
+			},
 			SOURCE,
 		);
 
@@ -293,7 +336,10 @@ describe(validateConfig, () => {
 		([flag]) => {
 			expect.assertions(1);
 
-			const result = validateConfig({ universe: { universeId: "1234567890" } }, SOURCE);
+			const result = validateConfig(
+				{ environments: MinEnvironments, universe: { universeId: "1234567890" } },
+				SOURCE,
+			);
 
 			assert(result.success);
 
@@ -305,7 +351,10 @@ describe(validateConfig, () => {
 		expect.assertions(1);
 
 		const result = validateConfig(
-			{ universe: { [flag]: "oops", universeId: "1234567890" } },
+			{
+				environments: MinEnvironments,
+				universe: { [flag]: "oops", universeId: "1234567890" },
+			},
 			SOURCE,
 		);
 
@@ -320,6 +369,7 @@ describe(validateConfig, () => {
 
 		const result = validateConfig(
 			{
+				environments: MinEnvironments,
 				universe: {
 					consoleEnabled: false,
 					desktopEnabled: true,
@@ -344,7 +394,10 @@ describe(validateConfig, () => {
 	it("should reject a universe block missing universeId", () => {
 		expect.assertions(1);
 
-		const result = validateConfig({ universe: { voiceChatEnabled: true } }, SOURCE);
+		const result = validateConfig(
+			{ environments: MinEnvironments, universe: { voiceChatEnabled: true } },
+			SOURCE,
+		);
 
 		assert(!result.success);
 		assert(result.err.kind === "validationFailed");
@@ -359,7 +412,10 @@ describe(validateConfig, () => {
 	] as const)("should reject a universe whose universeId has %s", ([, universeId]) => {
 		expect.assertions(1);
 
-		const result = validateConfig({ universe: { universeId } }, SOURCE);
+		const result = validateConfig(
+			{ environments: MinEnvironments, universe: { universeId } },
+			SOURCE,
+		);
 
 		assert(!result.success);
 		assert(result.err.kind === "validationFailed");
@@ -372,6 +428,7 @@ describe(validateConfig, () => {
 
 		const result = validateConfig(
 			{
+				environments: MinEnvironments,
 				universe: {
 					displayName: "Fun Universe",
 					privateServerPriceRobux: 250,
@@ -396,6 +453,7 @@ describe(validateConfig, () => {
 
 		const result = validateConfig(
 			{
+				environments: MinEnvironments,
 				universe: {
 					privateServerPriceRobux: undefined,
 					universeId: "1234567890",
@@ -413,7 +471,10 @@ describe(validateConfig, () => {
 	it("should omit privateServerPriceRobux when the user does not declare it", () => {
 		expect.assertions(1);
 
-		const result = validateConfig({ universe: { universeId: "1234567890" } }, SOURCE);
+		const result = validateConfig(
+			{ environments: MinEnvironments, universe: { universeId: "1234567890" } },
+			SOURCE,
+		);
 
 		assert(result.success);
 
@@ -426,7 +487,10 @@ describe(validateConfig, () => {
 			expect.assertions(1);
 
 			const result = validateConfig(
-				{ universe: { universeId: "1234567890", visibility: value } },
+				{
+					environments: MinEnvironments,
+					universe: { universeId: "1234567890", visibility: value },
+				},
 				SOURCE,
 			);
 
@@ -438,7 +502,10 @@ describe(validateConfig, () => {
 		expect.assertions(1);
 
 		const result = validateConfig(
-			{ universe: { universeId: "1234567890", visibility: "internal" } },
+			{
+				environments: MinEnvironments,
+				universe: { universeId: "1234567890", visibility: "internal" },
+			},
 			SOURCE,
 		);
 
@@ -452,7 +519,10 @@ describe(validateConfig, () => {
 		expect.assertions(1);
 
 		const result = validateConfig(
-			{ universe: { privateServerPriceRobux: -1, universeId: "1234567890" } },
+			{
+				environments: MinEnvironments,
+				universe: { privateServerPriceRobux: -1, universeId: "1234567890" },
+			},
 			SOURCE,
 		);
 
@@ -466,7 +536,10 @@ describe(validateConfig, () => {
 		expect.assertions(1);
 
 		const result = validateConfig(
-			{ universe: { privateServerPriceRobux: 12.5, universeId: "1234567890" } },
+			{
+				environments: MinEnvironments,
+				universe: { privateServerPriceRobux: 12.5, universeId: "1234567890" },
+			},
 			SOURCE,
 		);
 
@@ -480,7 +553,10 @@ describe(validateConfig, () => {
 		expect.assertions(1);
 
 		const result = validateConfig(
-			{ universe: { unexpected: "nope", universeId: "1234567890" } },
+			{
+				environments: MinEnvironments,
+				universe: { unexpected: "nope", universeId: "1234567890" },
+			},
 			SOURCE,
 		);
 
@@ -497,6 +573,7 @@ describe(validateConfig, () => {
 
 			const result = validateConfig(
 				{
+					environments: MinEnvironments,
 					universe: {
 						[field]: { title: "Join us", uri: "https://example.com/x" },
 						universeId: "1234567890",
@@ -521,7 +598,10 @@ describe(validateConfig, () => {
 			expect.assertions(2);
 
 			const result = validateConfig(
-				{ universe: { [field]: undefined, universeId: "1234567890" } },
+				{
+					environments: MinEnvironments,
+					universe: { [field]: undefined, universeId: "1234567890" },
+				},
 				SOURCE,
 			);
 
@@ -537,7 +617,10 @@ describe(validateConfig, () => {
 		(field) => {
 			expect.assertions(1);
 
-			const result = validateConfig({ universe: { universeId: "1234567890" } }, SOURCE);
+			const result = validateConfig(
+				{ environments: MinEnvironments, universe: { universeId: "1234567890" } },
+				SOURCE,
+			);
 
 			assert(result.success);
 
@@ -552,6 +635,7 @@ describe(validateConfig, () => {
 
 			const result = validateConfig(
 				{
+					environments: MinEnvironments,
 					universe: {
 						[field]: { title: "Join us" },
 						universeId: "1234567890",
@@ -572,6 +656,7 @@ describe(validateConfig, () => {
 
 		const result = validateConfig(
 			{
+				environments: MinEnvironments,
 				universe: {
 					[field]: { extra: 1, title: "Join us", uri: "https://example.com/x" },
 					universeId: "1234567890",
@@ -594,7 +679,7 @@ describe(validateConfig, () => {
 			entry[field] = { title: `t-${field}`, uri: `https://example.com/${field}` };
 		}
 
-		const result = validateConfig({ universe: entry }, SOURCE);
+		const result = validateConfig({ environments: MinEnvironments, universe: entry }, SOURCE);
 		assert(result.success);
 
 		for (const field of SOCIAL_LINK_FIELDS) {
@@ -620,7 +705,7 @@ describe(validateConfig, () => {
 
 		assert(result.success);
 
-		expect(result.data.environments?.["production"]?.state).toContainEntry([
+		expect(result.data.environments["production"]?.state).toContainEntry([
 			"gistId",
 			"prod-gist",
 		]);
@@ -642,7 +727,7 @@ describe(validateConfig, () => {
 		expect(result.success).toBeTrue();
 	});
 
-	it("should reject an environments key that does not match the ResourceKey pattern", () => {
+	it("should reject an environments key that does not match the environment-name pattern", () => {
 		expect.assertions(1);
 
 		const result = validateConfig(
@@ -657,6 +742,18 @@ describe(validateConfig, () => {
 		assert(result.err.kind === "validationFailed");
 
 		expect(result.err.issues[0]!.path).toStrictEqual(["environments", "bad name!"]);
+	});
+
+	it("should reject an environments key that exceeds the 64-character length cap", () => {
+		expect.assertions(1);
+
+		const tooLong = "a".repeat(65);
+		const result = validateConfig({ environments: { [tooLong]: {} } }, SOURCE);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual(["environments", tooLong]);
 	});
 
 	it("should reject an undeclared field on an environments entry", () => {
@@ -684,7 +781,7 @@ describe(validateConfig, () => {
 		expect.assertions(2);
 
 		const result = validateConfig(
-			{ state: { backend: "gist", gistId: "abc123def456" } },
+			{ environments: MinEnvironments, state: { backend: "gist", gistId: "abc123def456" } },
 			SOURCE,
 		);
 
@@ -697,7 +794,10 @@ describe(validateConfig, () => {
 	it("should reject a state block missing the backend field and attribute the issue path to backend", () => {
 		expect.assertions(1);
 
-		const result = validateConfig({ state: { gistId: "abc123" } }, SOURCE);
+		const result = validateConfig(
+			{ environments: MinEnvironments, state: { gistId: "abc123" } },
+			SOURCE,
+		);
 
 		assert(!result.success);
 		assert(result.err.kind === "validationFailed");
@@ -708,7 +808,10 @@ describe(validateConfig, () => {
 	it("should reject a gist state block whose gistId is the empty string", () => {
 		expect.assertions(1);
 
-		const result = validateConfig({ state: { backend: "gist", gistId: "" } }, SOURCE);
+		const result = validateConfig(
+			{ environments: MinEnvironments, state: { backend: "gist", gistId: "" } },
+			SOURCE,
+		);
 
 		assert(!result.success);
 		assert(result.err.kind === "validationFailed");
@@ -719,7 +822,10 @@ describe(validateConfig, () => {
 	it("should accept a state block whose backend is an unrecognized string at the runtime layer", () => {
 		expect.assertions(1);
 
-		const result = validateConfig({ state: { backend: "future-backend" } }, SOURCE);
+		const result = validateConfig(
+			{ environments: MinEnvironments, state: { backend: "future-backend" } },
+			SOURCE,
+		);
 
 		expect(result.success).toBeTrue();
 	});
@@ -728,7 +834,10 @@ describe(validateConfig, () => {
 		expect.assertions(1);
 
 		const result = validateConfig(
-			{ state: { backend: "gist", gistId: "abc123", unexpected: "nope" } },
+			{
+				environments: MinEnvironments,
+				state: { backend: "gist", gistId: "abc123", unexpected: "nope" },
+			},
 			SOURCE,
 		);
 
@@ -743,6 +852,7 @@ describe(validateConfig, () => {
 
 		const result = validateConfig(
 			{
+				environments: MinEnvironments,
 				passes: {
 					"vip-pass": {
 						name: 42,

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -29,7 +29,9 @@ describe(validateConfig, () => {
 		assert(result.err.kind === "validationFailed");
 
 		expect(result.err.issues[0]!.path).toStrictEqual(["environments"]);
-		expect(result.err.issues[0]!.message).toContain("non-empty record of environment entries");
+		expect(result.err.issues[0]!.message).toContain(
+			"environments record with at least one declared environment",
+		);
 	});
 
 	it("should accept a minimal config that declares only environments", () => {

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -21,7 +21,7 @@ describe(validateConfig, () => {
 	});
 
 	it("should reject a config whose environments collection is empty", () => {
-		expect.assertions(1);
+		expect.assertions(2);
 
 		const result = validateConfig({ environments: {} }, SOURCE);
 
@@ -29,6 +29,7 @@ describe(validateConfig, () => {
 		assert(result.err.kind === "validationFailed");
 
 		expect(result.err.issues[0]!.path).toStrictEqual(["environments"]);
+		expect(result.err.issues[0]!.message).toContain("non-empty record of environment entries");
 	});
 
 	it("should accept a minimal config that declares only environments", () => {

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -756,6 +756,180 @@ describe(validateConfig, () => {
 		expect(result.err.issues[0]!.path).toStrictEqual(["environments", tooLong]);
 	});
 
+	it("should accept a per-environment universe overlay declaring only universeId", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: {
+					production: { universe: { universeId: "9999999999" } },
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+				universe: { universeId: "1111111111" },
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.environments["production"]?.universe?.universeId).toBe("9999999999");
+	});
+
+	it("should reject a per-environment universe overlay missing universeId", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: {
+					production: { universe: { voiceChatEnabled: true } },
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual([
+			"environments",
+			"production",
+			"universe",
+			"universeId",
+		]);
+	});
+
+	it("should accept a per-environment places overlay that declares placeId without filePath", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: {
+					staging: {
+						places: {
+							"start-place": { placeId: "5555" },
+						},
+					},
+				},
+				places: { "start-place": { filePath: "places/start.rbxl", placeId: "1111" } },
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.environments["staging"]?.places?.["start-place"]?.placeId).toBe("5555");
+	});
+
+	it("should reject a per-environment places overlay entry that omits placeId", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: {
+					staging: {
+						places: {
+							"start-place": { filePath: "places/start-staging.rbxl" },
+						},
+					},
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual([
+			"environments",
+			"staging",
+			"places",
+			"start-place",
+			"placeId",
+		]);
+	});
+
+	it("should accept a per-environment passes overlay that omits every field as a no-op", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: {
+					staging: { passes: { "vip-pass": {} } },
+				},
+				passes: {
+					"vip-pass": {
+						name: "VIP Pass",
+						description: "Grants VIP perks.",
+						iconFilePath: "assets/vip.png",
+						price: 500,
+					},
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		expect(result.success).toBeTrue();
+	});
+
+	it("should accept a per-environment passes overlay that supplies a partial subset of fields", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: {
+					staging: { passes: { "vip-pass": { price: 250 } } },
+				},
+				passes: {
+					"vip-pass": {
+						name: "VIP Pass",
+						description: "Grants VIP perks.",
+						iconFilePath: "assets/vip.png",
+						price: 500,
+					},
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.environments["staging"]?.passes?.["vip-pass"]?.price).toBe(250);
+	});
+
+	it("should reject an undeclared field inside a per-environment places overlay entry", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: {
+					staging: {
+						places: {
+							"start-place": { placeId: "5555", unexpected: "nope" },
+						},
+					},
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual([
+			"environments",
+			"staging",
+			"places",
+			"start-place",
+			"unexpected",
+		]);
+	});
+
 	it("should reject an undeclared field on an environments entry", () => {
 		expect.assertions(1);
 

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -5,6 +5,7 @@ import { ArkErrors, type, type Type } from "arktype";
 
 import { RESOURCE_KEY_PATTERN_SOURCE } from "../types/ids.ts";
 import type { ConfigError } from "./config-error.ts";
+import { ENV_NAME_PATTERN_SOURCE } from "./environment.ts";
 
 /**
  * Body of a single entry in the `passes` collection. Keys in the parent
@@ -203,6 +204,7 @@ export interface ResourceEntryByKind {
  * import type { Config } from "@bedrock/core";
  *
  * const config: Config = {
+ *     environments: { production: {} },
  *     state: { backend: "gist", gistId: "abc123def456" },
  *     passes: {
  *         "vip-pass": {
@@ -218,8 +220,13 @@ export interface ResourceEntryByKind {
  * ```
  */
 export interface Config {
-	/** Per-environment overrides keyed by environment name. */
-	environments?: Record<string, EnvironmentEntry>;
+	/**
+	 * Per-environment overrides keyed by environment name. Required and
+	 * non-empty: every project declares at least one environment, and
+	 * `deploy()` rejects any environment name that is not a key of this
+	 * record. Environment names match `[A-Za-z0-9_-]{1,64}`.
+	 */
+	environments: Record<string, EnvironmentEntry>;
 	/** Reserved at the root for c12's config layering / overlay work. */
 	extends?: unknown;
 	/** Keyed-map collection of game-pass entries by user-supplied ResourceKey. */
@@ -323,11 +330,19 @@ const environmentEntry = type({
 }).onUndeclaredKey("reject");
 
 const environmentsCollection = type({
-	[`[/${RESOURCE_KEY_PATTERN_SOURCE}/]`]: environmentEntry,
-}).onUndeclaredKey("reject");
+	[`[/^${ENV_NAME_PATTERN_SOURCE}$/]`]: environmentEntry,
+})
+	.onUndeclaredKey("reject")
+	.narrow((value, ctx) => {
+		if (Object.keys(value).length === 0) {
+			return ctx.mustBe("a non-empty record of environment entries");
+		}
+
+		return true;
+	});
 
 const rootSchema: Type<Config> = type({
-	"environments?": environmentsCollection,
+	"environments": environmentsCollection,
 	"extends?": "unknown",
 	"passes?": passesCollection,
 	"places?": placesCollection,
@@ -354,6 +369,7 @@ const rootSchema: Type<Config> = type({
  *
  * const ok = validateConfig(
  *     {
+ *         environments: { production: {} },
  *         passes: {
  *             "vip-pass": {
  *                 description: "VIP perks.",
@@ -368,7 +384,7 @@ const rootSchema: Type<Config> = type({
  * expect(ok.success).toBeTrue();
  *
  * const err = validateConfig(
- *     { passes: { "vip-pass": { name: "VIP" } } },
+ *     { environments: { production: {} }, passes: { "vip-pass": { name: "VIP" } } },
  *     "bedrock.config.ts",
  * );
  * expect(err.success).toBeFalse();

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -163,6 +163,11 @@ export interface EnvironmentEntry {
 	/**
 	 * Per-environment game-pass overlay. Every field is optional; missing
 	 * fields fall through to the matching root `passes` entry at merge time.
+	 *
+	 * Uses `Partial<GamePassEntry>` directly rather than `Overlay<T, K>`
+	 * because game passes have no user-supplied identity key (Open Cloud
+	 * mints the asset ID). The other overlay fields use `Overlay<T, K>`
+	 * to keep their identity-bearing key required.
 	 */
 	passes?: Record<string, Partial<GamePassEntry>>;
 	/**
@@ -402,7 +407,7 @@ const environmentEntry: Type<EnvironmentEntry> = type({
 }).onUndeclaredKey("reject");
 
 const environmentsCollection = type({
-	[`[/^${ENV_NAME_PATTERN_SOURCE}$/]`]: environmentEntry,
+	[`[/${ENV_NAME_PATTERN_SOURCE}/]`]: environmentEntry,
 })
 	.onUndeclaredKey("reject")
 	.narrow((value, ctx) => {

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -2,6 +2,7 @@ import type { Result } from "@bedrock/ocale";
 import type { SocialLink } from "@bedrock/ocale/universes";
 
 import { ArkErrors, type, type Type } from "arktype";
+import type { SetRequired } from "type-fest";
 
 import { RESOURCE_KEY_PATTERN_SOURCE } from "../types/ids.ts";
 import type { ConfigError } from "./config-error.ts";
@@ -149,11 +150,35 @@ export type StateConfig = GistStateConfig | { readonly backend: string & {} };
 /**
  * Body of a single entry under `environments`. Per-environment overrides
  * narrow root-level settings for that environment without redefining
- * unrelated fields.
+ * unrelated fields. Resource overlays (`passes`, `places`, `universe`)
+ * derive their field shapes from the matching root entry types so adding
+ * a field to a base entry surfaces on the overlay automatically.
+ *
+ * `placeId` and `universeId` stay required when the matching overlay is
+ * present because each environment targets its own Roblox object: an
+ * overlay that mentions a place or universe must re-assert which Roblox
+ * resource it points at.
  */
 export interface EnvironmentEntry {
+	/**
+	 * Per-environment game-pass overlay. Every field is optional; missing
+	 * fields fall through to the matching root `passes` entry at merge time.
+	 */
+	passes?: Record<string, Partial<GamePassEntry>>;
+	/**
+	 * Per-environment places overlay. `placeId` is required on every
+	 * declared entry; other fields fall through to the matching root
+	 * `places` entry when omitted.
+	 */
+	places?: Record<string, Overlay<PlaceEntry, "placeId">>;
 	/** Per-environment state override; takes precedence over root `state`. */
 	state?: StateConfig;
+	/**
+	 * Per-environment universe overlay. `universeId` is required when the
+	 * overlay is present; other fields fall through to the root `universe`
+	 * block when omitted.
+	 */
+	universe?: Overlay<UniverseEntry, "universeId">;
 }
 
 /**
@@ -240,6 +265,18 @@ export interface Config {
 }
 
 /**
+ * Overlay shape used by per-environment entries: every field of `T`
+ * becomes optional, except `RequiredKey`, which stays required so the
+ * overlay still re-asserts the identity-bearing field of its target
+ * resource.
+ *
+ * @template T - Base entry type whose field shapes the overlay derives from.
+ * @template RequiredKey - Identity-bearing key on `T` that the overlay must
+ * still declare (for example `"placeId"` or `"universeId"`).
+ */
+type Overlay<T, RequiredKey extends keyof T> = SetRequired<Partial<T>, RequiredKey>;
+
+/**
  * Narrow a `StateConfig` to the `GistStateConfig` arm. The `(string & {})`
  * autocomplete idiom prevents TypeScript from narrowing on
  * `backend === "gist"` alone, so dispatch sites use this guard to
@@ -282,9 +319,11 @@ const passesCollection = type({
 	[`[/${RESOURCE_KEY_PATTERN_SOURCE}/]`]: gamePassEntry,
 }).onUndeclaredKey("reject");
 
+const ROBLOX_ID_DIGITS = "string.digits";
+
 const placeEntry = type({
 	filePath: "string",
-	placeId: "string.digits",
+	placeId: ROBLOX_ID_DIGITS,
 }).onUndeclaredKey("reject");
 
 const placesCollection = type({
@@ -313,7 +352,7 @@ const universeEntry = type({
 	"tabletEnabled?": OPTIONAL_BOOLEAN,
 	"twitchSocialLink?": socialLinkOrUndefined,
 	"twitterSocialLink?": socialLinkOrUndefined,
-	"universeId": "string.digits",
+	"universeId": ROBLOX_ID_DIGITS,
 	"visibility?": "'private' | 'public' | 'unspecified' | undefined",
 	"voiceChatEnabled?": OPTIONAL_BOOLEAN,
 	"vrEnabled?": OPTIONAL_BOOLEAN,
@@ -325,8 +364,41 @@ const stateConfig = type({
 	"gistId?": "string > 0",
 }).onUndeclaredKey("reject");
 
-const environmentEntry = type({
+// Overlay schemas mirror the base entry schemas but with every field
+// optional, except the identity-bearing key (`placeId`, `universeId`)
+// which stays required. Game passes have no user-supplied identity, so
+// the overlay is fully partial.
+const gamePassOverlay = type({
+	"description?": "string",
+	"iconFilePath?": "string",
+	"name?": "string",
+	"price?": "number | undefined",
+}).onUndeclaredKey("reject");
+
+const passesOverlayCollection = type({
+	[`[/${RESOURCE_KEY_PATTERN_SOURCE}/]`]: gamePassOverlay,
+}).onUndeclaredKey("reject");
+
+const placeOverlay = type({
+	"filePath?": "string",
+	"placeId": ROBLOX_ID_DIGITS,
+}).onUndeclaredKey("reject");
+
+const placesOverlayCollection = type({
+	[`[/${RESOURCE_KEY_PATTERN_SOURCE}/]`]: placeOverlay,
+}).onUndeclaredKey("reject");
+
+// `Overlay<UniverseEntry, "universeId">` is structurally equal to
+// `UniverseEntry` itself: the base type already has every field except
+// `universeId` declared as optional. Reusing `universeEntry` here keeps
+// the field set in lockstep and avoids a parallel declaration to drift.
+const universeOverlay = universeEntry;
+
+const environmentEntry: Type<EnvironmentEntry> = type({
+	"passes?": passesOverlayCollection,
+	"places?": placesOverlayCollection,
 	"state?": stateConfig,
+	"universe?": universeOverlay,
 }).onUndeclaredKey("reject");
 
 const environmentsCollection = type({

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -412,7 +412,7 @@ const environmentsCollection = type({
 	.onUndeclaredKey("reject")
 	.narrow((value, ctx) => {
 		if (Object.keys(value).length === 0) {
-			return ctx.mustBe("a non-empty record of environment entries");
+			return ctx.mustBe("an environments record with at least one declared environment");
 		}
 
 		return true;

--- a/packages/bedrock/src/index.spec-d.ts
+++ b/packages/bedrock/src/index.spec-d.ts
@@ -63,11 +63,11 @@ interface ExpectedValidationFailed {
 }
 
 function syncConfigBuilder(_ctx: ConfigContext): Config {
-	return { passes: {} };
+	return { environments: { production: {} }, passes: {} };
 }
 
 async function asyncConfigBuilder(_ctx: ConfigContext): Promise<Config> {
-	return { passes: {} };
+	return { environments: { production: {} }, passes: {} };
 }
 
 const brandShapeCases: ReadonlyArray<readonly [name: string, assertShape: () => void]> = [
@@ -215,14 +215,19 @@ describe("Config", () => {
 		expectTypeOf<Config["extends"]>().toEqualTypeOf<unknown>();
 	});
 
-	it("should treat every root field as optional so an empty object satisfies Config", () => {
-		expectTypeOf<Record<string, never>>().toExtend<Config>();
+	it("should require the environments field so an empty object does not satisfy Config", () => {
+		expectTypeOf<Record<string, never>>().not.toExtend<Config>();
+	});
+
+	it("should treat every root field except environments as optional", () => {
+		expectTypeOf<{ environments: Record<string, never> }>().toExtend<Config>();
 	});
 });
 
 describe(defineConfig, () => {
 	it("should preserve the literal type when given a plain object", () => {
 		const literal = {
+			environments: { production: {} },
 			passes: {
 				"vip-pass": {
 					name: "VIP Pass",

--- a/packages/bedrock/src/shell/build-default-registry.example.spec.ts
+++ b/packages/bedrock/src/shell/build-default-registry.example.spec.ts
@@ -5,6 +5,7 @@ import { buildDefaultRegistry } from '@bedrock/core'
 it('Example 1', () => {
   const registry = buildDefaultRegistry({
     config: {
+      environments: { production: {} },
       state: { backend: 'gist', gistId: 'abc' },
       universe: { universeId: '1234567890' },
     },

--- a/packages/bedrock/src/shell/build-default-registry.spec.ts
+++ b/packages/bedrock/src/shell/build-default-registry.spec.ts
@@ -6,7 +6,11 @@ import { buildDefaultRegistry } from "./build-default-registry.ts";
 const STATE_CONFIG = { backend: "gist" as const, gistId: "abc123" };
 
 function configWithUniverse(): Config {
-	return { state: STATE_CONFIG, universe: { universeId: "1234567890" } };
+	return {
+		environments: { production: {} },
+		state: STATE_CONFIG,
+		universe: { universeId: "1234567890" },
+	};
 }
 
 function environmentFrom(values: Record<string, string>): (name: string) => string | undefined {
@@ -55,7 +59,7 @@ describe(buildDefaultRegistry, () => {
 		expect.assertions(3);
 
 		const result = buildDefaultRegistry({
-			config: { state: STATE_CONFIG },
+			config: { environments: { production: {} }, state: STATE_CONFIG },
 			getEnv: environmentFrom({ ROBLOX_API_KEY: "rbx-test" }),
 			readFile: neverReadFile,
 		});

--- a/packages/bedrock/src/shell/build-default-registry.ts
+++ b/packages/bedrock/src/shell/build-default-registry.ts
@@ -55,6 +55,7 @@ interface AssembleRegistryInputs {
  *
  * const registry = buildDefaultRegistry({
  *     config: {
+ *         environments: { production: {} },
  *         state: { backend: "gist", gistId: "abc" },
  *         universe: { universeId: "1234567890" },
  *     },

--- a/packages/bedrock/src/shell/define-config.example.spec.ts
+++ b/packages/bedrock/src/shell/define-config.example.spec.ts
@@ -4,6 +4,7 @@ import { defineConfig } from '@bedrock/core'
 
 it('Example 1', () => {
   const config = defineConfig({
+    environments: { production: {} },
     passes: {
       'vip-pass': {
         description: 'Grants VIP perks.',

--- a/packages/bedrock/src/shell/define-config.spec.ts
+++ b/packages/bedrock/src/shell/define-config.spec.ts
@@ -4,6 +4,7 @@ import type { Config } from "../core/schema.ts";
 import { defineConfig } from "./define-config.ts";
 
 const BASE_CONFIG: Config = {
+	environments: { production: {} },
 	passes: {
 		"vip-pass": {
 			name: "VIP Pass",

--- a/packages/bedrock/src/shell/define-config.ts
+++ b/packages/bedrock/src/shell/define-config.ts
@@ -32,6 +32,7 @@ export type ConfigInput = ((ctx: ConfigContext) => Config | Promise<Config>) | C
  * import { defineConfig } from "@bedrock/core";
  *
  * const config = defineConfig({
+ *     environments: { production: {} },
  *     passes: {
  *         "vip-pass": {
  *             description: "Grants VIP perks.",

--- a/packages/bedrock/src/shell/deploy.example.spec.ts
+++ b/packages/bedrock/src/shell/deploy.example.spec.ts
@@ -47,7 +47,11 @@ it('Example 2', () => {
     },
   }
   return deploy({
-    config: { state: { backend: 'gist', gistId: 'abc' }, passes: {} },
+    config: {
+      environments: { production: {} },
+      state: { backend: 'gist', gistId: 'abc' },
+      passes: {},
+    },
     environment: 'production',
     registry,
     statePort,

--- a/packages/bedrock/src/shell/deploy.spec.ts
+++ b/packages/bedrock/src/shell/deploy.spec.ts
@@ -55,6 +55,7 @@ function inMemoryStatePort(initial?: BedrockState): {
 
 function vipPassConfig(): Config {
 	return {
+		environments: { production: {} },
 		passes: {
 			"vip-pass": {
 				name: "VIP Pass",
@@ -87,6 +88,7 @@ function twoPassConfig(): Config {
 	// alphabetically, so alpha-pass runs first and vip-pass second. Tests
 	// rely on that order when asserting which dispatch failed.
 	return {
+		environments: { production: {} },
 		passes: {
 			"alpha-pass": {
 				name: "Alpha Pass",
@@ -106,6 +108,7 @@ function twoPassConfig(): Config {
 
 function configWithState(): Config {
 	return {
+		environments: { production: {} },
 		passes: {
 			"vip-pass": {
 				name: "VIP Pass",
@@ -246,6 +249,7 @@ describe(deploy, () => {
 			version: 1,
 		});
 		const config: Config = {
+			environments: { production: {} },
 			passes: {
 				"vip-pass": {
 					name: "VIP Pass",
@@ -499,7 +503,7 @@ describe(deploy, () => {
 		expect.assertions(2);
 
 		const result = await deploy({
-			config: { passes: {} },
+			config: { environments: { production: {} }, passes: {} },
 			environment: "production",
 			getEnv: environmentFrom({}),
 			readFile: readIcon,
@@ -517,7 +521,7 @@ describe(deploy, () => {
 		expect.assertions(2);
 
 		const result = await deploy({
-			config: { state: { backend: "s3" } },
+			config: { environments: { production: {} }, state: { backend: "s3" } },
 			environment: "production",
 			getEnv: environmentFrom({ GITHUB_TOKEN: "ghp_test" }),
 			readFile: readIcon,
@@ -555,7 +559,11 @@ describe(deploy, () => {
 		const { port } = inMemoryStatePort();
 
 		const result = await deploy({
-			config: { state: { backend: "gist", gistId: "abc" }, universe: { universeId: "1" } },
+			config: {
+				environments: { production: {} },
+				state: { backend: "gist", gistId: "abc" },
+				universe: { universeId: "1" },
+			},
 			environment: "production",
 			getEnv: environmentFrom({ GITHUB_TOKEN: "ghp_test", ROBLOX_API_KEY: "rbx-test" }),
 			readFile: readIcon,
@@ -571,7 +579,11 @@ describe(deploy, () => {
 		expect.assertions(2);
 
 		const result = await deploy({
-			config: { state: { backend: "gist", gistId: "abc" }, universe: { universeId: "1" } },
+			config: {
+				environments: { production: {} },
+				state: { backend: "gist", gistId: "abc" },
+				universe: { universeId: "1" },
+			},
 			environment: "production",
 			getEnv: environmentFrom({ GITHUB_TOKEN: "ghp_test" }),
 			readFile: readIcon,
@@ -589,7 +601,10 @@ describe(deploy, () => {
 		expect.assertions(2);
 
 		const result = await deploy({
-			config: { state: { backend: "gist", gistId: "abc" } },
+			config: {
+				environments: { production: {} },
+				state: { backend: "gist", gistId: "abc" },
+			},
 			environment: "production",
 			getEnv: environmentFrom({ GITHUB_TOKEN: "ghp_test", ROBLOX_API_KEY: "rbx-test" }),
 			readFile: readIcon,
@@ -606,7 +621,10 @@ describe(deploy, () => {
 	it("should call the loadConfig override when config is omitted and use the result", async () => {
 		expect.assertions(2);
 
-		const minimalConfig: Config = { state: { backend: "gist", gistId: "abc-test" } };
+		const minimalConfig: Config = {
+			environments: { production: {} },
+			state: { backend: "gist", gistId: "abc-test" },
+		};
 		const loadConfigStub = vi.fn<() => Promise<{ data: Config; success: true }>>(async () => {
 			return { data: minimalConfig, success: true };
 		});
@@ -653,6 +671,7 @@ describe(deploy, () => {
 		try {
 			const result = await deploy({
 				config: {
+					environments: { production: {} },
 					state: { backend: "gist", gistId: "abc" },
 					universe: { universeId: "1234567890" },
 				},

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -139,7 +139,11 @@ interface PickRegistryInputs {
  * };
  *
  * return deploy({
- *     config: { state: { backend: "gist", gistId: "abc" }, passes: {} },
+ *     config: {
+ *         environments: { production: {} },
+ *         state: { backend: "gist", gistId: "abc" },
+ *         passes: {},
+ *     },
  *     environment: "production",
  *     registry,
  *     statePort,

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -42,6 +42,7 @@ describe(loadConfig, () => {
 			writeFixtureConfig(cwd, [
 				"import { defineConfig } from '@bedrock/core';",
 				"export default defineConfig({",
+				"  environments: { production: {} },",
 				"  passes: {",
 				"    'vip-pass': {",
 				"      description: 'Grants VIP perks.',",
@@ -68,6 +69,7 @@ describe(loadConfig, () => {
 			writeFixtureConfig(cwd, [
 				"import { defineConfig } from '@bedrock/core';",
 				"export default defineConfig(() => ({",
+				"  environments: { production: {} },",
 				"  passes: {",
 				"    'vip-pass': {",
 				"      description: 'Grants VIP perks.',",
@@ -94,6 +96,7 @@ describe(loadConfig, () => {
 			writeFixtureConfig(cwd, [
 				"import { defineConfig } from '@bedrock/core';",
 				"export default defineConfig(async () => ({",
+				"  environments: { production: {} },",
 				"  passes: {",
 				"    'vip-pass': {",
 				"      description: 'Grants VIP perks.',",
@@ -199,6 +202,8 @@ describe(loadConfig, () => {
 			writeFileSync(
 				join(cwd, "bedrock.staging.config.yaml"),
 				[
+					"environments:",
+					"  staging: {}",
 					"passes:",
 					"  staging-pass:",
 					"    description: Staging perks.",
@@ -249,6 +254,7 @@ describe(loadConfig, () => {
 				[
 					"import { defineConfig } from '@bedrock/core';",
 					"export default defineConfig({",
+					"  environments: { production: {} },",
 					"  passes: {",
 					"    'absolute-pass': {",
 					"      description: 'Loaded by absolute path.',",
@@ -275,6 +281,7 @@ describe(loadConfig, () => {
 		await withTemporaryDirectory(async (cwd) => {
 			writeFixtureConfig(cwd, [
 				"export default {",
+				"  environments: { production: {} },",
 				"  passes: {",
 				"    'vip-pass': {",
 				"      description: 'Bad price.',",
@@ -320,6 +327,7 @@ describe(loadConfig, () => {
 		await withTemporaryDirectory(async (cwd) => {
 			writeFixtureConfig(cwd, [
 				"export default {",
+				"  environments: { production: {} },",
 				"  passes: {",
 				"    'vip-pass': {",
 				"      description: 'd',",

--- a/packages/bedrock/tests/integration/fixtures/javascript/bedrock.config.js
+++ b/packages/bedrock/tests/integration/fixtures/javascript/bedrock.config.js
@@ -1,4 +1,5 @@
 export default {
+	environments: { production: {} },
 	passes: {
 		"vip-pass": {
 			name: "VIP Pass",

--- a/packages/bedrock/tests/integration/fixtures/json/bedrock.config.json
+++ b/packages/bedrock/tests/integration/fixtures/json/bedrock.config.json
@@ -1,4 +1,7 @@
 {
+	"environments": {
+		"production": {}
+	},
 	"passes": {
 		"vip-pass": {
 			"name": "VIP Pass",

--- a/packages/bedrock/tests/integration/fixtures/places/bedrock.config.ts
+++ b/packages/bedrock/tests/integration/fixtures/places/bedrock.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "@bedrock/core";
 
 export default defineConfig({
+	environments: { production: {} },
 	places: {
 		"start-place": {
 			filePath: "places/start.rbxl",

--- a/packages/bedrock/tests/integration/fixtures/typescript-function/bedrock.config.ts
+++ b/packages/bedrock/tests/integration/fixtures/typescript-function/bedrock.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "@bedrock/core";
 
 export default defineConfig(async () => {
 	return {
+		environments: { production: {} },
 		passes: {
 			"vip-pass": {
 				name: "VIP Pass",

--- a/packages/bedrock/tests/integration/fixtures/typescript/bedrock.config.ts
+++ b/packages/bedrock/tests/integration/fixtures/typescript/bedrock.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "@bedrock/core";
 
 export default defineConfig({
+	environments: { production: {} },
 	passes: {
 		"vip-pass": {
 			name: "VIP Pass",

--- a/packages/bedrock/tests/integration/fixtures/universe/bedrock.config.ts
+++ b/packages/bedrock/tests/integration/fixtures/universe/bedrock.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "@bedrock/core";
 
 export default defineConfig({
+	environments: { production: {} },
 	universe: {
 		desktopEnabled: false,
 		discordSocialLink: { title: "Join our Discord", uri: "https://discord.gg/example" },

--- a/packages/bedrock/tests/integration/fixtures/yaml/bedrock.config.yaml
+++ b/packages/bedrock/tests/integration/fixtures/yaml/bedrock.config.yaml
@@ -1,3 +1,5 @@
+environments:
+  production: {}
 passes:
   vip-pass:
     name: VIP Pass


### PR DESCRIPTION
## Summary

- Make `Config.environments` required and non-empty so every project explicitly declares its environments. Validates env-name keys with the same `[A-Za-z0-9_-]{1,64}` regex that adapter boundaries already use.
- Extend `EnvironmentEntry` with `passes`, `places`, and `universe` overlay fields. Their TS shapes derive from the matching root entry types via `Overlay<T, K> = SetRequired<Partial<T>, K>` (type-fest), so adding a field to a base entry surfaces on the corresponding overlay automatically. `placeId` and `universeId` stay required when the overlay is present because each environment targets its own Roblox object.
- Runtime arktype schema mirrors the new shape under a `Type<EnvironmentEntry>` constraint, so any TS-vs-runtime drift surfaces as a build-time compile error.

Foundational portion of issue #110 (branch-based environments). The pure `selectEnvironment` resolver that defu-merges base + overlay, the deploy wiring, and the ADR-020 amendment land as follow-up commits on this branch.

## Why now

Pre-1.0 issue #110 was tracked as deferred from v0.1; PRs #188, #189, #190 landed the load-config / deploy / CLI scaffolding it depends on. The schema slot (`Config.environments?: Record<...>`) was already reserved per ADR-020 but only carried per-env `state` overrides, leaving every environment pointing at the same Roblox universe. This change makes per-env Roblox universes/places expressible at the type level so the resolver in the next commit can act on them.

## Breaking change

`Config.environments` was optional; it is now required. Configs that omit the field no longer validate. Migration: add `environments: { production: {} }` (or the appropriate set of environments) to the root config. Internal tests, JSDoc examples, and integration fixtures were updated in slice 1.

## Test plan

- [x] `pnpm gen:example-tests && pnpm lint && pnpm typecheck && pnpm test && pnpm build` clean
- [x] Schema rejects `{}`, rejects `{ environments: {} }`, accepts `{ environments: { production: {} } }`
- [x] Schema rejects env-name keys outside `/^[A-Za-z0-9_-]{1,64}$/` (bad chars and >64 chars)
- [x] `EnvironmentEntry` overlay rejects places entry without `placeId`, universe overlay without `universeId`
- [x] Type-level tests confirm overlay key sets equal `keyof PlaceEntry` / `keyof UniverseEntry` / `keyof GamePassEntry` (drift guard)
- [ ] `selectEnvironment` end-to-end (lands on this branch in next commit)
- [ ] `deploy()` routes through `selectEnvironment` (lands on this branch)
- [ ] ADR-020 amendment (lands on this branch, collaborative)

## Refs

Refs #110
ADR-020 governs the `environments` slot; an amendment recording the chosen overlay shape, defu merge semantics, and strict-unknown-env decision will land on this branch before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)