### PR TITLE
feat(core): add luau config file support via lute

### DIFF
--- a/.config/cspell.config.yaml
+++ b/.config/cspell.config.yaml
@@ -8,6 +8,9 @@ words:
   - bedrockrc
   - defu
   - guilded
+  - luau
+  - luaurc
+  - lute
   - monocart
   - retryable
   - ocale

--- a/mise.toml
+++ b/mise.toml
@@ -17,6 +17,7 @@ experimental = true
 "npm:vercel" = "latest"
 bun = "1.3.12"
 hk = { version = "1.42.0", postinstall = "if [ -z \"$CI\" ]; then hk install --mise; fi" }
+"github:luau-lang/lute" = "1.0.0"
 node = { version = "lts", postinstall = "corepack enable" }
 pkl = "latest"
 

--- a/packages/bedrock/src/core/config-error.example.spec.ts
+++ b/packages/bedrock/src/core/config-error.example.spec.ts
@@ -28,6 +28,9 @@ it('Example 2', () => {
           ? `${err.sourceFile}: ${first.path.join('.')} ${first.message}`
           : `${err.sourceFile}: invalid`
       }
+      case 'luauRuntimeMissing': {
+        return `${err.sourceFile}: ${err.hint}`
+      }
     }
   }
   expect(describe({ kind: 'fileNotFound', searchedFrom: '/proj' })).toBe(
@@ -56,4 +59,11 @@ it('Example 2', () => {
       ],
     }),
   ).toBe('bedrock.config.ts: passes.vip.price must be a number')
+  expect(
+    describe({
+      kind: 'luauRuntimeMissing',
+      sourceFile: 'bedrock.config.luau',
+      hint: 'install lute via mise',
+    }),
+  ).toBe('bedrock.config.luau: install lute via mise')
 })

--- a/packages/bedrock/src/core/config-error.spec-d.ts
+++ b/packages/bedrock/src/core/config-error.spec-d.ts
@@ -1,0 +1,76 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { ConfigError, ConfigValidationIssue } from "./config-error.ts";
+
+interface ExpectedFileNotFound {
+	readonly kind: "fileNotFound";
+	readonly searchedFrom: string;
+}
+
+interface ExpectedParseFailed {
+	readonly kind: "parseFailed";
+	readonly message: string;
+	readonly sourceFile: string;
+}
+
+interface ExpectedConfigFunctionFailed {
+	readonly kind: "configFunctionFailed";
+	readonly message: string;
+	readonly sourceFile: string;
+}
+
+interface ExpectedValidationFailed {
+	readonly issues: ReadonlyArray<ConfigValidationIssue>;
+	readonly kind: "validationFailed";
+	readonly sourceFile: string;
+}
+
+interface ExpectedLuauRuntimeMissing {
+	readonly hint: string;
+	readonly kind: "luauRuntimeMissing";
+	readonly sourceFile: string;
+}
+
+describe("ConfigError discriminant", () => {
+	it("should discriminate on kind across the five documented variants", () => {
+		expectTypeOf<ConfigError["kind"]>().toEqualTypeOf<
+			| "configFunctionFailed"
+			| "fileNotFound"
+			| "luauRuntimeMissing"
+			| "parseFailed"
+			| "validationFailed"
+		>();
+	});
+});
+
+describe("ConfigError variants", () => {
+	it("should narrow fileNotFound to carry only searchedFrom", () => {
+		expectTypeOf<
+			Extract<ConfigError, { kind: "fileNotFound" }>
+		>().toEqualTypeOf<ExpectedFileNotFound>();
+	});
+
+	it("should narrow parseFailed to carry message and sourceFile", () => {
+		expectTypeOf<
+			Extract<ConfigError, { kind: "parseFailed" }>
+		>().toEqualTypeOf<ExpectedParseFailed>();
+	});
+
+	it("should narrow configFunctionFailed to carry message and sourceFile", () => {
+		expectTypeOf<
+			Extract<ConfigError, { kind: "configFunctionFailed" }>
+		>().toEqualTypeOf<ExpectedConfigFunctionFailed>();
+	});
+
+	it("should narrow validationFailed to carry issues and sourceFile", () => {
+		expectTypeOf<
+			Extract<ConfigError, { kind: "validationFailed" }>
+		>().toEqualTypeOf<ExpectedValidationFailed>();
+	});
+
+	it("should narrow luauRuntimeMissing to carry hint and sourceFile", () => {
+		expectTypeOf<
+			Extract<ConfigError, { kind: "luauRuntimeMissing" }>
+		>().toEqualTypeOf<ExpectedLuauRuntimeMissing>();
+	});
+});

--- a/packages/bedrock/src/core/config-error.ts
+++ b/packages/bedrock/src/core/config-error.ts
@@ -40,6 +40,10 @@ export interface ConfigValidationIssue {
  * - `configFunctionFailed` - a function-form config threw or its returned
  *   promise rejected while being invoked. `message` carries the thrown
  *   error's message verbatim.
+ * - `luauRuntimeMissing` - a `bedrock.config.luau` file was found but the
+ *   `lute` runtime needed to evaluate it could not be located on PATH or
+ *   via the `BEDROCK_LUTE_PATH` environment variable. `hint` carries an
+ *   actionable install message.
  *
  * @example
  *
@@ -62,6 +66,9 @@ export interface ConfigValidationIssue {
  *             return first
  *                 ? `${err.sourceFile}: ${first.path.join(".")} ${first.message}`
  *                 : `${err.sourceFile}: invalid`;
+ *         }
+ *         case "luauRuntimeMissing": {
+ *             return `${err.sourceFile}: ${err.hint}`;
  *         }
  *     }
  * }
@@ -90,9 +97,21 @@ export interface ConfigValidationIssue {
  *         issues: [{ path: ["passes", "vip", "price"], message: "must be a number" }],
  *     }),
  * ).toBe("bedrock.config.ts: passes.vip.price must be a number");
+ * expect(
+ *     describe({
+ *         kind: "luauRuntimeMissing",
+ *         sourceFile: "bedrock.config.luau",
+ *         hint: "install lute via mise",
+ *     }),
+ * ).toBe("bedrock.config.luau: install lute via mise");
  * ```
  */
 export type ConfigError =
+	| {
+			readonly hint: string;
+			readonly kind: "luauRuntimeMissing";
+			readonly sourceFile: string;
+	  }
 	| {
 			readonly issues: ReadonlyArray<ConfigValidationIssue>;
 			readonly kind: "validationFailed";

--- a/packages/bedrock/src/index.spec-d.ts
+++ b/packages/bedrock/src/index.spec-d.ts
@@ -24,7 +24,6 @@ import type {
 	ConfigContext,
 	ConfigError,
 	ConfigInput,
-	ConfigValidationIssue,
 	DeployError,
 	DeployOptions,
 	LoadConfigOptions,
@@ -38,35 +37,6 @@ import type {
 	RobloxAssetId,
 	Sha256Hex,
 } from "./index.ts";
-
-interface ExpectedFileNotFound {
-	readonly kind: "fileNotFound";
-	readonly searchedFrom: string;
-}
-
-interface ExpectedParseFailed {
-	readonly kind: "parseFailed";
-	readonly message: string;
-	readonly sourceFile: string;
-}
-
-interface ExpectedConfigFunctionFailed {
-	readonly kind: "configFunctionFailed";
-	readonly message: string;
-	readonly sourceFile: string;
-}
-
-interface ExpectedValidationFailed {
-	readonly issues: ReadonlyArray<ConfigValidationIssue>;
-	readonly kind: "validationFailed";
-	readonly sourceFile: string;
-}
-
-interface ExpectedLuauRuntimeMissing {
-	readonly hint: string;
-	readonly kind: "luauRuntimeMissing";
-	readonly sourceFile: string;
-}
 
 function syncConfigBuilder(_ctx: ConfigContext): Config {
 	return { environments: { production: {} }, passes: {} };
@@ -273,50 +243,6 @@ describe(loadConfig, () => {
 
 	it("should expose configFile as an optional string on LoadConfigOptions", () => {
 		expectTypeOf<LoadConfigOptions["configFile"]>().toEqualTypeOf<string | undefined>();
-	});
-});
-
-describe("ConfigError discriminant", () => {
-	it("should discriminate on kind across the five documented variants", () => {
-		expectTypeOf<ConfigError["kind"]>().toEqualTypeOf<
-			| "configFunctionFailed"
-			| "fileNotFound"
-			| "luauRuntimeMissing"
-			| "parseFailed"
-			| "validationFailed"
-		>();
-	});
-});
-
-describe("ConfigError variants", () => {
-	it("should narrow fileNotFound to carry only searchedFrom", () => {
-		expectTypeOf<
-			Extract<ConfigError, { kind: "fileNotFound" }>
-		>().toEqualTypeOf<ExpectedFileNotFound>();
-	});
-
-	it("should narrow parseFailed to carry message and sourceFile", () => {
-		expectTypeOf<
-			Extract<ConfigError, { kind: "parseFailed" }>
-		>().toEqualTypeOf<ExpectedParseFailed>();
-	});
-
-	it("should narrow configFunctionFailed to carry message and sourceFile", () => {
-		expectTypeOf<
-			Extract<ConfigError, { kind: "configFunctionFailed" }>
-		>().toEqualTypeOf<ExpectedConfigFunctionFailed>();
-	});
-
-	it("should narrow validationFailed to carry issues and sourceFile", () => {
-		expectTypeOf<
-			Extract<ConfigError, { kind: "validationFailed" }>
-		>().toEqualTypeOf<ExpectedValidationFailed>();
-	});
-
-	it("should narrow luauRuntimeMissing to carry hint and sourceFile", () => {
-		expectTypeOf<
-			Extract<ConfigError, { kind: "luauRuntimeMissing" }>
-		>().toEqualTypeOf<ExpectedLuauRuntimeMissing>();
 	});
 });
 

--- a/packages/bedrock/src/index.spec-d.ts
+++ b/packages/bedrock/src/index.spec-d.ts
@@ -62,6 +62,12 @@ interface ExpectedValidationFailed {
 	readonly sourceFile: string;
 }
 
+interface ExpectedLuauRuntimeMissing {
+	readonly hint: string;
+	readonly kind: "luauRuntimeMissing";
+	readonly sourceFile: string;
+}
+
 function syncConfigBuilder(_ctx: ConfigContext): Config {
 	return { environments: { production: {} }, passes: {} };
 }
@@ -270,13 +276,19 @@ describe(loadConfig, () => {
 	});
 });
 
-describe("ConfigError", () => {
-	it("should discriminate on kind across the four documented variants", () => {
+describe("ConfigError discriminant", () => {
+	it("should discriminate on kind across the five documented variants", () => {
 		expectTypeOf<ConfigError["kind"]>().toEqualTypeOf<
-			"configFunctionFailed" | "fileNotFound" | "parseFailed" | "validationFailed"
+			| "configFunctionFailed"
+			| "fileNotFound"
+			| "luauRuntimeMissing"
+			| "parseFailed"
+			| "validationFailed"
 		>();
 	});
+});
 
+describe("ConfigError variants", () => {
 	it("should narrow fileNotFound to carry only searchedFrom", () => {
 		expectTypeOf<
 			Extract<ConfigError, { kind: "fileNotFound" }>
@@ -299,6 +311,12 @@ describe("ConfigError", () => {
 		expectTypeOf<
 			Extract<ConfigError, { kind: "validationFailed" }>
 		>().toEqualTypeOf<ExpectedValidationFailed>();
+	});
+
+	it("should narrow luauRuntimeMissing to carry hint and sourceFile", () => {
+		expectTypeOf<
+			Extract<ConfigError, { kind: "luauRuntimeMissing" }>
+		>().toEqualTypeOf<ExpectedLuauRuntimeMissing>();
 	});
 });
 

--- a/packages/bedrock/src/shell/deploy.spec-d.ts
+++ b/packages/bedrock/src/shell/deploy.spec-d.ts
@@ -50,7 +50,11 @@ describe("DeployError - registry and config variants", () => {
 		expectTypeOf<
 			Extract<DeployError, { kind: "configLoadFailed" }>["cause"]["kind"]
 		>().toEqualTypeOf<
-			"configFunctionFailed" | "fileNotFound" | "parseFailed" | "validationFailed"
+			| "configFunctionFailed"
+			| "fileNotFound"
+			| "luauRuntimeMissing"
+			| "parseFailed"
+			| "validationFailed"
 		>();
 	});
 });

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -1,9 +1,20 @@
+import { spawnSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import process from "node:process";
 import { assert, describe, expect, it } from "vitest";
 
 import { loadConfig } from "./load-config.ts";
+
+const HAS_LUTE = (() => {
+	if ((process.env["BEDROCK_LUTE_PATH"] ?? "").length > 0) {
+		return true;
+	}
+
+	const lookup = process.platform === "win32" ? "where" : "which";
+	return spawnSync(lookup, ["lute"]).status === 0;
+})();
 
 async function withTemporaryDirectory<T>(run: (directory: string) => Promise<T>): Promise<T> {
 	const directory = mkdtempSync(join(tmpdir(), "bedrock-load-config-"));
@@ -319,6 +330,35 @@ describe(loadConfig, () => {
 			"bedrock.config.json",
 			'{ "passes": { "vip-pass": { "name": "VIP Pass", } } }\n',
 		);
+	});
+
+	it.skipIf(!HAS_LUTE)("should load a Luau config file via Lute", async () => {
+		expect.assertions(1);
+
+		await withTemporaryDirectory(async (cwd) => {
+			writeFileSync(
+				join(cwd, "bedrock.config.luau"),
+				[
+					"return {",
+					"  passes = {",
+					"    ['vip-pass'] = {",
+					"      description = 'Grants VIP perks.',",
+					"      iconFilePath = 'assets/vip-icon.png',",
+					"      name = 'VIP Pass',",
+					"      price = 500,",
+					"    },",
+					"  },",
+					"}",
+					"",
+				].join("\n"),
+			);
+
+			const result = await loadConfig({ cwd });
+
+			assert(result.success);
+
+			expect(result.data.passes!["vip-pass"]!.name).toBe("VIP Pass");
+		});
 	});
 
 	it("should return a fresh copy on each call so mutation does not leak between invocations", async () => {

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -421,6 +421,52 @@ describe(loadConfig, () => {
 		});
 	});
 
+	it.skipIf(!HAS_LUTE)(
+		"should layer a Luau base config when the main TypeScript config extends it",
+		async () => {
+			expect.assertions(2);
+
+			await withTemporaryDirectory(async (cwd) => {
+				writeFileSync(
+					join(cwd, "base.luau"),
+					[
+						"return {",
+						"  passes = {",
+						"    ['vip-pass'] = {",
+						"      description = 'Grants VIP perks.',",
+						"      iconFilePath = 'assets/vip-icon.png',",
+						"      name = 'VIP Pass',",
+						"      price = 500,",
+						"    },",
+						"  },",
+						"}",
+						"",
+					].join("\n"),
+				);
+				writeFixtureConfig(cwd, [
+					"export default {",
+					"  extends: './base.luau',",
+					"  passes: {",
+					"    'gold-pass': {",
+					"      description: 'Gold tier perks.',",
+					"      iconFilePath: 'assets/gold-icon.png',",
+					"      name: 'Gold Pass',",
+					"      price: 1000,",
+					"    },",
+					"  },",
+					"};",
+				]);
+
+				const result = await loadConfig({ cwd });
+
+				assert(result.success);
+
+				expect(result.data.passes!["vip-pass"]!.name).toBe("VIP Pass");
+				expect(result.data.passes!["gold-pass"]!.name).toBe("Gold Pass");
+			});
+		},
+	);
+
 	it("should return a fresh copy on each call so mutation does not leak between invocations", async () => {
 		expect.assertions(1);
 

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -1,6 +1,6 @@
 import { HAS_LUTE } from "@bedrock/testing/lute";
 
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
@@ -534,6 +534,186 @@ describe(loadConfig, () => {
 				assert(result.success);
 
 				expect(result.data.passes!["vip-pass"]!.name).toBe("Staging Pass");
+			});
+		},
+	);
+
+	it.skipIf(!HAS_LUTE)("should reject a Luau config that returns a non-table value", async () => {
+		expect.assertions(2);
+
+		await withTemporaryDirectory(async (cwd) => {
+			writeFileSync(join(cwd, "bedrock.config.luau"), "return 42\n");
+
+			const result = await loadConfig({ cwd });
+
+			assert(!result.success);
+			assert(result.err.kind === "parseFailed");
+
+			expect(result.err.sourceFile).toBe(join(cwd, "bedrock.config.luau"));
+			expect(result.err.message).toContain("table at the root");
+		});
+	});
+
+	it.skipIf(!HAS_LUTE)(
+		"should fall back to the PATH lute when BEDROCK_LUTE_PATH is set to an empty string",
+		async () => {
+			expect.assertions(1);
+
+			await withTemporaryDirectory(async (cwd) => {
+				writeFileSync(
+					join(cwd, "bedrock.config.luau"),
+					["return { passes = {} }", ""].join("\n"),
+				);
+
+				const previous = process.env["BEDROCK_LUTE_PATH"];
+				process.env["BEDROCK_LUTE_PATH"] = "";
+				let result: Awaited<ReturnType<typeof loadConfig>>;
+				try {
+					result = await loadConfig({ cwd });
+				} finally {
+					if (previous === undefined) {
+						delete process.env["BEDROCK_LUTE_PATH"];
+					} else {
+						process.env["BEDROCK_LUTE_PATH"] = previous;
+					}
+				}
+
+				// An empty override must be treated as "not set" so the loader
+				// falls through to `lute` on PATH; gating on `length > 0` is what
+				// makes that fallback observable.
+				expect(result.success).toBeTrue();
+			});
+		},
+	);
+
+	it.skipIf(!HAS_LUTE)(
+		"should remove the bootstrap temp directory after evaluating a Luau config",
+		async () => {
+			expect.assertions(1);
+
+			await withTemporaryDirectory(async (cwd) => {
+				writeFileSync(
+					join(cwd, "bedrock.config.luau"),
+					["return { passes = {} }", ""].join("\n"),
+				);
+
+				const before = new Set(readdirSync(tmpdir()));
+
+				await loadConfig({ cwd });
+
+				const after = readdirSync(tmpdir());
+				const leaked = after.filter((entry) => !before.has(entry));
+
+				expect(leaked).toStrictEqual([]);
+			});
+		},
+	);
+
+	it.skipIf(!HAS_LUTE)(
+		"should bound a hanging Luau config with the bootstrap timeout",
+		async () => {
+			expect.assertions(1);
+
+			await withTemporaryDirectory(async (cwd) => {
+				writeFileSync(
+					join(cwd, "bedrock.config.luau"),
+					["while true do end", ""].join("\n"),
+				);
+
+				const result = await loadConfig({ cwd });
+
+				assert(!result.success);
+
+				expect(result.err.kind).toBe("parseFailed");
+			});
+		},
+		15_000,
+	);
+
+	it.skipIf(!HAS_LUTE)(
+		"should surface a non-ENOENT spawn failure as parseFailed rather than luauRuntimeMissing",
+		async () => {
+			expect.assertions(1);
+
+			await withTemporaryDirectory(async (cwd) => {
+				writeFileSync(
+					join(cwd, "bedrock.config.luau"),
+					["return { passes = {} }", ""].join("\n"),
+				);
+
+				const previous = process.env["BEDROCK_LUTE_PATH"];
+				// Pointing at the directory itself (not a binary inside it) makes
+				// execFile fail with EACCES/EISDIR, not ENOENT - the loader must
+				// fall through to parseFailed instead of claiming the runtime is
+				// missing.
+				process.env["BEDROCK_LUTE_PATH"] = cwd;
+				let result: Awaited<ReturnType<typeof loadConfig>>;
+				try {
+					result = await loadConfig({ cwd });
+				} finally {
+					if (previous === undefined) {
+						delete process.env["BEDROCK_LUTE_PATH"];
+					} else {
+						process.env["BEDROCK_LUTE_PATH"] = previous;
+					}
+				}
+
+				assert(!result.success);
+
+				expect(result.err.kind).toBe("parseFailed");
+			});
+		},
+	);
+
+	it.skipIf(!HAS_LUTE)(
+		"should layer extends from a Luau configFile when it references another Luau file",
+		async () => {
+			expect.assertions(2);
+
+			await withTemporaryDirectory(async (cwd) => {
+				writeFileSync(
+					join(cwd, "base.luau"),
+					[
+						"return {",
+						"  passes = {",
+						"    ['vip-pass'] = {",
+						"      description = 'VIP perks.',",
+						"      iconFilePath = 'assets/vip.png',",
+						"      name = 'VIP Pass',",
+						"      price = 500,",
+						"    },",
+						"  },",
+						"}",
+						"",
+					].join("\n"),
+				);
+				writeFileSync(
+					join(cwd, "bedrock.staging.config.luau"),
+					[
+						"return {",
+						"  extends = './base.luau',",
+						"  passes = {",
+						"    ['gold-pass'] = {",
+						"      description = 'Gold tier perks.',",
+						"      iconFilePath = 'assets/gold.png',",
+						"      name = 'Gold Pass',",
+						"      price = 1000,",
+						"    },",
+						"  },",
+						"}",
+						"",
+					].join("\n"),
+				);
+
+				const result = await loadConfig({
+					configFile: "bedrock.staging.config.luau",
+					cwd,
+				});
+
+				assert(result.success);
+
+				expect(result.data.passes!["vip-pass"]!.name).toBe("VIP Pass");
+				expect(result.data.passes!["gold-pass"]!.name).toBe("Gold Pass");
 			});
 		},
 	);

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -361,6 +361,35 @@ describe(loadConfig, () => {
 		});
 	});
 
+	it.skipIf(!HAS_LUTE)(
+		"should return a parseFailed error attributed to the file when a Luau config returns a non-serializable value",
+		async () => {
+			expect.assertions(3);
+
+			await withTemporaryDirectory(async (cwd) => {
+				writeFileSync(
+					join(cwd, "bedrock.config.luau"),
+					[
+						"return {",
+						"  -- Function-valued field cannot be JSON-encoded; bootstrap must fail loudly.",
+						"  computed = function() return 42 end,",
+						"}",
+						"",
+					].join("\n"),
+				);
+
+				const result = await loadConfig({ cwd });
+
+				assert(!result.success);
+				assert(result.err.kind === "parseFailed");
+
+				expect(result.err.sourceFile).toBe(join(cwd, "bedrock.config.luau"));
+				expect(result.err.message).toContain("Unknown value");
+				expect(result.err.message).not.toContain("__BEDROCK_LUAU_");
+			});
+		},
+	);
+
 	it("should return a fresh copy on each call so mutation does not leak between invocations", async () => {
 		expect.assertions(1);
 

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -586,28 +586,28 @@ describe(loadConfig, () => {
 		},
 	);
 
-	it.skipIf(!HAS_LUTE)(
-		"should remove the bootstrap temp directory after evaluating a Luau config",
-		async () => {
-			expect.assertions(1);
+	// Not gated on HAS_LUTE: the cleanup runs in `finally` whether lute spawns
+	// successfully or fails with ENOENT, so the test exercises the same
+	// behaviour either way.
+	it("should remove the bootstrap temp directory after evaluating a Luau config", async () => {
+		expect.assertions(1);
 
-			await withTemporaryDirectory(async (cwd) => {
-				writeFileSync(
-					join(cwd, "bedrock.config.luau"),
-					["return { passes = {} }", ""].join("\n"),
-				);
+		await withTemporaryDirectory(async (cwd) => {
+			writeFileSync(
+				join(cwd, "bedrock.config.luau"),
+				["return { passes = {} }", ""].join("\n"),
+			);
 
-				const before = new Set(readdirSync(tmpdir()));
+			const before = new Set(readdirSync(tmpdir()));
 
-				await loadConfig({ cwd });
+			await loadConfig({ cwd });
 
-				const after = readdirSync(tmpdir());
-				const leaked = after.filter((entry) => !before.has(entry));
+			const after = readdirSync(tmpdir());
+			const leaked = after.filter((entry) => !before.has(entry));
 
-				expect(leaked).toStrictEqual([]);
-			});
-		},
-	);
+			expect(leaked).toStrictEqual([]);
+		});
+	});
 
 	it.skipIf(!HAS_LUTE)(
 		"should bound a hanging Luau config with the bootstrap timeout",

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -1,4 +1,5 @@
-import { spawnSync } from "node:child_process";
+import { HAS_LUTE } from "@bedrock/testing/lute";
+
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -6,15 +7,6 @@ import process from "node:process";
 import { assert, describe, expect, it } from "vitest";
 
 import { loadConfig } from "./load-config.ts";
-
-const HAS_LUTE = (() => {
-	if ((process.env["BEDROCK_LUTE_PATH"] ?? "").length > 0) {
-		return true;
-	}
-
-	const lookup = process.platform === "win32" ? "where" : "which";
-	return spawnSync(lookup, ["lute"]).status === 0;
-})();
 
 async function withTemporaryDirectory<T>(run: (directory: string) => Promise<T>): Promise<T> {
 	const directory = mkdtempSync(join(tmpdir(), "bedrock-load-config-"));

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -467,6 +467,50 @@ describe(loadConfig, () => {
 		},
 	);
 
+	it.skipIf(!HAS_LUTE)(
+		"should defer to a TypeScript sibling when both bedrock.config.ts and bedrock.config.luau exist",
+		async () => {
+			expect.assertions(1);
+
+			await withTemporaryDirectory(async (cwd) => {
+				writeFixtureConfig(cwd, [
+					"export default {",
+					"  passes: {",
+					"    'vip-pass': {",
+					"      description: 'TS wins.',",
+					"      iconFilePath: 'assets/vip-icon.png',",
+					"      name: 'TS Pass',",
+					"      price: 500,",
+					"    },",
+					"  },",
+					"};",
+				]);
+				writeFileSync(
+					join(cwd, "bedrock.config.luau"),
+					[
+						"return {",
+						"  passes = {",
+						"    ['vip-pass'] = {",
+						"      description = 'Luau loses.',",
+						"      iconFilePath = 'assets/vip-icon.png',",
+						"      name = 'Luau Pass',",
+						"      price = 500,",
+						"    },",
+						"  },",
+						"}",
+						"",
+					].join("\n"),
+				);
+
+				const result = await loadConfig({ cwd });
+
+				assert(result.success);
+
+				expect(result.data.passes!["vip-pass"]!.name).toBe("TS Pass");
+			});
+		},
+	);
+
 	it("should return a fresh copy on each call so mutation does not leak between invocations", async () => {
 		expect.assertions(1);
 

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -503,6 +503,41 @@ describe(loadConfig, () => {
 		},
 	);
 
+	it.skipIf(!HAS_LUTE)(
+		"should evaluate a Luau file when configFile names it explicitly",
+		async () => {
+			expect.assertions(1);
+
+			await withTemporaryDirectory(async (cwd) => {
+				writeFileSync(
+					join(cwd, "bedrock.staging.config.luau"),
+					[
+						"return {",
+						"  passes = {",
+						"    ['vip-pass'] = {",
+						"      description = 'Staging perks.',",
+						"      iconFilePath = 'assets/staging.png',",
+						"      name = 'Staging Pass',",
+						"      price = 100,",
+						"    },",
+						"  },",
+						"}",
+						"",
+					].join("\n"),
+				);
+
+				const result = await loadConfig({
+					configFile: "bedrock.staging.config.luau",
+					cwd,
+				});
+
+				assert(result.success);
+
+				expect(result.data.passes!["vip-pass"]!.name).toBe("Staging Pass");
+			});
+		},
+	);
+
 	it("should return a fresh copy on each call so mutation does not leak between invocations", async () => {
 		expect.assertions(1);
 

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -332,6 +332,7 @@ describe(loadConfig, () => {
 				join(cwd, "bedrock.config.luau"),
 				[
 					"return {",
+					"  environments = { production = {} },",
 					"  passes = {",
 					"    ['vip-pass'] = {",
 					"      description = 'Grants VIP perks.',",
@@ -438,6 +439,7 @@ describe(loadConfig, () => {
 				writeFixtureConfig(cwd, [
 					"export default {",
 					"  extends: './base.luau',",
+					"  environments: { production: {} },",
 					"  passes: {",
 					"    'gold-pass': {",
 					"      description: 'Gold tier perks.',",
@@ -467,6 +469,7 @@ describe(loadConfig, () => {
 			await withTemporaryDirectory(async (cwd) => {
 				writeFixtureConfig(cwd, [
 					"export default {",
+					"  environments: { production: {} },",
 					"  passes: {",
 					"    'vip-pass': {",
 					"      description: 'TS wins.',",
@@ -513,6 +516,7 @@ describe(loadConfig, () => {
 					join(cwd, "bedrock.staging.config.luau"),
 					[
 						"return {",
+						"  environments = { staging = {} },",
 						"  passes = {",
 						"    ['vip-pass'] = {",
 						"      description = 'Staging perks.',",
@@ -562,7 +566,7 @@ describe(loadConfig, () => {
 			await withTemporaryDirectory(async (cwd) => {
 				writeFileSync(
 					join(cwd, "bedrock.config.luau"),
-					["return { passes = {} }", ""].join("\n"),
+					["return { environments = { production = {} }, passes = {} }", ""].join("\n"),
 				);
 
 				const previous = process.env["BEDROCK_LUTE_PATH"];
@@ -692,6 +696,7 @@ describe(loadConfig, () => {
 					[
 						"return {",
 						"  extends = './base.luau',",
+						"  environments = { staging = {} },",
 						"  passes = {",
 						"    ['gold-pass'] = {",
 						"      description = 'Gold tier perks.',",

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -390,6 +390,37 @@ describe(loadConfig, () => {
 		},
 	);
 
+	it("should return a luauRuntimeMissing error when no lute binary is reachable", async () => {
+		expect.assertions(3);
+
+		await withTemporaryDirectory(async (cwd) => {
+			writeFileSync(
+				join(cwd, "bedrock.config.luau"),
+				["return { passes = {} }", ""].join("\n"),
+			);
+
+			const previous = process.env["BEDROCK_LUTE_PATH"];
+			process.env["BEDROCK_LUTE_PATH"] = "/nonexistent/path/to/lute-binary-xyz";
+			let result: Awaited<ReturnType<typeof loadConfig>>;
+			try {
+				result = await loadConfig({ cwd });
+			} finally {
+				if (previous === undefined) {
+					delete process.env["BEDROCK_LUTE_PATH"];
+				} else {
+					process.env["BEDROCK_LUTE_PATH"] = previous;
+				}
+			}
+
+			assert(!result.success);
+			assert(result.err.kind === "luauRuntimeMissing");
+
+			expect(result.err.kind).toBe("luauRuntimeMissing");
+			expect(result.err.sourceFile).toBe(join(cwd, "bedrock.config.luau"));
+			expect(result.err.hint).toContain("BEDROCK_LUTE_PATH");
+		});
+	});
+
 	it("should return a fresh copy on each call so mutation does not leak between invocations", async () => {
 		expect.assertions(1);
 

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -1,8 +1,10 @@
 import type { Result } from "@bedrock/ocale";
 
 import { loadConfig as c12LoadConfig } from "c12";
-import { readdirSync, statSync } from "node:fs";
-import { isAbsolute, join } from "node:path";
+import { execFile } from "node:child_process";
+import { existsSync, mkdtempSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, isAbsolute, join } from "node:path";
 import process from "node:process";
 
 import type { ConfigError } from "../core/config-error.ts";
@@ -26,6 +28,14 @@ export interface LoadConfigOptions {
 	 * each invocation sees the current working directory.
 	 */
 	readonly cwd?: string;
+}
+
+interface LuauResolveResult {
+	/* eslint-disable-next-line flawless/naming-convention -- c12 reads `_configFile` to detect that a config file was found. */
+	readonly _configFile: string;
+	readonly config: Record<string, unknown>;
+	readonly configFile: string;
+	readonly cwd: string;
 }
 
 /**
@@ -82,6 +92,7 @@ export async function loadConfig(
 		resolved = await c12LoadConfig<Record<string, unknown>>({
 			name: "bedrock",
 			cwd,
+			resolve: makeLuauResolver(cwd),
 			...(configFile === undefined ? {} : { configFile }),
 		});
 	} catch (err) {
@@ -105,6 +116,138 @@ function isExistingFile(path: string): boolean {
 	} catch {
 		return false;
 	}
+}
+
+function makeLuauResolver(
+	defaultCwd: string,
+): (
+	source: string,
+	c12Options: { readonly configFile?: string; readonly cwd?: string },
+) => Promise<LuauResolveResult | undefined> {
+	return async (source, c12Options) => {
+		if (source !== ".") {
+			return;
+		}
+
+		// Defer to c12 when the caller named a specific configFile - their
+		// intent is to load that exact file, not whatever bedrock.config.luau
+		// happens to be sitting next to it.
+		if (c12Options.configFile !== undefined) {
+			return;
+		}
+
+		const cwd = c12Options.cwd ?? defaultCwd;
+		const luauPath = join(cwd, LUAU_CONFIG_BASENAME);
+		if (!existsSync(luauPath)) {
+			return;
+		}
+
+		const config = await evaluateLuauConfig(luauPath);
+		return {
+			_configFile: luauPath,
+			config,
+			configFile: luauPath,
+			cwd,
+		};
+	};
+}
+
+const LUAU_CONFIG_BASENAME = "bedrock.config.luau";
+
+const LUTE_BOOTSTRAP_LUAU = `--!strict
+local json = require("@std/json")
+local process = require("@std/process")
+local io = require("@std/io")
+
+local function emit(kind, payload)
+    io.write("__BEDROCK_LUAU_" .. kind .. "__")
+    io.write(json.serialize(payload))
+end
+
+local userBasename = process.args[2]
+-- The user file lives in a different directory from this bootstrap, so we
+-- require it via the @user alias defined in the .luaurc written alongside.
+local req = "@user/" .. string.gsub(userBasename, "%.luau$", "")
+
+local loadOk, modOrErr = pcall(require, req)
+if not loadOk then
+    emit("ERR", { kind = "loadFailed", message = tostring(modOrErr) })
+    return
+end
+
+local value = if type(modOrErr) == "function" then modOrErr() else modOrErr
+
+local encOk, encoded = pcall(json.serialize, value)
+if not encOk then
+    emit("ERR", { kind = "serializeFailed", message = tostring(encoded) })
+    return
+end
+
+io.write("__BEDROCK_LUAU_OK__")
+io.write(encoded)
+`;
+
+interface LuteRunOptions {
+	readonly bin: string;
+	readonly bootstrapPath: string;
+	readonly cwd: string;
+	readonly userBasename: string;
+}
+
+async function runLuteBootstrap(runOptions: LuteRunOptions): Promise<string> {
+	const { bin, bootstrapPath, cwd, userBasename } = runOptions;
+	return new Promise((resolve, reject) => {
+		execFile(
+			bin,
+			["run", bootstrapPath, userBasename],
+			{ cwd, encoding: "utf8" },
+			(error, stdout) => {
+				if (error instanceof Error) {
+					reject(error);
+					return;
+				}
+
+				resolve(stdout);
+			},
+		);
+	});
+}
+
+async function evaluateLuauConfig(absPath: string): Promise<Record<string, unknown>> {
+	const overridePath = process.env["BEDROCK_LUTE_PATH"];
+	const lute = overridePath !== undefined && overridePath.length > 0 ? overridePath : "lute";
+	const cwd = dirname(absPath);
+	const base = basename(absPath);
+
+	const bootstrapDirectory = mkdtempSync(join(tmpdir(), "bedrock-lute-"));
+	const bootstrapPath = join(bootstrapDirectory, "bootstrap.luau");
+	writeFileSync(bootstrapPath, LUTE_BOOTSTRAP_LUAU);
+	// Lute resolves `require` relative to the calling script's directory, not
+	// the process cwd. The bootstrap lives in a temp dir, so we expose the
+	// user's directory via a `.luaurc` alias that the bootstrap requires by name.
+	writeFileSync(join(bootstrapDirectory, ".luaurc"), JSON.stringify({ aliases: { user: cwd } }));
+
+	const stdout = await runLuteBootstrap({
+		bin: lute,
+		bootstrapPath,
+		cwd,
+		userBasename: base,
+	});
+
+	const okPrefix = "__BEDROCK_LUAU_OK__";
+	if (!stdout.startsWith(okPrefix)) {
+		throw new Error(
+			`Luau config evaluation produced unexpected output: ${stdout.slice(0, 200)}`,
+		);
+	}
+
+	const parsed = JSON.parse(stdout.slice(okPrefix.length));
+
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new TypeError("Luau config must return a table at the root");
+	}
+
+	return parsed as Record<string, unknown>;
 }
 
 const CONFIG_FILE_IN_FRAME = /[^\s():"']*bedrock\.config\.(?:ts|js|mjs|cjs|yaml|yml|json)/;

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -92,7 +92,7 @@ export async function loadConfig(
 		resolved = await c12LoadConfig<Record<string, unknown>>({
 			name: "bedrock",
 			cwd,
-			resolve: makeLuauResolver(cwd, configFile !== undefined),
+			resolve: makeLuauResolver(cwd, configFile),
 			...(configFile === undefined ? {} : { configFile }),
 		});
 	} catch (err) {
@@ -174,27 +174,44 @@ const NATIVE_CONFIG_EXTENSIONS = [
 	"yml",
 ] as const;
 
+interface PickLuauTargetContext {
+	readonly callerConfigFile: string | undefined;
+	readonly cwd: string;
+}
+
+/**
+ * Decide which Luau file the resolver should evaluate for a given c12 source,
+ * or `undefined` to defer to c12's built-in loaders.
+ *
+ * When the caller named a specific configFile, c12 always invokes us with
+ * source === "." for the main config (and normalizes its own
+ * options.configFile to "bedrock.config", so we cannot inspect it). Route
+ * the explicit path through our evaluator if it points at a `.luau` file;
+ * otherwise defer.
+ * @param source - The c12 `resolve` source string.
+ * @param context - Caller-side state: the resolved cwd to search in, and the
+ * caller's configFile path (or undefined when no explicit path was supplied).
+ * @returns The absolute path of the Luau file to evaluate, or `undefined`.
+ */
+function pickLuauTarget(source: string, context: PickLuauTargetContext): string | undefined {
+	const { callerConfigFile, cwd } = context;
+	if (source === "." && callerConfigFile !== undefined) {
+		return callerConfigFile.endsWith(".luau") ? callerConfigFile : undefined;
+	}
+
+	return locateLuauConfig(source, cwd);
+}
+
 function makeLuauResolver(
 	defaultCwd: string,
-	callerSetConfigFile: boolean,
+	callerConfigFile: string | undefined,
 ): (
 	source: string,
 	c12Options: { readonly cwd?: string },
 ) => Promise<LuauResolveResult | undefined> {
 	return async (source, c12Options) => {
-		// For auto-discovery (source === "."), defer when the caller named a
-		// specific configFile - their intent is to load that exact file, not
-		// whatever bedrock.config.luau happens to be sitting next to it.
-		// Note: c12 normalizes options.configFile to "bedrock.config" by default,
-		// so we cannot inspect c12Options here; the caller-set flag is captured
-		// from loadConfig's own options before c12 sees them.
-		// Explicit `.luau` paths (e.g. an extends clause) always go through us.
-		if (source === "." && callerSetConfigFile) {
-			return;
-		}
-
 		const cwd = c12Options.cwd ?? defaultCwd;
-		const luauPath = locateLuauConfig(source, cwd);
+		const luauPath = pickLuauTarget(source, { callerConfigFile, cwd });
 		if (luauPath === undefined) {
 			return;
 		}
@@ -278,13 +295,18 @@ function isEnoentError(error: unknown): boolean {
 	return error.code === "ENOENT";
 }
 
+// 10s is generous for evaluating a config file: real configs run in
+// milliseconds, and a value this high is meant to catch infinite loops in
+// user code (or a hung lute) without surprising slow-startup environments.
+const LUTE_BOOTSTRAP_TIMEOUT_MS = 10_000;
+
 async function runLuteBootstrap(runOptions: LuteRunOptions): Promise<string> {
 	const { bin, bootstrapPath, cwd, userBasename } = runOptions;
 	return new Promise((resolve, reject) => {
 		execFile(
 			bin,
 			["run", bootstrapPath, userBasename],
-			{ cwd, encoding: "utf8" },
+			{ cwd, encoding: "utf8", timeout: LUTE_BOOTSTRAP_TIMEOUT_MS },
 			(error, stdout) => {
 				if (error instanceof Error) {
 					reject(error);
@@ -305,12 +327,20 @@ function isLuauErrorEnvelope(value: unknown): value is { readonly message: strin
 	return "message" in value && typeof value.message === "string";
 }
 
+function parseEnvelope(raw: string, label: string): JSONValue {
+	try {
+		return JSON.parse(raw);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		throw new Error(`Malformed Luau bootstrap ${label} envelope: ${message}`);
+	}
+}
+
 function parseBootstrapOutput(stdout: string): Record<string, unknown> {
 	if (stdout.startsWith(ERR_PREFIX)) {
-		const envelope = JSON.parse(stdout.slice(ERR_PREFIX.length));
-		const message = isLuauErrorEnvelope(envelope)
-			? envelope.message
-			: stdout.slice(ERR_PREFIX.length);
+		const raw = stdout.slice(ERR_PREFIX.length);
+		const envelope = parseEnvelope(raw, "ERR");
+		const message = isLuauErrorEnvelope(envelope) ? envelope.message : raw;
 		throw new Error(message);
 	}
 
@@ -320,7 +350,7 @@ function parseBootstrapOutput(stdout: string): Record<string, unknown> {
 		);
 	}
 
-	const parsed = JSON.parse(stdout.slice(OK_PREFIX.length));
+	const parsed = parseEnvelope(stdout.slice(OK_PREFIX.length), "OK");
 
 	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
 		throw new TypeError("Luau config must return a table at the root");
@@ -367,6 +397,9 @@ async function evaluateLuauConfig(absPath: string): Promise<Record<string, unkno
 	}
 }
 
+// `.luau` is intentionally absent: Luau errors travel through the bootstrap
+// ERR sentinel, not JS stack frames, so the file path is attributed by
+// `discoverConfigFile` rather than scraped from the throw site.
 const CONFIG_FILE_IN_FRAME = /[^\s():"']*bedrock\.config\.(?:ts|js|mjs|cjs|yaml|yml|json)/;
 
 function extractConfigFileFromStack(err: unknown): string | undefined {

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -4,7 +4,7 @@ import { loadConfig as c12LoadConfig } from "c12";
 import { execFile } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
 import process from "node:process";
 
 import type { ConfigError } from "../core/config-error.ts";
@@ -118,6 +118,38 @@ function isExistingFile(path: string): boolean {
 	}
 }
 
+/**
+ * Resolve a c12 `resolve` source string to an absolute path of a Luau
+ * config file, if one applies. Handles two shapes:
+ *
+ * - Explicit `.luau` paths (`extends: "./base.luau"` or absolute) - always
+ *   ours when the file exists.
+ * - The `"."` auto-discovery source - claim only when `bedrock.config.luau`
+ *   is present in the search directory.
+ *
+ * Returns `undefined` for every other shape so c12 falls through to its
+ * built-in resolution.
+ * @param source - The c12 `resolve` source string (`"."` for auto-discovery,
+ * or a relative or absolute path for explicit `extends` references).
+ * @param cwd - The directory to resolve relative paths against and to search
+ * for `bedrock.config.luau` in.
+ * @returns The absolute path of the matched Luau config, or `undefined` to
+ * defer to c12's built-in resolution.
+ */
+function locateLuauConfig(source: string, cwd: string): string | undefined {
+	if (source.endsWith(".luau")) {
+		const candidate = isAbsolute(source) ? source : resolvePath(cwd, source);
+		return existsSync(candidate) ? candidate : undefined;
+	}
+
+	if (source === ".") {
+		const candidate = join(cwd, LUAU_CONFIG_BASENAME);
+		return existsSync(candidate) ? candidate : undefined;
+	}
+
+	return undefined;
+}
+
 function makeLuauResolver(
 	defaultCwd: string,
 ): (
@@ -125,20 +157,17 @@ function makeLuauResolver(
 	c12Options: { readonly configFile?: string; readonly cwd?: string },
 ) => Promise<LuauResolveResult | undefined> {
 	return async (source, c12Options) => {
-		if (source !== ".") {
-			return;
-		}
-
-		// Defer to c12 when the caller named a specific configFile - their
-		// intent is to load that exact file, not whatever bedrock.config.luau
-		// happens to be sitting next to it.
-		if (c12Options.configFile !== undefined) {
+		// For auto-discovery (source === "."), defer when the caller named a
+		// specific configFile - their intent is to load that exact file, not
+		// whatever bedrock.config.luau happens to be sitting next to it.
+		// Explicit `.luau` paths (e.g. an extends clause) always go through us.
+		if (source === "." && c12Options.configFile !== undefined) {
 			return;
 		}
 
 		const cwd = c12Options.cwd ?? defaultCwd;
-		const luauPath = join(cwd, LUAU_CONFIG_BASENAME);
-		if (!existsSync(luauPath)) {
+		const luauPath = locateLuauConfig(source, cwd);
+		if (luauPath === undefined) {
 			return;
 		}
 

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -234,14 +234,36 @@ async function evaluateLuauConfig(absPath: string): Promise<Record<string, unkno
 		userBasename: base,
 	});
 
-	const okPrefix = "__BEDROCK_LUAU_OK__";
-	if (!stdout.startsWith(okPrefix)) {
+	return parseBootstrapOutput(stdout);
+}
+
+const OK_PREFIX = "__BEDROCK_LUAU_OK__";
+const ERR_PREFIX = "__BEDROCK_LUAU_ERR__";
+
+function isLuauErrorEnvelope(value: unknown): value is { readonly message: string } {
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
+
+	return "message" in value && typeof value.message === "string";
+}
+
+function parseBootstrapOutput(stdout: string): Record<string, unknown> {
+	if (stdout.startsWith(ERR_PREFIX)) {
+		const envelope = JSON.parse(stdout.slice(ERR_PREFIX.length));
+		const message = isLuauErrorEnvelope(envelope)
+			? envelope.message
+			: stdout.slice(ERR_PREFIX.length);
+		throw new Error(message);
+	}
+
+	if (!stdout.startsWith(OK_PREFIX)) {
 		throw new Error(
 			`Luau config evaluation produced unexpected output: ${stdout.slice(0, 200)}`,
 		);
 	}
 
-	const parsed = JSON.parse(stdout.slice(okPrefix.length));
+	const parsed = JSON.parse(stdout.slice(OK_PREFIX.length));
 
 	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
 		throw new TypeError("Luau config must return a table at the root");

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -207,13 +207,17 @@ function makeLuauResolver(
 
 const LUAU_CONFIG_BASENAME = "bedrock.config.luau";
 
+const SENTINEL_BASE = "__BEDROCK_LUAU_";
+const OK_PREFIX = `${SENTINEL_BASE}OK__`;
+const ERR_PREFIX = `${SENTINEL_BASE}ERR__`;
+
 const LUTE_BOOTSTRAP_LUAU = `--!strict
 local json = require("@std/json")
 local process = require("@std/process")
 local io = require("@std/io")
 
 local function emit(kind, payload)
-    io.write("__BEDROCK_LUAU_" .. kind .. "__")
+    io.write("${SENTINEL_BASE}" .. kind .. "__")
     io.write(json.serialize(payload))
 end
 
@@ -236,7 +240,7 @@ if not encOk then
     return
 end
 
-io.write("__BEDROCK_LUAU_OK__")
+io.write("${OK_PREFIX}")
 io.write(encoded)
 `;
 
@@ -289,6 +293,38 @@ async function runLuteBootstrap(runOptions: LuteRunOptions): Promise<string> {
 	});
 }
 
+function isLuauErrorEnvelope(value: unknown): value is { readonly message: string } {
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
+
+	return "message" in value && typeof value.message === "string";
+}
+
+function parseBootstrapOutput(stdout: string): Record<string, unknown> {
+	if (stdout.startsWith(ERR_PREFIX)) {
+		const envelope = JSON.parse(stdout.slice(ERR_PREFIX.length));
+		const message = isLuauErrorEnvelope(envelope)
+			? envelope.message
+			: stdout.slice(ERR_PREFIX.length);
+		throw new Error(message);
+	}
+
+	if (!stdout.startsWith(OK_PREFIX)) {
+		throw new Error(
+			`Luau config evaluation produced unexpected output: ${stdout.slice(0, 200)}`,
+		);
+	}
+
+	const parsed = JSON.parse(stdout.slice(OK_PREFIX.length));
+
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new TypeError("Luau config must return a table at the root");
+	}
+
+	return parsed;
+}
+
 async function evaluateLuauConfig(absPath: string): Promise<Record<string, unknown>> {
 	const overridePath = process.env["BEDROCK_LUTE_PATH"];
 	const lute = overridePath !== undefined && overridePath.length > 0 ? overridePath : "lute";
@@ -325,41 +361,6 @@ async function evaluateLuauConfig(absPath: string): Promise<Record<string, unkno
 	} finally {
 		rmSync(bootstrapDirectory, { force: true, recursive: true });
 	}
-}
-
-const OK_PREFIX = "__BEDROCK_LUAU_OK__";
-const ERR_PREFIX = "__BEDROCK_LUAU_ERR__";
-
-function isLuauErrorEnvelope(value: unknown): value is { readonly message: string } {
-	if (typeof value !== "object" || value === null) {
-		return false;
-	}
-
-	return "message" in value && typeof value.message === "string";
-}
-
-function parseBootstrapOutput(stdout: string): Record<string, unknown> {
-	if (stdout.startsWith(ERR_PREFIX)) {
-		const envelope = JSON.parse(stdout.slice(ERR_PREFIX.length));
-		const message = isLuauErrorEnvelope(envelope)
-			? envelope.message
-			: stdout.slice(ERR_PREFIX.length);
-		throw new Error(message);
-	}
-
-	if (!stdout.startsWith(OK_PREFIX)) {
-		throw new Error(
-			`Luau config evaluation produced unexpected output: ${stdout.slice(0, 200)}`,
-		);
-	}
-
-	const parsed = JSON.parse(stdout.slice(OK_PREFIX.length));
-
-	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-		throw new TypeError("Luau config must return a table at the root");
-	}
-
-	return parsed;
 }
 
 const CONFIG_FILE_IN_FRAME = /[^\s():"']*bedrock\.config\.(?:ts|js|mjs|cjs|yaml|yml|json)/;

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -92,7 +92,7 @@ export async function loadConfig(
 		resolved = await c12LoadConfig<Record<string, unknown>>({
 			name: "bedrock",
 			cwd,
-			resolve: makeLuauResolver(cwd),
+			resolve: makeLuauResolver(cwd, configFile !== undefined),
 			...(configFile === undefined ? {} : { configFile }),
 		});
 	} catch (err) {
@@ -176,16 +176,20 @@ const NATIVE_CONFIG_EXTENSIONS = [
 
 function makeLuauResolver(
 	defaultCwd: string,
+	callerSetConfigFile: boolean,
 ): (
 	source: string,
-	c12Options: { readonly configFile?: string; readonly cwd?: string },
+	c12Options: { readonly cwd?: string },
 ) => Promise<LuauResolveResult | undefined> {
 	return async (source, c12Options) => {
 		// For auto-discovery (source === "."), defer when the caller named a
 		// specific configFile - their intent is to load that exact file, not
 		// whatever bedrock.config.luau happens to be sitting next to it.
+		// Note: c12 normalizes options.configFile to "bedrock.config" by default,
+		// so we cannot inspect c12Options here; the caller-set flag is captured
+		// from loadConfig's own options before c12 sees them.
 		// Explicit `.luau` paths (e.g. an extends clause) always go through us.
-		if (source === "." && c12Options.configFile !== undefined) {
+		if (source === "." && callerSetConfigFile) {
 			return;
 		}
 

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -187,11 +187,34 @@ io.write("__BEDROCK_LUAU_OK__")
 io.write(encoded)
 `;
 
+class LuauRuntimeMissingError extends Error {
+	public readonly hint: string;
+	public override readonly name = "LuauRuntimeMissingError";
+	public readonly sourceFile: string;
+
+	constructor(sourceFile: string, hint: string) {
+		super(`Luau runtime missing: ${hint}`);
+		this.hint = hint;
+		this.sourceFile = sourceFile;
+	}
+}
+
+const LUAU_RUNTIME_HINT =
+	"install lute (e.g. `mise install` with `github:luau-lang/lute`) or set BEDROCK_LUTE_PATH to the binary.";
+
 interface LuteRunOptions {
 	readonly bin: string;
 	readonly bootstrapPath: string;
 	readonly cwd: string;
 	readonly userBasename: string;
+}
+
+function isEnoentError(error: unknown): boolean {
+	if (!(error instanceof Error) || !("code" in error)) {
+		return false;
+	}
+
+	return error.code === "ENOENT";
 }
 
 async function runLuteBootstrap(runOptions: LuteRunOptions): Promise<string> {
@@ -227,12 +250,21 @@ async function evaluateLuauConfig(absPath: string): Promise<Record<string, unkno
 	// user's directory via a `.luaurc` alias that the bootstrap requires by name.
 	writeFileSync(join(bootstrapDirectory, ".luaurc"), JSON.stringify({ aliases: { user: cwd } }));
 
-	const stdout = await runLuteBootstrap({
-		bin: lute,
-		bootstrapPath,
-		cwd,
-		userBasename: base,
-	});
+	let stdout: string;
+	try {
+		stdout = await runLuteBootstrap({
+			bin: lute,
+			bootstrapPath,
+			cwd,
+			userBasename: base,
+		});
+	} catch (err) {
+		if (isEnoentError(err)) {
+			throw new LuauRuntimeMissingError(absPath, LUAU_RUNTIME_HINT);
+		}
+
+		throw err;
+	}
 
 	return parseBootstrapOutput(stdout);
 }
@@ -307,6 +339,10 @@ function discoverConfigFile(cwd: string): string | undefined {
 }
 
 function attributeLoadError(err: unknown, cwd: string): ConfigError {
+	if (err instanceof LuauRuntimeMissingError) {
+		return { hint: err.hint, kind: "luauRuntimeMissing", sourceFile: err.sourceFile };
+	}
+
 	const message = err instanceof Error ? err.message : String(err);
 	const frameFile = extractConfigFileFromStack(err);
 	if (frameFile !== undefined) {

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -143,12 +143,36 @@ function locateLuauConfig(source: string, cwd: string): string | undefined {
 	}
 
 	if (source === ".") {
+		// Defer to c12's built-in resolution when a native-format config sits
+		// alongside the Luau one. This matches the documented precedence:
+		// TypeScript / JavaScript / JSON / YAML beat Luau when both are
+		// present. Only claim the Luau file when it's the sole candidate.
+		if (
+			NATIVE_CONFIG_EXTENSIONS.some((extension) =>
+				existsSync(join(cwd, `bedrock.config.${extension}`)),
+			)
+		) {
+			return undefined;
+		}
+
 		const candidate = join(cwd, LUAU_CONFIG_BASENAME);
 		return existsSync(candidate) ? candidate : undefined;
 	}
 
 	return undefined;
 }
+
+const NATIVE_CONFIG_EXTENSIONS = [
+	"ts",
+	"mts",
+	"cts",
+	"js",
+	"mjs",
+	"cjs",
+	"json",
+	"yaml",
+	"yml",
+] as const;
 
 function makeLuauResolver(
 	defaultCwd: string,

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -4,7 +4,7 @@ import { loadConfig as c12LoadConfig } from "c12";
 import { execFile } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve as resolvePath, sep } from "node:path";
 import process from "node:process";
 
 import type { ConfigError } from "../core/config-error.ts";
@@ -271,7 +271,10 @@ class LuauRuntimeMissingError extends Error {
 	public readonly sourceFile: string;
 
 	constructor(sourceFile: string, hint: string) {
-		super(`Luau runtime missing: ${hint}`);
+		// `super()` message would only ever surface as `.message`, but every
+		// consumer narrows on `instanceof` and reads `.hint` / `.sourceFile`
+		// instead, so a message string here would be dead.
+		super();
 		this.hint = hint;
 		this.sourceFile = sourceFile;
 	}
@@ -283,16 +286,11 @@ const LUAU_RUNTIME_HINT =
 interface LuteRunOptions {
 	readonly bin: string;
 	readonly bootstrapPath: string;
-	readonly cwd: string;
 	readonly userBasename: string;
 }
 
 function isEnoentError(error: unknown): boolean {
-	if (!(error instanceof Error) || !("code" in error)) {
-		return false;
-	}
-
-	return error.code === "ENOENT";
+	return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
 
 // 10s is generous for evaluating a config file: real configs run in
@@ -301,12 +299,12 @@ function isEnoentError(error: unknown): boolean {
 const LUTE_BOOTSTRAP_TIMEOUT_MS = 10_000;
 
 async function runLuteBootstrap(runOptions: LuteRunOptions): Promise<string> {
-	const { bin, bootstrapPath, cwd, userBasename } = runOptions;
+	const { bin, bootstrapPath, userBasename } = runOptions;
 	return new Promise((resolve, reject) => {
 		execFile(
 			bin,
 			["run", bootstrapPath, userBasename],
-			{ cwd, encoding: "utf8", timeout: LUTE_BOOTSTRAP_TIMEOUT_MS },
+			{ encoding: "utf8", timeout: LUTE_BOOTSTRAP_TIMEOUT_MS },
 			(error, stdout) => {
 				if (error instanceof Error) {
 					reject(error);
@@ -319,38 +317,19 @@ async function runLuteBootstrap(runOptions: LuteRunOptions): Promise<string> {
 	});
 }
 
-function isLuauErrorEnvelope(value: unknown): value is { readonly message: string } {
-	if (typeof value !== "object" || value === null) {
-		return false;
-	}
-
-	return "message" in value && typeof value.message === "string";
-}
-
-function parseEnvelope(raw: string, label: string): JSONValue {
-	try {
-		return JSON.parse(raw);
-	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err);
-		throw new Error(`Malformed Luau bootstrap ${label} envelope: ${message}`);
-	}
-}
-
 function parseBootstrapOutput(stdout: string): Record<string, unknown> {
 	if (stdout.startsWith(ERR_PREFIX)) {
-		const raw = stdout.slice(ERR_PREFIX.length);
-		const envelope = parseEnvelope(raw, "ERR");
-		const message = isLuauErrorEnvelope(envelope) ? envelope.message : raw;
-		throw new Error(message);
+		// The bootstrap contract pairs ERR_PREFIX with `{ kind, message }`. Pass
+		// the raw envelope through as the error text rather than reach into the
+		// JSON: any unwrapping logic we add here is paranoid with no test
+		// surface (the bootstrap is the only producer and always conforms).
+		throw new Error(stdout.slice(ERR_PREFIX.length));
 	}
 
-	if (!stdout.startsWith(OK_PREFIX)) {
-		throw new Error(
-			`Luau config evaluation produced unexpected output: ${stdout.slice(0, 200)}`,
-		);
-	}
-
-	const parsed = parseEnvelope(stdout.slice(OK_PREFIX.length), "OK");
+	// Stdout that doesn't carry the OK prefix is unsupported; let JSON.parse
+	// surface a SyntaxError rather than guard a defensive fallback that has
+	// no observable behaviour.
+	const parsed = JSON.parse(stdout.slice(OK_PREFIX.length));
 
 	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
 		throw new TypeError("Luau config must return a table at the root");
@@ -365,7 +344,10 @@ async function evaluateLuauConfig(absPath: string): Promise<Record<string, unkno
 	const cwd = dirname(absPath);
 	const base = basename(absPath);
 
-	const bootstrapDirectory = mkdtempSync(join(tmpdir(), "bedrock-lute-"));
+	// `tmpdir() + sep` keeps the directory inside tmpdir without a mutable
+	// debug-label string. The trailing separator is required so mkdtempSync
+	// creates a child of tmpdir rather than a sibling whose name extends it.
+	const bootstrapDirectory = mkdtempSync(tmpdir() + sep);
 	try {
 		const bootstrapPath = join(bootstrapDirectory, "bootstrap.luau");
 		writeFileSync(bootstrapPath, LUTE_BOOTSTRAP_LUAU);
@@ -381,7 +363,6 @@ async function evaluateLuauConfig(absPath: string): Promise<Record<string, unkno
 		const stdout = await runLuteBootstrap({
 			bin: lute,
 			bootstrapPath,
-			cwd,
 			userBasename: base,
 		}).catch((err: unknown) => {
 			if (isEnoentError(err)) {
@@ -393,7 +374,7 @@ async function evaluateLuauConfig(absPath: string): Promise<Record<string, unkno
 
 		return parseBootstrapOutput(stdout);
 	} finally {
-		rmSync(bootstrapDirectory, { force: true, recursive: true });
+		rmSync(bootstrapDirectory, { recursive: true });
 	}
 }
 

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -2,7 +2,7 @@ import type { Result } from "@bedrock/ocale";
 
 import { loadConfig as c12LoadConfig } from "c12";
 import { execFile } from "node:child_process";
-import { existsSync, mkdtempSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
 import process from "node:process";
@@ -296,30 +296,35 @@ async function evaluateLuauConfig(absPath: string): Promise<Record<string, unkno
 	const base = basename(absPath);
 
 	const bootstrapDirectory = mkdtempSync(join(tmpdir(), "bedrock-lute-"));
-	const bootstrapPath = join(bootstrapDirectory, "bootstrap.luau");
-	writeFileSync(bootstrapPath, LUTE_BOOTSTRAP_LUAU);
-	// Lute resolves `require` relative to the calling script's directory, not
-	// the process cwd. The bootstrap lives in a temp dir, so we expose the
-	// user's directory via a `.luaurc` alias that the bootstrap requires by name.
-	writeFileSync(join(bootstrapDirectory, ".luaurc"), JSON.stringify({ aliases: { user: cwd } }));
-
-	let stdout: string;
 	try {
-		stdout = await runLuteBootstrap({
+		const bootstrapPath = join(bootstrapDirectory, "bootstrap.luau");
+		writeFileSync(bootstrapPath, LUTE_BOOTSTRAP_LUAU);
+		// Lute resolves `require` relative to the calling script's directory, not
+		// the process cwd. The bootstrap lives in a temp dir, so we expose the
+		// user's directory via a `.luaurc` alias that the bootstrap requires by
+		// name.
+		writeFileSync(
+			join(bootstrapDirectory, ".luaurc"),
+			JSON.stringify({ aliases: { user: cwd } }),
+		);
+
+		const stdout = await runLuteBootstrap({
 			bin: lute,
 			bootstrapPath,
 			cwd,
 			userBasename: base,
+		}).catch((err: unknown) => {
+			if (isEnoentError(err)) {
+				throw new LuauRuntimeMissingError(absPath, LUAU_RUNTIME_HINT);
+			}
+
+			throw err;
 		});
-	} catch (err) {
-		if (isEnoentError(err)) {
-			throw new LuauRuntimeMissingError(absPath, LUAU_RUNTIME_HINT);
-		}
 
-		throw err;
+		return parseBootstrapOutput(stdout);
+	} finally {
+		rmSync(bootstrapDirectory, { force: true, recursive: true });
 	}
-
-	return parseBootstrapOutput(stdout);
 }
 
 const OK_PREFIX = "__BEDROCK_LUAU_OK__";

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -354,7 +354,7 @@ function parseBootstrapOutput(stdout: string): Record<string, unknown> {
 		throw new TypeError("Luau config must return a table at the root");
 	}
 
-	return parsed as Record<string, unknown>;
+	return parsed;
 }
 
 const CONFIG_FILE_IN_FRAME = /[^\s():"']*bedrock\.config\.(?:ts|js|mjs|cjs|yaml|yml|json)/;

--- a/packages/bedrock/tests/integration/config-pipeline.spec.ts
+++ b/packages/bedrock/tests/integration/config-pipeline.spec.ts
@@ -20,7 +20,9 @@ import {
 	validGamePassBody,
 } from "@bedrock/ocale/testing";
 
+import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
+import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { assert, describe, expect, it } from "vitest";
 
@@ -30,7 +32,20 @@ const ICON_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
 const UNIVERSE_ID = asRobloxAssetId("1234567890");
 const VIP_PASS_KEY = "vip-pass";
 
-const SUPPORTED_FORMATS = ["typescript", "yaml", "json", "javascript"] as const;
+const HAS_LUTE = (() => {
+	if ((process.env["BEDROCK_LUTE_PATH"] ?? "").length > 0) {
+		return true;
+	}
+
+	const lookup = process.platform === "win32" ? "where" : "which";
+	return spawnSync(lookup, ["lute"]).status === 0;
+})();
+
+const SUPPORTED_FORMATS = (
+	HAS_LUTE
+		? (["typescript", "yaml", "json", "javascript", "luau"] as const)
+		: (["typescript", "yaml", "json", "javascript"] as const)
+) satisfies ReadonlyArray<string>;
 
 interface CreateFlowResult {
 	readonly applyOutcome: Awaited<ReturnType<typeof applyOps>>;

--- a/packages/bedrock/tests/integration/config-pipeline.spec.ts
+++ b/packages/bedrock/tests/integration/config-pipeline.spec.ts
@@ -19,10 +19,9 @@ import {
 	type FakeHttpClient,
 	validGamePassBody,
 } from "@bedrock/ocale/testing";
+import { HAS_LUTE } from "@bedrock/testing/lute";
 
-import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
-import process from "node:process";
 import { fileURLToPath } from "node:url";
 import { assert, describe, expect, it } from "vitest";
 
@@ -31,15 +30,6 @@ const TYPESCRIPT_FIXTURE_DIR = join(FIXTURES_ROOT, "typescript");
 const ICON_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
 const UNIVERSE_ID = asRobloxAssetId("1234567890");
 const VIP_PASS_KEY = "vip-pass";
-
-const HAS_LUTE = (() => {
-	if ((process.env["BEDROCK_LUTE_PATH"] ?? "").length > 0) {
-		return true;
-	}
-
-	const lookup = process.platform === "win32" ? "where" : "which";
-	return spawnSync(lookup, ["lute"]).status === 0;
-})();
 
 const SUPPORTED_FORMATS = (
 	HAS_LUTE

--- a/packages/bedrock/tests/integration/fixtures/luau/bedrock.config.luau
+++ b/packages/bedrock/tests/integration/fixtures/luau/bedrock.config.luau
@@ -1,4 +1,7 @@
 return {
+	environments = {
+		production = {},
+	},
 	passes = {
 		["vip-pass"] = {
 			name = "VIP Pass",

--- a/packages/bedrock/tests/integration/fixtures/luau/bedrock.config.luau
+++ b/packages/bedrock/tests/integration/fixtures/luau/bedrock.config.luau
@@ -1,0 +1,10 @@
+return {
+	passes = {
+		["vip-pass"] = {
+			name = "VIP Pass",
+			description = "Grants VIP perks.",
+			iconFilePath = "assets/vip-icon.png",
+			price = 500,
+		},
+	},
+}

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -12,6 +12,7 @@
 	"type": "module",
 	"exports": {
 		"./jest-extended": "./src/jest-extended.ts",
+		"./lute": "./src/lute.ts",
 		"./stryker": "./src/stryker.ts",
 		"./stryker-diff": "./src/stryker-diff.ts"
 	},

--- a/packages/testing/src/lute.ts
+++ b/packages/testing/src/lute.ts
@@ -26,6 +26,10 @@ export const HAS_LUTE: boolean = (() => {
 		return false;
 	}
 
+	// Assumes `lute --version` prints a bare semver string like "1.0.0", which
+	// is the v1.0.0 binary's actual format. A future build that prepends a
+	// label (e.g. "lute 1.0.0") would parse to NaN here and the gate would
+	// silently skip Luau tests on a perfectly good runtime.
 	const major = Number.parseInt(result.stdout.trim().split(".")[0] ?? "", 10);
 	return Number.isFinite(major) && major >= MIN_MAJOR_VERSION;
 })();

--- a/packages/testing/src/lute.ts
+++ b/packages/testing/src/lute.ts
@@ -1,20 +1,31 @@
 import { spawnSync } from "node:child_process";
 import process from "node:process";
 
+const MIN_MAJOR_VERSION = 1;
+
 /**
- * Whether the `lute` Luau runtime is reachable from this process. True when
- * either `BEDROCK_LUTE_PATH` points at a binary or `lute` resolves on PATH.
+ * Whether a usable `lute` Luau runtime is reachable from this process. True
+ * when either `BEDROCK_LUTE_PATH` points at a binary or `lute` resolves on
+ * PATH **and** the binary reports a major version >= 1.
+ *
+ * Older `lute` builds (notably the v0.1.x nightly series) use different
+ * `@std` module shapes that the bootstrap does not target;
+ * they would fail at runtime in confusing ways. Gating on the version means
+ * tests skip cleanly on machines that happen to have an older binary first
+ * on PATH.
  *
  * Computed once at module load. Tests that exercise the Luau config loader
- * gate themselves on this constant via `it.skipIf(!HAS_LUTE)` so the suite
- * stays runnable on machines without lute installed (CI installs it through
- * mise; local contributors may not).
+ * gate themselves on this constant via `it.skipIf(!HAS_LUTE)`.
  */
 export const HAS_LUTE: boolean = (() => {
-	if ((process.env["BEDROCK_LUTE_PATH"] ?? "").length > 0) {
-		return true;
+	const override = process.env["BEDROCK_LUTE_PATH"];
+	const bin = override !== undefined && override.length > 0 ? override : "lute";
+
+	const result = spawnSync(bin, ["--version"], { encoding: "utf8" });
+	if (result.status !== 0) {
+		return false;
 	}
 
-	const lookup = process.platform === "win32" ? "where" : "which";
-	return spawnSync(lookup, ["lute"]).status === 0;
+	const major = Number.parseInt(result.stdout.trim().split(".")[0] ?? "", 10);
+	return Number.isFinite(major) && major >= MIN_MAJOR_VERSION;
 })();

--- a/packages/testing/src/lute.ts
+++ b/packages/testing/src/lute.ts
@@ -1,0 +1,20 @@
+import { spawnSync } from "node:child_process";
+import process from "node:process";
+
+/**
+ * Whether the `lute` Luau runtime is reachable from this process. True when
+ * either `BEDROCK_LUTE_PATH` points at a binary or `lute` resolves on PATH.
+ *
+ * Computed once at module load. Tests that exercise the Luau config loader
+ * gate themselves on this constant via `it.skipIf(!HAS_LUTE)` so the suite
+ * stays runnable on machines without lute installed (CI installs it through
+ * mise; local contributors may not).
+ */
+export const HAS_LUTE: boolean = (() => {
+	if ((process.env["BEDROCK_LUTE_PATH"] ?? "").length > 0) {
+		return true;
+	}
+
+	const lookup = process.platform === "win32" ? "where" : "which";
+	return spawnSync(lookup, ["lute"]).status === 0;
+})();


### PR DESCRIPTION
## Summary

Adds first-class support for `bedrock.config.luau` files, evaluated by the [Lute](https://github.com/luau-lang/lute) Luau runtime. Sits on top of the existing c12 loader via its public `options.resolve` hook, so no fork or pnpm patch is needed.

- Auto-discovers `bedrock.config.luau` when no native-format sibling exists.
- A `.ts` / `.js` / `.json` / `.yaml` sibling wins the precedence race (resolves the open ambiguity question by deferring to c12's documented order).
- `extends: "./base.luau"` from any format layers correctly.
- Function-form Luau configs are evaluated inside Lute (note: JS-side `options.context` is **not** plumbed in — Lute runs out-of-process).
- Non-serializable Luau values (functions, threads, userdata) surface as a clean `parseFailed` carrying the inner Luau error message; no sentinel envelope leaks to the user.
- A missing `lute` binary surfaces as a new `luauRuntimeMissing` `ConfigError` discriminant carrying an install hint pointing at mise / `BEDROCK_LUTE_PATH`.

## Why

ADR-020 names the Luau-population audience as a peer audience, and `docs/plans/2025-12-06-bedrock-design.md:149-151` already flagged `.luau` config support via Lute as an open question. This closes that loop.

## Notes for the reviewer

- **Lute v1.0.0 always returns exit code 0** — even for `process.exit(3)` and uncaught `error()`. Worth filing upstream eventually. The bootstrap works around this with a stdout sentinel envelope (`__BEDROCK_LUAU_OK__` / `__BEDROCK_LUAU_ERR__`) parsed on the JS side.
- **`require()` rejects absolute paths in Luau.** The bootstrap lives in a per-call temp directory and uses a generated `.luaurc` to expose the user's project as `@user`, then does `require("@user/" .. basename)`. Temp dir is cleaned up in a `finally`.
- **Discovery strategy** answers the four open questions from the plan:
  1. PATH first, `BEDROCK_LUTE_PATH` env override
  2. Precedence: c12 default order wins (TS > JS > JSON > YAML > Luau) — implemented as deferred discovery in `locateLuauConfig`
  3. Missing binary = hard error with install hint
  4. HMR explicitly out of scope (bedrock today only calls `loadConfig`, never `watchConfig`)
- **Testing infra**: `HAS_LUTE` lives in a new `@bedrock/testing/lute` subpath and gates on lute v1+. Older nightlies on PATH cause the relevant tests to skip cleanly rather than fail in confusing ways.
- **Tooling**: pinned `github:luau-lang/lute@1.0.0` in `mise.toml` so `mise install` brings in a usable runtime.

## Test plan

- [x] `pnpm test` - 1163 tests pass (luau-gated tests skip when lute v1+ isn't reachable, run when it is)
- [x] `pnpm lint` - clean
- [x] `pnpm typecheck` - clean
- [x] `pnpm build` - clean (`@bedrock/core` 67 kB, publint clean)
- [x] Pre-push hook (lint, typecheck, gen-example-tests, unused, build, test) green
- [ ] Manual: drop a `bedrock.config.luau` exporting a function-form config, run `bun --conditions source packages/bedrock/src/index.ts`, confirm load + validate succeed

## Out of scope

- `.bedrockrc.luau` (rc files don't pass through c12's `resolveConfig`; would need a separate codepath)
- HMR for `.luau` (would need a parallel chokidar watcher because c12's frozen `SUPPORTED_EXTENSIONS` doesn't include `.luau`)
- Plumbing `options.context` into Luau function-form configs (Lute runs out-of-process; would need a JSON-encoded handshake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)