### PR TITLE
chore: add pre-push mutation gate matching ci scope

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -72,6 +72,16 @@ local mutate = new Step {
     exclusive = true
 }
 
+// Pre-push variant of `mutate` that scopes against `origin/main`, mirroring
+// the CI mutation job. Pre-commit's `mutate` only sees the current slice; a
+// survivor exposed by a later slice's tests would slip past without this.
+local mutatePush = new Step {
+    glob = List("*.ts", "*.tsx")
+    check = "MUTATE_BASE_REF=origin/main pnpm mutate:changed"
+    shell = bash
+    exclusive = true
+}
+
 local unused = new Step {
     glob = List("*.ts", "*.tsx", "package.json", "pnpm-workspace.yaml")
     check = "pnpm lint:unused"
@@ -101,6 +111,7 @@ hooks {
             ["unused"] = unused
             ["build"] = build
             ["test"] = test
+            ["mutate"] = (mutatePush) { condition = isAgent }
         }
     }
     ["commit-msg"] {


### PR DESCRIPTION
## Summary

- New `mutatePush` step in `hk.pkl` invokes `pnpm mutate:changed` with `MUTATE_BASE_REF=origin/main`, mirroring the env the CI mutation job sets at `.github/workflows/ci.yaml:93`.
- Wires it into the `pre-push` hook, gated on `isAgent` so human pushes stay fast.
- Pre-commit's existing `mutate` step is unchanged.

## Why

CI run [24943044294](https://github.com/christopher-buss/bedrock/actions/runs/24943044294/job/73039791234?pr=192) caught a surviving mutant in `packages/bedrock/src/core/schema.ts:410` that local pre-commit had not flagged. Cause: scope mismatch.

`scripts/mutate-changed.ts:15-17` reads `MUTATE_BASE_REF` and falls back to `git diff HEAD` when unset.

| Environment | `MUTATE_BASE_REF` | Diff target | Files mutated |
|---|---|---|---|
| CI | `origin/main` | `origin/main...HEAD` | Whole PR |
| Pre-commit (agent) | unset | `HEAD` | Just the current slice |
| Pre-push (before this PR) | n/a (no step) | n/a | Nothing |

A test added in slice N can change coverage on lines first touched in slice 1, opening a survivor that no per-slice pre-commit run re-checks. Pre-push is the right boundary to mirror CI scope: pay the ~2-3 min cost once per push instead of per slice. Gating on `isAgent` keeps human pushes fast.

## Test plan

- [x] `hk validate` passes after the change.
- [x] `git push` from this branch ran the existing pre-push steps cleanly (no `.ts` changes, so mutate step was correctly skipped by glob).
- [ ] On a follow-up branch with a `.ts` change, confirm `hk run pre-push` (under `IS_AGENT=true` or equivalent) invokes `pnpm mutate:changed` with `MUTATE_BASE_REF=origin/main` and matches the mutant set CI runs.
- [ ] On a clean working tree with no diff vs `origin/main`, confirm pre-push still exits 0 (`mutate-changed` reports "No modified files").

🤖 Generated with [Claude Code](https://claude.com/claude-code)