### PR TITLE
feat(core): allow --env omission with bedrock-environment fallback

### DIFF
--- a/packages/bedrock/src/cli/commands/deploy.spec.ts
+++ b/packages/bedrock/src/cli/commands/deploy.spec.ts
@@ -78,6 +78,11 @@ describe(deployCommand, () => {
 	])("should surface a $label parse error and exit with code 1", async ({ rawOptions }) => {
 		expect.assertions(4);
 
+		onTestFinished(() => {
+			vi.unstubAllEnvs();
+		});
+		vi.stubEnv("BEDROCK_ENVIRONMENT", undefined);
+
 		const deps = makeDeps();
 
 		await deployCommand(deps)(rawOptions);

--- a/packages/bedrock/src/cli/commands/deploy.spec.ts
+++ b/packages/bedrock/src/cli/commands/deploy.spec.ts
@@ -2,7 +2,7 @@ import type { Result } from "@bedrock/ocale";
 
 import { fakeClackPort } from "#tests/helpers/clack";
 import process from "node:process";
-import { assert, describe, expect, it, vi } from "vitest";
+import { assert, describe, expect, it, onTestFinished, vi } from "vitest";
 
 import type { ResourceCurrentState } from "../../core/resources.ts";
 import type { Config } from "../../core/schema.ts";
@@ -292,6 +292,26 @@ describe(deployCommand, () => {
 		} finally {
 			vi.unstubAllEnvs();
 		}
+	});
+
+	it("should deploy with BEDROCK_ENVIRONMENT when --env is omitted", async () => {
+		expect.assertions(2);
+
+		onTestFinished(() => {
+			vi.unstubAllEnvs();
+		});
+		vi.stubEnv("BEDROCK_ENVIRONMENT", "production");
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const deploy = fakeDeploy([{ data: bedrockState("production"), success: true }]);
+		const deps = makeDeps({ deploy, loadConfig });
+
+		await deployCommand(deps)({});
+
+		expect(deploy).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({ config: sampleConfig, environment: "production" }),
+		);
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(0);
 	});
 
 	it("should default to process.exit when no exit slot is provided", async () => {

--- a/packages/bedrock/src/cli/commands/diff.spec.ts
+++ b/packages/bedrock/src/cli/commands/diff.spec.ts
@@ -98,6 +98,11 @@ describe(diffCommand, () => {
 	])("should surface a $label parse error and exit with code 1", async ({ rawOptions }) => {
 		expect.assertions(4);
 
+		onTestFinished(() => {
+			vi.unstubAllEnvs();
+		});
+		vi.stubEnv("BEDROCK_ENVIRONMENT", undefined);
+
 		const deps = makeDeps();
 
 		await diffCommand(deps)(rawOptions);

--- a/packages/bedrock/src/cli/commands/diff.spec.ts
+++ b/packages/bedrock/src/cli/commands/diff.spec.ts
@@ -2,7 +2,7 @@ import type { Result } from "@bedrock/ocale";
 
 import { fakeClackPort } from "#tests/helpers/clack";
 import process from "node:process";
-import { assert, describe, expect, it, vi } from "vitest";
+import { assert, describe, expect, it, onTestFinished, vi } from "vitest";
 
 import type { Operation } from "../../core/operations.ts";
 import type { Config } from "../../core/schema.ts";
@@ -351,6 +351,26 @@ describe(diffCommand, () => {
 		} finally {
 			vi.unstubAllEnvs();
 		}
+	});
+
+	it("should preview with BEDROCK_ENVIRONMENT when --env is omitted", async () => {
+		expect.assertions(2);
+
+		onTestFinished(() => {
+			vi.unstubAllEnvs();
+		});
+		vi.stubEnv("BEDROCK_ENVIRONMENT", "production");
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const previewDiff = fakePreview([preview("production", [])]);
+		const deps = makeDeps({ loadConfig, previewDiff });
+
+		await diffCommand(deps)({});
+
+		expect(previewDiff).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({ config: sampleConfig, environment: "production" }),
+		);
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(0);
 	});
 
 	it("should default to process.exit when no exit slot is provided", async () => {

--- a/packages/bedrock/src/cli/parse-options.spec-d.ts
+++ b/packages/bedrock/src/cli/parse-options.spec-d.ts
@@ -38,4 +38,10 @@ describe(parseCommonOptions, () => {
 			Result<CommonOptions, ParseOptionsError>
 		>();
 	});
+
+	it("should accept an optional env reader as the second positional argument", () => {
+		expectTypeOf<Parameters<typeof parseCommonOptions>[1]>().toEqualTypeOf<
+			((name: string) => string | undefined) | undefined
+		>();
+	});
 });

--- a/packages/bedrock/src/cli/parse-options.spec.ts
+++ b/packages/bedrock/src/cli/parse-options.spec.ts
@@ -160,6 +160,17 @@ describe(parseCommonOptions, () => {
 
 		expect(result.data.environments).toStrictEqual(["staging"]);
 	});
+
+	it("should let --env win over BEDROCK_ENVIRONMENT when both are present", () => {
+		expect.assertions(1);
+
+		const readEnvironment = bindEnvironment({ BEDROCK_ENVIRONMENT: "staging" });
+		const result = parseCommonOptions({ env: "production" }, readEnvironment);
+
+		assert(result.success);
+
+		expect(result.data.environments).toStrictEqual(["production"]);
+	});
 });
 
 function bindEnvironment(

--- a/packages/bedrock/src/cli/parse-options.spec.ts
+++ b/packages/bedrock/src/cli/parse-options.spec.ts
@@ -6,7 +6,18 @@ describe(parseCommonOptions, () => {
 	it("should reject when --env is missing", () => {
 		expect.assertions(2);
 
-		const result = parseCommonOptions({ "--": [], "_": [] });
+		const result = parseCommonOptions({ "--": [], "_": [] }, empty);
+
+		assert(!result.success);
+
+		expect(result.err.kind).toBe("missingRequired");
+		expect(result.err.flag).toBe("env");
+	});
+
+	it("should report missingRequired when --env is absent and BEDROCK_ENVIRONMENT is unset", () => {
+		expect.assertions(2);
+
+		const result = parseCommonOptions({}, empty);
 
 		assert(!result.success);
 
@@ -177,4 +188,8 @@ function bindEnvironment(
 	bindings: Readonly<Record<string, string>>,
 ): (name: string) => string | undefined {
 	return (name) => bindings[name];
+}
+
+function empty(): string | undefined {
+	return undefined;
 }

--- a/packages/bedrock/src/cli/parse-options.spec.ts
+++ b/packages/bedrock/src/cli/parse-options.spec.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it } from "vitest";
+import { assert, describe, expect, it, onTestFinished, vi } from "vitest";
 
 import { parseCommonOptions } from "./parse-options.ts";
 
@@ -181,6 +181,21 @@ describe(parseCommonOptions, () => {
 		assert(result.success);
 
 		expect(result.data.environments).toStrictEqual(["production"]);
+	});
+
+	it("should default to a process.env reader when getEnvironment is omitted", () => {
+		expect.assertions(1);
+
+		onTestFinished(() => {
+			vi.unstubAllEnvs();
+		});
+		vi.stubEnv("BEDROCK_ENVIRONMENT", "from-env");
+
+		const result = parseCommonOptions({});
+
+		assert(result.success);
+
+		expect(result.data.environments).toStrictEqual(["from-env"]);
 	});
 });
 

--- a/packages/bedrock/src/cli/parse-options.spec.ts
+++ b/packages/bedrock/src/cli/parse-options.spec.ts
@@ -149,4 +149,21 @@ describe(parseCommonOptions, () => {
 
 		expect(result.success).toBeTrue();
 	});
+
+	it("should fall back to BEDROCK_ENVIRONMENT when --env is absent", () => {
+		expect.assertions(1);
+
+		const readEnvironment = bindEnvironment({ BEDROCK_ENVIRONMENT: "staging" });
+		const result = parseCommonOptions({}, readEnvironment);
+
+		assert(result.success);
+
+		expect(result.data.environments).toStrictEqual(["staging"]);
+	});
 });
+
+function bindEnvironment(
+	bindings: Readonly<Record<string, string>>,
+): (name: string) => string | undefined {
+	return (name) => bindings[name];
+}

--- a/packages/bedrock/src/cli/parse-options.ts
+++ b/packages/bedrock/src/cli/parse-options.ts
@@ -1,5 +1,7 @@
 import type { Result } from "@bedrock/ocale";
 
+import process from "node:process";
+
 /**
  * Typed shape command actions consume after the raw sade options object has
  * been validated and normalized.
@@ -39,11 +41,15 @@ const SADE_RESERVED: ReadonlySet<string> = new Set(["--", "_", "h", "help", "v",
  * Translate the raw sade options POJO into a typed `CommonOptions`. Pure: no
  * I/O, no clack, no sade types. Reused by `bedrock deploy` and `bedrock diff`.
  * @param rawOptions - The options object sade hands the action callback.
+ * @param getEnvironment - Reads an environment variable; consulted as a
+ *   fallback for `--env` when no flag was supplied. Defaults to a
+ *   `process.env` reader.
  * @returns `Ok(CommonOptions)` on success, or `Err(ParseOptionsError)` when a
  *   required flag is missing or an unrecognized flag was supplied.
  */
 export function parseCommonOptions(
 	rawOptions: Readonly<Record<string, unknown>>,
+	getEnvironment: (name: string) => string | undefined = readProcessEnvironment,
 ): Result<CommonOptions, ParseOptionsError> {
 	for (const key of Object.keys(rawOptions)) {
 		if (!RECOGNIZED_FLAGS.has(key) && !SADE_RESERVED.has(key)) {
@@ -51,7 +57,7 @@ export function parseCommonOptions(
 		}
 	}
 
-	const environments = resolveEnvironments(rawOptions["env"]);
+	const environments = resolveEnvironments(rawOptions["env"], getEnvironment);
 	if (!environments.success) {
 		return environments;
 	}
@@ -71,9 +77,17 @@ export function parseCommonOptions(
 	};
 }
 
-function resolveEnvironments(raw: unknown): Result<ReadonlyArray<string>, ParseOptionsError> {
+function resolveEnvironments(
+	raw: unknown,
+	getEnvironment: (name: string) => string | undefined,
+): Result<ReadonlyArray<string>, ParseOptionsError> {
 	if (raw === undefined) {
-		return { err: { flag: "env", kind: "missingRequired" }, success: false };
+		const fallback = getEnvironment("BEDROCK_ENVIRONMENT");
+		if (fallback === undefined) {
+			return { err: { flag: "env", kind: "missingRequired" }, success: false };
+		}
+
+		return { data: [fallback], success: true };
 	}
 
 	const candidates = Array.isArray(raw) ? raw : [raw];
@@ -87,6 +101,10 @@ function resolveEnvironments(raw: unknown): Result<ReadonlyArray<string>, ParseO
 	}
 
 	return { data: environments, success: true };
+}
+
+function readProcessEnvironment(name: string): string | undefined {
+	return process.env[name];
 }
 
 function pickString(

--- a/packages/bedrock/src/cli/parse-options.ts
+++ b/packages/bedrock/src/cli/parse-options.ts
@@ -38,8 +38,10 @@ const RECOGNIZED_FLAGS: ReadonlySet<string> = new Set([
 const SADE_RESERVED: ReadonlySet<string> = new Set(["--", "_", "h", "help", "v", "version"]);
 
 /**
- * Translate the raw sade options POJO into a typed `CommonOptions`. Pure: no
- * I/O, no clack, no sade types. Reused by `bedrock deploy` and `bedrock diff`.
+ * Translate the raw sade options POJO into a typed `CommonOptions`. Reads
+ * `BEDROCK_ENVIRONMENT` from `process.env` as a fallback when `--env` is
+ * absent; inject `getEnvironment` to redirect or isolate the lookup. No
+ * clack, no sade types. Reused by `bedrock deploy` and `bedrock diff`.
  * @param rawOptions - The options object sade hands the action callback.
  * @param getEnvironment - Reads an environment variable; consulted as a
  *   fallback for `--env` when no flag was supplied. Defaults to a


### PR DESCRIPTION
Closes #243

- `bedrock deploy` and `bedrock diff` now accept `BEDROCK_ENVIRONMENT` as a fallback when `--env` is omitted.
- `--env` continues to win when both are set; the env reader is only consulted when no `--env` flag was collected.
- The existing missing-required diagnostic is preserved when neither input is present.