### PR TITLE
feat(core)!: require place-id under environments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,9 +201,11 @@ PR titles are linted by commitlint (`.github/workflows/lint-pr-title.yaml`) —
    `type(scope):`, including code identifiers (`mergeConfig` → `merge-config`,
    `GamePassesClient` → `game-passes-client`).
 2. **Scope-enum**: if a scope is present it MUST be one of
-   `bedrock, e2e, global, ocale, testing, tsconfig, vite, website`. `ci`,
-   `chore`, `docs`, `build`, `refactor` are **types, not scopes** — write
-   `ci: …` with no scope, not `fix(ci): …`.
+   `core, deps, e2e, global, ocale, testing, tsconfig, vite, website`.
+   The `bedrock` package was renamed to `@bedrock/core`, so changes in
+   `packages/bedrock/` take the `core` scope. `ci`, `chore`, `docs`,
+   `build`, `refactor` are **types, not scopes** — write `ci: …` with no
+   scope, not `fix(ci): …`.
 3. **Consumer-useful subject**: PR titles become changelog entries for
    people installing the published package. Write what *changed in the
    package from the consumer's perspective*, not how the work was organised.

--- a/packages/bedrock/src/core/flatten.example.spec.ts
+++ b/packages/bedrock/src/core/flatten.example.spec.ts
@@ -8,6 +8,7 @@ import {
   UNIVERSE_SINGLETON_KEY,
   type UniverseDesiredInput,
   flattenConfig,
+  selectEnvironment,
   type Config,
 } from '@bedrock/core'
 
@@ -54,7 +55,9 @@ it('Example 3', () => {
 
 it('Example 4', () => {
   const config: Config = {
-    environments: { production: {} },
+    environments: {
+      production: { places: { 'start-place': { placeId: '4711' } } },
+    },
     passes: {
       'vip-pass': {
         description: 'Grants VIP perks.',
@@ -63,14 +66,16 @@ it('Example 4', () => {
         price: 500,
       },
     },
-    places: {
-      'start-place': {
-        filePath: 'places/start.rbxl',
-        placeId: '4711',
-      },
-    },
+    places: { 'start-place': { filePath: 'places/start.rbxl' } },
   }
-  const inputs = flattenConfig(config)
-  expect(inputs.map((input) => input.kind)).toEqual(['gamePass', 'place'])
-  expect(inputs.map((input) => input.key)).toEqual(['vip-pass', 'start-place'])
+  const resolved = selectEnvironment(config, 'production')
+  expect(resolved.success).toBeTrue()
+  if (resolved.success) {
+    const inputs = flattenConfig(resolved.data)
+    expect(inputs.map((input) => input.kind)).toEqual(['gamePass', 'place'])
+    expect(inputs.map((input) => input.key)).toEqual([
+      'vip-pass',
+      'start-place',
+    ])
+  }
 })

--- a/packages/bedrock/src/core/flatten.spec.ts
+++ b/packages/bedrock/src/core/flatten.spec.ts
@@ -4,7 +4,7 @@ import { assert, describe, expect, it } from "vitest";
 import { asResourceKey, asRobloxAssetId } from "../types/ids.ts";
 import { flattenConfig } from "./flatten.ts";
 import { SOCIAL_LINK_FIELDS, UNIVERSE_SINGLETON_KEY } from "./resources.ts";
-import { validateConfig } from "./schema.ts";
+import type { ResolvedConfig } from "./schema.ts";
 
 const MinimumEnvironments = { production: {} } as const;
 
@@ -12,32 +12,27 @@ describe(flattenConfig, () => {
 	it("should return an empty array for a config without resource collections", () => {
 		expect.assertions(1);
 
-		const config = validateConfig({ environments: MinimumEnvironments }, "bedrock.config.ts");
-		assert(config.success);
+		const config: ResolvedConfig = { environments: MinimumEnvironments };
 
-		expect(flattenConfig(config.data)).toStrictEqual([]);
+		expect(flattenConfig(config)).toStrictEqual([]);
 	});
 
 	it("should tag a passes entry with kind gamePass and the ResourceKey-branded key", () => {
 		expect.assertions(1);
 
-		const config = validateConfig(
-			{
-				environments: MinimumEnvironments,
-				passes: {
-					"vip-pass": {
-						name: "VIP Pass",
-						description: "Grants VIP perks.",
-						iconFilePath: "assets/vip-icon.png",
-						price: 500,
-					},
+		const config: ResolvedConfig = {
+			environments: MinimumEnvironments,
+			passes: {
+				"vip-pass": {
+					name: "VIP Pass",
+					description: "Grants VIP perks.",
+					iconFilePath: "assets/vip-icon.png",
+					price: 500,
 				},
 			},
-			"bedrock.config.ts",
-		);
-		assert(config.success);
+		};
 
-		expect(flattenConfig(config.data)).toStrictEqual([
+		expect(flattenConfig(config)).toStrictEqual([
 			{
 				key: asResourceKey("vip-pass"),
 				name: "VIP Pass",
@@ -52,22 +47,18 @@ describe(flattenConfig, () => {
 	it("should carry price as undefined when the entry omits it", () => {
 		expect.assertions(1);
 
-		const config = validateConfig(
-			{
-				environments: MinimumEnvironments,
-				passes: {
-					"free-pass": {
-						name: "Free",
-						description: "Free pass.",
-						iconFilePath: "assets/free.png",
-					},
+		const config: ResolvedConfig = {
+			environments: MinimumEnvironments,
+			passes: {
+				"free-pass": {
+					name: "Free",
+					description: "Free pass.",
+					iconFilePath: "assets/free.png",
 				},
 			},
-			"bedrock.config.ts",
-		);
-		assert(config.success);
+		};
 
-		const input = flattenConfig(config.data)[0]!;
+		const input = flattenConfig(config)[0]!;
 		assert(input.kind === "gamePass");
 
 		expect(input.price).toBeUndefined();
@@ -76,32 +67,16 @@ describe(flattenConfig, () => {
 	it("should preserve the insertion order of passes entries", () => {
 		expect.assertions(1);
 
-		const config = validateConfig(
-			{
-				environments: MinimumEnvironments,
-				passes: {
-					alpha: {
-						name: "A",
-						description: "A.",
-						iconFilePath: "a.png",
-					},
-					beta: {
-						name: "B",
-						description: "B.",
-						iconFilePath: "b.png",
-					},
-					gamma: {
-						name: "G",
-						description: "G.",
-						iconFilePath: "g.png",
-					},
-				},
+		const config: ResolvedConfig = {
+			environments: MinimumEnvironments,
+			passes: {
+				alpha: { name: "A", description: "A.", iconFilePath: "a.png" },
+				beta: { name: "B", description: "B.", iconFilePath: "b.png" },
+				gamma: { name: "G", description: "G.", iconFilePath: "g.png" },
 			},
-			"bedrock.config.ts",
-		);
-		assert(config.success);
+		};
 
-		expect(flattenConfig(config.data).map((input) => input.key)).toStrictEqual([
+		expect(flattenConfig(config).map((input) => input.key)).toStrictEqual([
 			"alpha",
 			"beta",
 			"gamma",
@@ -111,18 +86,14 @@ describe(flattenConfig, () => {
 	it("should tag a places entry with kind place and brand placeId as a RobloxAssetId", () => {
 		expect.assertions(1);
 
-		const config = validateConfig(
-			{
-				environments: MinimumEnvironments,
-				places: {
-					"start-place": { filePath: "places/start.rbxl", placeId: "4711" },
-				},
+		const config: ResolvedConfig = {
+			environments: MinimumEnvironments,
+			places: {
+				"start-place": { filePath: "places/start.rbxl", placeId: "4711" },
 			},
-			"bedrock.config.ts",
-		);
-		assert(config.success);
+		};
 
-		expect(flattenConfig(config.data)).toStrictEqual([
+		expect(flattenConfig(config)).toStrictEqual([
 			{
 				key: asResourceKey("start-place"),
 				filePath: "places/start.rbxl",
@@ -135,25 +106,21 @@ describe(flattenConfig, () => {
 	it("should emit passes before places when both collections are declared", () => {
 		expect.assertions(1);
 
-		const config = validateConfig(
-			{
-				environments: MinimumEnvironments,
-				passes: {
-					"vip-pass": {
-						name: "VIP Pass",
-						description: "Grants VIP perks.",
-						iconFilePath: "assets/vip.png",
-					},
-				},
-				places: {
-					"start-place": { filePath: "places/start.rbxl", placeId: "4711" },
+		const config: ResolvedConfig = {
+			environments: MinimumEnvironments,
+			passes: {
+				"vip-pass": {
+					name: "VIP Pass",
+					description: "Grants VIP perks.",
+					iconFilePath: "assets/vip.png",
 				},
 			},
-			"bedrock.config.ts",
-		);
-		assert(config.success);
+			places: {
+				"start-place": { filePath: "places/start.rbxl", placeId: "4711" },
+			},
+		};
 
-		expect(flattenConfig(config.data).map((input) => input.kind)).toStrictEqual([
+		expect(flattenConfig(config).map((input) => input.kind)).toStrictEqual([
 			"gamePass",
 			"place",
 		]);
@@ -162,16 +129,12 @@ describe(flattenConfig, () => {
 	it("should tag a universe block with the singleton key and brand universeId as a RobloxAssetId", () => {
 		expect.assertions(1);
 
-		const config = validateConfig(
-			{
-				environments: MinimumEnvironments,
-				universe: { universeId: "1234567890", voiceChatEnabled: true },
-			},
-			"bedrock.config.ts",
-		);
-		assert(config.success);
+		const config: ResolvedConfig = {
+			environments: MinimumEnvironments,
+			universe: { universeId: "1234567890", voiceChatEnabled: true },
+		};
 
-		expect(flattenConfig(config.data)).toStrictEqual([
+		expect(flattenConfig(config)).toStrictEqual([
 			{
 				key: UNIVERSE_SINGLETON_KEY,
 				consoleEnabled: undefined,
@@ -191,26 +154,22 @@ describe(flattenConfig, () => {
 	it("should emit the universe block after places when all three are declared", () => {
 		expect.assertions(1);
 
-		const config = validateConfig(
-			{
-				environments: MinimumEnvironments,
-				passes: {
-					"vip-pass": {
-						name: "VIP Pass",
-						description: "Grants VIP perks.",
-						iconFilePath: "assets/vip.png",
-					},
+		const config: ResolvedConfig = {
+			environments: MinimumEnvironments,
+			passes: {
+				"vip-pass": {
+					name: "VIP Pass",
+					description: "Grants VIP perks.",
+					iconFilePath: "assets/vip.png",
 				},
-				places: {
-					"start-place": { filePath: "places/start.rbxl", placeId: "4711" },
-				},
-				universe: { universeId: "1234567890" },
 			},
-			"bedrock.config.ts",
-		);
-		assert(config.success);
+			places: {
+				"start-place": { filePath: "places/start.rbxl", placeId: "4711" },
+			},
+			universe: { universeId: "1234567890" },
+		};
 
-		expect(flattenConfig(config.data).map((input) => input.kind)).toStrictEqual([
+		expect(flattenConfig(config).map((input) => input.kind)).toStrictEqual([
 			"gamePass",
 			"place",
 			"universe",
@@ -220,13 +179,12 @@ describe(flattenConfig, () => {
 	it("should carry voiceChatEnabled as undefined when the universe entry omits it", () => {
 		expect.assertions(1);
 
-		const config = validateConfig(
-			{ environments: MinimumEnvironments, universe: { universeId: "1234567890" } },
-			"bedrock.config.ts",
-		);
-		assert(config.success);
+		const config: ResolvedConfig = {
+			environments: MinimumEnvironments,
+			universe: { universeId: "1234567890" },
+		};
 
-		const input = flattenConfig(config.data)[0]!;
+		const input = flattenConfig(config)[0]!;
 		assert(input.kind === "universe");
 
 		expect(input.voiceChatEnabled).toBeUndefined();
@@ -237,16 +195,12 @@ describe(flattenConfig, () => {
 		([flag]) => {
 			expect.assertions(1);
 
-			const config = validateConfig(
-				{
-					environments: MinimumEnvironments,
-					universe: { [flag]: true, universeId: "1234567890" },
-				},
-				"bedrock.config.ts",
-			);
-			assert(config.success);
+			const config: ResolvedConfig = {
+				environments: MinimumEnvironments,
+				universe: { [flag]: true, universeId: "1234567890" },
+			};
 
-			const input = flattenConfig(config.data)[0]!;
+			const input = flattenConfig(config)[0]!;
 			assert(input.kind === "universe");
 
 			expect(input[flag]).toBeTrue();
@@ -258,13 +212,12 @@ describe(flattenConfig, () => {
 		([flag]) => {
 			expect.assertions(1);
 
-			const config = validateConfig(
-				{ environments: MinimumEnvironments, universe: { universeId: "1234567890" } },
-				"bedrock.config.ts",
-			);
-			assert(config.success);
+			const config: ResolvedConfig = {
+				environments: MinimumEnvironments,
+				universe: { universeId: "1234567890" },
+			};
 
-			const input = flattenConfig(config.data)[0]!;
+			const input = flattenConfig(config)[0]!;
 			assert(input.kind === "universe");
 
 			expect(input[flag]).toBeUndefined();
@@ -274,22 +227,18 @@ describe(flattenConfig, () => {
 	it("should carry every declared universe managed field onto the input", () => {
 		expect.assertions(5);
 
-		const config = validateConfig(
-			{
-				environments: MinimumEnvironments,
-				universe: {
-					displayName: "Fun Universe",
-					privateServerPriceRobux: 250,
-					universeId: "1234567890",
-					visibility: "public",
-					voiceChatEnabled: true,
-				},
+		const config: ResolvedConfig = {
+			environments: MinimumEnvironments,
+			universe: {
+				displayName: "Fun Universe",
+				privateServerPriceRobux: 250,
+				universeId: "1234567890",
+				visibility: "public",
+				voiceChatEnabled: true,
 			},
-			"bedrock.config.ts",
-		);
-		assert(config.success);
+		};
 
-		const input = flattenConfig(config.data)[0]!;
+		const input = flattenConfig(config)[0]!;
 		assert(input.kind === "universe");
 
 		expect(input.displayName).toBe("Fun Universe");
@@ -302,19 +251,15 @@ describe(flattenConfig, () => {
 	it("should preserve key-presence when privateServerPriceRobux is declared as undefined", () => {
 		expect.assertions(2);
 
-		const config = validateConfig(
-			{
-				environments: MinimumEnvironments,
-				universe: {
-					privateServerPriceRobux: undefined,
-					universeId: "1234567890",
-				},
+		const config: ResolvedConfig = {
+			environments: MinimumEnvironments,
+			universe: {
+				privateServerPriceRobux: undefined,
+				universeId: "1234567890",
 			},
-			"bedrock.config.ts",
-		);
-		assert(config.success);
+		};
 
-		const input = flattenConfig(config.data)[0]!;
+		const input = flattenConfig(config)[0]!;
 		assert(input.kind === "universe");
 
 		expect("privateServerPriceRobux" in input).toBeTrue();
@@ -324,13 +269,12 @@ describe(flattenConfig, () => {
 	it("should omit privateServerPriceRobux from the input when the user does not declare it", () => {
 		expect.assertions(1);
 
-		const config = validateConfig(
-			{ environments: MinimumEnvironments, universe: { universeId: "1234567890" } },
-			"bedrock.config.ts",
-		);
-		assert(config.success);
+		const config: ResolvedConfig = {
+			environments: MinimumEnvironments,
+			universe: { universeId: "1234567890" },
+		};
 
-		const input = flattenConfig(config.data)[0]!;
+		const input = flattenConfig(config)[0]!;
 		assert(input.kind === "universe");
 
 		expect("privateServerPriceRobux" in input).toBeFalse();
@@ -339,10 +283,9 @@ describe(flattenConfig, () => {
 	it("should omit the universe block from output when the config has no universe", () => {
 		expect.assertions(1);
 
-		const config = validateConfig({ environments: MinimumEnvironments }, "bedrock.config.ts");
-		assert(config.success);
+		const config: ResolvedConfig = { environments: MinimumEnvironments };
 
-		expect(flattenConfig(config.data).some((input) => input.kind === "universe")).toBeFalse();
+		expect(flattenConfig(config).some((input) => input.kind === "universe")).toBeFalse();
 	});
 
 	it.for(SOCIAL_LINK_FIELDS)(
@@ -351,16 +294,12 @@ describe(flattenConfig, () => {
 			expect.assertions(2);
 
 			const value = { title: `t-${field}`, uri: `https://example.com/${field}` };
-			const config = validateConfig(
-				{
-					environments: MinimumEnvironments,
-					universe: { [field]: value, universeId: "1234567890" },
-				},
-				"bedrock.config.ts",
-			);
-			assert(config.success);
+			const config: ResolvedConfig = {
+				environments: MinimumEnvironments,
+				universe: { [field]: value, universeId: "1234567890" },
+			};
 
-			const input = flattenConfig(config.data)[0]!;
+			const input = flattenConfig(config)[0]!;
 			assert(input.kind === "universe");
 
 			expect(input).toContainKey(field);
@@ -373,16 +312,12 @@ describe(flattenConfig, () => {
 		(field) => {
 			expect.assertions(2);
 
-			const config = validateConfig(
-				{
-					environments: MinimumEnvironments,
-					universe: { [field]: undefined, universeId: "1234567890" },
-				},
-				"bedrock.config.ts",
-			);
-			assert(config.success);
+			const config: ResolvedConfig = {
+				environments: MinimumEnvironments,
+				universe: { [field]: undefined, universeId: "1234567890" },
+			};
 
-			const input = flattenConfig(config.data)[0]!;
+			const input = flattenConfig(config)[0]!;
 			assert(input.kind === "universe");
 
 			expect(input).toContainKey(field);
@@ -395,13 +330,12 @@ describe(flattenConfig, () => {
 		(field) => {
 			expect.assertions(1);
 
-			const config = validateConfig(
-				{ environments: MinimumEnvironments, universe: { universeId: "1234567890" } },
-				"bedrock.config.ts",
-			);
-			assert(config.success);
+			const config: ResolvedConfig = {
+				environments: MinimumEnvironments,
+				universe: { universeId: "1234567890" },
+			};
 
-			const input = flattenConfig(config.data)[0]!;
+			const input = flattenConfig(config)[0]!;
 			assert(input.kind === "universe");
 
 			expect(input).not.toContainKey(field);
@@ -412,20 +346,16 @@ describe(flattenConfig, () => {
 		expect.assertions(4);
 
 		const discord = { title: "Discord", uri: "https://discord.gg/example" };
-		const config = validateConfig(
-			{
-				environments: MinimumEnvironments,
-				universe: {
-					discordSocialLink: discord,
-					twitterSocialLink: undefined,
-					universeId: "1234567890",
-				},
+		const config: ResolvedConfig = {
+			environments: MinimumEnvironments,
+			universe: {
+				discordSocialLink: discord,
+				twitterSocialLink: undefined,
+				universeId: "1234567890",
 			},
-			"bedrock.config.ts",
-		);
-		assert(config.success);
+		};
 
-		const input = flattenConfig(config.data)[0]!;
+		const input = flattenConfig(config)[0]!;
 		assert(input.kind === "universe");
 
 		expect(input).toContainKey("discordSocialLink");

--- a/packages/bedrock/src/core/flatten.ts
+++ b/packages/bedrock/src/core/flatten.ts
@@ -4,7 +4,7 @@ import type { ResourceKey, RobloxAssetId } from "../types/ids.ts";
 import { defaultKindRegistry } from "./kinds/index.ts";
 import type { ResourceKindModule } from "./kinds/module.ts";
 import type { ResourceKind } from "./resources.ts";
-import type { Config, GamePassEntry, UniverseVisibility } from "./schema.ts";
+import type { GamePassEntry, ResolvedConfig, UniverseVisibility } from "./schema.ts";
 
 /**
  * Pre-I/O game-pass input the flattener emits. Extends the authored
@@ -37,10 +37,11 @@ export interface GamePassDesiredInput extends Readonly<GamePassEntry> {
 }
 
 /**
- * Pre-I/O place input the flattener emits. Extends the authored
- * `PlaceEntry` with the tag discriminator, the `ResourceKey`-branded key,
- * and the `RobloxAssetId`-branded `placeId` so `buildDesired` can consume
- * a flat tagged list and layer on the SHA-256 file digest.
+ * Pre-I/O place input the flattener emits. Carries the resolved place
+ * fields (`filePath` from the root, `placeId` from the per-environment
+ * overlay) plus the tag discriminator and the `ResourceKey`-branded key,
+ * so `buildDesired` can consume a flat tagged list and layer on the
+ * SHA-256 file digest.
  *
  * @example
  *
@@ -159,22 +160,25 @@ export interface UniverseDesiredInput {
 export type ResourceDesiredInput = GamePassDesiredInput | PlaceDesiredInput | UniverseDesiredInput;
 
 /**
- * Turn a validated `Config` into a flat, tagged list of resource inputs.
+ * Turn a resolved `Config` into a flat, tagged list of resource inputs.
  *
- * Pure and infallible: the schema has already enforced every invariant this
- * function relies on, so there is nothing left to fail. Entries appear in
- * the insertion order of each collection; `passes` are emitted before
- * `places`.
+ * Pure and infallible: validation and per-environment overlay merging
+ * have already happened upstream (typically via `selectEnvironment`), so
+ * every invariant this function relies on is guaranteed by the input
+ * shape. Entries appear in the insertion order of each collection;
+ * `passes` are emitted before `places`.
  *
- * @param config - Validated config from `loadConfig` or `validateConfig`.
+ * @param config - Resolved config returned by `selectEnvironment`.
  * @returns Flat tagged list ready for `buildDesired`.
  * @example
  *
  * ```ts
- * import { flattenConfig, type Config } from "@bedrock/core";
+ * import { flattenConfig, selectEnvironment, type Config } from "@bedrock/core";
  *
  * const config: Config = {
- *     environments: { production: {} },
+ *     environments: {
+ *         production: { places: { "start-place": { placeId: "4711" } } },
+ *     },
  *     passes: {
  *         "vip-pass": {
  *             description: "Grants VIP perks.",
@@ -183,20 +187,19 @@ export type ResourceDesiredInput = GamePassDesiredInput | PlaceDesiredInput | Un
  *             price: 500,
  *         },
  *     },
- *     places: {
- *         "start-place": {
- *             filePath: "places/start.rbxl",
- *             placeId: "4711",
- *         },
- *     },
+ *     places: { "start-place": { filePath: "places/start.rbxl" } },
  * };
  *
- * const inputs = flattenConfig(config);
- * expect(inputs.map((input) => input.kind)).toEqual(["gamePass", "place"]);
- * expect(inputs.map((input) => input.key)).toEqual(["vip-pass", "start-place"]);
+ * const resolved = selectEnvironment(config, "production");
+ * expect(resolved.success).toBeTrue();
+ * if (resolved.success) {
+ *     const inputs = flattenConfig(resolved.data);
+ *     expect(inputs.map((input) => input.kind)).toEqual(["gamePass", "place"]);
+ *     expect(inputs.map((input) => input.key)).toEqual(["vip-pass", "start-place"]);
+ * }
  * ```
  */
-export function flattenConfig(config: Config): ReadonlyArray<ResourceDesiredInput> {
+export function flattenConfig(config: ResolvedConfig): ReadonlyArray<ResourceDesiredInput> {
 	const modules = Object.values(defaultKindRegistry) as ReadonlyArray<
 		ResourceKindModule<ResourceKind>
 	>;

--- a/packages/bedrock/src/core/kinds/game-pass.ts
+++ b/packages/bedrock/src/core/kinds/game-pass.ts
@@ -5,7 +5,7 @@ import { type } from "arktype";
 import { asResourceKey, asSha256Hex } from "../../types/ids.ts";
 import type { GamePassDesiredInput } from "../flatten.ts";
 import type { GamePassDesiredState, ResourceCurrentState } from "../resources.ts";
-import type { Config } from "../schema.ts";
+import type { ResolvedConfig } from "../schema.ts";
 import { sha256Hex } from "./hash.ts";
 import type { BuildDesiredError, KindIo, ResourceKindModule } from "./module.ts";
 import { readBytes } from "./read-bytes.ts";
@@ -17,7 +17,7 @@ const entrySchema = type({
 	"price?": "number | undefined",
 });
 
-function flatten(config: Config): ReadonlyArray<GamePassDesiredInput> {
+function flatten(config: ResolvedConfig): ReadonlyArray<GamePassDesiredInput> {
 	return Object.entries(config.passes ?? {}).map<GamePassDesiredInput>(([key, entry]) => {
 		return {
 			key: asResourceKey(key),

--- a/packages/bedrock/src/core/kinds/module.ts
+++ b/packages/bedrock/src/core/kinds/module.ts
@@ -5,7 +5,7 @@ import type { Type } from "arktype";
 import type { ResourceKey } from "../../types/ids.ts";
 import type { ResourceDesiredInput } from "../flatten.ts";
 import type { ResourceCurrentState, ResourceDesiredState, ResourceKind } from "../resources.ts";
-import type { Config, ResourceEntryByKind } from "../schema.ts";
+import type { ResolvedConfig, ResourceEntryByKind } from "../schema.ts";
 
 /**
  * Failure surfaced during desired-state normalization when the pre-I/O
@@ -119,11 +119,12 @@ export interface ResourceKindModule<K extends ResourceKind> {
 	fieldsEqual(desired: DesiredFor<K>, current: ResourceCurrentState<K>): boolean;
 
 	/**
-	 * Project a validated `Config` into a flat, tagged list of this kind's
-	 * pre-I/O inputs. Pure and infallible: the schema has already enforced
-	 * every invariant this function relies on.
+	 * Project a resolved `Config` into a flat, tagged list of this kind's
+	 * pre-I/O inputs. Pure and infallible: validation and per-environment
+	 * overlay merging have already happened upstream, so every invariant
+	 * this function relies on is guaranteed by the input shape.
 	 */
-	flatten(config: Config): ReadonlyArray<InputFor<K>>;
+	flatten(config: ResolvedConfig): ReadonlyArray<InputFor<K>>;
 
 	/** Discriminator literal for this kind. */
 	readonly kind: K;

--- a/packages/bedrock/src/core/kinds/place.ts
+++ b/packages/bedrock/src/core/kinds/place.ts
@@ -5,7 +5,7 @@ import { type } from "arktype";
 import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../../types/ids.ts";
 import type { PlaceDesiredInput } from "../flatten.ts";
 import type { PlaceDesiredState, ResourceCurrentState } from "../resources.ts";
-import type { Config } from "../schema.ts";
+import type { ResolvedConfig } from "../schema.ts";
 import { sha256Hex } from "./hash.ts";
 import type { BuildDesiredError, KindIo, ResourceKindModule } from "./module.ts";
 import { readBytes } from "./read-bytes.ts";
@@ -15,7 +15,7 @@ const entrySchema = type({
 	placeId: "string.digits",
 }).onUndeclaredKey("reject");
 
-function flatten(config: Config): ReadonlyArray<PlaceDesiredInput> {
+function flatten(config: ResolvedConfig): ReadonlyArray<PlaceDesiredInput> {
 	return Object.entries(config.places ?? {}).map<PlaceDesiredInput>(([key, entry]) => {
 		return {
 			key: asResourceKey(key),

--- a/packages/bedrock/src/core/kinds/universe.ts
+++ b/packages/bedrock/src/core/kinds/universe.ts
@@ -13,7 +13,7 @@ import {
 	UNIVERSE_SINGLETON_KEY,
 	type UniverseDesiredState,
 } from "../resources.ts";
-import type { Config } from "../schema.ts";
+import type { ResolvedConfig } from "../schema.ts";
 import type { BuildDesiredError, ResourceKindModule } from "./module.ts";
 
 const OPTIONAL_BOOLEAN = "boolean | undefined";
@@ -45,7 +45,7 @@ const entrySchema = type({
 	"youtubeSocialLink?": socialLinkOrUndefined,
 }).onUndeclaredKey("reject");
 
-function flatten(config: Config): ReadonlyArray<UniverseDesiredInput> {
+function flatten(config: ResolvedConfig): ReadonlyArray<UniverseDesiredInput> {
 	const entry = config.universe;
 	if (entry === undefined) {
 		return [];

--- a/packages/bedrock/src/core/schema.example.spec.ts
+++ b/packages/bedrock/src/core/schema.example.spec.ts
@@ -3,6 +3,8 @@ import { expect, it } from "vitest";
 import {
   type ResourceEntryByKind,
   type Config,
+  selectEnvironment,
+  type ResolvedConfig,
   isGistStateConfig,
   type StateConfig,
   validateConfig,
@@ -35,6 +37,22 @@ it('Example 2', () => {
 })
 
 it('Example 3', () => {
+  const config: Config = {
+    environments: {
+      production: { places: { 'start-place': { placeId: '4711' } } },
+    },
+    places: { 'start-place': { filePath: 'places/start.rbxl' } },
+    state: { backend: 'gist', gistId: 'abc' },
+  }
+  const result = selectEnvironment(config, 'production')
+  expect(result.success).toBeTrue()
+  if (result.success) {
+    const resolved: ResolvedConfig = result.data
+    expect(resolved.places?.['start-place']?.placeId).toBe('4711')
+  }
+})
+
+it('Example 4', () => {
   const config: StateConfig = { backend: 'gist', gistId: 'abc' }
   expect(isGistStateConfig(config)).toBeTrue()
   if (isGistStateConfig(config)) {
@@ -42,7 +60,7 @@ it('Example 3', () => {
   }
 })
 
-it('Example 4', () => {
+it('Example 5', () => {
   const ok = validateConfig(
     {
       environments: { production: {} },

--- a/packages/bedrock/src/core/schema.spec-d.ts
+++ b/packages/bedrock/src/core/schema.spec-d.ts
@@ -5,6 +5,7 @@ import type {
 	EnvironmentEntry,
 	GamePassEntry,
 	PlaceEntry,
+	ResolvedPlaceEntry,
 	StateConfig,
 	UniverseEntry,
 } from "./schema.ts";
@@ -83,12 +84,30 @@ describe("EnvironmentEntry overlay derivation", () => {
 		expectTypeOf<keyof PassesOverlayEntry>().toEqualTypeOf<keyof GamePassEntry>();
 	});
 
-	it("should match the keys of PlaceEntry on a places overlay entry", () => {
-		expectTypeOf<keyof PlaceOverlayEntry>().toEqualTypeOf<keyof PlaceEntry>();
+	it("should match the keys of ResolvedPlaceEntry on a places overlay entry", () => {
+		expectTypeOf<keyof PlaceOverlayEntry>().toEqualTypeOf<keyof ResolvedPlaceEntry>();
 	});
 
 	it("should match the keys of UniverseEntry on a universe overlay", () => {
 		expectTypeOf<keyof UniverseOverlayEntry>().toEqualTypeOf<keyof UniverseEntry>();
+	});
+});
+
+describe("PlaceEntry / ResolvedPlaceEntry split", () => {
+	it("should expose only filePath at the root PlaceEntry level", () => {
+		expectTypeOf<keyof PlaceEntry>().toEqualTypeOf<"filePath">();
+		expectTypeOf<PlaceEntry["filePath"]>().toEqualTypeOf<string>();
+	});
+
+	it("should expose filePath and placeId on ResolvedPlaceEntry as the post-merge invariant", () => {
+		expectTypeOf<keyof ResolvedPlaceEntry>().toEqualTypeOf<"filePath" | "placeId">();
+		expectTypeOf<ResolvedPlaceEntry["filePath"]>().toEqualTypeOf<string>();
+		expectTypeOf<ResolvedPlaceEntry["placeId"]>().toEqualTypeOf<string>();
+	});
+
+	it("should make ResolvedPlaceEntry assignable to PlaceEntry but not the reverse", () => {
+		expectTypeOf<ResolvedPlaceEntry>().toExtend<PlaceEntry>();
+		expectTypeOf<PlaceEntry>().not.toExtend<ResolvedPlaceEntry>();
 	});
 });
 

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -182,29 +182,7 @@ describe(validateConfig, () => {
 		expect(result.err.issues[0]!.path).toStrictEqual(["passes", "vip-pass", "price"]);
 	});
 
-	it("should accept a places collection with a valid place entry", () => {
-		expect.assertions(2);
-
-		const result = validateConfig(
-			{
-				environments: MinEnvironments,
-				places: {
-					"start-place": {
-						filePath: "places/start.rbxl",
-						placeId: "4711",
-					},
-				},
-			},
-			SOURCE,
-		);
-
-		assert(result.success);
-
-		expect(result.data.places!["start-place"]!.placeId).toBe("4711");
-		expect(result.data.places!["start-place"]!.filePath).toBe("places/start.rbxl");
-	});
-
-	it("should reject a place entry missing placeId and attribute the issue path to that field", () => {
+	it("should accept a root places collection that declares only filePath", () => {
 		expect.assertions(1);
 
 		const result = validateConfig(
@@ -217,13 +195,31 @@ describe(validateConfig, () => {
 			SOURCE,
 		);
 
+		assert(result.success);
+
+		expect(result.data.places!["start-place"]!.filePath).toBe("places/start.rbxl");
+	});
+
+	it("should reject a placeId declared on a root place entry and attribute the issue to that field", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: MinEnvironments,
+				places: {
+					"start-place": { filePath: "places/start.rbxl", placeId: "4711" },
+				},
+			},
+			SOURCE,
+		);
+
 		assert(!result.success);
 		assert(result.err.kind === "validationFailed");
 
 		expect(result.err.issues[0]!.path).toStrictEqual(["places", "start-place", "placeId"]);
 	});
 
-	it("should reject an undeclared field on a place entry", () => {
+	it("should reject an undeclared field on a root place entry", () => {
 		expect.assertions(1);
 
 		const result = validateConfig(
@@ -232,7 +228,6 @@ describe(validateConfig, () => {
 				places: {
 					"start-place": {
 						filePath: "places/start.rbxl",
-						placeId: "4711",
 						unexpected: "nope",
 					},
 				},
@@ -250,15 +245,17 @@ describe(validateConfig, () => {
 		["trailing non-digits", "4711abc"],
 		["leading non-digits", "abc4711"],
 		["embedded non-digits", "47abc11"],
-	] as const)("should reject a place entry whose placeId has %s", ([, placeId]) => {
+	] as const)("should reject an env-overlay placeId that has %s", ([, placeId]) => {
 		expect.assertions(1);
 
 		const result = validateConfig(
 			{
-				environments: MinEnvironments,
-				places: {
-					"start-place": { filePath: "places/start.rbxl", placeId },
+				environments: {
+					production: {
+						places: { "start-place": { placeId } },
+					},
 				},
+				places: { "start-place": { filePath: "places/start.rbxl" } },
 			},
 			SOURCE,
 		);
@@ -266,7 +263,13 @@ describe(validateConfig, () => {
 		assert(!result.success);
 		assert(result.err.kind === "validationFailed");
 
-		expect(result.err.issues[0]!.path).toStrictEqual(["places", "start-place", "placeId"]);
+		expect(result.err.issues[0]!.path).toStrictEqual([
+			"environments",
+			"production",
+			"places",
+			"start-place",
+			"placeId",
+		]);
 	});
 
 	it("should reject a places key that does not match the ResourceKey pattern", () => {
@@ -276,7 +279,7 @@ describe(validateConfig, () => {
 			{
 				environments: MinEnvironments,
 				places: {
-					"bad key!": { filePath: "places/start.rbxl", placeId: "4711" },
+					"bad key!": { filePath: "places/start.rbxl" },
 				},
 			},
 			SOURCE,
@@ -814,7 +817,7 @@ describe(validateConfig, () => {
 						},
 					},
 				},
-				places: { "start-place": { filePath: "places/start.rbxl", placeId: "1111" } },
+				places: { "start-place": { filePath: "places/start.rbxl" } },
 				state: { backend: "gist", gistId: "root-gist" },
 			},
 			SOURCE,

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -2,7 +2,7 @@ import type { Result } from "@bedrock/ocale";
 import type { SocialLink } from "@bedrock/ocale/universes";
 
 import { ArkErrors, type, type Type } from "arktype";
-import type { SetRequired } from "type-fest";
+import type { Except, SetRequired } from "type-fest";
 
 import { RESOURCE_KEY_PATTERN_SOURCE } from "../types/ids.ts";
 import type { ConfigError } from "./config-error.ts";
@@ -24,14 +24,28 @@ export interface GamePassEntry {
 }
 
 /**
- * Body of a single entry in the `places` collection. Keys in the parent
- * record are `ResourceKey`-shaped strings enforced at schema validation.
+ * Body of a single entry under the root `places` collection. Carries only
+ * the file-path that environments share. The Roblox `placeId` is
+ * environment-specific and lives on each per-environment overlay so the
+ * same `.rbxl` file can publish to different places across staging,
+ * production, and so on.
+ */
+export interface PlaceEntry {
+	/** Path to the `.rbxl` or `.rbxlx` file; handed to `readFile` verbatim by `buildDesired`. */
+	filePath: string;
+}
+
+/**
+ * Body of a places entry after `selectEnvironment` has merged the
+ * matching per-environment overlay onto the root entry. Both fields are
+ * present: `filePath` flows from the root (or an overlay override) and
+ * `placeId` is supplied by the per-environment overlay.
  *
  * `placeId` is user-supplied because Open Cloud cannot mint places; the
  * place must already exist in Roblox before Bedrock can publish versions
  * to it.
  */
-export interface PlaceEntry {
+export interface ResolvedPlaceEntry {
 	/** Path to the `.rbxl` or `.rbxlx` file; handed to `readFile` verbatim by `buildDesired`. */
 	filePath: string;
 	/** Existing Roblox place ID. */
@@ -172,10 +186,10 @@ export interface EnvironmentEntry {
 	passes?: Record<string, Partial<GamePassEntry>>;
 	/**
 	 * Per-environment places overlay. `placeId` is required on every
-	 * declared entry; other fields fall through to the matching root
-	 * `places` entry when omitted.
+	 * declared entry; `filePath` is optional and falls through to the
+	 * matching root `places` entry when omitted.
 	 */
-	places?: Record<string, Overlay<PlaceEntry, "placeId">>;
+	places?: Record<string, Overlay<ResolvedPlaceEntry, "placeId">>;
 	/** Per-environment state override; takes precedence over root `state`. */
 	state?: StateConfig;
 	/**
@@ -211,8 +225,8 @@ export interface EnvironmentEntry {
 export interface ResourceEntryByKind {
 	/** Authored entry body for a game-pass resource. */
 	gamePass: GamePassEntry;
-	/** Authored entry body for a place resource. */
-	place: PlaceEntry;
+	/** Post-merge entry body for a place resource (root + env overlay). */
+	place: ResolvedPlaceEntry;
 	/** Authored entry body for a universe resource. */
 	universe: UniverseEntry;
 }
@@ -267,6 +281,42 @@ export interface Config {
 	state?: StateConfig;
 	/** Singleton universe block declaring the Roblox universe bedrock manages. */
 	universe?: UniverseEntry;
+}
+
+/**
+ * Project config after `selectEnvironment` has merged a single
+ * environment's overlays onto the root. The shape mirrors `Config`
+ * except `places` carries `ResolvedPlaceEntry` (both `filePath` and
+ * `placeId`), since the resolver fails before this point if an entry is
+ * missing its environment-supplied `placeId`. Downstream consumers
+ * (`flattenConfig`, `buildDefaultRegistry`, the deploy pipeline) accept
+ * this shape rather than `Config` so the post-merge invariant is visible
+ * in the type system.
+ *
+ * @example
+ *
+ * ```ts
+ * import { selectEnvironment, type Config, type ResolvedConfig } from "@bedrock/core";
+ *
+ * const config: Config = {
+ *     environments: {
+ *         production: { places: { "start-place": { placeId: "4711" } } },
+ *     },
+ *     places: { "start-place": { filePath: "places/start.rbxl" } },
+ *     state: { backend: "gist", gistId: "abc" },
+ * };
+ *
+ * const result = selectEnvironment(config, "production");
+ * expect(result.success).toBeTrue();
+ * if (result.success) {
+ *     const resolved: ResolvedConfig = result.data;
+ *     expect(resolved.places?.["start-place"]?.placeId).toBe("4711");
+ * }
+ * ```
+ */
+export interface ResolvedConfig extends Except<Config, "places"> {
+	/** Keyed-map collection of resolved place entries; both `filePath` and `placeId` are present. */
+	places?: Record<string, ResolvedPlaceEntry>;
 }
 
 /**
@@ -328,7 +378,6 @@ const ROBLOX_ID_DIGITS = "string.digits";
 
 const placeEntry = type({
 	filePath: "string",
-	placeId: ROBLOX_ID_DIGITS,
 }).onUndeclaredKey("reject");
 
 const placesCollection = type({

--- a/packages/bedrock/src/core/select-environment.spec-d.ts
+++ b/packages/bedrock/src/core/select-environment.spec-d.ts
@@ -21,8 +21,10 @@ describe("selectEnvironment signature", () => {
 		>();
 	});
 
-	it("should constrain SelectEnvironmentError to the unknownEnvironment kind", () => {
-		expectTypeOf<SelectEnvironmentError["kind"]>().toEqualTypeOf<"unknownEnvironment">();
+	it("should discriminate SelectEnvironmentError across the unknownEnvironment and incompletePlaceEntry kinds", () => {
+		expectTypeOf<SelectEnvironmentError["kind"]>().toEqualTypeOf<
+			"incompletePlaceEntry" | "unknownEnvironment"
+		>();
 	});
 });
 

--- a/packages/bedrock/src/core/select-environment.spec-d.ts
+++ b/packages/bedrock/src/core/select-environment.spec-d.ts
@@ -2,7 +2,7 @@ import type { Result } from "@bedrock/ocale";
 
 import { describe, expectTypeOf, it } from "vitest";
 
-import type { Config } from "./schema.ts";
+import type { Config, ResolvedConfig } from "./schema.ts";
 import {
 	selectEnvironment,
 	type SelectEnvironmentError,
@@ -15,9 +15,9 @@ describe("selectEnvironment signature", () => {
 		expectTypeOf(selectEnvironment).parameter(1).toEqualTypeOf<string>();
 	});
 
-	it("should return a Result of Config or SelectEnvironmentError so downstream functions consume it as Config", () => {
+	it("should return a Result of ResolvedConfig or SelectEnvironmentError so downstream functions consume the post-merge view", () => {
 		expectTypeOf<ReturnType<typeof selectEnvironment>>().toEqualTypeOf<
-			Result<Config, SelectEnvironmentError>
+			Result<ResolvedConfig, SelectEnvironmentError>
 		>();
 	});
 

--- a/packages/bedrock/src/core/select-environment.spec.ts
+++ b/packages/bedrock/src/core/select-environment.spec.ts
@@ -15,7 +15,6 @@ const VIP_PASS: GamePassEntry = {
 
 const START_PLACE: PlaceEntry = {
 	filePath: "places/start.rbxl",
-	placeId: "1111",
 };
 
 describe(selectEnvironment, () => {
@@ -126,7 +125,7 @@ describe(selectEnvironment, () => {
 				staging: { places: { "start-place": { placeId: "5555" } } },
 			},
 			places: {
-				"lobby": { filePath: "places/lobby.rbxl", placeId: "2222" },
+				"lobby": { filePath: "places/lobby.rbxl" },
 				"start-place": START_PLACE,
 			},
 			state: ROOT_STATE,
@@ -139,7 +138,6 @@ describe(selectEnvironment, () => {
 		expect(result.data.places?.["start-place"]?.placeId).toBe("5555");
 		expect(result.data.places?.["lobby"]).toStrictEqual({
 			filePath: "places/lobby.rbxl",
-			placeId: "2222",
 		});
 	});
 

--- a/packages/bedrock/src/core/select-environment.spec.ts
+++ b/packages/bedrock/src/core/select-environment.spec.ts
@@ -29,6 +29,7 @@ describe(selectEnvironment, () => {
 		const result = selectEnvironment(config, "staging");
 
 		assert(!result.success);
+		assert(result.err.kind === "unknownEnvironment");
 
 		expect(result.err.kind).toBe("unknownEnvironment");
 		expect(result.err.environment).toBe("staging");
@@ -117,12 +118,17 @@ describe(selectEnvironment, () => {
 		expect(result.data.places?.["start-place"]?.filePath).toBe("places/start.rbxl");
 	});
 
-	it("should preserve root entries that the overlay does not mention", () => {
-		expect.assertions(2);
+	it("should preserve every root place that the overlay declares alongside the one it touches", () => {
+		expect.assertions(3);
 
 		const config: Config = {
 			environments: {
-				staging: { places: { "start-place": { placeId: "5555" } } },
+				staging: {
+					places: {
+						"lobby": { placeId: "2222" },
+						"start-place": { placeId: "5555" },
+					},
+				},
 			},
 			places: {
 				"lobby": { filePath: "places/lobby.rbxl" },
@@ -136,9 +142,8 @@ describe(selectEnvironment, () => {
 		assert(result.success);
 
 		expect(result.data.places?.["start-place"]?.placeId).toBe("5555");
-		expect(result.data.places?.["lobby"]).toStrictEqual({
-			filePath: "places/lobby.rbxl",
-		});
+		expect(result.data.places?.["lobby"]?.placeId).toBe("2222");
+		expect(result.data.places?.["lobby"]?.filePath).toBe("places/lobby.rbxl");
 	});
 
 	it("should overlay partial pass fields onto matching root entries by key", () => {
@@ -198,7 +203,12 @@ describe(selectEnvironment, () => {
 		expect.assertions(2);
 
 		const config: Config = {
-			environments: { production: { state: PROD_STATE } },
+			environments: {
+				production: {
+					places: { "start-place": { placeId: "1111" } },
+					state: PROD_STATE,
+				},
+			},
 			passes: { "vip-pass": VIP_PASS },
 			places: { "start-place": START_PLACE },
 			state: ROOT_STATE,
@@ -209,7 +219,69 @@ describe(selectEnvironment, () => {
 		assert(result.success);
 
 		expect(result.data.passes).toStrictEqual({ "vip-pass": VIP_PASS });
-		expect(result.data.places).toStrictEqual({ "start-place": START_PLACE });
+		expect(result.data.places).toStrictEqual({
+			"start-place": { ...START_PLACE, placeId: "1111" },
+		});
+	});
+
+	it("should return Err(incompletePlaceEntry) when a root place has no overlay supplying placeId", () => {
+		expect.assertions(4);
+
+		const config: Config = {
+			environments: { production: {} },
+			places: { "start-place": START_PLACE },
+			state: ROOT_STATE,
+		};
+
+		const result = selectEnvironment(config, "production");
+
+		assert(!result.success);
+		assert(result.err.kind === "incompletePlaceEntry");
+
+		expect(result.err.kind).toBe("incompletePlaceEntry");
+		expect(result.err.environment).toBe("production");
+		expect(result.err.key).toBe("start-place");
+		expect(result.err.missingField).toBe("placeId");
+	});
+
+	it("should return Err(incompletePlaceEntry) for the first incomplete place when several root entries lack overlays", () => {
+		expect.assertions(2);
+
+		const config: Config = {
+			environments: { production: {} },
+			places: {
+				alpha: { filePath: "places/alpha.rbxl" },
+				beta: { filePath: "places/beta.rbxl" },
+			},
+			state: ROOT_STATE,
+		};
+
+		const result = selectEnvironment(config, "production");
+
+		assert(!result.success);
+		assert(result.err.kind === "incompletePlaceEntry");
+
+		expect(result.err.key).toBe("alpha");
+		expect(result.err.missingField).toBe("placeId");
+	});
+
+	it("should accept a root place when the requested environment overlays it with a placeId", () => {
+		expect.assertions(2);
+
+		const config: Config = {
+			environments: {
+				production: { places: { "start-place": { placeId: "1111" } } },
+			},
+			places: { "start-place": START_PLACE },
+			state: ROOT_STATE,
+		};
+
+		const result = selectEnvironment(config, "production");
+
+		assert(result.success);
+
+		expect(result.data.places?.["start-place"]?.placeId).toBe("1111");
+		expect(result.data.places?.["start-place"]?.filePath).toBe("places/start.rbxl");
 	});
 
 	it("should preserve environments and extends so the returned shape stays assignable to Config", () => {

--- a/packages/bedrock/src/core/select-environment.spec.ts
+++ b/packages/bedrock/src/core/select-environment.spec.ts
@@ -165,8 +165,30 @@ describe(selectEnvironment, () => {
 		expect(result.data.passes?.["vip-pass"]?.name).toBe("VIP Pass");
 	});
 
-	it("should surface a brand-new overlay-only place entry when root has no matching key", () => {
-		expect.assertions(1);
+	it("should accept a brand-new overlay-only place entry when the overlay declares both filePath and placeId", () => {
+		expect.assertions(2);
+
+		const config: Config = {
+			environments: {
+				staging: {
+					places: {
+						"debug-place": { filePath: "places/debug.rbxl", placeId: "9999" },
+					},
+				},
+			},
+			state: ROOT_STATE,
+		};
+
+		const result = selectEnvironment(config, "staging");
+
+		assert(result.success);
+
+		expect(result.data.places?.["debug-place"]?.placeId).toBe("9999");
+		expect(result.data.places?.["debug-place"]?.filePath).toBe("places/debug.rbxl");
+	});
+
+	it("should return Err(incompletePlaceEntry) for an overlay-only place that omits filePath", () => {
+		expect.assertions(4);
 
 		const config: Config = {
 			environments: {
@@ -177,9 +199,13 @@ describe(selectEnvironment, () => {
 
 		const result = selectEnvironment(config, "staging");
 
-		assert(result.success);
+		assert(!result.success);
+		assert(result.err.kind === "incompletePlaceEntry");
 
-		expect(result.data.places?.["debug-place"]).toStrictEqual({ placeId: "9999" });
+		expect(result.err.environment).toBe("staging");
+		expect(result.err.key).toBe("debug-place");
+		expect(result.err.missingField).toBe("filePath");
+		expect(result.err.kind).toBe("incompletePlaceEntry");
 	});
 
 	it("should surface an env-only universe entry when root has no universe block", () => {

--- a/packages/bedrock/src/core/select-environment.ts
+++ b/packages/bedrock/src/core/select-environment.ts
@@ -169,14 +169,18 @@ function mergeEntry<Resolved extends object>(
 	overlay: Partial<Resolved>,
 	base: Partial<Resolved> | undefined,
 ): Resolved {
+	// Precondition for the cast: every public success path of
+	// `selectEnvironment` MUST run completeness validation (today only
+	// `findIncompletePlace`) before exposing the merged record to a caller.
+	// The cast trades compile-time soundness for the freedom to surface
+	// partial entries to a validator that can attribute the missing field to
+	// a typed error. New resource kinds that adopt this merge pattern owe
+	// their own `findIncomplete<Kind>Entry` validator before returning.
+	//
 	// defu treats `undefined` as the empty object, so an overlay-only entry
-	// (no matching root) flows through unchanged. Required fields the overlay
-	// omits and the base lacks are caught by post-merge validation
-	// (`incompletePlaceEntry` for places). defu's return type is
+	// (no matching root) flows through unchanged. defu's return type is
 	// `MergeObjects<Partial<Resolved>, Partial<Resolved>>` which the compiler
-	// cannot prove equals `Resolved`; the merge is structurally correct when
-	// the union of overlay + base fields covers every required field of
-	// `Resolved`.
+	// cannot prove equals `Resolved`.
 	return defu(overlay, base ?? {}) as Resolved;
 }
 

--- a/packages/bedrock/src/core/select-environment.ts
+++ b/packages/bedrock/src/core/select-environment.ts
@@ -26,8 +26,26 @@ export interface UnknownEnvironmentError {
 	readonly kind: "unknownEnvironment";
 }
 
+/**
+ * Failure surfaced when post-merge a place entry has no `placeId`. The
+ * root collection holds only `filePath`, so every place must receive its
+ * `placeId` from the per-environment overlay; a place declared at the
+ * root with no matching overlay key produces this error rather than
+ * surfacing as a downstream driver failure.
+ */
+export interface IncompletePlaceEntryError {
+	/** ResourceKey of the place entry that is missing `placeId`. */
+	readonly key: string;
+	/** Environment whose overlay was projected onto the config. */
+	readonly environment: string;
+	/** Literal discriminator for narrowing. */
+	readonly kind: "incompletePlaceEntry";
+	/** Field that the merged entry lacks; always `"placeId"` today. */
+	readonly missingField: "placeId";
+}
+
 /** Failure modes returned by {@link selectEnvironment}. */
-export type SelectEnvironmentError = UnknownEnvironmentError;
+export type SelectEnvironmentError = IncompletePlaceEntryError | UnknownEnvironmentError;
 
 interface ProjectInputs {
 	readonly config: Config;
@@ -64,12 +82,12 @@ interface ProjectInputs {
  * case surfaces as a typed `stateNotConfigured` there.
  *
  * Limitation in v1: a per-environment universe overlay that introduces a
- * brand-new universe block (one not declared at the root) may still have
- * optional fields missing, since the overlay type only requires the
- * identity-bearing key. The resolver surfaces the entry as-is; the
- * universe driver reports the missing field when it tries to consume the
- * entry. The matching gap for `places` is closed: post-merge entries
- * without a `placeId` are rejected as `incompletePlaceEntry` here.
+ * brand-new universe block may still have optional fields missing, since
+ * the overlay type only requires the identity-bearing key. The resolver
+ * surfaces the entry as-is; the universe driver reports the missing
+ * field when it tries to consume the entry. Universe is a singleton with
+ * 20+ optional fields, so the same `incompletePlaceEntry`-style validation
+ * is deferred to a separate follow-up.
  *
  * @example
  *
@@ -110,10 +128,41 @@ export function selectEnvironment(
 		return { err: unknownEnvironment(config, environment), success: false };
 	}
 
-	return {
-		data: projectConfig({ config, entry }),
-		success: true,
-	};
+	const projected = projectConfig({ config, entry });
+	const incomplete = findIncompletePlace(projected, environment);
+	if (incomplete !== undefined) {
+		return { err: incomplete, success: false };
+	}
+
+	return { data: projected, success: true };
+}
+
+function findIncompletePlace(
+	projected: ResolvedConfig,
+	environment: string,
+): IncompletePlaceEntryError | undefined {
+	const { places } = projected;
+	if (places === undefined) {
+		return undefined;
+	}
+
+	// `places` is typed as `Record<string, ResolvedPlaceEntry>` because the
+	// merge boundary already promised completeness; this routine exists to
+	// honour that promise at runtime, so it widens the view back to
+	// `Partial<ResolvedPlaceEntry>` for the duration of the check.
+	const candidates: Record<string, Partial<ResolvedPlaceEntry>> = places;
+	for (const [key, entry] of Object.entries(candidates)) {
+		if (entry.placeId === undefined) {
+			return {
+				key,
+				environment,
+				kind: "incompletePlaceEntry",
+				missingField: "placeId",
+			};
+		}
+	}
+
+	return undefined;
 }
 
 function mergeEntry<Resolved extends object>(

--- a/packages/bedrock/src/core/select-environment.ts
+++ b/packages/bedrock/src/core/select-environment.ts
@@ -27,21 +27,23 @@ export interface UnknownEnvironmentError {
 }
 
 /**
- * Failure surfaced when post-merge a place entry has no `placeId`. The
- * root collection holds only `filePath`, so every place must receive its
- * `placeId` from the per-environment overlay; a place declared at the
- * root with no matching overlay key produces this error rather than
- * surfacing as a downstream driver failure.
+ * Failure surfaced when a merged place entry is missing a required field.
+ * Two paths reach this error: a root place declared without a matching
+ * per-environment overlay supplying `placeId`, and an overlay-only place
+ * declared under `environments.X.places` with no matching root entry to
+ * supply `filePath`. Surfacing both at the resolution boundary attributes
+ * the missing field to the offending entry's key instead of letting
+ * `buildDesired` crash with a generic `fileReadFailed` later on.
  */
 export interface IncompletePlaceEntryError {
-	/** ResourceKey of the place entry that is missing `placeId`. */
+	/** ResourceKey of the place entry that is missing a required field. */
 	readonly key: string;
 	/** Environment whose overlay was projected onto the config. */
 	readonly environment: string;
 	/** Literal discriminator for narrowing. */
 	readonly kind: "incompletePlaceEntry";
-	/** Field that the merged entry lacks; always `"placeId"` today. */
-	readonly missingField: "placeId";
+	/** Field that the merged entry lacks. */
+	readonly missingField: "filePath" | "placeId";
 }
 
 /** Failure modes returned by {@link selectEnvironment}. */
@@ -160,6 +162,15 @@ function findIncompletePlace(
 				missingField: "placeId",
 			};
 		}
+
+		if (entry.filePath === undefined) {
+			return {
+				key,
+				environment,
+				kind: "incompletePlaceEntry",
+				missingField: "filePath",
+			};
+		}
 	}
 
 	return undefined;
@@ -189,6 +200,9 @@ function mergeKeyedRecord<Resolved extends object>(
 	base: Record<string, Partial<Resolved>> | undefined,
 ): Record<string, Resolved> | undefined {
 	if (overlay === undefined) {
+		// Same precondition as `mergeEntry`: passing the base record straight
+		// through is sound only when the caller validates completeness on the
+		// returned record before publishing it.
 		return base as Record<string, Resolved> | undefined;
 	}
 

--- a/packages/bedrock/src/core/select-environment.ts
+++ b/packages/bedrock/src/core/select-environment.ts
@@ -3,7 +3,13 @@ import type { Result } from "@bedrock/ocale";
 import { defu } from "defu";
 import type { SetRequired } from "type-fest";
 
-import type { Config, GamePassEntry, PlaceEntry, UniverseEntry } from "./schema.ts";
+import type {
+	Config,
+	GamePassEntry,
+	ResolvedConfig,
+	ResolvedPlaceEntry,
+	UniverseEntry,
+} from "./schema.ts";
 
 /**
  * Failure surfaced when `selectEnvironment` is asked for an environment
@@ -35,12 +41,13 @@ interface ProjectInputs {
  * and applies the env-level state override when present (the env entry's
  * `state` field wins; otherwise the root `state` flows through).
  *
- * Pure: no I/O. Returns a `Config` ready to feed into downstream
- * functions that already accept `Config` (`flattenConfig`,
- * `buildDefaultRegistry`, `resolveStateConfig`) without signature
- * changes. `environments` and `extends` are passed through unchanged
- * because they preserve the shape relationship to `Config`; downstream
- * consumers do not read them post-merge.
+ * Pure: no I/O. Returns a `ResolvedConfig` ready to feed into downstream
+ * functions (`flattenConfig`, `buildDefaultRegistry`, `resolveStateConfig`).
+ * The post-merge view promotes `places` from `Record<string, PlaceEntry>`
+ * (root: file-paths only) to `Record<string, ResolvedPlaceEntry>` (root +
+ * overlay merged). `environments` and `extends` are passed through
+ * unchanged because they preserve the shape relationship to `Config`;
+ * downstream consumers do not read them post-merge.
  *
  * Defu's merge semantics are deliberate: keyed-map collections merge by
  * key (so a place declared in both root and overlay produces a single
@@ -56,13 +63,13 @@ interface ProjectInputs {
  * route through `resolveStateConfig` or `buildStatePort`; the absent
  * case surfaces as a typed `stateNotConfigured` there.
  *
- * Limitation in v1: a per-environment overlay that introduces a brand-new
- * place or universe overlay key (one not declared at the root) may still
- * have optional fields missing, since the overlay type only requires the
- * identity-bearing key. The resolver surfaces the entry as-is; downstream
- * consumers (`buildDesired`, the universe driver) report the missing
- * field when they try to consume the entry. Post-merge schema validation
- * is deferred to a follow-up that wires it through `validateConfig`.
+ * Limitation in v1: a per-environment universe overlay that introduces a
+ * brand-new universe block (one not declared at the root) may still have
+ * optional fields missing, since the overlay type only requires the
+ * identity-bearing key. The resolver surfaces the entry as-is; the
+ * universe driver reports the missing field when it tries to consume the
+ * entry. The matching gap for `places` is closed: post-merge entries
+ * without a `placeId` are rejected as `incompletePlaceEntry` here.
  *
  * @example
  *
@@ -90,14 +97,14 @@ interface ProjectInputs {
  * environment under `environments`.
  * @param environment - Environment name to project onto. Must be a key
  * of `config.environments`.
- * @returns `Ok(Config)` with the merged resource fields and the resolved
- * state, or `Err(SelectEnvironmentError)` describing why the projection
- * failed.
+ * @returns `Ok(ResolvedConfig)` with the merged resource fields and the
+ * resolved state, or `Err(SelectEnvironmentError)` describing why the
+ * projection failed.
  */
 export function selectEnvironment(
 	config: Config,
 	environment: string,
-): Result<Config, SelectEnvironmentError> {
+): Result<ResolvedConfig, SelectEnvironmentError> {
 	const entry = config.environments[environment];
 	if (entry === undefined) {
 		return { err: unknownEnvironment(config, environment), success: false };
@@ -109,30 +116,34 @@ export function selectEnvironment(
 	};
 }
 
-function mergeEntry<Base extends object>(overlay: Partial<Base>, base: Base | undefined): Base {
-	// New overlay-only entries are surfaced as-is; the overlay type guarantees
-	// its identity-bearing key, and required base fields the overlay omits
-	// surface downstream as typed errors. defu's own return type is
-	// `MergeObjects<Partial<Base>, Base>` which the compiler cannot prove
-	// equals `Base` for an arbitrary `Base extends object`, but the merge is
-	// structurally correct because deep-merging a partial onto a complete
-	// entry yields a complete entry.
-	return base === undefined ? (overlay as Base) : (defu(overlay, base) as Base);
+function mergeEntry<Resolved extends object>(
+	overlay: Partial<Resolved>,
+	base: Partial<Resolved> | undefined,
+): Resolved {
+	// defu treats `undefined` as the empty object, so an overlay-only entry
+	// (no matching root) flows through unchanged. Required fields the overlay
+	// omits and the base lacks are caught by post-merge validation
+	// (`incompletePlaceEntry` for places). defu's return type is
+	// `MergeObjects<Partial<Resolved>, Partial<Resolved>>` which the compiler
+	// cannot prove equals `Resolved`; the merge is structurally correct when
+	// the union of overlay + base fields covers every required field of
+	// `Resolved`.
+	return defu(overlay, base ?? {}) as Resolved;
 }
 
-function mergeKeyedRecord<Base extends object>(
-	overlay: Record<string, Partial<Base>> | undefined,
-	base: Record<string, Base> | undefined,
-): Record<string, Base> | undefined {
+function mergeKeyedRecord<Resolved extends object>(
+	overlay: Record<string, Partial<Resolved>> | undefined,
+	base: Record<string, Partial<Resolved>> | undefined,
+): Record<string, Resolved> | undefined {
 	if (overlay === undefined) {
-		return base;
+		return base as Record<string, Resolved> | undefined;
 	}
 
 	return {
-		...(base ?? {}),
+		...((base ?? {}) as Record<string, Resolved>),
 		...Object.fromEntries(
 			Object.entries(overlay).map(([key, partial]) => {
-				return [key, mergeEntry(partial, base?.[key])];
+				return [key, mergeEntry<Resolved>(partial, base?.[key])];
 			}),
 		),
 	};
@@ -149,15 +160,17 @@ function mergeUniverse(
 	return mergeEntry(overlay, base);
 }
 
-function projectConfig(inputs: ProjectInputs): Config {
+function projectConfig(inputs: ProjectInputs): ResolvedConfig {
 	const { config, entry } = inputs;
 	const passes = mergeKeyedRecord<GamePassEntry>(entry.passes, config.passes);
-	const places = mergeKeyedRecord<PlaceEntry>(entry.places, config.places);
+	const places = mergeKeyedRecord<ResolvedPlaceEntry>(entry.places, config.places);
 	const universe = mergeUniverse(entry.universe, config.universe);
 	const state = entry.state ?? config.state;
 
+	const { places: _placesRoot, ...rest } = config;
+
 	return {
-		...config,
+		...rest,
 		...(passes === undefined ? {} : { passes }),
 		...(places === undefined ? {} : { places }),
 		...(state === undefined ? {} : { state }),

--- a/packages/bedrock/src/index.spec-d.ts
+++ b/packages/bedrock/src/index.spec-d.ts
@@ -166,6 +166,7 @@ describe(deploy, () => {
 			| "applyFailed"
 			| "buildDesiredFailed"
 			| "configLoadFailed"
+			| "incompletePlaceEntry"
 			| "missingCredential"
 			| "registryConfigMissing"
 			| "stateNotConfigured"

--- a/packages/bedrock/src/index.spec-d.ts
+++ b/packages/bedrock/src/index.spec-d.ts
@@ -31,6 +31,8 @@ import type {
 	PlaceDriverDeps,
 	PlaceEntry,
 	PlaceOutputs,
+	ResolvedConfig,
+	ResolvedPlaceEntry,
 	ResourceCurrentState,
 	ResourceDesiredState,
 	ResourceKey,
@@ -247,10 +249,27 @@ describe(loadConfig, () => {
 });
 
 describe("PlaceEntry", () => {
-	it("should expose exactly placeId and filePath as strings", () => {
-		expectTypeOf<keyof PlaceEntry>().toEqualTypeOf<"filePath" | "placeId">();
-		expectTypeOf<PlaceEntry["placeId"]>().toEqualTypeOf<string>();
+	it("should expose only filePath at the root entry level", () => {
+		expectTypeOf<keyof PlaceEntry>().toEqualTypeOf<"filePath">();
 		expectTypeOf<PlaceEntry["filePath"]>().toEqualTypeOf<string>();
+	});
+});
+
+describe("ResolvedPlaceEntry", () => {
+	it("should expose filePath and placeId as the post-merge invariant", () => {
+		expectTypeOf<keyof ResolvedPlaceEntry>().toEqualTypeOf<"filePath" | "placeId">();
+		expectTypeOf<ResolvedPlaceEntry["filePath"]>().toEqualTypeOf<string>();
+		expectTypeOf<ResolvedPlaceEntry["placeId"]>().toEqualTypeOf<string>();
+	});
+});
+
+describe("ResolvedConfig", () => {
+	it("should narrow places to ResolvedPlaceEntry while keeping every other Config field", () => {
+		expectTypeOf<ResolvedConfig["places"]>().toEqualTypeOf<
+			Record<string, ResolvedPlaceEntry> | undefined
+		>();
+		expectTypeOf<ResolvedConfig["environments"]>().toEqualTypeOf<Config["environments"]>();
+		expectTypeOf<ResolvedConfig["state"]>().toEqualTypeOf<Config["state"]>();
 	});
 });
 

--- a/packages/bedrock/src/index.ts
+++ b/packages/bedrock/src/index.ts
@@ -54,6 +54,8 @@ export {
 	type GamePassEntry,
 	type GistStateConfig,
 	type PlaceEntry,
+	type ResolvedConfig,
+	type ResolvedPlaceEntry,
 	type ResourceEntryByKind,
 	type StateConfig,
 	type UniverseEntry,

--- a/packages/bedrock/src/index.ts
+++ b/packages/bedrock/src/index.ts
@@ -63,6 +63,7 @@ export {
 } from "./core/schema.ts";
 export {
 	selectEnvironment,
+	type IncompletePlaceEntryError,
 	type SelectEnvironmentError,
 	type UnknownEnvironmentError,
 } from "./core/select-environment.ts";

--- a/packages/bedrock/src/shell/build-default-registry.spec.ts
+++ b/packages/bedrock/src/shell/build-default-registry.spec.ts
@@ -1,11 +1,11 @@
 import { assert, describe, expect, it } from "vitest";
 
-import type { Config } from "../core/schema.ts";
+import type { ResolvedConfig } from "../core/schema.ts";
 import { buildDefaultRegistry } from "./build-default-registry.ts";
 
 const STATE_CONFIG = { backend: "gist" as const, gistId: "abc123" };
 
-function configWithUniverse(): Config {
+function configWithUniverse(): ResolvedConfig {
 	return {
 		environments: { production: {} },
 		state: STATE_CONFIG,

--- a/packages/bedrock/src/shell/build-default-registry.ts
+++ b/packages/bedrock/src/shell/build-default-registry.ts
@@ -6,7 +6,7 @@ import { UniversesClient } from "@bedrock/ocale/universes";
 import { createGamePassDriver } from "../adapters/game-pass-driver.ts";
 import { createPlaceDriver } from "../adapters/place-driver.ts";
 import { createUniverseDriver } from "../adapters/universe-driver.ts";
-import type { Config } from "../core/schema.ts";
+import type { ResolvedConfig } from "../core/schema.ts";
 import type { DriverRegistry } from "../ports/resource-driver.ts";
 import { asRobloxAssetId } from "../types/ids.ts";
 import type { MissingCredentialError } from "./build-state-port.ts";
@@ -28,8 +28,8 @@ export interface RegistryConfigError {
 
 /** Inputs for {@link buildDefaultRegistry}. */
 interface BuildDefaultRegistryDeps {
-	/** Validated project config; supplies `universe.universeId` and is read for nothing else. */
-	readonly config: Config;
+	/** Resolved project config; supplies `universe.universeId` and is read for nothing else. */
+	readonly config: ResolvedConfig;
 	/** Reads an environment variable; injected so tests stay free of `process.env`. */
 	readonly getEnv: (name: string) => string | undefined;
 	/** Reader plumbed into kind-specific drivers that ingest file bytes. */

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -10,7 +10,11 @@ import { flattenConfig } from "../core/flatten.ts";
 import { resolveStateConfig, type StateNotConfiguredError } from "../core/resolve-state-config.ts";
 import type { ResourceCurrentState } from "../core/resources.ts";
 import type { Config, ResolvedConfig } from "../core/schema.ts";
-import { selectEnvironment, type UnknownEnvironmentError } from "../core/select-environment.ts";
+import {
+	type IncompletePlaceEntryError,
+	selectEnvironment,
+	type UnknownEnvironmentError,
+} from "../core/select-environment.ts";
 import type { BedrockState, StateError } from "../core/state.ts";
 import type { DriverRegistry } from "../ports/resource-driver.ts";
 import type { StatePort } from "../ports/state-port.ts";
@@ -54,9 +58,11 @@ export interface DeployOptions {
  * `kind` to distinguish reconciliation failures (`stateReadFailed`,
  * `applyFailed`, ...) from default-construction failures
  * (`configLoadFailed`, `stateNotConfigured`, `unknownEnvironment`,
- * `missingCredential`, `unsupportedBackend`, `registryConfigMissing`).
+ * `incompletePlaceEntry`, `missingCredential`, `unsupportedBackend`,
+ * `registryConfigMissing`).
  */
 export type DeployError =
+	| IncompletePlaceEntryError
 	| MissingCredentialError
 	| RegistryConfigError
 	| StateNotConfiguredError

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -9,7 +9,7 @@ import { diff } from "../core/diff.ts";
 import { flattenConfig } from "../core/flatten.ts";
 import { resolveStateConfig, type StateNotConfiguredError } from "../core/resolve-state-config.ts";
 import type { ResourceCurrentState } from "../core/resources.ts";
-import type { Config } from "../core/schema.ts";
+import type { Config, ResolvedConfig } from "../core/schema.ts";
 import { selectEnvironment, type UnknownEnvironmentError } from "../core/select-environment.ts";
 import type { BedrockState, StateError } from "../core/state.ts";
 import type { DriverRegistry } from "../ports/resource-driver.ts";
@@ -85,14 +85,14 @@ interface FinalizeInputs {
 }
 
 interface ResolvedDeps {
-	readonly config: Config;
+	readonly config: ResolvedConfig;
 	readonly readFile: (path: string) => Promise<Uint8Array>;
 	readonly registry: DriverRegistry;
 	readonly statePort: StatePort;
 }
 
 interface PickRegistryInputs {
-	readonly config: Config;
+	readonly config: ResolvedConfig;
 	readonly options: DeployOptions;
 	readonly readFile: (path: string) => Promise<Uint8Array>;
 }
@@ -189,7 +189,10 @@ function getEnvironmentOf(options: DeployOptions): (name: string) => string | un
 	return options.getEnv ?? readProcessEnvironment;
 }
 
-function pickStatePort(options: DeployOptions, config: Config): Result<StatePort, DeployError> {
+function pickStatePort(
+	options: DeployOptions,
+	config: ResolvedConfig,
+): Result<StatePort, DeployError> {
 	if (options.statePort !== undefined) {
 		return { data: options.statePort, success: true };
 	}

--- a/packages/bedrock/tests/integration/config-pipeline.spec.ts
+++ b/packages/bedrock/tests/integration/config-pipeline.spec.ts
@@ -12,6 +12,7 @@ import {
 	type Operation,
 	type ResourceCurrentState,
 	type ResourceDriver,
+	selectEnvironment,
 } from "@bedrock/core";
 import { GamePassesClient } from "@bedrock/ocale/game-passes";
 import {
@@ -105,7 +106,10 @@ async function runPipelineFromFixture(cwd: string): Promise<CreateFlowResult> {
 	const loaded = await loadConfig({ cwd });
 	assert(loaded.success);
 
-	const desiredResult = await buildDesired(flattenConfig(loaded.data), readIcon);
+	const resolved = selectEnvironment(loaded.data, "production");
+	assert(resolved.success);
+
+	const desiredResult = await buildDesired(flattenConfig(resolved.data), readIcon);
 	assert(desiredResult.success);
 
 	const httpClient = createFakeHttpClient().mockResponse({
@@ -179,7 +183,10 @@ describe("config pipeline end-to-end", () => {
 		const loaded = await loadConfig({ cwd: TYPESCRIPT_FIXTURE_DIR });
 		assert(loaded.success);
 
-		const desiredResult = await buildDesired(flattenConfig(loaded.data), readIcon);
+		const resolved = selectEnvironment(loaded.data, "production");
+		assert(resolved.success);
+
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readIcon);
 		assert(desiredResult.success);
 
 		const ops = diff(desiredResult.data, [await buildExistingPass()]);

--- a/packages/bedrock/tests/integration/fixtures/places/bedrock.config.ts
+++ b/packages/bedrock/tests/integration/fixtures/places/bedrock.config.ts
@@ -1,11 +1,12 @@
 import { defineConfig } from "@bedrock/core";
 
 export default defineConfig({
-	environments: { production: {} },
-	places: {
-		"start-place": {
-			filePath: "places/start.rbxl",
-			placeId: "4711",
+	environments: {
+		production: {
+			places: { "start-place": { placeId: "4711" } },
 		},
+	},
+	places: {
+		"start-place": { filePath: "places/start.rbxl" },
 	},
 });

--- a/packages/bedrock/tests/integration/places.spec.ts
+++ b/packages/bedrock/tests/integration/places.spec.ts
@@ -8,6 +8,7 @@ import {
 	flattenConfig,
 	loadConfig,
 	type ResourceDriver,
+	selectEnvironment,
 } from "@bedrock/core";
 import { PlacesClient } from "@bedrock/ocale/places";
 import { createFakeHttpClient } from "@bedrock/ocale/testing";
@@ -47,7 +48,10 @@ describe("places pipeline end-to-end", () => {
 		const loaded = await loadConfig({ cwd: PLACES_FIXTURE_DIR });
 		assert(loaded.success);
 
-		const desiredResult = await buildDesired(flattenConfig(loaded.data), readPlaceFile);
+		const resolved = selectEnvironment(loaded.data, "production");
+		assert(resolved.success);
+
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readPlaceFile);
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient().mockResponse({

--- a/packages/bedrock/tests/integration/universe.spec.ts
+++ b/packages/bedrock/tests/integration/universe.spec.ts
@@ -8,6 +8,7 @@ import {
 	flattenConfig,
 	loadConfig,
 	type ResourceDriver,
+	selectEnvironment,
 	UNIVERSE_SINGLETON_KEY,
 } from "@bedrock/core";
 import { PlacesClient } from "@bedrock/ocale/places";
@@ -70,7 +71,10 @@ describe("universe pipeline end-to-end", () => {
 		const loaded = await loadConfig({ cwd: UNIVERSE_FIXTURE_DIR });
 		assert(loaded.success);
 
-		const desiredResult = await buildDesired(flattenConfig(loaded.data), readFileNever);
+		const resolved = selectEnvironment(loaded.data, "production");
+		assert(resolved.success);
+
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFileNever);
 		assert(desiredResult.success);
 
 		// `twitterSocialLink: undefined` in the fixture flows through as a
@@ -120,7 +124,10 @@ describe("universe pipeline end-to-end", () => {
 		const loaded = await loadConfig({ cwd: UNIVERSE_FIXTURE_DIR });
 		assert(loaded.success);
 
-		const desiredResult = await buildDesired(flattenConfig(loaded.data), readFileNever);
+		const resolved = selectEnvironment(loaded.data, "production");
+		assert(resolved.success);
+
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFileNever);
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient({ schemaValidation: "off" }).mockResponse({
@@ -156,7 +163,10 @@ describe("universe pipeline end-to-end", () => {
 		const loaded = await loadConfig({ cwd: UNIVERSE_FIXTURE_DIR });
 		assert(loaded.success);
 
-		const desiredResult = await buildDesired(flattenConfig(loaded.data), readFileNever);
+		const resolved = selectEnvironment(loaded.data, "production");
+		assert(resolved.success);
+
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFileNever);
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient({ schemaValidation: "off" }).mockResponse({
@@ -254,7 +264,10 @@ describe("universe pipeline end-to-end", () => {
 		const loaded = await loadConfig({ cwd: UNIVERSE_FIXTURE_DIR });
 		assert(loaded.success);
 
-		const desiredResult = await buildDesired(flattenConfig(loaded.data), readFileNever);
+		const resolved = selectEnvironment(loaded.data, "production");
+		assert(resolved.success);
+
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFileNever);
 		assert(desiredResult.success);
 
 		const ops = diff(desiredResult.data, [
@@ -302,7 +315,10 @@ describe("universe pipeline end-to-end", () => {
 		const loaded = await loadConfig({ cwd: UNIVERSE_FIXTURE_DIR });
 		assert(loaded.success);
 
-		const desiredResult = await buildDesired(flattenConfig(loaded.data), readFileNever);
+		const resolved = selectEnvironment(loaded.data, "production");
+		assert(resolved.success);
+
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFileNever);
 		assert(desiredResult.success);
 
 		const ops = diff(desiredResult.data, [


### PR DESCRIPTION
Closes #191.

## Summary

Splits the place-entry shape so `placeId` lives only on per-environment overlays. Each environment of a bedrock project targets its own Roblox place (staging publishes to one `placeId`, production to another), so a root `placeId` had no real role: every functioning project clobbered it from every env overlay anyway. The schema now rejects `placeId` at the root, and `selectEnvironment` fails fast with a typed `incompletePlaceEntry` error if no overlay supplies one.

## What changed

- `PlaceEntry` (root, exported public type) is now `{ filePath: string }`. The post-merge invariant is captured by a new exported `ResolvedPlaceEntry` type and a new exported `ResolvedConfig` (mirrors `Config` but with `places: Record<string, ResolvedPlaceEntry>`).
- `selectEnvironment` returns `Result<ResolvedConfig, SelectEnvironmentError>` instead of `Result<Config, ...>`. After merging the per-environment overlay onto the root, it scans `places` and returns `Err({ kind: "incompletePlaceEntry", environment, key, missingField: "placeId" })` when an entry is missing its identity-bearing field.
- Downstream consumers (`flattenConfig`, every `ResourceKindModule.flatten`, `buildDefaultRegistry`, `deploy`) now take `ResolvedConfig`. `DeployError` widens to surface `incompletePlaceEntry`.
- Type tests cover the `PlaceEntry` / `ResolvedPlaceEntry` split, the `ResolvedConfig` shape, the new `SelectEnvironmentError` discriminator, and the widened `DeployError`.
- A precondition comment on the merge helpers documents that the unsafe casts are honest only because every public success path runs completeness validation before publishing the merged record.

The matching gap on `passes` and `universe` overlays is tracked in #198.

## Why

Issue #191 calls out that the type system silently accepted misconfigurations where a project author put `placeId` at the root and forgot to override per environment. The same publish call would land at the wrong place (or always the same place) with no diagnostic. After this change the schema rejects the root form at validation time and the resolver attributes any remaining gap to the offending entry's key.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test` all pass (781 tests, 10 skipped).
- `pnpm mutate:changed` reports 100% mutation score on touched files (`select-environment.ts`).
- Integration tests (`tests/integration/places.spec.ts`, `universe.spec.ts`, `config-pipeline.spec.ts`) thread through `selectEnvironment` end-to-end.
- The places integration fixture moved `placeId` from the root into `environments.production.places["start-place"]`.

## Notes for reviewers

- The merge helpers in `select-environment.ts` keep three internal `as` casts. They are load-bearing for the "ResolvedConfig is honest" contract: the type-system promise that every `places[key]` has a `placeId` post-merge is upheld at runtime by `findIncompletePlace`. The new comment block on `mergeEntry` names that precondition explicitly so a future refactor doesn't move the merge into a callable that bypasses validation.
- bedrock is pre-1.0 / unpublished, so the `!` on the slice-1 commit is informational rather than a semver gate.
- The fourth commit is a `docs:` cleanup that fixes the stale scope-enum in `CLAUDE.md` (the `bedrock` package was renamed to `@bedrock/core`, but the repo guide still listed the old name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)