### PR TITLE
refactor(core): route deploy through select-environment

### DIFF
--- a/apps/e2e/tests/smoke/deploy-place.spec.ts
+++ b/apps/e2e/tests/smoke/deploy-place.spec.ts
@@ -75,6 +75,7 @@ describe("deploy place to real Roblox", () => {
 
 			const result = await deploy({
 				config: {
+					environments: { smoke: {} },
 					places: {
 						"smoke-place": {
 							filePath: FIXTURE_PATH,

--- a/packages/bedrock/src/core/select-environment.example.spec.ts
+++ b/packages/bedrock/src/core/select-environment.example.spec.ts
@@ -10,10 +10,10 @@ it('Example 1', () => {
     state: { backend: 'gist', gistId: 'abc123' },
     universe: { universeId: '111' },
   }
-  const effective = selectEnvironment(config, 'production')
-  expect(effective.success).toBeTrue()
-  if (effective.success) {
-    expect(effective.data.universe?.universeId).toBe('999')
-    expect(effective.data.state.backend).toBe('gist')
+  const result = selectEnvironment(config, 'production')
+  expect(result.success).toBeTrue()
+  if (result.success) {
+    expect(result.data.universe?.universeId).toBe('999')
+    expect(result.data.state?.backend).toBe('gist')
   }
 })

--- a/packages/bedrock/src/core/select-environment.spec-d.ts
+++ b/packages/bedrock/src/core/select-environment.spec-d.ts
@@ -2,9 +2,8 @@ import type { Result } from "@bedrock/ocale";
 
 import { describe, expectTypeOf, it } from "vitest";
 
-import type { Config, StateConfig } from "./schema.ts";
+import type { Config } from "./schema.ts";
 import {
-	type EffectiveConfig,
 	selectEnvironment,
 	type SelectEnvironmentError,
 	type UnknownEnvironmentError,
@@ -16,16 +15,14 @@ describe("selectEnvironment signature", () => {
 		expectTypeOf(selectEnvironment).parameter(1).toEqualTypeOf<string>();
 	});
 
-	it("should return a Result of EffectiveConfig or SelectEnvError", () => {
+	it("should return a Result of Config or SelectEnvironmentError so downstream functions consume it as Config", () => {
 		expectTypeOf<ReturnType<typeof selectEnvironment>>().toEqualTypeOf<
-			Result<EffectiveConfig, SelectEnvironmentError>
+			Result<Config, SelectEnvironmentError>
 		>();
 	});
 
-	it("should discriminate SelectEnvError on the unknownEnvironment and stateNotConfigured kinds", () => {
-		expectTypeOf<SelectEnvironmentError["kind"]>().toEqualTypeOf<
-			"stateNotConfigured" | "unknownEnvironment"
-		>();
+	it("should constrain SelectEnvironmentError to the unknownEnvironment kind", () => {
+		expectTypeOf<SelectEnvironmentError["kind"]>().toEqualTypeOf<"unknownEnvironment">();
 	});
 });
 
@@ -33,19 +30,5 @@ describe("UnknownEnvironmentError", () => {
 	it("should expose the requested environment and the declared name list", () => {
 		expectTypeOf<UnknownEnvironmentError["environment"]>().toEqualTypeOf<string>();
 		expectTypeOf<UnknownEnvironmentError["declared"]>().toEqualTypeOf<ReadonlyArray<string>>();
-	});
-});
-
-describe("EffectiveConfig", () => {
-	it("should make state non-optional after the resolver projects an environment", () => {
-		expectTypeOf<EffectiveConfig["state"]>().toEqualTypeOf<StateConfig>();
-	});
-
-	it("should strip environments from the projected output", () => {
-		expectTypeOf<EffectiveConfig>().not.toHaveProperty("environments");
-	});
-
-	it("should strip extends from the projected output", () => {
-		expectTypeOf<EffectiveConfig>().not.toHaveProperty("extends");
 	});
 });

--- a/packages/bedrock/src/core/select-environment.spec.ts
+++ b/packages/bedrock/src/core/select-environment.spec.ts
@@ -20,7 +20,7 @@ const START_PLACE: PlaceEntry = {
 
 describe(selectEnvironment, () => {
 	it("should return Err(unknownEnvironment) when the env name is not declared", () => {
-		expect.assertions(2);
+		expect.assertions(3);
 
 		const config: Config = {
 			environments: { production: {} },
@@ -30,25 +30,25 @@ describe(selectEnvironment, () => {
 		const result = selectEnvironment(config, "staging");
 
 		assert(!result.success);
-		assert(result.err.kind === "unknownEnvironment");
 
+		expect(result.err.kind).toBe("unknownEnvironment");
 		expect(result.err.environment).toBe("staging");
 		expect(result.err.declared).toStrictEqual(["production"]);
 	});
 
-	it("should propagate Err(stateNotConfigured) when neither env nor root provides state", () => {
+	it("should leave state absent when neither env nor root declares it", () => {
 		expect.assertions(1);
 
 		const config: Config = { environments: { production: {} } };
 
 		const result = selectEnvironment(config, "production");
 
-		assert(!result.success);
+		assert(result.success);
 
-		expect(result.err.kind).toBe("stateNotConfigured");
+		expect(result.data.state).toBeUndefined();
 	});
 
-	it("should resolve state from the env override when both root and env declare state", () => {
+	it("should prefer the env state override when both root and env declare state", () => {
 		expect.assertions(1);
 
 		const config: Config = {
@@ -214,7 +214,7 @@ describe(selectEnvironment, () => {
 		expect(result.data.places).toStrictEqual({ "start-place": START_PLACE });
 	});
 
-	it("should strip environments and extends from the EffectiveConfig output", () => {
+	it("should preserve environments and extends so the returned shape stays assignable to Config", () => {
 		expect.assertions(2);
 
 		const config: Config = {
@@ -227,7 +227,7 @@ describe(selectEnvironment, () => {
 
 		assert(result.success);
 
-		expect(result.data).not.toContainKey("environments");
-		expect(result.data).not.toContainKey("extends");
+		expect(result.data.environments).toContainKey("production");
+		expect(result.data.extends).toBe("./base.config.ts");
 	});
 });

--- a/packages/bedrock/src/core/select-environment.ts
+++ b/packages/bedrock/src/core/select-environment.ts
@@ -1,10 +1,9 @@
 import type { Result } from "@bedrock/ocale";
 
 import { defu } from "defu";
-import type { Except, SetRequired } from "type-fest";
+import type { SetRequired } from "type-fest";
 
-import { resolveStateConfig, type StateNotConfiguredError } from "./resolve-state-config.ts";
-import type { Config, GamePassEntry, PlaceEntry, StateConfig, UniverseEntry } from "./schema.ts";
+import type { Config, GamePassEntry, PlaceEntry, UniverseEntry } from "./schema.ts";
 
 /**
  * Failure surfaced when `selectEnvironment` is asked for an environment
@@ -22,41 +21,40 @@ export interface UnknownEnvironmentError {
 }
 
 /** Failure modes returned by {@link selectEnvironment}. */
-export type SelectEnvironmentError = StateNotConfiguredError | UnknownEnvironmentError;
-
-/**
- * `Config` projected onto a single environment. `environments` and
- * `extends` are stripped because the resolver has already collapsed the
- * overlay into the resource fields, and `state` is non-optional because
- * the resolver resolved it from the env override or the root block.
- */
-export type EffectiveConfig = Except<Config, "environments" | "extends" | "state"> & {
-	readonly state: StateConfig;
-};
+export type SelectEnvironmentError = UnknownEnvironmentError;
 
 interface ProjectInputs {
 	readonly config: Config;
 	readonly entry: Config["environments"][string];
-	readonly state: StateConfig;
 }
 
 /**
  * Project a validated `Config` onto a single environment. Looks up the
  * matching `environments[environment]` entry, deep-merges its resource
  * overlay (`passes`, `places`, `universe`) over the root config via defu,
- * and resolves the effective state via {@link resolveStateConfig}.
+ * and applies the env-level state override when present (the env entry's
+ * `state` field wins; otherwise the root `state` flows through).
  *
- * Pure: no I/O. The returned `EffectiveConfig` carries the merged
- * resource fields plus the resolved `state` and is ready to feed into
- * `flattenConfig` or `buildStatePort` without further pre-processing.
+ * Pure: no I/O. Returns a `Config` ready to feed into downstream
+ * functions that already accept `Config` (`flattenConfig`,
+ * `buildDefaultRegistry`, `resolveStateConfig`) without signature
+ * changes. `environments` and `extends` are passed through unchanged
+ * because they preserve the shape relationship to `Config`; downstream
+ * consumers do not read them post-merge.
  *
  * Defu's merge semantics are deliberate: keyed-map collections merge by
  * key (so a place declared in both root and overlay produces a single
  * entry whose overlay-supplied fields win), and `null` / `undefined` in
  * the overlay are skipped (so the overlay never deletes a root field).
- * State has its own resolution path because it is a tagged union: a
- * full deep-merge of `{ backend: "s3" }` over `{ backend: "gist", gistId }`
- * would produce a malformed `{ backend: "s3", gistId }`.
+ * State has its own resolution path (a single replacement, not a
+ * deep-merge) because it is a tagged union: a deep-merge of
+ * `{ backend: "s3" }` over `{ backend: "gist", gistId }` would produce
+ * a malformed `{ backend: "s3", gistId }`.
+ *
+ * State is left absent when neither the env override nor the root block
+ * provides one. Callers that require a resolved `StateConfig` should
+ * route through `resolveStateConfig` or `buildStatePort`; the absent
+ * case surfaces as a typed `stateNotConfigured` there.
  *
  * Limitation in v1: a per-environment overlay that introduces a brand-new
  * place or universe overlay key (one not declared at the root) may still
@@ -79,12 +77,12 @@ interface ProjectInputs {
  *     universe: { universeId: "111" },
  * };
  *
- * const effective = selectEnvironment(config, "production");
+ * const result = selectEnvironment(config, "production");
  *
- * expect(effective.success).toBeTrue();
- * if (effective.success) {
- *     expect(effective.data.universe?.universeId).toBe("999");
- *     expect(effective.data.state.backend).toBe("gist");
+ * expect(result.success).toBeTrue();
+ * if (result.success) {
+ *     expect(result.data.universe?.universeId).toBe("999");
+ *     expect(result.data.state?.backend).toBe("gist");
  * }
  * ```
  *
@@ -92,26 +90,21 @@ interface ProjectInputs {
  * environment under `environments`.
  * @param environment - Environment name to project onto. Must be a key
  * of `config.environments`.
- * @returns `Ok(EffectiveConfig)` with the merged resource fields and the
- * resolved state, or `Err(SelectEnvironmentError)` describing why the
- * projection failed.
+ * @returns `Ok(Config)` with the merged resource fields and the resolved
+ * state, or `Err(SelectEnvironmentError)` describing why the projection
+ * failed.
  */
 export function selectEnvironment(
 	config: Config,
 	environment: string,
-): Result<EffectiveConfig, SelectEnvironmentError> {
+): Result<Config, SelectEnvironmentError> {
 	const entry = config.environments[environment];
 	if (entry === undefined) {
 		return { err: unknownEnvironment(config, environment), success: false };
 	}
 
-	const stateResult = resolveStateConfig(config, environment);
-	if (!stateResult.success) {
-		return stateResult;
-	}
-
 	return {
-		data: projectConfig({ config, entry, state: stateResult.data }),
+		data: projectConfig({ config, entry }),
 		success: true,
 	};
 }
@@ -156,17 +149,19 @@ function mergeUniverse(
 	return mergeEntry(overlay, base);
 }
 
-function projectConfig(inputs: ProjectInputs): EffectiveConfig {
-	const { config, entry, state } = inputs;
+function projectConfig(inputs: ProjectInputs): Config {
+	const { config, entry } = inputs;
 	const passes = mergeKeyedRecord<GamePassEntry>(entry.passes, config.passes);
 	const places = mergeKeyedRecord<PlaceEntry>(entry.places, config.places);
 	const universe = mergeUniverse(entry.universe, config.universe);
+	const state = entry.state ?? config.state;
 
 	return {
+		...config,
 		...(passes === undefined ? {} : { passes }),
 		...(places === undefined ? {} : { places }),
+		...(state === undefined ? {} : { state }),
 		...(universe === undefined ? {} : { universe }),
-		state,
 	};
 }
 

--- a/packages/bedrock/src/index.spec-d.ts
+++ b/packages/bedrock/src/index.spec-d.ts
@@ -193,6 +193,7 @@ describe(deploy, () => {
 			| "stateNotConfigured"
 			| "stateReadFailed"
 			| "stateWriteFailed"
+			| "unknownEnvironment"
 			| "unsupportedBackend"
 		>();
 	});

--- a/packages/bedrock/src/index.ts
+++ b/packages/bedrock/src/index.ts
@@ -61,7 +61,6 @@ export {
 } from "./core/schema.ts";
 export {
 	selectEnvironment,
-	type EffectiveConfig,
 	type SelectEnvironmentError,
 	type UnknownEnvironmentError,
 } from "./core/select-environment.ts";

--- a/packages/bedrock/src/shell/deploy.spec.ts
+++ b/packages/bedrock/src/shell/deploy.spec.ts
@@ -499,6 +499,24 @@ describe(deploy, () => {
 		expect(result.data.environment).toBe("production");
 	});
 
+	it("should return Err(unknownEnvironment) when the environment is not declared in the config", async () => {
+		expect.assertions(2);
+
+		const result = await deploy({
+			config: vipPassConfig(),
+			environment: "staging",
+			readFile: readIcon,
+			registry: stubRegistry(),
+			statePort: inMemoryStatePort().port,
+		});
+
+		assert(!result.success);
+		assert(result.err.kind === "unknownEnvironment");
+
+		expect(result.err.environment).toBe("staging");
+		expect(result.err.declared).toStrictEqual(["production"]);
+	});
+
 	it("should return Err(stateNotConfigured) when statePort is omitted and the config has no state for the environment", async () => {
 		expect.assertions(2);
 

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -10,6 +10,7 @@ import { flattenConfig } from "../core/flatten.ts";
 import { resolveStateConfig, type StateNotConfiguredError } from "../core/resolve-state-config.ts";
 import type { ResourceCurrentState } from "../core/resources.ts";
 import type { Config } from "../core/schema.ts";
+import { selectEnvironment, type UnknownEnvironmentError } from "../core/select-environment.ts";
 import type { BedrockState, StateError } from "../core/state.ts";
 import type { DriverRegistry } from "../ports/resource-driver.ts";
 import type { StatePort } from "../ports/state-port.ts";
@@ -52,13 +53,14 @@ export interface DeployOptions {
  * Failure surfaced by `deploy`. Stage-tagged so callers can branch on
  * `kind` to distinguish reconciliation failures (`stateReadFailed`,
  * `applyFailed`, ...) from default-construction failures
- * (`configLoadFailed`, `stateNotConfigured`, `missingCredential`,
- * `unsupportedBackend`, `registryConfigMissing`).
+ * (`configLoadFailed`, `stateNotConfigured`, `unknownEnvironment`,
+ * `missingCredential`, `unsupportedBackend`, `registryConfigMissing`).
  */
 export type DeployError =
 	| MissingCredentialError
 	| RegistryConfigError
 	| StateNotConfiguredError
+	| UnknownEnvironmentError
 	| UnsupportedBackendError
 	| { readonly cause: ApplyError; readonly kind: "applyFailed" }
 	| { readonly cause: BuildDesiredError; readonly kind: "buildDesiredFailed" }
@@ -222,21 +224,27 @@ async function resolveDeps(options: DeployOptions): Promise<Result<ResolvedDeps,
 		return config;
 	}
 
+	const selected = selectEnvironment(config.data, options.environment);
+	if (!selected.success) {
+		return { err: selected.err, success: false };
+	}
+
+	const effective = selected.data;
 	const readFile = options.readFile ?? nodeReadFile;
 
-	const statePort = pickStatePort(options, config.data);
+	const statePort = pickStatePort(options, effective);
 	if (!statePort.success) {
 		return statePort;
 	}
 
-	const registry = pickRegistry({ config: config.data, options, readFile });
+	const registry = pickRegistry({ config: effective, options, readFile });
 	if (!registry.success) {
 		return registry;
 	}
 
 	return {
 		data: {
-			config: config.data,
+			config: effective,
 			readFile,
 			registry: registry.data,
 			statePort: statePort.data,


### PR DESCRIPTION
## Summary

- `deploy()` now projects the loaded config through `selectEnvironment` before resolving the state port and registry, so per-environment resource overlays declared on the `environments` entry actually take effect at deploy time.
- `DeployError` gains an `unknownEnvironment` variant surfaced when the requested env name is not a key of `config.environments`.
- Walks back the state-subsume design from #193: `selectEnvironment` no longer rejects on missing state. It applies the env-vs-root state preference inline and lets `resolveStateConfig` (called by `pickStatePort` when no explicit `statePort` is supplied) handle the "must have state" check. `SelectEnvironmentError` collapses to just `UnknownEnvironmentError` and the `EffectiveConfig` type alias is dropped.

## Stacked on

This PR is stacked on #193 (`feat/issue-110-select-environment`). Base: `feat/issue-110-select-environment`. Merge that first.

## Why the walk-back

The state-subsume design from #193 collided with `deploy()`'s existing contract that an explicit `statePort` makes config-side state unnecessary. Tests passing `statePort: port` with no config state were failing because `selectEnvironment` rejected with `stateNotConfigured` before `deploy()` could reach the state-port short-circuit. The minimal-blast-radius fix: `selectEnvironment` returns the merged `Config` (state pre-applied where present, absent where not), and `pickStatePort` continues calling `resolveStateConfig` only when no explicit `statePort` was supplied.

Net effect on the shell layer: one new `DeployError` variant (`unknownEnvironment`), `flattenConfig` and `buildDefaultRegistry` keep their `Config` parameter unchanged, and the merged resource overlays flow through to `buildDesired` and `applyOps` without further plumbing.

## Test plan

- [x] `pnpm gen:example-tests && pnpm lint && pnpm typecheck && pnpm test && pnpm build` clean
- [x] New `deploy.spec.ts` test: `deploy({ config, environment: 'staging' })` returns `Err({ kind: 'unknownEnvironment', environment: 'staging', declared: ['production'] })` when the env is not declared
- [x] Existing `stateNotConfigured` / `unsupportedBackend` / `missingCredential` paths unchanged (regression coverage in `deploy.spec.ts`)
- [x] `selectEnvironment` no longer fails on missing state; new `'should leave state absent when neither env nor root declares it'` test
- [x] `index.spec-d.ts` `DeployError["kind"]` union now includes `'unknownEnvironment'`
- [ ] Programmatic smoke test: `deploy()` against fake adapters with two envs declaring different `universe.universeId` values, asserting each calls Open Cloud against its own ID (will be added once a CLI command handler exists in a follow-up)

## Refs

Refs #110
Stacked on #193, transitively #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)