### PR TITLE
feat(core): reject non-integer robux prices in config validation

### DIFF
--- a/packages/bedrock/src/core/kinds/developer-product.spec.ts
+++ b/packages/bedrock/src/core/kinds/developer-product.spec.ts
@@ -1,21 +1,14 @@
-import { developerProductCurrent, developerProductDesired } from "#tests/helpers/resources";
+import {
+	developerProductCurrent,
+	developerProductDesired,
+	INVALID_ROBUX_PRICES,
+	ValidDeveloperProductEntry,
+} from "#tests/helpers/resources";
 import { ArkErrors } from "arktype";
 import { assert, describe, expect, it } from "vitest";
 
 import { asResourceKey } from "../../types/ids.ts";
 import { developerProductKind } from "./developer-product.ts";
-
-const INVALID_ROBUX_PRICES = [
-	["a negative integer", -1],
-	["a fractional value", 99.5],
-	["NaN", Number.NaN],
-	["Infinity", Number.POSITIVE_INFINITY],
-] as const;
-
-const ValidDeveloperProduct = {
-	name: "Gem Pack",
-	description: "Stocks the player up with 1,000 premium gems.",
-} as const;
 
 describe("developerProductKind", () => {
 	it("should tag its kind discriminator as developerProduct", () => {
@@ -28,7 +21,7 @@ describe("developerProductKind", () => {
 		it("should accept a valid entry that omits price", () => {
 			expect.assertions(1);
 
-			expect(developerProductKind.entrySchema(ValidDeveloperProduct)).not.toBeInstanceOf(
+			expect(developerProductKind.entrySchema(ValidDeveloperProductEntry)).not.toBeInstanceOf(
 				ArkErrors,
 			);
 		});
@@ -37,7 +30,7 @@ describe("developerProductKind", () => {
 			expect.assertions(1);
 
 			expect(
-				developerProductKind.entrySchema({ ...ValidDeveloperProduct, price: 100 }),
+				developerProductKind.entrySchema({ ...ValidDeveloperProductEntry, price: 100 }),
 			).not.toBeInstanceOf(ArkErrors);
 		});
 
@@ -45,7 +38,7 @@ describe("developerProductKind", () => {
 			expect.assertions(1);
 
 			expect(
-				developerProductKind.entrySchema({ ...ValidDeveloperProduct, price }),
+				developerProductKind.entrySchema({ ...ValidDeveloperProductEntry, price }),
 			).toBeInstanceOf(ArkErrors);
 		});
 	});

--- a/packages/bedrock/src/core/kinds/developer-product.spec.ts
+++ b/packages/bedrock/src/core/kinds/developer-product.spec.ts
@@ -1,14 +1,53 @@
 import { developerProductCurrent, developerProductDesired } from "#tests/helpers/resources";
+import { ArkErrors } from "arktype";
 import { assert, describe, expect, it } from "vitest";
 
 import { asResourceKey } from "../../types/ids.ts";
 import { developerProductKind } from "./developer-product.ts";
+
+const INVALID_ROBUX_PRICES = [
+	["a negative integer", -1],
+	["a fractional value", 99.5],
+	["NaN", Number.NaN],
+	["Infinity", Number.POSITIVE_INFINITY],
+] as const;
+
+const ValidDeveloperProduct = {
+	name: "Gem Pack",
+	description: "Stocks the player up with 1,000 premium gems.",
+} as const;
 
 describe("developerProductKind", () => {
 	it("should tag its kind discriminator as developerProduct", () => {
 		expect.assertions(1);
 
 		expect(developerProductKind.kind).toBe("developerProduct");
+	});
+
+	describe("entrySchema", () => {
+		it("should accept a valid entry that omits price", () => {
+			expect.assertions(1);
+
+			expect(developerProductKind.entrySchema(ValidDeveloperProduct)).not.toBeInstanceOf(
+				ArkErrors,
+			);
+		});
+
+		it("should accept a valid entry with a non-negative integer price", () => {
+			expect.assertions(1);
+
+			expect(
+				developerProductKind.entrySchema({ ...ValidDeveloperProduct, price: 100 }),
+			).not.toBeInstanceOf(ArkErrors);
+		});
+
+		it.for(INVALID_ROBUX_PRICES)("should reject %s as a price", ([, price]) => {
+			expect.assertions(1);
+
+			expect(
+				developerProductKind.entrySchema({ ...ValidDeveloperProduct, price }),
+			).toBeInstanceOf(ArkErrors);
+		});
 	});
 
 	describe("flatten", () => {

--- a/packages/bedrock/src/core/kinds/developer-product.ts
+++ b/packages/bedrock/src/core/kinds/developer-product.ts
@@ -5,13 +5,13 @@ import { type } from "arktype";
 import { asResourceKey } from "../../types/ids.ts";
 import type { DeveloperProductDesiredInput } from "../flatten.ts";
 import type { DeveloperProductDesiredState, ResourceCurrentState } from "../resources.ts";
-import type { ResolvedConfig } from "../schema.ts";
+import { OPTIONAL_ROBUX_PRICE, type ResolvedConfig } from "../schema.ts";
 import type { BuildDesiredError, ResourceKindModule } from "./module.ts";
 
 const entrySchema = type({
 	"name": "string",
 	"description": "string",
-	"price?": "number.integer >= 0 | undefined",
+	"price?": OPTIONAL_ROBUX_PRICE,
 });
 
 function flatten(config: ResolvedConfig): ReadonlyArray<DeveloperProductDesiredInput> {

--- a/packages/bedrock/src/core/kinds/developer-product.ts
+++ b/packages/bedrock/src/core/kinds/developer-product.ts
@@ -11,7 +11,7 @@ import type { BuildDesiredError, ResourceKindModule } from "./module.ts";
 const entrySchema = type({
 	"name": "string",
 	"description": "string",
-	"price?": "number | undefined",
+	"price?": "number.integer >= 0 | undefined",
 });
 
 function flatten(config: ResolvedConfig): ReadonlyArray<DeveloperProductDesiredInput> {

--- a/packages/bedrock/src/core/kinds/game-pass.spec.ts
+++ b/packages/bedrock/src/core/kinds/game-pass.spec.ts
@@ -1,4 +1,5 @@
 import { gamePassCurrent, gamePassDesired } from "#tests/helpers/resources";
+import { ArkErrors } from "arktype";
 import { assert, describe, expect, it } from "vitest";
 
 import { asResourceKey, asSha256Hex } from "../../types/ids.ts";
@@ -6,11 +7,46 @@ import { gamePassKind } from "./game-pass.ts";
 
 const ALT_HASH = asSha256Hex("a3f2c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852e1b0");
 
+const INVALID_ROBUX_PRICES = [
+	["a negative integer", -1],
+	["a fractional value", 99.5],
+	["NaN", Number.NaN],
+	["Infinity", Number.POSITIVE_INFINITY],
+] as const;
+
+const ValidGamePass = {
+	name: "VIP Pass",
+	description: "Grants VIP perks.",
+	iconFilePath: "assets/vip.png",
+} as const;
+
 describe("gamePassKind", () => {
 	it("should tag its kind discriminator as gamePass", () => {
 		expect.assertions(1);
 
 		expect(gamePassKind.kind).toBe("gamePass");
+	});
+
+	describe("entrySchema", () => {
+		it("should accept a valid entry that omits price", () => {
+			expect.assertions(1);
+
+			expect(gamePassKind.entrySchema(ValidGamePass)).not.toBeInstanceOf(ArkErrors);
+		});
+
+		it("should accept a valid entry with a non-negative integer price", () => {
+			expect.assertions(1);
+
+			expect(gamePassKind.entrySchema({ ...ValidGamePass, price: 100 })).not.toBeInstanceOf(
+				ArkErrors,
+			);
+		});
+
+		it.for(INVALID_ROBUX_PRICES)("should reject %s as a price", ([, price]) => {
+			expect.assertions(1);
+
+			expect(gamePassKind.entrySchema({ ...ValidGamePass, price })).toBeInstanceOf(ArkErrors);
+		});
 	});
 
 	describe("flatten", () => {

--- a/packages/bedrock/src/core/kinds/game-pass.spec.ts
+++ b/packages/bedrock/src/core/kinds/game-pass.spec.ts
@@ -1,4 +1,9 @@
-import { gamePassCurrent, gamePassDesired } from "#tests/helpers/resources";
+import {
+	gamePassCurrent,
+	gamePassDesired,
+	INVALID_ROBUX_PRICES,
+	ValidGamePassEntry,
+} from "#tests/helpers/resources";
 import { ArkErrors } from "arktype";
 import { assert, describe, expect, it } from "vitest";
 
@@ -6,19 +11,6 @@ import { asResourceKey, asSha256Hex } from "../../types/ids.ts";
 import { gamePassKind } from "./game-pass.ts";
 
 const ALT_HASH = asSha256Hex("a3f2c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852e1b0");
-
-const INVALID_ROBUX_PRICES = [
-	["a negative integer", -1],
-	["a fractional value", 99.5],
-	["NaN", Number.NaN],
-	["Infinity", Number.POSITIVE_INFINITY],
-] as const;
-
-const ValidGamePass = {
-	name: "VIP Pass",
-	description: "Grants VIP perks.",
-	iconFilePath: "assets/vip.png",
-} as const;
 
 describe("gamePassKind", () => {
 	it("should tag its kind discriminator as gamePass", () => {
@@ -31,21 +23,23 @@ describe("gamePassKind", () => {
 		it("should accept a valid entry that omits price", () => {
 			expect.assertions(1);
 
-			expect(gamePassKind.entrySchema(ValidGamePass)).not.toBeInstanceOf(ArkErrors);
+			expect(gamePassKind.entrySchema(ValidGamePassEntry)).not.toBeInstanceOf(ArkErrors);
 		});
 
 		it("should accept a valid entry with a non-negative integer price", () => {
 			expect.assertions(1);
 
-			expect(gamePassKind.entrySchema({ ...ValidGamePass, price: 100 })).not.toBeInstanceOf(
-				ArkErrors,
-			);
+			expect(
+				gamePassKind.entrySchema({ ...ValidGamePassEntry, price: 100 }),
+			).not.toBeInstanceOf(ArkErrors);
 		});
 
 		it.for(INVALID_ROBUX_PRICES)("should reject %s as a price", ([, price]) => {
 			expect.assertions(1);
 
-			expect(gamePassKind.entrySchema({ ...ValidGamePass, price })).toBeInstanceOf(ArkErrors);
+			expect(gamePassKind.entrySchema({ ...ValidGamePassEntry, price })).toBeInstanceOf(
+				ArkErrors,
+			);
 		});
 	});
 

--- a/packages/bedrock/src/core/kinds/game-pass.ts
+++ b/packages/bedrock/src/core/kinds/game-pass.ts
@@ -5,7 +5,7 @@ import { type } from "arktype";
 import { asResourceKey, asSha256Hex } from "../../types/ids.ts";
 import type { GamePassDesiredInput } from "../flatten.ts";
 import type { GamePassDesiredState, ResourceCurrentState } from "../resources.ts";
-import type { ResolvedConfig } from "../schema.ts";
+import { OPTIONAL_ROBUX_PRICE, type ResolvedConfig } from "../schema.ts";
 import { sha256Hex } from "./hash.ts";
 import type { BuildDesiredError, KindIo, ResourceKindModule } from "./module.ts";
 import { readBytes } from "./read-bytes.ts";
@@ -14,7 +14,7 @@ const entrySchema = type({
 	"name": "string",
 	"description": "string",
 	"iconFilePath": "string",
-	"price?": "number.integer >= 0 | undefined",
+	"price?": OPTIONAL_ROBUX_PRICE,
 });
 
 function flatten(config: ResolvedConfig): ReadonlyArray<GamePassDesiredInput> {

--- a/packages/bedrock/src/core/kinds/game-pass.ts
+++ b/packages/bedrock/src/core/kinds/game-pass.ts
@@ -14,7 +14,7 @@ const entrySchema = type({
 	"name": "string",
 	"description": "string",
 	"iconFilePath": "string",
-	"price?": "number | undefined",
+	"price?": "number.integer >= 0 | undefined",
 });
 
 function flatten(config: ResolvedConfig): ReadonlyArray<GamePassDesiredInput> {

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -1,4 +1,4 @@
-import { PLATFORM_FLAG_ROWS } from "#tests/helpers/resources";
+import { INVALID_ROBUX_PRICES, PLATFORM_FLAG_ROWS } from "#tests/helpers/resources";
 import { assert, describe, expect, it } from "vitest";
 
 import { SOCIAL_LINK_FIELDS } from "./resources.ts";
@@ -7,13 +7,6 @@ import { validateConfig } from "./schema.ts";
 const SOURCE = "bedrock.config.ts";
 
 const MinEnvironments = { production: {} } as const;
-
-const INVALID_ROBUX_PRICES = [
-	["a negative integer", -1],
-	["a fractional value", 99.5],
-	["NaN", Number.NaN],
-	["Infinity", Number.POSITIVE_INFINITY],
-] as const;
 
 describe(validateConfig, () => {
 	it("should reject a config missing the required environments collection", () => {

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -8,6 +8,13 @@ const SOURCE = "bedrock.config.ts";
 
 const MinEnvironments = { production: {} } as const;
 
+const INVALID_ROBUX_PRICES = [
+	["a negative integer", -1],
+	["a fractional value", 99.5],
+	["NaN", Number.NaN],
+	["Infinity", Number.POSITIVE_INFINITY],
+] as const;
+
 describe(validateConfig, () => {
 	it("should reject a config missing the required environments collection", () => {
 		expect.assertions(1);
@@ -182,6 +189,33 @@ describe(validateConfig, () => {
 		expect(result.err.issues[0]!.path).toStrictEqual(["passes", "vip-pass", "price"]);
 	});
 
+	it.for(INVALID_ROBUX_PRICES)(
+		"should reject %s as a passes price and attribute the issue path to that field",
+		([, price]) => {
+			expect.assertions(1);
+
+			const result = validateConfig(
+				{
+					environments: MinEnvironments,
+					passes: {
+						"vip-pass": {
+							name: "VIP Pass",
+							description: "Grants VIP perks.",
+							iconFilePath: "assets/vip.png",
+							price,
+						},
+					},
+				},
+				SOURCE,
+			);
+
+			assert(!result.success);
+			assert(result.err.kind === "validationFailed");
+
+			expect(result.err.issues[0]!.path).toStrictEqual(["passes", "vip-pass", "price"]);
+		},
+	);
+
 	it("should accept a products collection with a valid developer-product entry", () => {
 		expect.assertions(1);
 
@@ -290,6 +324,32 @@ describe(validateConfig, () => {
 
 		expect(result.err.issues[0]!.path).toStrictEqual(["products", "gem-pack", "price"]);
 	});
+
+	it.for(INVALID_ROBUX_PRICES)(
+		"should reject %s as a products price and attribute the issue path to that field",
+		([, price]) => {
+			expect.assertions(1);
+
+			const result = validateConfig(
+				{
+					environments: MinEnvironments,
+					products: {
+						"gem-pack": {
+							name: "Gem Pack",
+							description: "Stocks the player up with 1,000 premium gems.",
+							price,
+						},
+					},
+				},
+				SOURCE,
+			);
+
+			assert(!result.success);
+			assert(result.err.kind === "validationFailed");
+
+			expect(result.err.issues[0]!.path).toStrictEqual(["products", "gem-pack", "price"]);
+		},
+	);
 
 	it("should reject an undeclared field on a root products entry", () => {
 		expect.assertions(1);
@@ -1061,6 +1121,34 @@ describe(validateConfig, () => {
 		expect(result.data.environments["staging"]?.products?.["gem-pack"]?.price).toBe(100);
 	});
 
+	it.for(INVALID_ROBUX_PRICES)(
+		"should reject %s as a per-environment products overlay price",
+		([, price]) => {
+			expect.assertions(1);
+
+			const result = validateConfig(
+				{
+					environments: {
+						staging: { products: { "gem-pack": { price } } },
+					},
+					state: { backend: "gist", gistId: "root-gist" },
+				},
+				SOURCE,
+			);
+
+			assert(!result.success);
+			assert(result.err.kind === "validationFailed");
+
+			expect(result.err.issues[0]!.path).toStrictEqual([
+				"environments",
+				"staging",
+				"products",
+				"gem-pack",
+				"price",
+			]);
+		},
+	);
+
 	it("should reject an undeclared field inside a per-environment products overlay entry", () => {
 		expect.assertions(1);
 
@@ -1115,6 +1203,34 @@ describe(validateConfig, () => {
 			"bad key!",
 		]);
 	});
+
+	it.for(INVALID_ROBUX_PRICES)(
+		"should reject %s as a per-environment passes overlay price",
+		([, price]) => {
+			expect.assertions(1);
+
+			const result = validateConfig(
+				{
+					environments: {
+						staging: { passes: { "vip-pass": { price } } },
+					},
+					state: { backend: "gist", gistId: "root-gist" },
+				},
+				SOURCE,
+			);
+
+			assert(!result.success);
+			assert(result.err.kind === "validationFailed");
+
+			expect(result.err.issues[0]!.path).toStrictEqual([
+				"environments",
+				"staging",
+				"passes",
+				"vip-pass",
+				"price",
+			]);
+		},
+	);
 
 	it("should accept a per-environment passes overlay that supplies a partial subset of fields", () => {
 		expect.assertions(1);

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -390,7 +390,7 @@ export function isGistStateConfig(config: StateConfig): config is GistStateConfi
 }
 
 const OPTIONAL_BOOLEAN = "boolean | undefined";
-const OPTIONAL_NUMBER = "number | undefined";
+const OPTIONAL_ROBUX_PRICE = "number.integer >= 0 | undefined";
 
 // Resource-kind entry schemas. Adding a new kind is two additions:
 // 1. Declare its entry schema and keyed-map collection below.
@@ -402,7 +402,7 @@ const gamePassEntry = type({
 	"name": "string",
 	"description": "string",
 	"iconFilePath": "string",
-	"price?": OPTIONAL_NUMBER,
+	"price?": OPTIONAL_ROBUX_PRICE,
 });
 
 const passesCollection = type({
@@ -412,7 +412,7 @@ const passesCollection = type({
 const developerProductEntry = type({
 	"name": "string",
 	"description": "string",
-	"price?": OPTIONAL_NUMBER,
+	"price?": OPTIONAL_ROBUX_PRICE,
 }).onUndeclaredKey("reject");
 
 const productsCollection = type({
@@ -444,7 +444,7 @@ const universeEntry = type({
 	"facebookSocialLink?": socialLinkOrUndefined,
 	"guildedSocialLink?": socialLinkOrUndefined,
 	"mobileEnabled?": OPTIONAL_BOOLEAN,
-	"privateServerPriceRobux?": "number.integer >= 0 | undefined",
+	"privateServerPriceRobux?": OPTIONAL_ROBUX_PRICE,
 	"robloxGroupSocialLink?": socialLinkOrUndefined,
 	"tabletEnabled?": OPTIONAL_BOOLEAN,
 	"twitchSocialLink?": socialLinkOrUndefined,
@@ -469,7 +469,7 @@ const gamePassOverlay = type({
 	"description?": "string",
 	"iconFilePath?": "string",
 	"name?": "string",
-	"price?": OPTIONAL_NUMBER,
+	"price?": OPTIONAL_ROBUX_PRICE,
 }).onUndeclaredKey("reject");
 
 const passesOverlayCollection = type({
@@ -479,7 +479,7 @@ const passesOverlayCollection = type({
 const developerProductOverlay = type({
 	"description?": "string",
 	"name?": "string",
-	"price?": OPTIONAL_NUMBER,
+	"price?": OPTIONAL_ROBUX_PRICE,
 }).onUndeclaredKey("reject");
 
 const productsOverlayCollection = type({

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -390,7 +390,17 @@ export function isGistStateConfig(config: StateConfig): config is GistStateConfi
 }
 
 const OPTIONAL_BOOLEAN = "boolean | undefined";
-const OPTIONAL_ROBUX_PRICE = "number.integer >= 0 | undefined";
+
+/**
+ * Shared arktype constraint for any optional Robux-price field. The schema
+ * rejects negatives, fractional values, `NaN`, and `Infinity` at config
+ * validation time so a malformed price surfaces with a path attributing the
+ * failure to the offending field, rather than slipping through to the
+ * Roblox API and surfacing as an opaque error at apply time. Per-kind entry
+ * schemas reuse this constant so all Robux-price fields validate
+ * identically.
+ */
+export const OPTIONAL_ROBUX_PRICE = "number.integer >= 0 | undefined";
 
 // Resource-kind entry schemas. Adding a new kind is two additions:
 // 1. Declare its entry schema and keyed-map collection below.

--- a/packages/bedrock/tests/helpers/resources.ts
+++ b/packages/bedrock/tests/helpers/resources.ts
@@ -19,6 +19,42 @@ export const PLATFORM_FLAG_ROWS = UNIVERSE_MANAGED_FLAGS.filter(
 	(flag): flag is Exclude<UniverseManagedFlag, "voiceChatEnabled"> => flag !== "voiceChatEnabled",
 ).map((flag) => [flag] as const);
 
+/**
+ * `it.for` rows covering every value the Robux-price schema must reject:
+ * negative integers, fractional values, `NaN`, and `Infinity`. Shared by
+ * the schema validation and per-kind entry-schema specs so a newly-added
+ * rejection case lands in every consumer.
+ */
+export const INVALID_ROBUX_PRICES = [
+	["a negative integer", -1],
+	["a fractional value", 99.5],
+	["NaN", Number.NaN],
+	["Infinity", Number.POSITIVE_INFINITY],
+] as const;
+
+/**
+ * Minimal valid `gamePass` entry shape (the user-facing fields, without the
+ * derived `key`/`kind`/`iconFileHash` that the desired-state fixture carries).
+ * Spread into per-test inputs to exercise the entry schema without
+ * re-stating the required fields.
+ */
+export const ValidGamePassEntry = {
+	name: "VIP Pass",
+	description: "Grants VIP perks.",
+	iconFilePath: "assets/vip.png",
+} as const;
+
+/**
+ * Minimal valid `developerProduct` entry shape (the user-facing fields,
+ * without the derived `key`/`kind` that the desired-state fixture carries).
+ * Spread into per-test inputs to exercise the entry schema without
+ * re-stating the required fields.
+ */
+export const ValidDeveloperProductEntry = {
+	name: "Gem Pack",
+	description: "Stocks the player up with 1,000 premium gems.",
+} as const;
+
 const ICON_HASH = asSha256Hex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
 const PLACE_HASH = asSha256Hex("039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81");


### PR DESCRIPTION
## Summary

- Tightens the price validators on `gamePassEntry`, `developerProductEntry`, and their environment overlays from `OPTIONAL_NUMBER` to a shared `OPTIONAL_ROBUX_PRICE = "number.integer >= 0 | undefined"`, so negative integers, fractional values, `NaN`, and `Infinity` fail at `validateConfig` with a `path` attributing the failure to the offending field rather than slipping through to the Roblox API and surfacing as an opaque `ApiError` at apply time.
- Reuses the precedent that already existed on `universeEntry.privateServerPriceRobux` and consolidates that field onto the same constant for one source of truth across all Robux-price fields.
- Mirrors the same constraint inside `gamePassKind.entrySchema` and `developerProductKind.entrySchema` so the per-kind contract matches the root contract.
- The inferred TypeScript type stays `number | undefined`, so the change is purely a runtime tightening with no downstream code changes.

Closes #261.

## Test plan

- [x] `pnpm test` — 1060 passing (28 new cases): four-value parametric rejection (`-1`, `99.5`, `NaN`, `Infinity`) covering `passes.<key>.price`, `products.<key>.price`, and the same fields on per-environment overlays in `validateConfig`, plus per-kind `entrySchema` rejection tests with `ArkErrors` instance assertions.
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] Pre-commit `hk` ran lint, typecheck, gen-example-tests, test, build, and `mutate:changed` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)