### PR TITLE
chore(e2e): add typecheck script

### DIFF
--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -13,7 +13,8 @@
 	"scripts": {
 		"lint": "eslint --cache .",
 		"test": "vitest",
-		"test:smoke": "vp test run tests/smoke"
+		"test:smoke": "vp test run tests/smoke",
+		"typecheck": "tsgo --noEmit"
 	},
 	"dependencies": {
 		"@bedrock/core": "workspace:*",

--- a/apps/e2e/tests/smoke/deploy-place.spec.ts
+++ b/apps/e2e/tests/smoke/deploy-place.spec.ts
@@ -75,11 +75,14 @@ describe("deploy place to real Roblox", () => {
 
 			const result = await deploy({
 				config: {
-					environments: { smoke: {} },
+					environments: {
+						smoke: {
+							places: { "smoke-place": { placeId } },
+						},
+					},
 					places: {
 						"smoke-place": {
 							filePath: FIXTURE_PATH,
-							placeId,
 						},
 					},
 				},


### PR DESCRIPTION
## Summary

- Add `typecheck` script to `apps/e2e/package.json` so its sources participate in `pnpm typecheck` and the `hk` pre-commit hook's `typecheck:affected` task.
- Fix the smoke fixture in `apps/e2e/tests/smoke/deploy-place.spec.ts`: PR #200 ("feat(core)!: require place-id under environments") moved `placeId` into the per-environment overlay, but the smoke spec kept passing it at the root `places` entry. The bug landed silently because e2e was excluded from CI typechecking; the spec fix is included here as a precondition for the typecheck script to pass green.

## Test plan

- [x] `pnpm --filter @bedrock/e2e typecheck` clean
- [x] `pnpm typecheck` (root) now includes `apps/e2e` and passes
- [x] `pnpm typecheck:affected` (hk hook target) picks up `apps/e2e` when an e2e file is touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)