### PR TITLE
fix(core): surface inner-cause detail for wrapped deploy errors

### DIFF
--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -1,3 +1,4 @@
+import { ApiError } from "@bedrock/ocale";
 import { S_BAR, S_BAR_END, S_BAR_START, S_ERROR, S_SUCCESS } from "@clack/prompts";
 
 import { fakeClackPort } from "#tests/helpers/clack";
@@ -154,7 +155,7 @@ describe(renderDeployError, () => {
 				cause: { kind: "fileNotFound", searchedFrom: "/projects/example" },
 				kind: "configLoadFailed",
 			},
-			expected: "config load failed (fileNotFound)",
+			expected: "config load failed: no bedrock config under /projects/example",
 		},
 		{
 			err: {
@@ -166,14 +167,15 @@ describe(renderDeployError, () => {
 				},
 				kind: "buildDesiredFailed",
 			},
-			expected: "build desired state failed (fileReadFailed)",
+			expected:
+				"build desired state failed for 'main-place' (/projects/example/place.rbxl): ENOENT",
 		},
 		{
 			err: {
 				cause: { file: "state.json", kind: "stateError", reason: "invalid json" },
 				kind: "stateReadFailed",
 			},
-			expected: "state read failed (stateError)",
+			expected: "state read failed (state.json): invalid json",
 		},
 		{
 			err: {
@@ -181,7 +183,7 @@ describe(renderDeployError, () => {
 				kind: "stateWriteFailed",
 				unsavedState: { environment: "production", resources: [], version: 1 },
 			},
-			expected: "state write failed (stateError)",
+			expected: "state write failed (state.json): network error",
 		},
 		{
 			err: {
@@ -192,7 +194,74 @@ describe(renderDeployError, () => {
 				},
 				kind: "applyFailed",
 			},
-			expected: "apply failed (updateUnsupported)",
+			expected: "apply failed for 'vip-pass': update not supported",
+		},
+		{
+			err: {
+				cause: {
+					key: asResourceKey("main-place"),
+					appliedSoFar: [],
+					cause: new ApiError("auth failed (401)", { statusCode: 401 }),
+					kind: "driverFailure",
+				},
+				kind: "applyFailed",
+			},
+			expected: "apply failed for 'main-place': auth failed (401)",
+		},
+		{
+			err: {
+				cause: {
+					kind: "parseFailed",
+					message: "unexpected end of the stream",
+					sourceFile: "bedrock.config.yaml",
+				},
+				kind: "configLoadFailed",
+			},
+			expected: "config load failed: bedrock.config.yaml: unexpected end of the stream",
+		},
+		{
+			err: {
+				cause: {
+					issues: [{ message: "must be a number", path: ["passes", "vip", "price"] }],
+					kind: "validationFailed",
+					sourceFile: "bedrock.config.ts",
+				},
+				kind: "configLoadFailed",
+			},
+			expected: "config load failed: bedrock.config.ts: passes.vip.price must be a number",
+		},
+		{
+			err: {
+				cause: {
+					issues: [],
+					kind: "validationFailed",
+					sourceFile: "bedrock.config.ts",
+				},
+				kind: "configLoadFailed",
+			},
+			expected: "config load failed: bedrock.config.ts: invalid",
+		},
+		{
+			err: {
+				cause: {
+					kind: "configFunctionFailed",
+					message: "boom",
+					sourceFile: "bedrock.config.ts",
+				},
+				kind: "configLoadFailed",
+			},
+			expected: "config load failed: bedrock.config.ts: config function threw: boom",
+		},
+		{
+			err: {
+				cause: {
+					hint: "install lute via mise",
+					kind: "luauRuntimeMissing",
+					sourceFile: "bedrock.config.luau",
+				},
+				kind: "configLoadFailed",
+			},
+			expected: "config load failed: bedrock.config.luau: install lute via mise",
 		},
 		{
 			err: {

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -1,5 +1,9 @@
 import { cancel, intro, log, outro } from "@clack/prompts";
 
+import type { ConfigError } from "../core/config-error.ts";
+import type { StateError } from "../core/state.ts";
+import type { ApplyError } from "../shell/apply-ops.ts";
+import type { BuildDesiredError } from "../shell/build-desired.ts";
 import type { DeployError } from "../shell/deploy.ts";
 import type { ParseOptionsError } from "./parse-options.ts";
 
@@ -26,8 +30,9 @@ export interface ClackPort {
  * Render a `DeployError` to the supplied `ClackPort` as a single error line.
  * Each variant produces a distinct, terse diagnostic; wrapped variants
  * (`applyFailed`, `buildDesiredFailed`, `configLoadFailed`, `stateReadFailed`,
- * `stateWriteFailed`) include the inner cause's `kind` so the reader can
- * distinguish the failing stage without inspecting the full cause.
+ * `stateWriteFailed`) surface the inner cause's actionable detail (file path,
+ * resource key, parser message, HTTP failure, validator issue) so the reader
+ * does not have to inspect the full cause to act.
  * @param err - The deploy error to describe.
  * @param port - The output port the diagnostic is written to.
  */
@@ -74,17 +79,56 @@ export function createClackPort(): ClackPort {
 	};
 }
 
+function applyCauseDetail(cause: ApplyError): string {
+	if (cause.kind === "updateUnsupported") {
+		return "update not supported";
+	}
+
+	return cause.cause.message;
+}
+
+function buildDesiredDetail(cause: BuildDesiredError): string {
+	return `(${cause.filePath}): ${cause.reason}`;
+}
+
+function configErrorDetail(err: ConfigError): string {
+	switch (err.kind) {
+		case "configFunctionFailed": {
+			return `${err.sourceFile}: config function threw: ${err.message}`;
+		}
+		case "fileNotFound": {
+			return `no bedrock config under ${err.searchedFrom}`;
+		}
+		case "luauRuntimeMissing": {
+			return `${err.sourceFile}: ${err.hint}`;
+		}
+		case "parseFailed": {
+			return `${err.sourceFile}: ${err.message}`;
+		}
+		case "validationFailed": {
+			const first = err.issues[0];
+			return first === undefined
+				? `${err.sourceFile}: invalid`
+				: `${err.sourceFile}: ${first.path.join(".")} ${first.message}`;
+		}
+	}
+}
+
+function stateErrorDetail(cause: StateError): string {
+	return `(${cause.file}): ${cause.reason}`;
+}
+
 /* eslint-disable-next-line max-lines-per-function -- single exhaustive switch over every DeployError variant is clearer than splitting into a wrapped-vs-unwrapped predicate plus a parallel prefix table. */
 function deployErrorMessage(err: DeployError): string {
 	switch (err.kind) {
 		case "applyFailed": {
-			return `apply failed (${err.cause.kind})`;
+			return `apply failed for '${err.cause.key}': ${applyCauseDetail(err.cause)}`;
 		}
 		case "buildDesiredFailed": {
-			return `build desired state failed (${err.cause.kind})`;
+			return `build desired state failed for '${err.cause.key}' ${buildDesiredDetail(err.cause)}`;
 		}
 		case "configLoadFailed": {
-			return `config load failed (${err.cause.kind})`;
+			return `config load failed: ${configErrorDetail(err.cause)}`;
 		}
 		case "incompletePlaceEntry": {
 			return `place '${err.key}' is missing '${err.missingField}' under environment '${err.environment}'`;
@@ -99,10 +143,10 @@ function deployErrorMessage(err: DeployError): string {
 			return `state not configured for environment '${err.environment}'`;
 		}
 		case "stateReadFailed": {
-			return `state read failed (${err.cause.kind})`;
+			return `state read failed ${stateErrorDetail(err.cause)}`;
 		}
 		case "stateWriteFailed": {
-			return `state write failed (${err.cause.kind})`;
+			return `state write failed ${stateErrorDetail(err.cause)}`;
 		}
 		case "unknownEnvironment": {
 			return `unknown environment '${err.environment}' (declared: ${err.declared.join(", ")})`;

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -80,11 +80,14 @@ export function createClackPort(): ClackPort {
 }
 
 function applyCauseDetail(cause: ApplyError): string {
-	if (cause.kind === "updateUnsupported") {
-		return "update not supported";
+	switch (cause.kind) {
+		case "driverFailure": {
+			return cause.cause.message;
+		}
+		case "updateUnsupported": {
+			return "update not supported";
+		}
 	}
-
-	return cause.cause.message;
 }
 
 function buildDesiredDetail(cause: BuildDesiredError): string {


### PR DESCRIPTION
## Summary

- Wrapped `DeployError` variants now render the cause's actionable detail
  (resource key + OpenCloud message, file path + reason, gist file +
  reason, `ConfigError` describe-shape) instead of just `<stage> failed
  (<cause.kind>)`.
- Lifts the `describe(err: ConfigError): string` example from
  `ConfigError`'s JSDoc into a real `configErrorDetail` helper so the
  documented behaviour and the rendered output stay in lockstep.

Closes #255 partially — surfaces the detail bedrock already has.
Open work tracked in #255: HTTP body context on `OpenCloudError` /
`ApiError` (renderer can only show what ocale puts in `.message`) and
401-discriminating actionable hints (scope vs IP allowlist vs invalid
key).

## Before

```text
┌  bedrock deploy
│
■  state read failed (stateError)
└  deploy failed
```

```text
┌  bedrock deploy
│
■  apply failed (driverFailure)
└  deploy failed
```

## After

```text
┌  bedrock deploy
│
■  state read failed (state.production.json): auth failed (401): check token scopes
└  deploy failed
```

```text
┌  bedrock deploy
│
■  apply failed for 'main': HTTP 401
└  deploy failed
```

## Test plan

- [x] `pnpm --filter @bedrock/core test src/cli/render.spec.ts` (26/26 pass)
- [x] hk pre-commit (lint, typecheck, gen-example-tests, test, build, mutate, commitlint)
- [x] Real-world hit while running `bedrock deploy` against an anime-rush
  config with stale GH token then with a wrong-place API key — the
  improved messages identified each failure without a curl probe