### PR TITLE
fix(core): make luau spawn test cross-platform

### DIFF
--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -651,7 +651,7 @@ describe(loadConfig, () => {
 				);
 
 				const previous = process.env["BEDROCK_LUTE_PATH"];
-				// Node spawns, then exits non-zero for Lute args.
+				// Runtime binary exists, then exits non-zero for Lute args.
 				process.env["BEDROCK_LUTE_PATH"] = process.execPath;
 				let result: Awaited<ReturnType<typeof loadConfig>>;
 				try {

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -651,11 +651,8 @@ describe(loadConfig, () => {
 				);
 
 				const previous = process.env["BEDROCK_LUTE_PATH"];
-				// Pointing at the directory itself (not a binary inside it) makes
-				// execFile fail with EACCES/EISDIR, not ENOENT - the loader must
-				// fall through to parseFailed instead of claiming the runtime is
-				// missing.
-				process.env["BEDROCK_LUTE_PATH"] = cwd;
+				// Node spawns, then exits non-zero for Lute args.
+				process.env["BEDROCK_LUTE_PATH"] = process.execPath;
 				let result: Awaited<ReturnType<typeof loadConfig>>;
 				try {
 					result = await loadConfig({ cwd });


### PR DESCRIPTION
## Summary
- Make the Luau non-ENOENT spawn failure test use Node instead of a directory.
- Avoid Windows treating the directory executable probe as ENOENT.

## Testing
- RED: `pnpm --filter @bedrock/core test -- src/shell/load-config.spec.ts -t "should surface a non-ENOENT spawn failure"`
- GREEN: same targeted test
- `pnpm --filter @bedrock/core test -- src/shell/load-config.spec.ts`
- `pnpm test`
- pre-commit and pre-push hooks