### PR TITLE
fix(testing): invalidate stryker incremental cache when specs change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,7 +64,7 @@ jobs:
 
   mutation:
     name: Mutation Test
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -83,14 +83,15 @@ jobs:
         name: Restore Stryker incremental cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
-          key: stryker-${{ runner.os }}-${{ steps.stryker-hash.outputs.hash }}-${{ github.head_ref }}-${{ github.sha }}
+          key: stryker-${{ runner.os }}-${{ steps.stryker-hash.outputs.hash }}-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
           path: |
             packages/*/reports/stryker-incremental.json
           restore-keys: |
-            stryker-${{ runner.os }}-${{ steps.stryker-hash.outputs.hash }}-${{ github.head_ref }}-
+            stryker-${{ runner.os }}-${{ steps.stryker-hash.outputs.hash }}-${{ github.head_ref || github.ref_name }}-
+            stryker-${{ runner.os }}-${{ steps.stryker-hash.outputs.hash }}-main-
 
       - env:
-          MUTATE_BASE_REF: origin/${{ github.base_ref }}
+          MUTATE_BASE_REF: ${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || github.event.before }}
           VITEST_TYPECHECK: "false"
         name: Mutation test changed files
         run: pnpm mutate:changed

--- a/packages/testing/src/stryker-diff.spec.ts
+++ b/packages/testing/src/stryker-diff.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
 	buildMutateArgs,
 	filterMutableFiles,
+	findPackagesWithChangedSpecs,
 	groupByPackage,
 	isTypesOnlyModule,
 	parseDiff,
@@ -368,6 +369,64 @@ describe(groupByPackage, () => {
 				["packages/bedrock", [{ hunks: [{ endLine: 3, startLine: 3 }], path: "src/b.ts" }]],
 			]),
 		);
+	});
+});
+
+describe(findPackagesWithChangedSpecs, () => {
+	it("should return an empty set when no files changed", () => {
+		expect.assertions(1);
+
+		expect(findPackagesWithChangedSpecs([], ["packages/foo"])).toStrictEqual(new Set());
+	});
+
+	it.for<[label: string, path: string]>([
+		[".spec.ts", "packages/foo/src/a.spec.ts"],
+		[".test.ts", "packages/foo/src/a.test.ts"],
+	])(
+		"should mark a package as having changed runtime tests when a %s file in it changes",
+		([, path]) => {
+			expect.assertions(1);
+
+			const files = [{ hunks: [{ endLine: 1, startLine: 1 }], path }];
+
+			expect(findPackagesWithChangedSpecs(files, ["packages/foo"])).toStrictEqual(
+				new Set(["packages/foo"]),
+			);
+		},
+	);
+
+	it.for<[label: string, path: string]>([
+		["a .spec-d.ts type-only test", "packages/foo/src/a.spec-d.ts"],
+		["a plain source .ts file", "packages/foo/src/a.ts"],
+		["a .d.ts declaration", "packages/foo/src/a.d.ts"],
+	])("should not mark the package when only %s changes", ([, path]) => {
+		expect.assertions(1);
+
+		const files = [{ hunks: [{ endLine: 1, startLine: 1 }], path }];
+
+		expect(findPackagesWithChangedSpecs(files, ["packages/foo"])).toStrictEqual(new Set());
+	});
+
+	it("should ignore spec changes outside any known package directory", () => {
+		expect.assertions(1);
+
+		const files = [{ hunks: [{ endLine: 1, startLine: 1 }], path: "scripts/foo.spec.ts" }];
+
+		expect(findPackagesWithChangedSpecs(files, ["packages/foo"])).toStrictEqual(new Set());
+	});
+
+	it("should collect every package whose specs changed across a multi-package diff", () => {
+		expect.assertions(1);
+
+		const files = [
+			{ hunks: [{ endLine: 1, startLine: 1 }], path: "packages/foo/src/a.spec.ts" },
+			{ hunks: [{ endLine: 2, startLine: 2 }], path: "packages/bar/src/b.test.ts" },
+			{ hunks: [{ endLine: 3, startLine: 3 }], path: "packages/baz/src/c.ts" },
+		];
+
+		expect(
+			findPackagesWithChangedSpecs(files, ["packages/foo", "packages/bar", "packages/baz"]),
+		).toStrictEqual(new Set(["packages/bar", "packages/foo"]));
 	});
 });
 

--- a/packages/testing/src/stryker-diff.ts
+++ b/packages/testing/src/stryker-diff.ts
@@ -103,6 +103,7 @@ export function buildMutateArgs(files: ReadonlyArray<FileChange>): Array<string>
 
 const MUTABLE_SUFFIXES: ReadonlyArray<string> = [".ts", ".tsx"];
 const NON_MUTABLE_SUFFIXES: ReadonlyArray<string> = [".spec.ts", ".spec-d.ts", ".test.ts", ".d.ts"];
+const RUNTIME_SPEC_SUFFIXES: ReadonlyArray<string> = [".spec.ts", ".test.ts"];
 const SRC_SEGMENT = /(?:^|\/)src\//;
 
 /**
@@ -152,6 +153,35 @@ export function isTypesOnlyModule(source: string): boolean {
 		ts.ScriptKind.TS,
 	);
 	return sourceFile.statements.every(isErasableStatement);
+}
+
+/**
+ * Identify packages whose runtime test files changed in the diff.
+ * Stryker's vitest-runner has limited test-change detection in
+ * incremental mode, so callers must force a clean re-run for any
+ * package whose specs changed; otherwise the cache will return prior
+ * survivors even when newly-added tests would now kill them.
+ *
+ * Type-only spec files (`*.spec-d.ts`) are ignored: they exercise the
+ * type system, not runtime behaviour, and don't influence mutation
+ * outcomes.
+ *
+ * @param files - Parsed file changes from {@link parseDiff}.
+ * @param packageDirectories - Repo-relative package directories.
+ * @returns Set of package directories whose runtime tests changed.
+ */
+export function findPackagesWithChangedSpecs(
+	files: ReadonlyArray<FileChange>,
+	packageDirectories: ReadonlyArray<string>,
+): Set<string> {
+	return new Set(
+		files
+			.filter((file) => RUNTIME_SPEC_SUFFIXES.some((suffix) => file.path.endsWith(suffix)))
+			.map((file) =>
+				packageDirectories.find((directory) => file.path.startsWith(`${directory}/`)),
+			)
+			.filter((directory): directory is string => directory !== undefined),
+	);
 }
 
 /**

--- a/scripts/mutate-changed.ts
+++ b/scripts/mutate-changed.ts
@@ -1,6 +1,7 @@
 import {
 	buildMutateArgs,
 	filterMutableFiles,
+	findPackagesWithChangedSpecs,
 	groupByPackage,
 	isTypesOnlyModule,
 	parseDiff,
@@ -37,14 +38,21 @@ function runStrykerForEach(
 		string,
 		Array<{ hunks: Array<{ endLine: number; startLine: number }>; path: string }>
 	>,
+	packagesWithSpecChanges: ReadonlySet<string>,
 ): boolean {
 	const statuses = Array.from(grouped, ([packageDirectory, files]) => {
 		const args = buildMutateArgs(files);
-		console.log(`\n→ Running Stryker in ${packageDirectory}`);
-		return spawnSync("pnpm", ["exec", "stryker", "run", "stryker.config.ts", ...args], {
-			cwd: packageDirectory,
-			stdio: "inherit",
-		}).status;
+		const force = packagesWithSpecChanges.has(packageDirectory) ? ["--force"] : [];
+		const note = force.length > 0 ? " (--force: specs changed)" : "";
+		console.log(`\n→ Running Stryker in ${packageDirectory}${note}`);
+		return spawnSync(
+			"pnpm",
+			["exec", "stryker", "run", "stryker.config.ts", ...force, ...args],
+			{
+				cwd: packageDirectory,
+				stdio: "inherit",
+			},
+		).status;
 	});
 	return statuses.some((status) => status !== 0);
 }
@@ -77,7 +85,8 @@ async function main(): Promise<void> {
 		return;
 	}
 
-	const hasFailed = runStrykerForEach(grouped);
+	const packagesWithSpecChanges = findPackagesWithChangedSpecs(parsed.files, packageDirectories);
+	const hasFailed = runStrykerForEach(grouped, packagesWithSpecChanges);
 	if (hasFailed) {
 		process.exit(1);
 	}


### PR DESCRIPTION
## Summary

Two changes addressing the local-loop trust bug from #209 and the cold-cache CI cost concern.

**1. Local cache invalidation when specs change.** Stryker's vitest-runner has limited test-change detection in incremental mode. Adding tests that should kill previously-surviving mutants returned the same survivors from cache, leading developers to either invent unnecessary tests or give up. New `findPackagesWithChangedSpecs` in `@bedrock/testing/stryker-diff` inspects the diff for `*.spec.ts` / `*.test.ts` changes (type-only `*.spec-d.ts` files are excluded since they don't influence runtime mutation outcomes); the `mutate:changed` driver passes `--force` to Stryker for any package whose runtime tests changed.

**2. Warm PR caches from a main baseline.** The mutation job now also runs on `push` to `main`, producing a cache under a stable `…-main-` key prefix on every merge. PR runs add that prefix to `restore-keys` so a brand-new PR branch falls back to the latest main cache instead of running cold. For main pushes, `MUTATE_BASE_REF` uses `github.event.before` to scope the diff to just-merged commits.

## Why

Trust: stale cached results made local iteration unreliable; #2 reduces full-cost cold runs on new branches without changing the gate (mutation remains a hard CI blocker).

## Test plan

- [x] `pnpm --filter @bedrock/testing test` passes (5 new test cases for `findPackagesWithChangedSpecs`)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] Reproduce #209 locally before/after: add a spec to kill a known surviving mutant, run `pnpm mutate:changed`, confirm `--force` is logged for the affected package and the new test kills the mutant
- [ ] First main push after merge populates the `…-main-` cache key; subsequent PR-branch first-pushes restore from it

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)