### PR TITLE
fix(ocale): handle empty response bodies without parse errors

### DIFF
--- a/packages/open-cloud/src/client/types.ts
+++ b/packages/open-cloud/src/client/types.ts
@@ -43,7 +43,11 @@ export interface HttpRequest {
  * A normalized HTTP response from the Roblox Open Cloud API.
  */
 export interface HttpResponse {
-	/** The parsed response body. */
+	/**
+	 * The parsed response body. `undefined` when the response had an empty
+	 * body (for example HTTP 204 No Content, or any other status where the
+	 * server returned no payload).
+	 */
 	readonly body: unknown;
 	/** Response headers with lowercased keys. */
 	readonly headers: Readonly<Record<string, string>>;

--- a/packages/open-cloud/src/internal/http/fetch-client.spec.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.spec.ts
@@ -489,6 +489,52 @@ describe(createFetchHttpClient, () => {
 		expect(result.err.statusCode).toBe(200);
 	});
 
+	it.for([{ status: 204 }, { status: 200 }])(
+		"should return success with undefined body for empty-body $status responses",
+		async ({ status }) => {
+			expect.assertions(2);
+
+			async function fakeFetch(): Promise<Response> {
+				return new Response(undefined, { status });
+			}
+
+			const client = createFetchHttpClient(fakeFetch);
+			const result = await client.request(
+				{ method: "DELETE", url: "/test" },
+				{ apiKey: "key", baseUrl: "https://example.com" },
+			);
+
+			assert(result.success);
+
+			expect(result.data.status).toBe(status);
+			expect(result.data.body).toBeUndefined();
+		},
+	);
+
+	it.for([{ status: 404 }, { status: 500 }])(
+		"should return ApiError preserving status for empty-body $status responses",
+		async ({ status }) => {
+			expect.assertions(3);
+
+			async function fakeFetch(): Promise<Response> {
+				return new Response(undefined, { status });
+			}
+
+			const client = createFetchHttpClient(fakeFetch);
+			const result = await client.request(
+				{ method: "DELETE", url: "/test" },
+				{ apiKey: "key", baseUrl: "https://example.com" },
+			);
+
+			assert(!result.success);
+			assert(result.err instanceof ApiError);
+
+			expect(result.err.statusCode).toBe(status);
+			expect(result.err.message).toBe(`HTTP ${status}`);
+			expect(result.err.code).toBeUndefined();
+		},
+	);
+
 	it("should return NetworkError when fetch throws TypeError", async () => {
 		expect.assertions(2);
 

--- a/packages/open-cloud/src/internal/http/fetch-client.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.ts
@@ -154,17 +154,26 @@ function createRateLimitError(response: Response): RateLimitError {
 	});
 }
 
+async function readResponseBody(response: Response): Promise<Result<unknown, OpenCloudError>> {
+	try {
+		const text = await response.text();
+		return { data: text === "" ? undefined : JSON.parse(text), success: true };
+	} catch {
+		return {
+			err: new ApiError("Failed to parse response body", { statusCode: response.status }),
+			success: false,
+		};
+	}
+}
+
 async function classifyResponse(response: Response): Promise<Result<HttpResponse, OpenCloudError>> {
 	if (response.status === 429) {
 		return { err: createRateLimitError(response), success: false };
 	}
 
-	const bodyResult = await tryCatch(response.json());
+	const bodyResult = await readResponseBody(response);
 	if (!bodyResult.success) {
-		return {
-			err: new ApiError("Failed to parse response body", { statusCode: response.status }),
-			success: false,
-		};
+		return bodyResult;
 	}
 
 	if (response.status >= 300) {


### PR DESCRIPTION
## Summary

Closes [#215](https://github.com/christopher-buss/bedrock/issues/215). `classifyResponse` in `packages/open-cloud/src/internal/http/fetch-client.ts` called `response.json()` on every non-429 response, so any 2xx response with an empty body (HTTP 204 No Content, or any endpoint returning no payload) surfaced to consumers as `ApiError("Failed to parse response body")`. Empty 4xx/5xx responses hit the same masking, hiding the original status behind the parse-error message.

The fix reads the body as text first and treats an empty string as `body: undefined`. JSON parsing only runs on non-empty content. Status classification then runs against the resolved body, so 204 responses succeed and empty 4xx/5xx responses surface as the appropriate `ApiError` with the real status.

## Why

The `delete` and `reorder` methods on `ExperienceIconClient` and `ExperienceThumbnailsClient` (PR [#214](https://github.com/christopher-buss/bedrock/pull/214)) target legacy `gameinternationalization` endpoints that may return HTTP 204 on success. The integration tests pass because the fakes return `body: {}` (which `response.json()` accepts), so the bug was invisible until the SDK ran against a real authenticated universe. The same fix unblocks every future Open Cloud endpoint that idiomatically returns 204 (DELETE, PUT, async-accepted operations).

## Implementation notes

`HttpResponse.body` stays typed as `unknown`; `undefined` is already assignable to `unknown`, so no public type widening was needed. The JSDoc on `HttpResponse.body` now documents the `undefined`-on-empty-body contract. Resource parsers like `parseGamePassResponse` already gate on `isRecord(body)` and return their own `ApiError("Malformed ...")`, so an unexpected `undefined` body for a JSON endpoint surfaces a clean error rather than the misleading parse failure. `parseEmptyResponse` ignores the body entirely, so the icon and thumbnail success paths flow through unchanged.

The body extraction is one helper (`readResponseBody`) with a single try/catch wrapping the async `text()` read and the sync `JSON.parse`. Collapsing the two error sites into one is what kept `classifyResponse` under the 30-line lint cap and let the existing `"not json"` test cover both the text-stream rejection path and the JSON-parse failure path under mutation.

## Test plan

* [x] `pnpm --filter @bedrock/ocale test` passes (562 tests across 53 files); the new `it.for` blocks cover empty-body 200/204 success and empty-body 404/500 error preservation
* [x] `pnpm --filter @bedrock/ocale typecheck` clean
* [x] `pnpm lint` clean
* [x] `pnpm build` clean
* [x] `MUTATE_BASE_REF=origin/main pnpm mutate:changed` shows 100% kill rate on touched lines (8/8 killed, 0 survived, 0 no-coverage)
* [ ] End-to-end smoke against a real authenticated universe (`ExperienceIconClient.delete` should resolve as `{ success: true, data: undefined }` against a real 204)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/christopher-buss/codesmith/bedrock/pr/228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/christopher-buss/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->