### PR TITLE
fix(testing): ignore hybrid static mutants

### DIFF
--- a/packages/bedrock/src/shell/load-config-internal.ts
+++ b/packages/bedrock/src/shell/load-config-internal.ts
@@ -1,0 +1,1 @@
+export const LUAU_BOOTSTRAP_TEMP_PREFIX = "bedrock-luau-bootstrap-";

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -6,9 +6,8 @@ import { join } from "node:path";
 import process from "node:process";
 import { assert, describe, expect, it } from "vitest";
 
+import { LUAU_BOOTSTRAP_TEMP_PREFIX } from "./load-config-internal.ts";
 import { loadConfig } from "./load-config.ts";
-
-const LUAU_BOOTSTRAP_TEMP_PREFIX = "bedrock-luau-bootstrap-";
 
 async function withTemporaryDirectory<T>(run: (directory: string) => Promise<T>): Promise<T> {
 	const directory = mkdtempSync(join(tmpdir(), "bedrock-load-config-"));

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -8,6 +8,8 @@ import { assert, describe, expect, it } from "vitest";
 
 import { loadConfig } from "./load-config.ts";
 
+const LUAU_BOOTSTRAP_TEMP_PREFIX = "bedrock-luau-bootstrap-";
+
 async function withTemporaryDirectory<T>(run: (directory: string) => Promise<T>): Promise<T> {
 	const directory = mkdtempSync(join(tmpdir(), "bedrock-load-config-"));
 	try {
@@ -19,6 +21,10 @@ async function withTemporaryDirectory<T>(run: (directory: string) => Promise<T>)
 
 function writeFixtureConfig(directory: string, lines: ReadonlyArray<string>): void {
 	writeFileSync(join(directory, "bedrock.config.ts"), lines.join("\n"));
+}
+
+function readBootstrapDirectories(): Array<string> {
+	return readdirSync(tmpdir()).filter((entry) => entry.startsWith(LUAU_BOOTSTRAP_TEMP_PREFIX));
 }
 
 async function expectParseFailed(filename: string, contents: string): Promise<void> {
@@ -602,11 +608,11 @@ describe(loadConfig, () => {
 				["return { passes = {} }", ""].join("\n"),
 			);
 
-			const before = new Set(readdirSync(tmpdir()));
+			const before = new Set(readBootstrapDirectories());
 
 			await loadConfig({ cwd });
 
-			const after = readdirSync(tmpdir());
+			const after = readBootstrapDirectories();
 			const leaked = after.filter((entry) => !before.has(entry));
 
 			expect(leaked).toStrictEqual([]);

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -4,7 +4,7 @@ import { loadConfig as c12LoadConfig } from "c12";
 import { execFile } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join, resolve as resolvePath, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
 import process from "node:process";
 
 import type { ConfigError } from "../core/config-error.ts";
@@ -227,6 +227,7 @@ function makeLuauResolver(
 }
 
 const LUAU_CONFIG_BASENAME = "bedrock.config.luau";
+const LUAU_BOOTSTRAP_TEMP_PREFIX = "bedrock-luau-bootstrap-";
 
 const SENTINEL_BASE = "__BEDROCK_LUAU_";
 const OK_PREFIX = `${SENTINEL_BASE}OK__`;
@@ -344,10 +345,7 @@ async function evaluateLuauConfig(absPath: string): Promise<Record<string, unkno
 	const cwd = dirname(absPath);
 	const base = basename(absPath);
 
-	// `tmpdir() + sep` keeps the directory inside tmpdir without a mutable
-	// debug-label string. The trailing separator is required so mkdtempSync
-	// creates a child of tmpdir rather than a sibling whose name extends it.
-	const bootstrapDirectory = mkdtempSync(tmpdir() + sep);
+	const bootstrapDirectory = mkdtempSync(join(tmpdir(), LUAU_BOOTSTRAP_TEMP_PREFIX));
 	try {
 		const bootstrapPath = join(bootstrapDirectory, "bootstrap.luau");
 		writeFileSync(bootstrapPath, LUTE_BOOTSTRAP_LUAU);

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -9,6 +9,7 @@ import process from "node:process";
 
 import type { ConfigError } from "../core/config-error.ts";
 import { type Config, validateConfig } from "../core/schema.ts";
+import { LUAU_BOOTSTRAP_TEMP_PREFIX } from "./load-config-internal.ts";
 
 /**
  * Options for {@link loadConfig}. Matches a subset of c12's loader options;
@@ -227,7 +228,6 @@ function makeLuauResolver(
 }
 
 const LUAU_CONFIG_BASENAME = "bedrock.config.luau";
-const LUAU_BOOTSTRAP_TEMP_PREFIX = "bedrock-luau-bootstrap-";
 
 const SENTINEL_BASE = "__BEDROCK_LUAU_";
 const OK_PREFIX = `${SENTINEL_BASE}OK__`;

--- a/packages/bedrock/stryker.config.ts
+++ b/packages/bedrock/stryker.config.ts
@@ -3,22 +3,4 @@ import type { PartialStrykerOptions } from "@stryker-mutator/api/core";
 
 export default {
 	...sharedStrykerConfig,
-	// Override `coverageAnalysis: "perTest"` (and the coupled
-	// `ignoreStatic: true`) for this package only. The shared defaults
-	// rely on PR #199's vitest-runner patch to classify top-level
-	// arktype `type({...})` constructions in core/schema.ts as static
-	// and mark them Ignored. The patch works locally (macOS, fresh
-	// cache: 14 schema mutants Ignored, mutation score 100%), but on
-	// the Ubuntu CI runner the same mutants come back Survived with
-	// non-empty `coveredBy` lists, dropping the bedrock score to 80%.
-	// We have not reproduced the divergence locally despite matching
-	// `MUTATE_BASE_REF`, deleting all caches, and matching
-	// `VITEST_TYPECHECK=false`.
-	//
-	// `coverageAnalysis: "all"` runs the full test suite against every
-	// mutant rather than relying on per-test attribution, so the
-	// classification trap doesn't apply. `ignoreStatic` is coupled and
-	// must be disabled for "all" mode.
-	coverageAnalysis: "all",
-	ignoreStatic: false,
 } satisfies PartialStrykerOptions;

--- a/packages/testing/src/stryker-diff.spec.ts
+++ b/packages/testing/src/stryker-diff.spec.ts
@@ -354,6 +354,25 @@ describe(groupByPackage, () => {
 		);
 	});
 
+	it("should accept package directories with Windows separators", () => {
+		expect.assertions(1);
+
+		const files = [
+			{ hunks: [{ endLine: 3, startLine: 3 }], path: "packages/bedrock/src/schema.ts" },
+		];
+
+		const grouped = groupByPackage(files, ["packages\\bedrock"]);
+
+		expect(grouped).toStrictEqual(
+			new Map([
+				[
+					"packages/bedrock",
+					[{ hunks: [{ endLine: 3, startLine: 3 }], path: "src/schema.ts" }],
+				],
+			]),
+		);
+	});
+
 	it("should drop files that fall outside every known package", () => {
 		expect.assertions(1);
 
@@ -427,6 +446,18 @@ describe(findPackagesWithChangedSpecs, () => {
 		expect(
 			findPackagesWithChangedSpecs(files, ["packages/foo", "packages/bar", "packages/baz"]),
 		).toStrictEqual(new Set(["packages/bar", "packages/foo"]));
+	});
+
+	it("should accept package directories with Windows separators when specs change", () => {
+		expect.assertions(1);
+
+		const files = [
+			{ hunks: [{ endLine: 1, startLine: 1 }], path: "packages/foo/src/a.spec.ts" },
+		];
+
+		expect(findPackagesWithChangedSpecs(files, ["packages\\foo"])).toStrictEqual(
+			new Set(["packages/foo"]),
+		);
 	});
 });
 

--- a/packages/testing/src/stryker-diff.ts
+++ b/packages/testing/src/stryker-diff.ts
@@ -174,14 +174,24 @@ export function findPackagesWithChangedSpecs(
 	files: ReadonlyArray<FileChange>,
 	packageDirectories: ReadonlyArray<string>,
 ): Set<string> {
-	return new Set(
-		files
-			.filter((file) => RUNTIME_SPEC_SUFFIXES.some((suffix) => file.path.endsWith(suffix)))
-			.map((file) =>
-				packageDirectories.find((directory) => file.path.startsWith(`${directory}/`)),
-			)
-			.filter((directory): directory is string => directory !== undefined),
-	);
+	const normalizedPackageDirectories = packageDirectories.map(normalizePath);
+	const packagesWithChangedSpecs = new Set<string>();
+
+	for (const file of files) {
+		const filePath = normalizePath(file.path);
+		if (!RUNTIME_SPEC_SUFFIXES.some((suffix) => filePath.endsWith(suffix))) {
+			continue;
+		}
+
+		for (const packageDirectory of normalizedPackageDirectories) {
+			if (filePath.startsWith(`${packageDirectory}/`)) {
+				packagesWithChangedSpecs.add(packageDirectory);
+				break;
+			}
+		}
+	}
+
+	return packagesWithChangedSpecs;
 }
 
 /**
@@ -199,16 +209,18 @@ export function groupByPackage(
 	packageDirectories: ReadonlyArray<string>,
 ): Map<string, Array<FileChange>> {
 	const grouped = new Map<string, Array<FileChange>>();
+	const normalizedPackageDirectories = packageDirectories.map(normalizePath);
 
 	for (const file of files) {
-		const packageDirectory = packageDirectories.find((directory) => {
-			return file.path.startsWith(`${directory}/`);
+		const filePath = normalizePath(file.path);
+		const packageDirectory = normalizedPackageDirectories.find((directory) => {
+			return filePath.startsWith(`${directory}/`);
 		});
 		if (packageDirectory === undefined) {
 			continue;
 		}
 
-		const relativePath = file.path.slice(packageDirectory.length + 1);
+		const relativePath = filePath.slice(packageDirectory.length + 1);
 		const bucket = grouped.get(packageDirectory) ?? [];
 		bucket.push({ hunks: file.hunks, path: relativePath });
 		grouped.set(packageDirectory, bucket);
@@ -239,6 +251,10 @@ function isErasableStatement(statement: ts.Statement): boolean {
 	}
 
 	return false;
+}
+
+function normalizePath(filePath: string): string {
+	return filePath.replaceAll("\\", "/");
 }
 
 const HANDLERS: ReadonlyArray<LineHandler> = [

--- a/packages/testing/src/stryker.spec.ts
+++ b/packages/testing/src/stryker.spec.ts
@@ -1,0 +1,141 @@
+import {
+	type Mutant,
+	type MutantTestPlan,
+	PlanKind,
+	type StrykerOptions,
+} from "@stryker-mutator/api/core";
+import { type TestResult, TestStatus } from "@stryker-mutator/api/test-runner";
+
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+interface TestCoverageLike {
+	readonly hasCoverage: boolean;
+	hasStaticCoverage(mutantId: string): boolean;
+	readonly hitsByMutantId: Map<string, number>;
+	readonly testsById: Map<string, TestResult>;
+	readonly testsByMutantId: Map<string, Set<TestResult>>;
+}
+
+interface ReporterLike {
+	onMutationTestingPlanReady(event: {
+		readonly mutantPlans: ReadonlyArray<MutantTestPlan>;
+	}): void;
+}
+
+interface SandboxLike {
+	sandboxFileFor(fileName: string): string;
+}
+
+interface ProjectLike {
+	readonly incrementalReport: undefined;
+	readonly testFiles: ReadonlyArray<string>;
+}
+
+type PlannerOptions = Pick<
+	StrykerOptions,
+	"disableBail" | "ignoreStatic" | "timeoutFactor" | "timeoutMS" | "warnings"
+>;
+
+interface LoggerLike {
+	isWarningEnabled(): boolean;
+	warn(message: string): void;
+}
+
+type PlannerConstructor = new (
+	testCoverage: TestCoverageLike,
+	incrementalDiffer: unknown,
+	reporter: ReporterLike,
+	sandbox: SandboxLike,
+	project: ProjectLike,
+	timeOverheadMS: number,
+	options: PlannerOptions,
+	logger: LoggerLike,
+) => { makePlan(mutants: ReadonlyArray<Mutant>): Promise<ReadonlyArray<MutantTestPlan>> };
+
+type PlannerModule = Record<typeof PLANNER_EXPORT, PlannerConstructor>;
+
+const PLANNER_EXPORT = "MutantTestPlanner";
+const require = createRequire(import.meta.url);
+
+describe("stryker static mutant planning patch", () => {
+	it("should ignore static mutants even when Vitest reports per-test coverage", async () => {
+		expect.assertions(1);
+
+		const plannerModule = await loadPlannerModule();
+		const test = {
+			id: "src/schema.spec.ts#should validate product keys",
+			name: "should validate product keys",
+			fileName: "src/schema.spec.ts",
+			status: TestStatus.Success,
+			timeSpentMs: 1,
+		} satisfies TestResult;
+		const mutant = {
+			id: "7",
+			fileName: "src/schema.ts",
+			location: {
+				end: { column: 8, line: 410 },
+				start: { column: 3, line: 410 },
+			},
+			mutatorName: "StringLiteral",
+			replacement: "``",
+		} satisfies Mutant;
+
+		const planner = new plannerModule[PLANNER_EXPORT](
+			{
+				hasCoverage: true,
+				hasStaticCoverage: () => true,
+				hitsByMutantId: new Map([[mutant.id, 2]]),
+				testsById: new Map([[test.id, test]]),
+				testsByMutantId: new Map([[mutant.id, new Set([test])]]),
+			},
+			{},
+			{ onMutationTestingPlanReady: () => {} },
+			{ sandboxFileFor: (fileName) => fileName },
+			{ incrementalReport: undefined, testFiles: [] },
+			0,
+			{
+				disableBail: false,
+				ignoreStatic: true,
+				timeoutFactor: 1.5,
+				timeoutMS: 5_000,
+				warnings: false,
+			},
+			{ isWarningEnabled: () => false, warn: () => {} },
+		);
+
+		const [plan] = await planner.makePlan([mutant]);
+
+		expect(plan).toMatchObject({
+			mutant: {
+				coveredBy: [test.id],
+				static: true,
+				status: "Ignored",
+				statusReason: 'Static mutant (and "ignoreStatic" was enabled)',
+			},
+			plan: PlanKind.EarlyResult,
+		});
+	});
+});
+
+function isPlannerModule(value: unknown): value is PlannerModule {
+	if (typeof value !== "object" || !value) {
+		return false;
+	}
+
+	return PLANNER_EXPORT in value && typeof value[PLANNER_EXPORT] === "function";
+}
+
+async function loadPlannerModule(): Promise<PlannerModule> {
+	const packageJsonPath = require.resolve("@stryker-mutator/core/package.json");
+	const plannerPath = join(dirname(packageJsonPath), "dist/src/mutants/mutant-test-planner.js");
+	const module: unknown = await import(pathToFileURL(plannerPath).href);
+
+	if (!isPlannerModule(module)) {
+		throw new Error("Could not load Stryker MutantTestPlanner");
+	}
+
+	return module;
+}

--- a/packages/testing/src/stryker.spec.ts
+++ b/packages/testing/src/stryker.spec.ts
@@ -130,6 +130,8 @@ function isPlannerModule(value: unknown): value is PlannerModule {
 
 async function loadPlannerModule(): Promise<PlannerModule> {
 	const packageJsonPath = require.resolve("@stryker-mutator/core/package.json");
+	// Stryker does not expose the planner publicly; this test verifies our pnpm
+	// patch against the exact internal file it modifies.
 	const plannerPath = join(dirname(packageJsonPath), "dist/src/mutants/mutant-test-planner.js");
 	const module: unknown = await import(pathToFileURL(plannerPath).href);
 

--- a/patches/@stryker-mutator__core@9.6.1.patch
+++ b/patches/@stryker-mutator__core@9.6.1.patch
@@ -1,0 +1,17 @@
+diff --git a/dist/src/mutants/mutant-test-planner.js b/dist/src/mutants/mutant-test-planner.js
+index 78a25f2c2f0f0f63e8d7b00c0ef58a40de67f6cf..e4a39172140e5142b4b219dd50431a489c214f7d 100644
+--- a/dist/src/mutants/mutant-test-planner.js
++++ b/dist/src/mutants/mutant-test-planner.js
+@@ -68,9 +68,9 @@ export class MutantTestPlanner {
+             // If there was coverage information (coverageAnalysis not "off")
+             const tests = this.testCoverage.testsByMutantId.get(mutant.id) ?? [];
+             const coveredBy = toTestIds(tests);
+-            if (!isStatic || (this.options.ignoreStatic && coveredBy.length)) {
+-                // If not static, or it was "hybrid" (both static and perTest coverage) and ignoreStatic is on.
+-                // Only run covered tests with mutant active during runtime
++            if (!isStatic) {
++                // Only run covered tests with mutant active during runtime. Static mutants
++                // execute during module loading, so runtime activation cannot observe them.
+                 const netTime = calculateTotalTime(tests);
+                 return this.createMutantRunPlan(mutant, {
+                     netTime,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ overrides:
   vitest: npm:@voidzero-dev/vite-plus-test@0.1.19
 
 patchedDependencies:
+  '@stryker-mutator/core@9.6.1':
+    hash: e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08
+    path: patches/@stryker-mutator__core@9.6.1.patch
   '@stryker-mutator/vitest-runner@9.6.1':
     hash: da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63
     path: patches/@stryker-mutator__vitest-runner@9.6.1.patch
@@ -408,13 +411,13 @@ importers:
         version: 9.6.1
       '@stryker-mutator/core':
         specifier: catalog:test
-        version: 9.6.1(@types/node@24.10.1)
+        version: 9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1)
       '@stryker-mutator/typescript-checker':
         specifier: catalog:test
-        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@24.10.1))(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
+        version: 9.6.1(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
       '@stryker-mutator/vitest-runner':
         specifier: catalog:test
-        version: 9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19)
+        version: 9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19)
       '@types/bun':
         specifier: catalog:types
         version: 1.3.4
@@ -447,13 +450,13 @@ importers:
         version: 9.6.1
       '@stryker-mutator/core':
         specifier: catalog:test
-        version: 9.6.1(@types/node@24.10.1)
+        version: 9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1)
       '@stryker-mutator/typescript-checker':
         specifier: catalog:test
-        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@24.10.1))(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
+        version: 9.6.1(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
       '@stryker-mutator/vitest-runner':
         specifier: catalog:test
-        version: 9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19)
+        version: 9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19)
       '@types/bun':
         specifier: catalog:types
         version: 1.3.4
@@ -493,13 +496,13 @@ importers:
         version: 9.6.1
       '@stryker-mutator/core':
         specifier: catalog:test
-        version: 9.6.1(@types/node@24.10.1)
+        version: 9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1)
       '@stryker-mutator/typescript-checker':
         specifier: catalog:test
-        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@24.10.1))(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
+        version: 9.6.1(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))
       '@stryker-mutator/vitest-runner':
         specifier: catalog:test
-        version: 9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19)
+        version: 9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19)
       '@types/bun':
         specifier: catalog:types
         version: 1.3.4
@@ -8527,7 +8530,7 @@ snapshots:
       tslib: 2.8.1
       typed-inject: 5.0.0
 
-  '@stryker-mutator/core@9.6.1(@types/node@24.10.1)':
+  '@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1)':
     dependencies:
       '@inquirer/prompts': 8.4.1(@types/node@24.10.1)
       '@stryker-mutator/api': 9.6.1
@@ -8576,20 +8579,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@stryker-mutator/typescript-checker@9.6.1(@stryker-mutator/core@9.6.1(@types/node@24.10.1))(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))':
+  '@stryker-mutator/typescript-checker@9.6.1(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4))':
     dependencies:
       '@stryker-mutator/api': 9.6.1
-      '@stryker-mutator/core': 9.6.1(@types/node@24.10.1)
+      '@stryker-mutator/core': 9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1)
       '@stryker-mutator/util': 9.6.1
       semver: 7.7.4
       typescript: '@typescript/typescript6@6.0.0(patch_hash=5394e3586481834969e11b1ae283aa51712b4e70a5b7a3ce1557472ae43062f4)'
 
   '@stryker-mutator/util@9.6.1': {}
 
-  '@stryker-mutator/vitest-runner@9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19)':
+  '@stryker-mutator/vitest-runner@9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19)':
     dependencies:
       '@stryker-mutator/api': 9.6.1
-      '@stryker-mutator/core': 9.6.1(@types/node@24.10.1)
+      '@stryker-mutator/core': 9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1)
       '@stryker-mutator/util': 9.6.1
       semver: 7.7.4
       tslib: 2.8.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,7 @@ overrides:
   vitest: npm:@voidzero-dev/vite-plus-test@0.1.19
 
 patchedDependencies:
+  "@stryker-mutator/core@9.6.1": patches/@stryker-mutator__core@9.6.1.patch
   "@stryker-mutator/vitest-runner@9.6.1": patches/@stryker-mutator__vitest-runner@9.6.1.patch
   "@typescript/typescript6@6.0.0": patches/@typescript__typescript6@6.0.0.patch
   generate-jsdoc-example-tests: patches/generate-jsdoc-example-tests.patch


### PR DESCRIPTION
## Summary
- Patch Stryker core so `ignoreStatic` ignores hybrid static mutants.
- Remove bedrock package coverage workaround.
- Normalize Windows mutate-changed paths and harden Luau tempdir cleanup.

## Testing
- pre-commit hook: lint, typecheck, gen-example-tests, test, build, mutate
- pre-push hook: lint, typecheck, gen-example-tests, unused, build, test, mutate
- targeted Stryker schema check passed locally

Fixes #239