### PR TITLE
feat(core): cli deploy command

### DIFF
--- a/apps/e2e/tests/smoke/cli-deploy.spec.ts
+++ b/apps/e2e/tests/smoke/cli-deploy.spec.ts
@@ -1,0 +1,119 @@
+import type { Buffer } from "node:buffer";
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { assert, describe, expect, it } from "vitest";
+
+const TOKEN = process.env["GITHUB_TOKEN"];
+const API_KEY = process.env["ROBLOX_API_KEY"];
+const GIST_ID = process.env["BEDROCK_TEST_GIST_ID"];
+const PLACE_ID_ENV = process.env["ROBLOX_TEST_PLACE_ID"];
+
+const HAS_SECRETS =
+	TOKEN !== undefined &&
+	API_KEY !== undefined &&
+	GIST_ID !== undefined &&
+	PLACE_ID_ENV !== undefined;
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PLACE = join(HERE, "fixtures", "place.rbxlx");
+const REPO_ROOT = join(HERE, "..", "..", "..", "..");
+const BIN_ENTRY = join(REPO_ROOT, "packages", "bedrock", "src", "cli", "run.ts");
+
+interface SpawnResult {
+	readonly code: number;
+	readonly stderr: string;
+	readonly stdout: string;
+}
+
+async function runBin(args: ReadonlyArray<string>, cwd: string): Promise<SpawnResult> {
+	return new Promise((resolve, reject) => {
+		const child = spawn("bun", ["--conditions", "source", BIN_ENTRY, ...args], {
+			cwd,
+			env: process.env,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		let stdout = "";
+		let stderr = "";
+		child.stdout.on("data", (chunk: Buffer) => {
+			stdout += chunk.toString("utf8");
+		});
+		child.stderr.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString("utf8");
+		});
+		child.on("error", reject);
+		child.on("close", (code) => {
+			resolve({ code: code ?? -1, stderr, stdout });
+		});
+	});
+}
+
+async function deleteGistFile(filename: string): Promise<void> {
+	assert(TOKEN !== undefined);
+	assert(GIST_ID !== undefined);
+	await fetch(`https://api.github.com/gists/${GIST_ID}`, {
+		body: JSON.stringify({ files: { [filename]: null } }),
+		headers: {
+			"Accept": "application/vnd.github+json",
+			"Authorization": `Bearer ${TOKEN}`,
+			"Content-Type": "application/json",
+			"User-Agent": "bedrock",
+			"X-GitHub-Api-Version": "2026-03-10",
+		},
+		method: "PATCH",
+	});
+}
+
+describe("bedrock deploy bin against real gist + open cloud", () => {
+	it.skipIf(!HAS_SECRETS)(
+		"should reconcile a place end-to-end and exit 0 with a success line",
+		async () => {
+			expect.assertions(3);
+
+			assert(TOKEN !== undefined);
+			assert(API_KEY !== undefined);
+			assert(GIST_ID !== undefined);
+			assert(PLACE_ID_ENV !== undefined);
+
+			const environment = `cli-smoke-${String(Date.now())}`;
+			const project = await mkdtemp(join(tmpdir(), "bedrock-cli-smoke-"));
+			const configPath = join(project, "bedrock.config.ts");
+
+			const configSource = [
+				'import { defineConfig } from "@bedrock/core";',
+				"",
+				"export default defineConfig({",
+				`    environments: { ${environment}: {} },`,
+				"    places: {",
+				'        "smoke-place": {',
+				`            filePath: ${JSON.stringify(FIXTURE_PLACE)},`,
+				`            placeId: "${PLACE_ID_ENV}",`,
+				"        },",
+				"    },",
+				`    state: { backend: "gist", gistId: "${GIST_ID}" },`,
+				"});",
+				"",
+			].join("\n");
+			await writeFile(configPath, configSource, "utf8");
+
+			try {
+				const result = await runBin(
+					["deploy", "--env", environment, "--config", configPath],
+					project,
+				);
+
+				expect(result.code).toBe(0);
+				expect(result.stdout).toContain(environment);
+				expect(result.stdout).toMatch(/\d+ resources reconciled/);
+			} finally {
+				await deleteGistFile(`state.${environment}.json`);
+				await rm(project, { force: true, recursive: true });
+			}
+		},
+		120_000,
+	);
+});

--- a/packages/bedrock/src/cli/commands/deploy.spec.ts
+++ b/packages/bedrock/src/cli/commands/deploy.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ProgDeps } from "../index.ts";
+import type { ClackPort } from "../render.ts";
+import { deployCommand } from "./deploy.ts";
+
+function fakeClackPort(): ClackPort {
+	return {
+		cancel: vi.fn<ClackPort["cancel"]>(),
+		intro: vi.fn<ClackPort["intro"]>(),
+		logError: vi.fn<ClackPort["logError"]>(),
+		logMessage: vi.fn<ClackPort["logMessage"]>(),
+		logSuccess: vi.fn<ClackPort["logSuccess"]>(),
+		outro: vi.fn<ClackPort["outro"]>(),
+	};
+}
+
+function makeDeps(overrides: Partial<ProgDeps> = {}): ProgDeps {
+	return {
+		clack: fakeClackPort(),
+		exit: vi.fn<(code: number) => never>(),
+		...overrides,
+	};
+}
+
+describe(deployCommand, () => {
+	it.for<{ label: string; rawOptions: Record<string, unknown> }>([
+		{ label: "missingRequired", rawOptions: {} },
+		{ label: "unknownFlag", rawOptions: { env: "production", verbose: true } },
+		{ label: "invalidValue", rawOptions: { env: false } },
+	])("should surface a $label parse error and exit with code 1", async ({ rawOptions }) => {
+		expect.assertions(4);
+
+		const deps = makeDeps();
+
+		await deployCommand(deps)(rawOptions);
+
+		expect(deps.clack?.intro).toHaveBeenCalledExactlyOnceWith("bedrock deploy");
+		expect(deps.clack?.logError).toHaveBeenCalledOnce();
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("deploy failed");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+});

--- a/packages/bedrock/src/cli/commands/deploy.spec.ts
+++ b/packages/bedrock/src/cli/commands/deploy.spec.ts
@@ -1,8 +1,20 @@
+import type { Result } from "@bedrock/ocale";
+
 import { describe, expect, it, vi } from "vitest";
 
+import type { ConfigError } from "../../core/config-error.ts";
+import type { ResourceCurrentState } from "../../core/resources.ts";
+import type { Config } from "../../core/schema.ts";
+import type { BedrockState } from "../../core/state.ts";
+import type { DeployError, DeployOptions } from "../../shell/deploy.ts";
+import type { LoadConfigOptions } from "../../shell/load-config.ts";
+import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../../types/ids.ts";
 import type { ProgDeps } from "../index.ts";
 import type { ClackPort } from "../render.ts";
 import { deployCommand } from "./deploy.ts";
+
+type LoadConfigFunc = (options?: LoadConfigOptions) => Promise<Result<Config, ConfigError>>;
+type DeployFunc = (options: DeployOptions) => Promise<Result<BedrockState, DeployError>>;
 
 function fakeClackPort(): ClackPort {
 	return {
@@ -23,6 +35,51 @@ function makeDeps(overrides: Partial<ProgDeps> = {}): ProgDeps {
 	};
 }
 
+const sampleConfig: Config = { environments: { production: {}, staging: {} } };
+
+const SAMPLE_HASH = asSha256Hex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+
+function gamePassResource(suffix: number): ResourceCurrentState {
+	return {
+		key: asResourceKey(`pass-${String(suffix)}`),
+		name: `Pass ${String(suffix)}`,
+		description: "Sample pass.",
+		iconFileHash: SAMPLE_HASH,
+		iconFilePath: "assets/icon.png",
+		kind: "gamePass",
+		outputs: {
+			assetId: asRobloxAssetId(String(1_000_000 + suffix)),
+			iconAssetId: asRobloxAssetId(String(2_000_000 + suffix)),
+		},
+		price: undefined,
+	};
+}
+
+function bedrockState(environment: string, resourceCount = 0): BedrockState {
+	const resources: ReadonlyArray<ResourceCurrentState> = Array.from(
+		{ length: resourceCount },
+		(_, index) => gamePassResource(index),
+	);
+	return { environment, resources, version: 1 };
+}
+
+function fakeLoad(result: Result<Config, ConfigError>): LoadConfigFunc {
+	return vi.fn<LoadConfigFunc>(async () => result);
+}
+
+function fakeDeploy(mapping: ReadonlyArray<Result<BedrockState, DeployError>>): DeployFunc {
+	let callIndex = 0;
+	return vi.fn<DeployFunc>(async () => {
+		const next = mapping[callIndex];
+		callIndex += 1;
+		if (next === undefined) {
+			throw new Error("fakeDeploy invoked with no scripted result");
+		}
+
+		return next;
+	});
+}
+
 describe(deployCommand, () => {
 	it.for<{ label: string; rawOptions: Record<string, unknown> }>([
 		{ label: "missingRequired", rawOptions: {} },
@@ -37,6 +94,130 @@ describe(deployCommand, () => {
 
 		expect(deps.clack?.intro).toHaveBeenCalledExactlyOnceWith("bedrock deploy");
 		expect(deps.clack?.logError).toHaveBeenCalledOnce();
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("deploy failed");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should render configLoadFailed and exit 1 when loadConfig returns Err", async () => {
+		expect.assertions(3);
+
+		const loadConfig = fakeLoad({
+			err: { kind: "fileNotFound", searchedFrom: "/tmp/project" },
+			success: false,
+		});
+		const deps = makeDeps({ deploy: vi.fn<DeployFunc>(), loadConfig });
+
+		await deployCommand(deps)({ env: "production" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledOnce();
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("deploy failed");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should forward parsed configFile to loadConfig", async () => {
+		expect.assertions(1);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const deploy = fakeDeploy([{ data: bedrockState("production"), success: true }]);
+		const deps = makeDeps({ deploy, loadConfig });
+
+		await deployCommand(deps)({ config: "./bedrock.staging.config.ts", env: "production" });
+
+		expect(loadConfig).toHaveBeenCalledExactlyOnceWith({
+			configFile: "./bedrock.staging.config.ts",
+		});
+	});
+
+	it("should call loadConfig with no options when --config is absent", async () => {
+		expect.assertions(1);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const deploy = fakeDeploy([{ data: bedrockState("production"), success: true }]);
+		const deps = makeDeps({ deploy, loadConfig });
+
+		await deployCommand(deps)({ env: "production" });
+
+		expect(loadConfig).toHaveBeenCalledExactlyOnceWith(undefined);
+	});
+
+	it("should dispatch deploy with the loaded config and env, then log success and exit 0", async () => {
+		expect.assertions(4);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const deploy = fakeDeploy([{ data: bedrockState("production", 3), success: true }]);
+		const deps = makeDeps({ deploy, loadConfig });
+
+		await deployCommand(deps)({ env: "production" });
+
+		expect(deploy).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({ config: sampleConfig, environment: "production" }),
+		);
+		expect(deps.clack?.logSuccess).toHaveBeenCalledExactlyOnceWith(
+			"production: 3 resources reconciled",
+		);
+		expect(deps.clack?.outro).toHaveBeenCalledExactlyOnceWith("deploy succeeded");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(0);
+	});
+
+	it("should render the DeployError and exit 1 when deploy returns Err", async () => {
+		expect.assertions(3);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const deploy = fakeDeploy([
+			{
+				err: {
+					declared: ["production"],
+					environment: "ghost",
+					kind: "unknownEnvironment",
+				},
+				success: false,
+			},
+		]);
+		const deps = makeDeps({ deploy, loadConfig });
+
+		await deployCommand(deps)({ env: "ghost" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledOnce();
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("deploy failed");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should dispatch deploy once per --env in order and exit 0 when all succeed", async () => {
+		expect.assertions(3);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const deploy = fakeDeploy([
+			{ data: bedrockState("production", 1), success: true },
+			{ data: bedrockState("staging", 2), success: true },
+		]);
+		const deps = makeDeps({ deploy, loadConfig });
+
+		await deployCommand(deps)({ env: ["production", "staging"] });
+
+		expect(deploy).toHaveBeenCalledTimes(2);
+		expect(deps.clack?.outro).toHaveBeenCalledExactlyOnceWith("deploy succeeded");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(0);
+	});
+
+	it("should call deploy for every env even when one fails, then exit 1", async () => {
+		expect.assertions(4);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const deploy = fakeDeploy([
+			{
+				err: { environment: "production", kind: "stateNotConfigured" },
+				success: false,
+			},
+			{ data: bedrockState("staging", 5), success: true },
+		]);
+		const deps = makeDeps({ deploy, loadConfig });
+
+		await deployCommand(deps)({ env: ["production", "staging"] });
+
+		expect(deploy).toHaveBeenCalledTimes(2);
+		expect(deps.clack?.logSuccess).toHaveBeenCalledExactlyOnceWith(
+			"staging: 5 resources reconciled",
+		);
 		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("deploy failed");
 		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
 	});

--- a/packages/bedrock/src/cli/commands/deploy.spec.ts
+++ b/packages/bedrock/src/cli/commands/deploy.spec.ts
@@ -1,6 +1,6 @@
 import type { Result } from "@bedrock/ocale";
 
-import { describe, expect, it, vi } from "vitest";
+import { assert, describe, expect, it, vi } from "vitest";
 
 import type { ConfigError } from "../../core/config-error.ts";
 import type { ResourceCurrentState } from "../../core/resources.ts";
@@ -220,5 +220,29 @@ describe(deployCommand, () => {
 		);
 		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("deploy failed");
 		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should thread --api-key and --github-token through getEnv into deploy", async () => {
+		expect.assertions(3);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const deploy = fakeDeploy([{ data: bedrockState("production"), success: true }]);
+		const deps = makeDeps({ deploy, loadConfig });
+
+		await deployCommand(deps)({
+			"api-key": "ROBLOX_OVERRIDE",
+			"env": "production",
+			"github-token": "GH_OVERRIDE",
+		});
+
+		expect(deploy).toHaveBeenCalledOnce();
+
+		const firstCall = vi.mocked(deploy).mock.calls[0];
+		assert(firstCall !== undefined);
+
+		const [call] = firstCall;
+
+		expect(call.getEnv?.("ROBLOX_API_KEY")).toBe("ROBLOX_OVERRIDE");
+		expect(call.getEnv?.("GITHUB_TOKEN")).toBe("GH_OVERRIDE");
 	});
 });

--- a/packages/bedrock/src/cli/commands/deploy.spec.ts
+++ b/packages/bedrock/src/cli/commands/deploy.spec.ts
@@ -1,6 +1,7 @@
 import type { Result } from "@bedrock/ocale";
 
 import { fakeClackPort } from "#tests/helpers/clack";
+import process from "node:process";
 import { assert, describe, expect, it, vi } from "vitest";
 
 import type { ResourceCurrentState } from "../../core/resources.ts";
@@ -212,26 +213,100 @@ describe(deployCommand, () => {
 	});
 
 	it("should thread --api-key and --github-token through getEnv into deploy", async () => {
+		expect.assertions(4);
+
+		vi.stubEnv("UNRELATED_VAR", "from-process-unrelated");
+
+		try {
+			const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+			const deploy = fakeDeploy([{ data: bedrockState("production"), success: true }]);
+			const deps = makeDeps({ deploy, loadConfig });
+
+			await deployCommand(deps)({
+				"api-key": "ROBLOX_OVERRIDE",
+				"env": "production",
+				"github-token": "GH_OVERRIDE",
+			});
+
+			expect(deploy).toHaveBeenCalledOnce();
+
+			const firstCall = vi.mocked(deploy).mock.calls[0];
+			assert(firstCall !== undefined);
+
+			const [call] = firstCall;
+
+			expect(call.getEnv?.("ROBLOX_API_KEY")).toBe("ROBLOX_OVERRIDE");
+			expect(call.getEnv?.("GITHUB_TOKEN")).toBe("GH_OVERRIDE");
+			expect(call.getEnv?.("UNRELATED_VAR")).toBe("from-process-unrelated");
+		} finally {
+			vi.unstubAllEnvs();
+		}
+	});
+
+	it("should overlay each credential flag only on its named slot, not the other", async () => {
 		expect.assertions(3);
 
-		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
-		const deploy = fakeDeploy([{ data: bedrockState("production"), success: true }]);
-		const deps = makeDeps({ deploy, loadConfig });
+		vi.stubEnv("ROBLOX_API_KEY", "from-process-roblox");
+		vi.stubEnv("GITHUB_TOKEN", "from-process-github");
 
-		await deployCommand(deps)({
-			"api-key": "ROBLOX_OVERRIDE",
-			"env": "production",
-			"github-token": "GH_OVERRIDE",
-		});
+		try {
+			const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+			const deploy = fakeDeploy([{ data: bedrockState("production"), success: true }]);
+			const deps = makeDeps({ deploy, loadConfig });
 
-		expect(deploy).toHaveBeenCalledOnce();
+			await deployCommand(deps)({ "api-key": "FLAG_ROBLOX", "env": "production" });
 
-		const firstCall = vi.mocked(deploy).mock.calls[0];
-		assert(firstCall !== undefined);
+			const firstCall = vi.mocked(deploy).mock.calls[0];
+			assert(firstCall !== undefined);
 
-		const [call] = firstCall;
+			const [call] = firstCall;
 
-		expect(call.getEnv?.("ROBLOX_API_KEY")).toBe("ROBLOX_OVERRIDE");
-		expect(call.getEnv?.("GITHUB_TOKEN")).toBe("GH_OVERRIDE");
+			expect(call.getEnv?.("ROBLOX_API_KEY")).toBe("FLAG_ROBLOX");
+			expect(call.getEnv?.("GITHUB_TOKEN")).toBe("from-process-github");
+			expect(call.getEnv?.("UNRELATED_VAR")).toBeUndefined();
+		} finally {
+			vi.unstubAllEnvs();
+		}
+	});
+
+	it("should fall back to process.env when neither --api-key nor --github-token is supplied", async () => {
+		expect.assertions(2);
+
+		vi.stubEnv("ROBLOX_API_KEY", "process-roblox");
+		vi.stubEnv("GITHUB_TOKEN", "process-github");
+
+		try {
+			const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+			const deploy = fakeDeploy([{ data: bedrockState("production"), success: true }]);
+			const deps = makeDeps({ deploy, loadConfig });
+
+			await deployCommand(deps)({ env: "production" });
+
+			const firstCall = vi.mocked(deploy).mock.calls[0];
+			assert(firstCall !== undefined);
+
+			const [call] = firstCall;
+
+			expect(call.getEnv?.("ROBLOX_API_KEY")).toBe("process-roblox");
+			expect(call.getEnv?.("GITHUB_TOKEN")).toBe("process-github");
+		} finally {
+			vi.unstubAllEnvs();
+		}
+	});
+
+	it("should default to process.exit when no exit slot is provided", async () => {
+		expect.assertions(1);
+
+		const exitSpy = vi
+			.spyOn(process, "exit")
+			.mockImplementation((() => {}) as typeof process.exit);
+
+		try {
+			await deployCommand({ clack: fakeClackPort() })({});
+
+			expect(exitSpy).toHaveBeenCalledExactlyOnceWith(1);
+		} finally {
+			exitSpy.mockRestore();
+		}
 	});
 });

--- a/packages/bedrock/src/cli/commands/deploy.spec.ts
+++ b/packages/bedrock/src/cli/commands/deploy.spec.ts
@@ -1,36 +1,25 @@
 import type { Result } from "@bedrock/ocale";
 
+import { fakeClackPort } from "#tests/helpers/clack";
 import { assert, describe, expect, it, vi } from "vitest";
 
-import type { ConfigError } from "../../core/config-error.ts";
 import type { ResourceCurrentState } from "../../core/resources.ts";
 import type { Config } from "../../core/schema.ts";
 import type { BedrockState } from "../../core/state.ts";
-import type { DeployError, DeployOptions } from "../../shell/deploy.ts";
-import type { LoadConfigOptions } from "../../shell/load-config.ts";
+import type { DeployError } from "../../shell/deploy.ts";
 import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../../types/ids.ts";
 import type { ProgDeps } from "../index.ts";
-import type { ClackPort } from "../render.ts";
 import { deployCommand } from "./deploy.ts";
 
-type LoadConfigFunc = (options?: LoadConfigOptions) => Promise<Result<Config, ConfigError>>;
-type DeployFunc = (options: DeployOptions) => Promise<Result<BedrockState, DeployError>>;
-
-function fakeClackPort(): ClackPort {
-	return {
-		cancel: vi.fn<ClackPort["cancel"]>(),
-		intro: vi.fn<ClackPort["intro"]>(),
-		logError: vi.fn<ClackPort["logError"]>(),
-		logMessage: vi.fn<ClackPort["logMessage"]>(),
-		logSuccess: vi.fn<ClackPort["logSuccess"]>(),
-		outro: vi.fn<ClackPort["outro"]>(),
-	};
-}
+type LoadConfigFunc = NonNullable<ProgDeps["loadConfig"]>;
+type LoadConfigResult = Awaited<ReturnType<LoadConfigFunc>>;
+type DeployFunc = NonNullable<ProgDeps["deploy"]>;
+type ExitFunc = NonNullable<ProgDeps["exit"]>;
 
 function makeDeps(overrides: Partial<ProgDeps> = {}): ProgDeps {
 	return {
 		clack: fakeClackPort(),
-		exit: vi.fn<(code: number) => never>(),
+		exit: vi.fn<ExitFunc>(),
 		...overrides,
 	};
 }
@@ -63,7 +52,7 @@ function bedrockState(environment: string, resourceCount = 0): BedrockState {
 	return { environment, resources, version: 1 };
 }
 
-function fakeLoad(result: Result<Config, ConfigError>): LoadConfigFunc {
+function fakeLoad(result: LoadConfigResult): LoadConfigFunc {
 	return vi.fn<LoadConfigFunc>(async () => result);
 }
 

--- a/packages/bedrock/src/cli/commands/deploy.ts
+++ b/packages/bedrock/src/cli/commands/deploy.ts
@@ -23,6 +23,7 @@ interface ResolvedDeploy {
 interface DispatchInputs {
 	readonly config: Config;
 	readonly environments: ReadonlyArray<string>;
+	readonly getEnv: (name: string) => string | undefined;
 	readonly resolved: ResolvedDeploy;
 }
 
@@ -60,18 +61,14 @@ function loadOptionsFor(parsed: CommonOptions): LoadConfigOptions | undefined {
 	return parsed.configFile === undefined ? undefined : { configFile: parsed.configFile };
 }
 
-function readEnvironmentVariable(name: string): string | undefined {
-	return process.env[name];
-}
-
 async function dispatchEnvironments(inputs: DispatchInputs): Promise<ReadonlyArray<string>> {
-	const { config, environments, resolved } = inputs;
+	const { config, environments, getEnv, resolved } = inputs;
 	const failed: Array<string> = [];
 	for (const environment of environments) {
 		const result = await resolved.deploy({
 			config,
 			environment,
-			getEnv: readEnvironmentVariable,
+			getEnv,
 		});
 		if (result.success) {
 			resolved.clack.logSuccess(
@@ -84,6 +81,20 @@ async function dispatchEnvironments(inputs: DispatchInputs): Promise<ReadonlyArr
 	}
 
 	return failed;
+}
+
+function buildGetEnvironment(parsed: CommonOptions): (name: string) => string | undefined {
+	return (name) => {
+		if (name === "ROBLOX_API_KEY" && parsed.apiKey !== undefined) {
+			return parsed.apiKey;
+		}
+
+		if (name === "GITHUB_TOKEN" && parsed.githubToken !== undefined) {
+			return parsed.githubToken;
+		}
+
+		return process.env[name];
+	};
 }
 
 async function runDeploy(
@@ -109,6 +120,7 @@ async function runDeploy(
 	const failures = await dispatchEnvironments({
 		config: loaded.data,
 		environments: parsed.data.environments,
+		getEnv: buildGetEnvironment(parsed.data),
 		resolved,
 	});
 	if (failures.length > 0) {

--- a/packages/bedrock/src/cli/commands/deploy.ts
+++ b/packages/bedrock/src/cli/commands/deploy.ts
@@ -16,7 +16,7 @@ const DEPLOY_FAILED_MESSAGE = "deploy failed";
 interface ResolvedDeploy {
 	readonly clack: ClackPort;
 	readonly deploy: typeof defaultDeploy;
-	readonly exit: (code: number) => never;
+	readonly exit: (code: number) => void;
 	readonly loadConfig: typeof defaultLoadConfig;
 }
 

--- a/packages/bedrock/src/cli/commands/deploy.ts
+++ b/packages/bedrock/src/cli/commands/deploy.ts
@@ -1,15 +1,38 @@
 import process from "node:process";
 
-import { EXIT_ERROR } from "../exit-codes.ts";
+import type { Config } from "../../core/schema.ts";
+import { deploy as defaultDeploy } from "../../shell/deploy.ts";
+import {
+	loadConfig as defaultLoadConfig,
+	type LoadConfigOptions,
+} from "../../shell/load-config.ts";
+import { EXIT_ERROR, EXIT_OK } from "../exit-codes.ts";
 import type { ProgDeps } from "../index.ts";
-import { parseCommonOptions } from "../parse-options.ts";
-import { createClackPort, renderParseError } from "../render.ts";
+import { type CommonOptions, parseCommonOptions } from "../parse-options.ts";
+import { type ClackPort, createClackPort, renderDeployError, renderParseError } from "../render.ts";
+
+const DEPLOY_FAILED_MESSAGE = "deploy failed";
+
+interface ResolvedDeploy {
+	readonly clack: ClackPort;
+	readonly deploy: typeof defaultDeploy;
+	readonly exit: (code: number) => never;
+	readonly loadConfig: typeof defaultLoadConfig;
+}
+
+interface DispatchInputs {
+	readonly config: Config;
+	readonly environments: ReadonlyArray<string>;
+	readonly resolved: ResolvedDeploy;
+}
 
 /**
  * Build the sade action for `bedrock deploy`. The returned function consumes
  * the raw options object sade hands the action callback, parses it via
- * `parseCommonOptions`, and routes any parse failure through
- * `renderParseError` before exiting non-zero.
+ * `parseCommonOptions`, loads the project config once, and dispatches
+ * `deploy()` for each `--env` value in order. Per-env successes and failures
+ * render through clack as a single line each; the aggregated exit code is
+ * `EXIT_OK` only when every env succeeded.
  * @param deps - Dependency overrides; missing slots are default-constructed
  *   from real implementations.
  * @returns An async sade action that returns once `deps.exit` was invoked.
@@ -17,17 +40,82 @@ import { createClackPort, renderParseError } from "../render.ts";
 export function deployCommand(
 	deps: ProgDeps,
 ): (rawOptions: Record<string, unknown>) => Promise<void> {
-	const clack = deps.clack ?? createClackPort();
-	const exit = deps.exit ?? ((code: number) => process.exit(code));
-
+	const resolved = resolveDeploy(deps);
 	return async (rawOptions) => {
-		clack.intro("bedrock deploy");
-
-		const parsed = parseCommonOptions(rawOptions);
-		if (!parsed.success) {
-			renderParseError(parsed.err, clack);
-			clack.cancel("deploy failed");
-			return exit(EXIT_ERROR);
-		}
+		const code = await runDeploy(rawOptions, resolved);
+		resolved.exit(code);
 	};
+}
+
+function resolveDeploy(deps: ProgDeps): ResolvedDeploy {
+	return {
+		clack: deps.clack ?? createClackPort(),
+		deploy: deps.deploy ?? defaultDeploy,
+		exit: deps.exit ?? ((code: number) => process.exit(code)),
+		loadConfig: deps.loadConfig ?? defaultLoadConfig,
+	};
+}
+
+function loadOptionsFor(parsed: CommonOptions): LoadConfigOptions | undefined {
+	return parsed.configFile === undefined ? undefined : { configFile: parsed.configFile };
+}
+
+function readEnvironmentVariable(name: string): string | undefined {
+	return process.env[name];
+}
+
+async function dispatchEnvironments(inputs: DispatchInputs): Promise<ReadonlyArray<string>> {
+	const { config, environments, resolved } = inputs;
+	const failed: Array<string> = [];
+	for (const environment of environments) {
+		const result = await resolved.deploy({
+			config,
+			environment,
+			getEnv: readEnvironmentVariable,
+		});
+		if (result.success) {
+			resolved.clack.logSuccess(
+				`${environment}: ${result.data.resources.length} resources reconciled`,
+			);
+		} else {
+			renderDeployError(result.err, resolved.clack);
+			failed.push(environment);
+		}
+	}
+
+	return failed;
+}
+
+async function runDeploy(
+	rawOptions: Record<string, unknown>,
+	resolved: ResolvedDeploy,
+): Promise<number> {
+	resolved.clack.intro("bedrock deploy");
+
+	const parsed = parseCommonOptions(rawOptions);
+	if (!parsed.success) {
+		renderParseError(parsed.err, resolved.clack);
+		resolved.clack.cancel(DEPLOY_FAILED_MESSAGE);
+		return EXIT_ERROR;
+	}
+
+	const loaded = await resolved.loadConfig(loadOptionsFor(parsed.data));
+	if (!loaded.success) {
+		renderDeployError({ cause: loaded.err, kind: "configLoadFailed" }, resolved.clack);
+		resolved.clack.cancel(DEPLOY_FAILED_MESSAGE);
+		return EXIT_ERROR;
+	}
+
+	const failures = await dispatchEnvironments({
+		config: loaded.data,
+		environments: parsed.data.environments,
+		resolved,
+	});
+	if (failures.length > 0) {
+		resolved.clack.cancel(DEPLOY_FAILED_MESSAGE);
+		return EXIT_ERROR;
+	}
+
+	resolved.clack.outro("deploy succeeded");
+	return EXIT_OK;
 }

--- a/packages/bedrock/src/cli/commands/deploy.ts
+++ b/packages/bedrock/src/cli/commands/deploy.ts
@@ -11,8 +11,6 @@ import type { ProgDeps } from "../index.ts";
 import { type CommonOptions, parseCommonOptions } from "../parse-options.ts";
 import { type ClackPort, createClackPort, renderDeployError, renderParseError } from "../render.ts";
 
-const DEPLOY_FAILED_MESSAGE = "deploy failed";
-
 interface ResolvedDeploy {
 	readonly clack: ClackPort;
 	readonly deploy: typeof defaultDeploy;
@@ -97,6 +95,10 @@ function buildGetEnvironment(parsed: CommonOptions): (name: string) => string | 
 	};
 }
 
+function cancelAsFailed(clack: ClackPort): void {
+	clack.cancel("deploy failed");
+}
+
 async function runDeploy(
 	rawOptions: Record<string, unknown>,
 	resolved: ResolvedDeploy,
@@ -106,14 +108,14 @@ async function runDeploy(
 	const parsed = parseCommonOptions(rawOptions);
 	if (!parsed.success) {
 		renderParseError(parsed.err, resolved.clack);
-		resolved.clack.cancel(DEPLOY_FAILED_MESSAGE);
+		cancelAsFailed(resolved.clack);
 		return EXIT_ERROR;
 	}
 
 	const loaded = await resolved.loadConfig(loadOptionsFor(parsed.data));
 	if (!loaded.success) {
 		renderDeployError({ cause: loaded.err, kind: "configLoadFailed" }, resolved.clack);
-		resolved.clack.cancel(DEPLOY_FAILED_MESSAGE);
+		cancelAsFailed(resolved.clack);
 		return EXIT_ERROR;
 	}
 
@@ -124,7 +126,7 @@ async function runDeploy(
 		resolved,
 	});
 	if (failures.length > 0) {
-		resolved.clack.cancel(DEPLOY_FAILED_MESSAGE);
+		cancelAsFailed(resolved.clack);
 		return EXIT_ERROR;
 	}
 

--- a/packages/bedrock/src/cli/commands/deploy.ts
+++ b/packages/bedrock/src/cli/commands/deploy.ts
@@ -1,0 +1,33 @@
+import process from "node:process";
+
+import { EXIT_ERROR } from "../exit-codes.ts";
+import type { ProgDeps } from "../index.ts";
+import { parseCommonOptions } from "../parse-options.ts";
+import { createClackPort, renderParseError } from "../render.ts";
+
+/**
+ * Build the sade action for `bedrock deploy`. The returned function consumes
+ * the raw options object sade hands the action callback, parses it via
+ * `parseCommonOptions`, and routes any parse failure through
+ * `renderParseError` before exiting non-zero.
+ * @param deps - Dependency overrides; missing slots are default-constructed
+ *   from real implementations.
+ * @returns An async sade action that returns once `deps.exit` was invoked.
+ */
+export function deployCommand(
+	deps: ProgDeps,
+): (rawOptions: Record<string, unknown>) => Promise<void> {
+	const clack = deps.clack ?? createClackPort();
+	const exit = deps.exit ?? ((code: number) => process.exit(code));
+
+	return async (rawOptions) => {
+		clack.intro("bedrock deploy");
+
+		const parsed = parseCommonOptions(rawOptions);
+		if (!parsed.success) {
+			renderParseError(parsed.err, clack);
+			clack.cancel("deploy failed");
+			return exit(EXIT_ERROR);
+		}
+	};
+}

--- a/packages/bedrock/src/cli/index.spec-d.ts
+++ b/packages/bedrock/src/cli/index.spec-d.ts
@@ -35,8 +35,8 @@ describe("ProgDeps", () => {
 		expectTypeOf<NonNullable<ProgDeps["clack"]>>().toEqualTypeOf<ClackPort>();
 	});
 
-	it("should accept a never-returning exit handle in the exit slot", () => {
-		expectTypeOf<NonNullable<ProgDeps["exit"]>>().toEqualTypeOf<(code: number) => never>();
+	it("should accept a void-returning exit handle so test stubs can intercept termination", () => {
+		expectTypeOf<NonNullable<ProgDeps["exit"]>>().toEqualTypeOf<(code: number) => void>();
 	});
 });
 

--- a/packages/bedrock/src/cli/index.ts
+++ b/packages/bedrock/src/cli/index.ts
@@ -5,6 +5,7 @@ import manifest from "../../package.json" with { type: "json" };
 import type { diff as defaultDiff } from "../core/diff.ts";
 import type { deploy as defaultDeploy } from "../shell/deploy.ts";
 import type { loadConfig as defaultLoadConfig } from "../shell/load-config.ts";
+import { deployCommand } from "./commands/deploy.ts";
 import type { ClackPort } from "./render.ts";
 
 export { createClackPort } from "./render.ts";
@@ -33,12 +34,22 @@ export interface ProgDeps {
  * Construct the bedrock CLI program. Pure factory: no `process.argv` parsing,
  * no clack output, no exits. Callers (the `run.ts` shim, integration tests)
  * call `.parse()` on the returned sade instance.
- * @param _deps - Dependency overrides for command actions. Reserved for the
- *   `bedrock deploy` and `bedrock diff` slices; unused while no commands are
- *   registered.
+ * @param deps - Dependency overrides for command actions. Each command
+ *   resolves its own defaults from any omitted slots.
  * @returns A configured sade program with the bedrock name, description, and
- *   the currently installed `@bedrock/core` version.
+ *   the currently installed `@bedrock/core` version, plus the registered
+ *   `deploy` command.
  */
-export function createProg(_deps?: ProgDeps): Sade {
-	return sade(PROGRAM_NAME).describe(PROGRAM_DESCRIBE).version(manifest.version);
+export function createProg(deps: ProgDeps = {}): Sade {
+	const prog = sade(PROGRAM_NAME).describe(PROGRAM_DESCRIBE).version(manifest.version);
+
+	prog.command("deploy")
+		.describe("Reconcile a project's resources against the configured environment(s)")
+		.option("-e, --env", "Target environment (repeat for multiple)")
+		.option("-c, --config", "Config file path (overrides discovery)")
+		.option("--api-key", "Override the ROBLOX_API_KEY environment variable")
+		.option("--github-token", "Override the GITHUB_TOKEN environment variable")
+		.action(deployCommand(deps));
+
+	return prog;
 }

--- a/packages/bedrock/src/cli/index.ts
+++ b/packages/bedrock/src/cli/index.ts
@@ -24,8 +24,8 @@ export interface ProgDeps {
 	readonly deploy?: typeof defaultDeploy;
 	/** Pure desired-vs-current operation list builder; defaults to the public `diff`. */
 	readonly diff?: typeof defaultDiff;
-	/** Process exit handle; defaults to `process.exit` so tests can intercept termination. */
-	readonly exit?: (code: number) => never;
+	/** Process exit handle; defaults to `process.exit` so tests can intercept termination. The production default never returns; test stubs are free to return void. */
+	readonly exit?: (code: number) => void;
 	/** Project config loader; defaults to the public `loadConfig`. */
 	readonly loadConfig?: typeof defaultLoadConfig;
 }

--- a/packages/bedrock/src/cli/index.ts
+++ b/packages/bedrock/src/cli/index.ts
@@ -45,8 +45,8 @@ export function createProg(deps: ProgDeps = {}): Sade {
 
 	prog.command("deploy")
 		.describe("Reconcile a project's resources against the configured environment(s)")
-		.option("-e, --env", "Target environment (repeat for multiple)")
-		.option("-c, --config", "Config file path (overrides discovery)")
+		.option("--env", "Target environment (repeat for multiple)")
+		.option("--config", "Config file path (overrides discovery)")
 		.option("--api-key", "Override the ROBLOX_API_KEY environment variable")
 		.option("--github-token", "Override the GITHUB_TOKEN environment variable")
 		.action(deployCommand(deps));

--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -6,7 +6,8 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { DeployError } from "../shell/deploy.ts";
 import { asResourceKey } from "../types/ids.ts";
-import { type ClackPort, createClackPort, renderDeployError } from "./render.ts";
+import type { ParseOptionsError } from "./parse-options.ts";
+import { type ClackPort, createClackPort, renderDeployError, renderParseError } from "./render.ts";
 
 interface CapturedOutput {
 	readonly text: string;
@@ -209,6 +210,31 @@ describe(renderDeployError, () => {
 		const port = fakeClackPort();
 
 		renderDeployError(err, port);
+
+		expect(port.logError).toHaveBeenCalledExactlyOnceWith(expected);
+	});
+});
+
+describe(renderParseError, () => {
+	it.for<{ err: ParseOptionsError; expected: string }>([
+		{
+			err: { flag: "env", kind: "missingRequired" },
+			expected: "missing required flag --env",
+		},
+		{
+			err: { flag: "verbose", kind: "unknownFlag" },
+			expected: "unknown flag '--verbose'",
+		},
+		{
+			err: { flag: "env", kind: "invalidValue" },
+			expected: "invalid value for flag '--env' (expected a string)",
+		},
+	])("should render $err.kind via logError with a flag-specific message", ({ err, expected }) => {
+		expect.assertions(1);
+
+		const port = fakeClackPort();
+
+		renderParseError(err, port);
 
 		expect(port.logError).toHaveBeenCalledExactlyOnceWith(expected);
 	});

--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -1,5 +1,6 @@
 import { S_BAR, S_BAR_END, S_BAR_START, S_ERROR, S_SUCCESS } from "@clack/prompts";
 
+import { fakeClackPort } from "#tests/helpers/clack";
 import { Buffer } from "node:buffer";
 import process from "node:process";
 import { describe, expect, it, vi } from "vitest";
@@ -11,17 +12,6 @@ import { type ClackPort, createClackPort, renderDeployError, renderParseError } 
 
 interface CapturedOutput {
 	readonly text: string;
-}
-
-function fakeClackPort(): ClackPort {
-	return {
-		cancel: vi.fn<ClackPort["cancel"]>(),
-		intro: vi.fn<ClackPort["intro"]>(),
-		logError: vi.fn<ClackPort["logError"]>(),
-		logMessage: vi.fn<ClackPort["logMessage"]>(),
-		logSuccess: vi.fn<ClackPort["logSuccess"]>(),
-		outro: vi.fn<ClackPort["outro"]>(),
-	};
 }
 
 function captureWith(act: (port: ClackPort) => void): CapturedOutput {

--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -4,10 +4,23 @@ import { Buffer } from "node:buffer";
 import process from "node:process";
 import { describe, expect, it, vi } from "vitest";
 
-import { type ClackPort, createClackPort } from "./render.ts";
+import type { DeployError } from "../shell/deploy.ts";
+import { asResourceKey } from "../types/ids.ts";
+import { type ClackPort, createClackPort, renderDeployError } from "./render.ts";
 
 interface CapturedOutput {
 	readonly text: string;
+}
+
+function fakeClackPort(): ClackPort {
+	return {
+		cancel: vi.fn<ClackPort["cancel"]>(),
+		intro: vi.fn<ClackPort["intro"]>(),
+		logError: vi.fn<ClackPort["logError"]>(),
+		logMessage: vi.fn<ClackPort["logMessage"]>(),
+		logSuccess: vi.fn<ClackPort["logSuccess"]>(),
+		outro: vi.fn<ClackPort["outro"]>(),
+	};
 }
 
 function captureWith(act: (port: ClackPort) => void): CapturedOutput {
@@ -103,5 +116,100 @@ describe(createClackPort, () => {
 		expect(text).not.toContain(S_SUCCESS);
 		expect(text).not.toContain(S_ERROR);
 		expect(text).not.toContain(S_BAR_END);
+	});
+});
+
+describe(renderDeployError, () => {
+	it.for<{ err: DeployError; expected: string }>([
+		{
+			err: {
+				declared: ["production", "staging"],
+				environment: "foo",
+				kind: "unknownEnvironment",
+			},
+			expected: "unknown environment 'foo' (declared: production, staging)",
+		},
+		{
+			err: { environment: "production", kind: "stateNotConfigured" },
+			expected: "state not configured for environment 'production'",
+		},
+		{
+			err: {
+				kind: "missingCredential",
+				purpose: "stateBackend",
+				variable: "GITHUB_TOKEN",
+			},
+			expected: "missing credential: environment variable GITHUB_TOKEN is not set",
+		},
+		{
+			err: {
+				backend: "s3",
+				hint: "pass a custom statePort via opts.statePort",
+				kind: "unsupportedBackend",
+			},
+			expected: "unsupported state backend 's3' (pass a custom statePort via opts.statePort)",
+		},
+		{
+			err: {
+				hint: "set universe.universeId in your bedrock config",
+				kind: "registryConfigMissing",
+				missing: "universeId",
+			},
+			expected:
+				"registry config missing 'universeId' (set universe.universeId in your bedrock config)",
+		},
+		{
+			err: {
+				cause: { kind: "fileNotFound", searchedFrom: "/projects/example" },
+				kind: "configLoadFailed",
+			},
+			expected: "config load failed (fileNotFound)",
+		},
+		{
+			err: {
+				cause: {
+					key: asResourceKey("main-place"),
+					filePath: "/projects/example/place.rbxl",
+					kind: "fileReadFailed",
+					reason: "ENOENT",
+				},
+				kind: "buildDesiredFailed",
+			},
+			expected: "build desired state failed (fileReadFailed)",
+		},
+		{
+			err: {
+				cause: { file: "state.json", kind: "stateError", reason: "invalid json" },
+				kind: "stateReadFailed",
+			},
+			expected: "state read failed (stateError)",
+		},
+		{
+			err: {
+				cause: { file: "state.json", kind: "stateError", reason: "network error" },
+				kind: "stateWriteFailed",
+				unsavedState: { environment: "production", resources: [], version: 1 },
+			},
+			expected: "state write failed (stateError)",
+		},
+		{
+			err: {
+				cause: {
+					key: asResourceKey("vip-pass"),
+					appliedSoFar: [],
+					kind: "updateUnsupported",
+				},
+				kind: "applyFailed",
+			},
+			expected: "apply failed (updateUnsupported)",
+		},
+	])("should render $err.kind via logError with a kind-specific message", ({ err, expected }) => {
+		expect.assertions(1);
+
+		const port = fakeClackPort();
+
+		renderDeployError(err, port);
+
+		expect(port.logError).toHaveBeenCalledExactlyOnceWith(expected);
 	});
 });

--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -194,6 +194,15 @@ describe(renderDeployError, () => {
 			},
 			expected: "apply failed (updateUnsupported)",
 		},
+		{
+			err: {
+				key: "main-place",
+				environment: "production",
+				kind: "incompletePlaceEntry",
+				missingField: "placeId",
+			},
+			expected: "place 'main-place' is missing 'placeId' under environment 'production'",
+		},
 	])("should render $err.kind via logError with a kind-specific message", ({ err, expected }) => {
 		expect.assertions(1);
 

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -1,5 +1,7 @@
 import { cancel, intro, log, outro } from "@clack/prompts";
 
+import type { DeployError } from "../shell/deploy.ts";
+
 /**
  * Output port the CLI renders through. Mirrors the subset of `@clack/prompts`
  * the bedrock CLI uses today; tests inject a fake to assert what was rendered.
@@ -17,6 +19,21 @@ export interface ClackPort {
 	logSuccess(message: string): void;
 	/** Close the current framed section with a final message. */
 	outro(message: string): void;
+}
+
+type WrappedDeployError = Extract<DeployError, { readonly cause: { readonly kind: string } }>;
+
+/**
+ * Render a `DeployError` to the supplied `ClackPort` as a single error line.
+ * Each variant produces a distinct, terse diagnostic; wrapped variants
+ * (`applyFailed`, `buildDesiredFailed`, `configLoadFailed`, `stateReadFailed`,
+ * `stateWriteFailed`) include the inner cause's `kind` so the reader can
+ * distinguish the failing stage without inspecting the full cause.
+ * @param err - The deploy error to describe.
+ * @param port - The output port the diagnostic is written to.
+ */
+export function renderDeployError(err: DeployError, port: ClackPort): void {
+	port.logError(deployErrorMessage(err));
 }
 
 /**
@@ -45,4 +62,54 @@ export function createClackPort(): ClackPort {
 			outro(message);
 		},
 	};
+}
+
+function formatUnknownEnvironment(environment: string, declared: ReadonlyArray<string>): string {
+	return `unknown environment '${environment}' (declared: ${declared.join(", ")})`;
+}
+
+function isWrappedDeployError(err: DeployError): err is WrappedDeployError {
+	return (
+		err.kind === "applyFailed" ||
+		err.kind === "buildDesiredFailed" ||
+		err.kind === "configLoadFailed" ||
+		err.kind === "stateReadFailed" ||
+		err.kind === "stateWriteFailed"
+	);
+}
+
+const WRAPPED_PREFIX: Record<WrappedDeployError["kind"], string> = {
+	applyFailed: "apply failed",
+	buildDesiredFailed: "build desired state failed",
+	configLoadFailed: "config load failed",
+	stateReadFailed: "state read failed",
+	stateWriteFailed: "state write failed",
+};
+
+function deployErrorMessage(err: DeployError): string {
+	if (isWrappedDeployError(err)) {
+		return `${WRAPPED_PREFIX[err.kind]} (${err.cause.kind})`;
+	}
+
+	switch (err.kind) {
+		case "missingCredential": {
+			return `missing credential: environment variable ${err.variable} is not set`;
+		}
+		case "registryConfigMissing": {
+			return `registry config missing '${err.missing}' (${err.hint})`;
+		}
+		case "stateNotConfigured": {
+			return `state not configured for environment '${err.environment}'`;
+		}
+		case "unknownEnvironment": {
+			return formatUnknownEnvironment(err.environment, err.declared);
+		}
+		case "unsupportedBackend": {
+			return `unsupported state backend '${err.backend}' (${err.hint})`;
+		}
+		default: {
+			const exhaustive: never = err;
+			return exhaustive;
+		}
+	}
 }

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -22,8 +22,6 @@ export interface ClackPort {
 	outro(message: string): void;
 }
 
-type WrappedDeployError = Extract<DeployError, { readonly cause: { readonly kind: string } }>;
-
 /**
  * Render a `DeployError` to the supplied `ClackPort` as a single error line.
  * Each variant produces a distinct, terse diagnostic; wrapped variants
@@ -76,6 +74,42 @@ export function createClackPort(): ClackPort {
 	};
 }
 
+/* eslint-disable-next-line max-lines-per-function -- single exhaustive switch over ten DeployError variants is clearer than splitting into a wrapped-vs-unwrapped predicate plus a parallel prefix table. */
+function deployErrorMessage(err: DeployError): string {
+	switch (err.kind) {
+		case "applyFailed": {
+			return `apply failed (${err.cause.kind})`;
+		}
+		case "buildDesiredFailed": {
+			return `build desired state failed (${err.cause.kind})`;
+		}
+		case "configLoadFailed": {
+			return `config load failed (${err.cause.kind})`;
+		}
+		case "missingCredential": {
+			return `missing credential: environment variable ${err.variable} is not set`;
+		}
+		case "registryConfigMissing": {
+			return `registry config missing '${err.missing}' (${err.hint})`;
+		}
+		case "stateNotConfigured": {
+			return `state not configured for environment '${err.environment}'`;
+		}
+		case "stateReadFailed": {
+			return `state read failed (${err.cause.kind})`;
+		}
+		case "stateWriteFailed": {
+			return `state write failed (${err.cause.kind})`;
+		}
+		case "unknownEnvironment": {
+			return `unknown environment '${err.environment}' (declared: ${err.declared.join(", ")})`;
+		}
+		case "unsupportedBackend": {
+			return `unsupported state backend '${err.backend}' (${err.hint})`;
+		}
+	}
+}
+
 function parseErrorMessage(err: ParseOptionsError): string {
 	switch (err.kind) {
 		case "invalidValue": {
@@ -86,52 +120,6 @@ function parseErrorMessage(err: ParseOptionsError): string {
 		}
 		case "unknownFlag": {
 			return `unknown flag '--${err.flag}'`;
-		}
-	}
-}
-
-function formatUnknownEnvironment(environment: string, declared: ReadonlyArray<string>): string {
-	return `unknown environment '${environment}' (declared: ${declared.join(", ")})`;
-}
-
-function isWrappedDeployError(err: DeployError): err is WrappedDeployError {
-	return (
-		err.kind === "applyFailed" ||
-		err.kind === "buildDesiredFailed" ||
-		err.kind === "configLoadFailed" ||
-		err.kind === "stateReadFailed" ||
-		err.kind === "stateWriteFailed"
-	);
-}
-
-const WRAPPED_PREFIX: Record<WrappedDeployError["kind"], string> = {
-	applyFailed: "apply failed",
-	buildDesiredFailed: "build desired state failed",
-	configLoadFailed: "config load failed",
-	stateReadFailed: "state read failed",
-	stateWriteFailed: "state write failed",
-};
-
-function deployErrorMessage(err: DeployError): string {
-	if (isWrappedDeployError(err)) {
-		return `${WRAPPED_PREFIX[err.kind]} (${err.cause.kind})`;
-	}
-
-	switch (err.kind) {
-		case "missingCredential": {
-			return `missing credential: environment variable ${err.variable} is not set`;
-		}
-		case "registryConfigMissing": {
-			return `registry config missing '${err.missing}' (${err.hint})`;
-		}
-		case "stateNotConfigured": {
-			return `state not configured for environment '${err.environment}'`;
-		}
-		case "unknownEnvironment": {
-			return formatUnknownEnvironment(err.environment, err.declared);
-		}
-		case "unsupportedBackend": {
-			return `unsupported state backend '${err.backend}' (${err.hint})`;
 		}
 	}
 }

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -1,6 +1,7 @@
 import { cancel, intro, log, outro } from "@clack/prompts";
 
 import type { DeployError } from "../shell/deploy.ts";
+import type { ParseOptionsError } from "./parse-options.ts";
 
 /**
  * Output port the CLI renders through. Mirrors the subset of `@clack/prompts`
@@ -37,6 +38,17 @@ export function renderDeployError(err: DeployError, port: ClackPort): void {
 }
 
 /**
+ * Render a `ParseOptionsError` to the supplied `ClackPort` as a single
+ * error line. Each variant names the offending flag so the diagnostic
+ * pinpoints what the caller needs to change.
+ * @param err - The parse error to describe.
+ * @param port - The output port the diagnostic is written to.
+ */
+export function renderParseError(err: ParseOptionsError, port: ClackPort): void {
+	port.logError(parseErrorMessage(err));
+}
+
+/**
  * Construct a `ClackPort` whose methods delegate to `@clack/prompts`. The
  * resulting port writes to `process.stdout` via clack's defaults.
  * @returns A port whose six methods each invoke the matching clack helper.
@@ -62,6 +74,24 @@ export function createClackPort(): ClackPort {
 			outro(message);
 		},
 	};
+}
+
+function parseErrorMessage(err: ParseOptionsError): string {
+	switch (err.kind) {
+		case "invalidValue": {
+			return `invalid value for flag '--${err.flag}' (expected a string)`;
+		}
+		case "missingRequired": {
+			return `missing required flag --${err.flag}`;
+		}
+		case "unknownFlag": {
+			return `unknown flag '--${err.flag}'`;
+		}
+		default: {
+			const exhaustive: never = err;
+			return exhaustive;
+		}
+	}
 }
 
 function formatUnknownEnvironment(environment: string, declared: ReadonlyArray<string>): string {

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -87,10 +87,6 @@ function parseErrorMessage(err: ParseOptionsError): string {
 		case "unknownFlag": {
 			return `unknown flag '--${err.flag}'`;
 		}
-		default: {
-			const exhaustive: never = err;
-			return exhaustive;
-		}
 	}
 }
 
@@ -136,10 +132,6 @@ function deployErrorMessage(err: DeployError): string {
 		}
 		case "unsupportedBackend": {
 			return `unsupported state backend '${err.backend}' (${err.hint})`;
-		}
-		default: {
-			const exhaustive: never = err;
-			return exhaustive;
 		}
 	}
 }

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -74,7 +74,7 @@ export function createClackPort(): ClackPort {
 	};
 }
 
-/* eslint-disable-next-line max-lines-per-function -- single exhaustive switch over ten DeployError variants is clearer than splitting into a wrapped-vs-unwrapped predicate plus a parallel prefix table. */
+/* eslint-disable-next-line max-lines-per-function -- single exhaustive switch over every DeployError variant is clearer than splitting into a wrapped-vs-unwrapped predicate plus a parallel prefix table. */
 function deployErrorMessage(err: DeployError): string {
 	switch (err.kind) {
 		case "applyFailed": {
@@ -85,6 +85,9 @@ function deployErrorMessage(err: DeployError): string {
 		}
 		case "configLoadFailed": {
 			return `config load failed (${err.cause.kind})`;
+		}
+		case "incompletePlaceEntry": {
+			return `place '${err.key}' is missing '${err.missingField}' under environment '${err.environment}'`;
 		}
 		case "missingCredential": {
 			return `missing credential: environment variable ${err.variable} is not set`;

--- a/packages/bedrock/tests/helpers/clack.ts
+++ b/packages/bedrock/tests/helpers/clack.ts
@@ -1,0 +1,20 @@
+import type { ClackPort } from "#src/cli/render";
+import { vi } from "vitest";
+
+/**
+ * Build a `ClackPort` whose six methods are independent `vi.fn()` spies. Used
+ * by every layer of CLI test (unit, integration, smoke) to assert exactly
+ * what was rendered without touching real `@clack/prompts` output.
+ *
+ * @returns A `ClackPort` whose every method is a fresh `vi.fn()` instance.
+ */
+export function fakeClackPort(): ClackPort {
+	return {
+		cancel: vi.fn<ClackPort["cancel"]>(),
+		intro: vi.fn<ClackPort["intro"]>(),
+		logError: vi.fn<ClackPort["logError"]>(),
+		logMessage: vi.fn<ClackPort["logMessage"]>(),
+		logSuccess: vi.fn<ClackPort["logSuccess"]>(),
+		outro: vi.fn<ClackPort["outro"]>(),
+	};
+}

--- a/packages/bedrock/tests/integration/cli/deploy.spec.ts
+++ b/packages/bedrock/tests/integration/cli/deploy.spec.ts
@@ -1,15 +1,15 @@
 import type { Result } from "@bedrock/ocale";
 
 import { createProg, type ProgDeps } from "#src/cli/index";
-import type { ConfigError } from "#src/core/config-error";
 import type { Config } from "#src/core/schema";
 import type { BedrockState } from "#src/core/state";
-import type { DeployError, DeployOptions } from "#src/shell/deploy";
-import type { LoadConfigOptions } from "#src/shell/load-config";
+import type { DeployError } from "#src/shell/deploy";
+import { fakeClackPort } from "#tests/helpers/clack";
 import { describe, expect, it, vi } from "vitest";
 
-type LoadConfigFunc = (options?: LoadConfigOptions) => Promise<Result<Config, ConfigError>>;
-type DeployFunc = (options: DeployOptions) => Promise<Result<BedrockState, DeployError>>;
+type LoadConfigFunc = NonNullable<ProgDeps["loadConfig"]>;
+type DeployFunc = NonNullable<ProgDeps["deploy"]>;
+type ExitFunc = NonNullable<ProgDeps["exit"]>;
 
 const fakeConfig: Config = {
 	environments: { production: {}, staging: {} },
@@ -22,21 +22,8 @@ interface DeployHarness {
 	readonly prog: ReturnType<typeof createProg>;
 }
 
-type ClackPort = NonNullable<ProgDeps["clack"]>;
-
 function emptyState(environment: string): BedrockState {
 	return { environment, resources: [], version: 1 };
-}
-
-function silentClack(): ClackPort {
-	return {
-		cancel: vi.fn<ClackPort["cancel"]>(),
-		intro: vi.fn<ClackPort["intro"]>(),
-		logError: vi.fn<ClackPort["logError"]>(),
-		logMessage: vi.fn<ClackPort["logMessage"]>(),
-		logSuccess: vi.fn<ClackPort["logSuccess"]>(),
-		outro: vi.fn<ClackPort["outro"]>(),
-	};
 }
 
 function buildHarness(
@@ -46,9 +33,9 @@ function buildHarness(
 	const exitPromise = new Promise<number>((resolve) => {
 		resolveExit = resolve;
 	});
-	const exit = vi.fn<(code: number) => never>().mockImplementation(((code: number) => {
+	const exit = vi.fn<ExitFunc>((code) => {
 		resolveExit(code);
-	}) as (code: number) => never);
+	});
 
 	let callIndex = 0;
 	const deploy = vi.fn<DeployFunc>(async () => {
@@ -62,7 +49,7 @@ function buildHarness(
 	});
 	const loadConfig = vi.fn<LoadConfigFunc>(async () => ({ data: fakeConfig, success: true }));
 
-	const prog = createProg({ clack: silentClack(), deploy, exit, loadConfig });
+	const prog = createProg({ clack: fakeClackPort(), deploy, exit, loadConfig });
 	return { deploy, exitPromise, loadConfig, prog };
 }
 

--- a/packages/bedrock/tests/integration/cli/deploy.spec.ts
+++ b/packages/bedrock/tests/integration/cli/deploy.spec.ts
@@ -1,0 +1,114 @@
+import type { Result } from "@bedrock/ocale";
+
+import { createProg, type ProgDeps } from "#src/cli/index";
+import type { ConfigError } from "#src/core/config-error";
+import type { Config } from "#src/core/schema";
+import type { BedrockState } from "#src/core/state";
+import type { DeployError, DeployOptions } from "#src/shell/deploy";
+import type { LoadConfigOptions } from "#src/shell/load-config";
+import { describe, expect, it, vi } from "vitest";
+
+type LoadConfigFunc = (options?: LoadConfigOptions) => Promise<Result<Config, ConfigError>>;
+type DeployFunc = (options: DeployOptions) => Promise<Result<BedrockState, DeployError>>;
+
+const fakeConfig: Config = {
+	environments: { production: {}, staging: {} },
+};
+
+interface DeployHarness {
+	readonly deploy: ReturnType<typeof vi.fn<DeployFunc>>;
+	readonly exitPromise: Promise<number>;
+	readonly loadConfig: ReturnType<typeof vi.fn<LoadConfigFunc>>;
+	readonly prog: ReturnType<typeof createProg>;
+}
+
+type ClackPort = NonNullable<ProgDeps["clack"]>;
+
+function emptyState(environment: string): BedrockState {
+	return { environment, resources: [], version: 1 };
+}
+
+function silentClack(): ClackPort {
+	return {
+		cancel: vi.fn<ClackPort["cancel"]>(),
+		intro: vi.fn<ClackPort["intro"]>(),
+		logError: vi.fn<ClackPort["logError"]>(),
+		logMessage: vi.fn<ClackPort["logMessage"]>(),
+		logSuccess: vi.fn<ClackPort["logSuccess"]>(),
+		outro: vi.fn<ClackPort["outro"]>(),
+	};
+}
+
+function buildHarness(
+	deployResults: ReadonlyArray<Result<BedrockState, DeployError>>,
+): DeployHarness {
+	let resolveExit!: (code: number) => void;
+	const exitPromise = new Promise<number>((resolve) => {
+		resolveExit = resolve;
+	});
+	const exit = vi.fn<(code: number) => never>().mockImplementation(((code: number) => {
+		resolveExit(code);
+	}) as (code: number) => never);
+
+	let callIndex = 0;
+	const deploy = vi.fn<DeployFunc>(async () => {
+		const next = deployResults[callIndex];
+		callIndex += 1;
+		if (next === undefined) {
+			throw new Error("deploy invoked beyond scripted results");
+		}
+
+		return next;
+	});
+	const loadConfig = vi.fn<LoadConfigFunc>(async () => ({ data: fakeConfig, success: true }));
+
+	const prog = createProg({ clack: silentClack(), deploy, exit, loadConfig });
+	return { deploy, exitPromise, loadConfig, prog };
+}
+
+function dispatch(prog: ReturnType<typeof createProg>, argv: ReadonlyArray<string>): void {
+	prog.parse(["node", "bedrock", ...argv]);
+}
+
+describe("cli deploy dispatch", () => {
+	it("should route 'deploy --env production --config ./b.config.ts' through the action with the parsed options", async () => {
+		expect.assertions(3);
+
+		const harness = buildHarness([{ data: emptyState("production"), success: true }]);
+
+		dispatch(harness.prog, [
+			"deploy",
+			"--env",
+			"production",
+			"--config",
+			"./bedrock.staging.config.ts",
+		]);
+		const code = await harness.exitPromise;
+
+		expect(harness.loadConfig).toHaveBeenCalledExactlyOnceWith({
+			configFile: "./bedrock.staging.config.ts",
+		});
+		expect(harness.deploy).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({ config: fakeConfig, environment: "production" }),
+		);
+		expect(code).toBe(0);
+	});
+
+	it("should call deploy once per --env and exit 1 when any env fails", async () => {
+		expect.assertions(2);
+
+		const harness = buildHarness([
+			{ data: emptyState("production"), success: true },
+			{
+				err: { environment: "staging", kind: "stateNotConfigured" },
+				success: false,
+			},
+		]);
+
+		dispatch(harness.prog, ["deploy", "--env", "production", "--env", "staging"]);
+		const code = await harness.exitPromise;
+
+		expect(harness.deploy).toHaveBeenCalledTimes(2);
+		expect(code).toBe(1);
+	});
+});

--- a/packages/bedrock/tests/integration/cli/index.spec.ts
+++ b/packages/bedrock/tests/integration/cli/index.spec.ts
@@ -102,4 +102,25 @@ describe("cli program factory", () => {
 			expect(captured).toContain("Roblox");
 		}
 	});
+
+	it("should describe the deploy subcommand and each of its flags in 'deploy --help' output", async () => {
+		expect.assertions(5);
+
+		const { createProg } = await import("#src/cli/index");
+		const prog = createProg();
+
+		const collect = startCapture();
+		try {
+			prog.parse(["node", "bedrock", "deploy", "--help"]);
+		} finally {
+			const { stdout } = collect();
+			const captured = stdout.join("");
+
+			expect(captured).toContain("Reconcile");
+			expect(captured).toContain("Target environment");
+			expect(captured).toContain("Config file path");
+			expect(captured).toContain("ROBLOX_API_KEY");
+			expect(captured).toContain("GITHUB_TOKEN");
+		}
+	});
 });


### PR DESCRIPTION
## Summary

Adds the `bedrock deploy` action to the CLI. The command parses `--env` (required, repeatable), `--config`, `--api-key`, and `--github-token` via `parseCommonOptions`, loads the project config once, and dispatches the all-optional `deploy()` from `@bedrock/core` once per environment, aggregating exit codes (0 only if every env succeeded).

Output flows through clack: `intro("bedrock deploy")` opens the frame, per-env `logSuccess` lines or rendered `DeployError`s fill it, and `outro("deploy succeeded")` or `cancel("deploy failed")` closes. All ten `DeployError` variants render via an exhaustive switch in `render.ts`; adding a future variant fails compile until a render branch exists. The same exhaustiveness guarantee applies to the three `ParseOptionsError` variants.

Tier (c) unit tests in `src/cli/commands/deploy.spec.ts` cover every action branch with stubbed `ProgDeps`. Tier (b) integration test in `tests/integration/cli/deploy.spec.ts` exercises sade dispatch via `prog.parse([...])` with fakes for `loadConfig` and `deploy`. Tier (a) e2e smoke at `apps/e2e/tests/smoke/cli-deploy.spec.ts` spawns the real bin against a real gist + Open Cloud, gated on `GITHUB_TOKEN`, `ROBLOX_API_KEY`, `BEDROCK_TEST_GIST_ID`, `ROBLOX_TEST_PLACE_ID`.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm --filter @bedrock/core test` (798 passed, 10 skipped)
- [x] `pnpm build` clean (`dist/cli/run.mjs` produced)
- [x] `pnpm --filter @bedrock/e2e test:smoke` (3 skipped without secrets)
- [ ] e2e suite passes against real gist + universe (gated; needs CI secrets)

Closes #186
Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)