### PR TITLE
fix(core): persist declared universe and key resources by kind

### DIFF
--- a/packages/bedrock/src/core/diff.spec.ts
+++ b/packages/bedrock/src/core/diff.spec.ts
@@ -237,6 +237,25 @@ describe(diff, () => {
 		});
 	});
 
+	it("should match same-key entries to their same-kind current state when kinds collide on key", () => {
+		expect.assertions(1);
+
+		const universeDesiredEntry = universeDesired({ voiceChatEnabled: true });
+		const placeDesiredEntry = placeDesired({ key: UNIVERSE_SINGLETON_KEY });
+		const universeCurrentEntry = universeCurrent({ voiceChatEnabled: true });
+		const placeCurrentEntry = placeCurrent({ key: UNIVERSE_SINGLETON_KEY });
+
+		const ops = diff(
+			[universeDesiredEntry, placeDesiredEntry],
+			[universeCurrentEntry, placeCurrentEntry],
+		);
+
+		expect(ops).toStrictEqual([
+			{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+			{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+		]);
+	});
+
 	describe("place kind", () => {
 		it("should emit a noop when the place file hash matches", () => {
 			expect.assertions(1);
@@ -292,7 +311,7 @@ describe(diff, () => {
 			]);
 		});
 
-		it("should emit an update op when the key maps to a different kind in current state", () => {
+		it("should emit a create op for a place when current holds a gamePass under the same key", () => {
 			expect.assertions(1);
 
 			const desiredEntry = placeDesired();
@@ -300,12 +319,10 @@ describe(diff, () => {
 
 			const ops = diff([desiredEntry], [currentEntry]);
 
-			expect(ops).toStrictEqual([
-				{ key: PLACE_KEY, current: currentEntry, desired: desiredEntry, type: "update" },
-			]);
+			expect(ops).toStrictEqual([{ key: PLACE_KEY, desired: desiredEntry, type: "create" }]);
 		});
 
-		it("should emit an update op when a gamePass desired maps to a place current under the same key", () => {
+		it("should emit a create op for a gamePass when current holds a place under the same key", () => {
 			expect.assertions(1);
 
 			const desiredEntry = gamePassDesired({ key: PLACE_KEY });
@@ -313,9 +330,7 @@ describe(diff, () => {
 
 			const ops = diff([desiredEntry], [currentEntry]);
 
-			expect(ops).toStrictEqual([
-				{ key: PLACE_KEY, current: currentEntry, desired: desiredEntry, type: "update" },
-			]);
+			expect(ops).toStrictEqual([{ key: PLACE_KEY, desired: desiredEntry, type: "create" }]);
 		});
 	});
 
@@ -397,19 +412,14 @@ describe(diff, () => {
 			]);
 		});
 
-		it("should emit an update op when the key maps to a different kind in current state", () => {
+		it("should emit a create op when current holds a different kind under the universe key", () => {
 			expect.assertions(1);
 
 			const desiredEntry = universeDesired({ voiceChatEnabled: true });
 			const currentEntry = gamePassCurrent({ key: UNIVERSE_SINGLETON_KEY });
 
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-				{
-					key: UNIVERSE_SINGLETON_KEY,
-					current: currentEntry,
-					desired: desiredEntry,
-					type: "update",
-				},
+				{ key: UNIVERSE_SINGLETON_KEY, desired: desiredEntry, type: "create" },
 			]);
 		});
 

--- a/packages/bedrock/src/core/diff.spec.ts
+++ b/packages/bedrock/src/core/diff.spec.ts
@@ -345,13 +345,29 @@ describe(diff, () => {
 			]);
 		});
 
-		it("should emit a noop on first apply when no managed fields are declared", () => {
+		it("should emit a create op on first apply when only universeId is declared", () => {
 			expect.assertions(1);
 
 			const desiredEntry = universeDesired();
 
 			expect(diff([desiredEntry], [])).toStrictEqual([
-				{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+				{ key: UNIVERSE_SINGLETON_KEY, desired: desiredEntry, type: "create" },
+			]);
+		});
+
+		it("should emit an update op when only universeId is declared and current holds a different universeId", () => {
+			expect.assertions(1);
+
+			const desiredEntry = universeDesired({ universeId: asRobloxAssetId("9999") });
+			const currentEntry = universeCurrent();
+
+			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
+				{
+					key: UNIVERSE_SINGLETON_KEY,
+					current: currentEntry,
+					desired: desiredEntry,
+					type: "update",
+				},
 			]);
 		});
 

--- a/packages/bedrock/src/core/diff.ts
+++ b/packages/bedrock/src/core/diff.ts
@@ -15,8 +15,10 @@ import {
  * Computes the operations required to reconcile `current` state with `desired`
  * state. Pure and synchronous: no I/O, no side effects, no `Result` wrapper.
  *
- * Each entry in `desired` is matched to `current` by `key`. A key present only
- * in `desired` produces a `create` op; a key present in both produces an
+ * Each entry in `desired` is matched to `current` by `(kind, key)`: resources
+ * are uniquely identified by that pair, so a `place` and a `universe` keyed
+ * `"main"` are independent slots. A `(kind, key)` pair present only in
+ * `desired` produces a `create` op; a pair present in both produces an
  * `update` op if any declared field differs or a `noop` op if every field
  * matches.
  *
@@ -91,8 +93,12 @@ export function diff(
 	desired: ReadonlyArray<ResourceDesiredState>,
 	current: ReadonlyArray<ResourceCurrentState>,
 ): ReadonlyArray<Operation> {
-	const currentByKey = new Map(current.map((entry) => [entry.key, entry]));
-	return desired.map((entry) => operationFor(entry, currentByKey.get(entry.key)));
+	const currentByKey = new Map(current.map((entry) => [compositeKey(entry), entry]));
+	return desired.map((entry) => operationFor(entry, currentByKey.get(compositeKey(entry))));
+}
+
+function compositeKey(resource: { readonly key: string; readonly kind: ResourceKind }): string {
+	return `${resource.kind}:${resource.key}`;
 }
 
 // Resource-kind identity keys. Every field on a `ResourceDesiredState`

--- a/packages/bedrock/src/core/diff.ts
+++ b/packages/bedrock/src/core/diff.ts
@@ -1,15 +1,7 @@
 import { defaultKindRegistry } from "./kinds/index.ts";
 import type { ResourceKindModule } from "./kinds/module.ts";
 import type { Operation } from "./operations.ts";
-import {
-	type GamePassDesiredState,
-	type PlaceDesiredState,
-	type ResourceCurrentState,
-	type ResourceDesiredState,
-	type ResourceKind,
-	SOCIAL_LINK_FIELD_SET,
-	type UniverseDesiredState,
-} from "./resources.ts";
+import type { ResourceCurrentState, ResourceDesiredState, ResourceKind } from "./resources.ts";
 
 /**
  * Computes the operations required to reconcile `current` state with `desired`
@@ -101,52 +93,9 @@ function compositeKey(resource: { readonly key: string; readonly kind: ResourceK
 	return `${resource.kind}:${resource.key}`;
 }
 
-// Resource-kind identity keys. Every field on a `ResourceDesiredState`
-// that is not in this set is a user-managed field; `hasNoManagedFields`
-// returns true when no non-identity key is present on the object. Only
-// universe supports "all optional → noop on apply"; the other kinds'
-// required fields (name, description, filePath, etc.) are always present,
-// so the loop naturally returns false for them without a kind guard.
-const IDENTITY_KEYS: ReadonlySet<string> = new Set([
-	"key",
-	"kind",
-	"placeId",
-	"universeId",
-] satisfies Array<
-	keyof GamePassDesiredState | keyof PlaceDesiredState | keyof UniverseDesiredState
->);
-
-function hasNoManagedFields(desired: ResourceDesiredState): boolean {
-	if ("privateServerPriceRobux" in desired) {
-		return false;
-	}
-
-	for (const [key, value] of Object.entries(desired)) {
-		if (IDENTITY_KEYS.has(key)) {
-			continue;
-		}
-
-		// Social links use tri-state clearable semantics: key presence is
-		// management intent (set-or-clear), irrespective of the value.
-		if (SOCIAL_LINK_FIELD_SET.has(key)) {
-			return false;
-		}
-
-		if (value !== undefined) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 function desiredFieldsEqual(desired: ResourceDesiredState, current: ResourceCurrentState): boolean {
-	// Registry index returns a union of per-kind modules; widening its
-	// type parameter lets us call fieldsEqual without per-kind
-	// discriminator narrowing. When `desired.kind !== current.kind`
-	// the per-kind structural field comparison naturally returns false
-	// because every managed field read on the wrong side yields
-	// `undefined`, so no explicit kind guard is needed.
+	// Composite-key matching guarantees `desired.kind === current.kind`,
+	// so the per-kind module is consulted directly without a kind guard.
 	const module = defaultKindRegistry[desired.kind] as ResourceKindModule<ResourceKind>;
 	return module.fieldsEqual(desired, current);
 }
@@ -155,10 +104,6 @@ function operationFor(
 	desired: ResourceDesiredState,
 	current: ResourceCurrentState | undefined,
 ): Operation {
-	if (hasNoManagedFields(desired)) {
-		return { key: desired.key, type: "noop" };
-	}
-
 	if (current === undefined) {
 		return { key: desired.key, desired, type: "create" };
 	}

--- a/packages/bedrock/src/core/resources.ts
+++ b/packages/bedrock/src/core/resources.ts
@@ -257,14 +257,6 @@ export const SOCIAL_LINK_FIELDS = [
 export type SocialLinkField = (typeof SOCIAL_LINK_FIELDS)[number];
 
 /**
- * Set view of {@link SOCIAL_LINK_FIELDS} for O(1) membership checks when
- * classifying arbitrary `Object.keys(...)` values (for example
- * `hasNoManagedFields` in `diff`). Typed as a set of `string` so it can
- * accept unverified keys without a narrowing step at the call site.
- */
-export const SOCIAL_LINK_FIELD_SET: ReadonlySet<string> = new Set(SOCIAL_LINK_FIELDS);
-
-/**
  * Desired state for a developer product, the consumable a player can buy via
  * `MarketplaceService:PromptProductPurchase`.
  *

--- a/packages/bedrock/src/shell/deploy.spec.ts
+++ b/packages/bedrock/src/shell/deploy.spec.ts
@@ -1,8 +1,10 @@
 import { OpenCloudError } from "@bedrock/ocale";
 
+import { placeCurrent, universeCurrent } from "#tests/helpers/resources";
 import { assert, describe, expect, it, vi } from "vitest";
 
 import type { GistFetch } from "../adapters/gist-state-adapter.ts";
+import { UNIVERSE_SINGLETON_KEY } from "../core/resources.ts";
 import type { Config } from "../core/schema.ts";
 import type { BedrockState } from "../core/state.ts";
 import type { DriverRegistry, ResourceDriver } from "../ports/resource-driver.ts";
@@ -175,6 +177,31 @@ function alphaPassCurrent() {
 }
 
 describe(deploy, () => {
+	it("should preserve prior resources of distinct kinds that share a key when desired is empty", async () => {
+		expect.assertions(2);
+
+		const priorUniverse = universeCurrent();
+		const priorPlace = placeCurrent({ key: UNIVERSE_SINGLETON_KEY });
+		const { port, writes } = inMemoryStatePort({
+			environment: "production",
+			resources: [priorUniverse, priorPlace],
+			version: 1,
+		});
+
+		const result = await deploy({
+			config: { environments: { production: {} }, passes: {} },
+			environment: "production",
+			readFile: readIcon,
+			registry: stubRegistry(),
+			statePort: port,
+		});
+
+		assert(result.success);
+
+		expect(writes).toHaveLength(1);
+		expect(writes[0]!.resources).toStrictEqual([priorUniverse, priorPlace]);
+	});
+
 	it("should reconcile a first deploy by creating the desired resource and persisting the new state", async () => {
 		expect.assertions(5);
 

--- a/packages/bedrock/src/shell/deploy.spec.ts
+++ b/packages/bedrock/src/shell/deploy.spec.ts
@@ -177,6 +177,54 @@ function alphaPassCurrent() {
 }
 
 describe(deploy, () => {
+	it("should persist a universe-only-id alongside a place sharing the singleton key as separate state entries", async () => {
+		expect.assertions(3);
+
+		const placeIdValue = asRobloxAssetId("84607999013117");
+		const universeCreated = universeCurrent();
+		const placeCreated = placeCurrent({
+			key: UNIVERSE_SINGLETON_KEY,
+			placeId: placeIdValue,
+		});
+		const universeCreate = vi
+			.fn<ResourceDriver<"universe">["create"]>()
+			.mockResolvedValue({ data: universeCreated, success: true });
+		const placeCreate = vi
+			.fn<ResourceDriver<"place">["create"]>()
+			.mockResolvedValue({ data: placeCreated, success: true });
+		const registry: DriverRegistry = {
+			developerProduct: developerProductStub,
+			gamePass: {
+				create() {
+					throw new Error("gamePass driver must not run for this fixture");
+				},
+			},
+			place: { create: placeCreate },
+			universe: { create: universeCreate },
+		};
+		const { port, writes } = inMemoryStatePort();
+
+		const result = await deploy({
+			config: {
+				environments: {
+					production: { places: { main: { placeId: placeIdValue } } },
+				},
+				places: { main: { filePath: "anime-rush.rbxl" } },
+				universe: { universeId: "1234567890" },
+			},
+			environment: "production",
+			readFile: readIcon,
+			registry,
+			statePort: port,
+		});
+
+		assert(result.success);
+
+		expect(universeCreate).toHaveBeenCalledOnce();
+		expect(placeCreate).toHaveBeenCalledOnce();
+		expect(writes[0]!.resources).toStrictEqual([placeCreated, universeCreated]);
+	});
+
 	it("should preserve prior resources of distinct kinds that share a key when desired is empty", async () => {
 		expect.assertions(2);
 
@@ -512,11 +560,16 @@ describe(deploy, () => {
 		const create = vi
 			.fn<ResourceDriver<"gamePass">["create"]>()
 			.mockResolvedValue({ data: vipPassCurrent(), success: true });
+		const universeCreatedFixture = universeCurrent();
 		const registry: DriverRegistry = {
 			developerProduct: developerProductStub,
 			gamePass: { create },
 			place: placeStub,
-			universe: universeStub,
+			universe: {
+				async create() {
+					return { data: universeCreatedFixture, success: true };
+				},
+			},
 		};
 
 		const fetchSpy = vi.fn<GistFetch>(async (_input, init) => {
@@ -617,7 +670,14 @@ describe(deploy, () => {
 	it("should default-construct the registry from ROBLOX_API_KEY when registry is omitted", async () => {
 		expect.assertions(1);
 
-		const { port } = inMemoryStatePort();
+		// Provide prior universe state so the diff is a noop and the real
+		// universe driver default-constructed by the registry path never
+		// reaches Open Cloud.
+		const { port } = inMemoryStatePort({
+			environment: "production",
+			resources: [universeCurrent({ universeId: asRobloxAssetId("1") })],
+			version: 1,
+		});
 
 		const result = await deploy({
 			config: {
@@ -730,6 +790,13 @@ describe(deploy, () => {
 
 		vi.stubEnv("ROBLOX_API_KEY", "rbx-stub");
 		try {
+			// Prior universe state keeps the diff at noop so the
+			// default-constructed universe driver never hits Open Cloud.
+			const { port } = inMemoryStatePort({
+				environment: "production",
+				resources: [universeCurrent()],
+				version: 1,
+			});
 			const result = await deploy({
 				config: {
 					environments: { production: {} },
@@ -738,7 +805,7 @@ describe(deploy, () => {
 				},
 				environment: "production",
 				readFile: readIcon,
-				statePort: inMemoryStatePort().port,
+				statePort: port,
 			});
 
 			expect(result.success).toBeTrue();

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -18,7 +18,6 @@ import {
 import type { BedrockState, StateError } from "../core/state.ts";
 import type { DriverRegistry } from "../ports/resource-driver.ts";
 import type { StatePort } from "../ports/state-port.ts";
-import type { ResourceKey } from "../types/ids.ts";
 import { type ApplyError, applyOps } from "./apply-ops.ts";
 import { buildDefaultRegistry, type RegistryConfigError } from "./build-default-registry.ts";
 import { buildDesired, type BuildDesiredError } from "./build-desired.ts";
@@ -269,13 +268,13 @@ function mergeResources(
 	pre: ReadonlyArray<ResourceCurrentState>,
 	applied: ReadonlyArray<ResourceCurrentState>,
 ): ReadonlyArray<ResourceCurrentState> {
-	const byKey = new Map<ResourceKey, ResourceCurrentState>();
+	const byKey = new Map<string, ResourceCurrentState>();
 	for (const resource of pre) {
-		byKey.set(resource.key, resource);
+		byKey.set(`${resource.kind}:${resource.key}`, resource);
 	}
 
 	for (const resource of applied) {
-		byKey.set(resource.key, resource);
+		byKey.set(`${resource.kind}:${resource.key}`, resource);
 	}
 
 	return [...byKey.values()];

--- a/packages/bedrock/tests/integration/developer-products.spec.ts
+++ b/packages/bedrock/tests/integration/developer-products.spec.ts
@@ -11,6 +11,7 @@ import {
 	type ResourceCurrentState,
 	type ResourceDriver,
 	selectEnvironment,
+	UNIVERSE_SINGLETON_KEY,
 } from "@bedrock/core";
 import { DeveloperProductsClient } from "@bedrock/ocale/developer-products";
 import { createFakeHttpClient, validDeveloperProductBody } from "@bedrock/ocale/testing";
@@ -22,6 +23,7 @@ import { assert, describe, expect, it } from "vitest";
 const FIXTURES_ROOT = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
 const PRODUCTS_FIXTURE_DIR = join(FIXTURES_ROOT, "developer-products");
 const UNIVERSE_ID = asRobloxAssetId("1234567890");
+const ROOT_PLACE_ID = asRobloxAssetId("4711");
 
 const GAME_PASS_TRAP: ResourceDriver<"gamePass"> = {
 	create() {
@@ -35,9 +37,32 @@ const PLACE_TRAP: ResourceDriver<"place"> = {
 	},
 };
 
+const UNIVERSE_ADOPTED: ResourceCurrentState<"universe"> = {
+	key: UNIVERSE_SINGLETON_KEY,
+	consoleEnabled: undefined,
+	desktopEnabled: undefined,
+	displayName: undefined,
+	kind: "universe",
+	mobileEnabled: undefined,
+	outputs: { rootPlaceId: ROOT_PLACE_ID },
+	tabletEnabled: undefined,
+	universeId: UNIVERSE_ID,
+	visibility: undefined,
+	voiceChatEnabled: undefined,
+	vrEnabled: undefined,
+};
+
+const UNIVERSE_DRIVER: ResourceDriver<"universe"> = {
+	async create() {
+		return { data: UNIVERSE_ADOPTED, success: true };
+	},
+};
+
 const UNIVERSE_TRAP: ResourceDriver<"universe"> = {
 	create() {
-		throw new Error("UniverseDriver.create must not run for developer-product fixtures");
+		throw new Error(
+			"UniverseDriver.create must not run when current state already adopts the universe",
+		);
 	},
 };
 
@@ -79,22 +104,18 @@ describe("developer-products pipeline end-to-end", () => {
 			}),
 			gamePass: GAME_PASS_TRAP,
 			place: PLACE_TRAP,
-			universe: UNIVERSE_TRAP,
+			universe: UNIVERSE_DRIVER,
 		};
 
 		const ops = diff(desiredResult.data, []);
 
-		// Universe declared but with no managed fields produces a noop
-		// alongside the developer-product create.
-		expect(ops.map((op) => op.type).filter((type) => type !== "noop")).toStrictEqual([
-			"create",
-		]);
+		expect(ops.map((op) => op.type)).toStrictEqual(["create", "create"]);
 
 		const applyResult = await applyOps(ops, registry);
 
 		assert(applyResult.success);
 
-		expect(applyResult.data).toHaveLength(1);
+		expect(applyResult.data).toHaveLength(2);
 		expect(httpClient.requests).toHaveLength(1);
 
 		const [first] = httpClient.requests;
@@ -104,8 +125,8 @@ describe("developer-products pipeline end-to-end", () => {
 			`/developer-products/v2/universes/${UNIVERSE_ID}/developer-products`,
 		);
 
-		const created = applyResult.data[0]!;
-		assert(created.kind === "developerProduct");
+		const created = applyResult.data.find((entry) => entry.kind === "developerProduct");
+		assert(created !== undefined);
 
 		expect(created.outputs.productId).toBe("8172635495");
 	});
@@ -146,7 +167,7 @@ describe("developer-products pipeline end-to-end", () => {
 			price: undefined,
 		};
 
-		const ops = diff(desiredResult.data, [persisted]);
+		const ops = diff(desiredResult.data, [persisted, UNIVERSE_ADOPTED]);
 
 		expect(ops.every((op) => op.type === "noop")).toBeTrue();
 
@@ -187,7 +208,7 @@ describe("developer-products pipeline end-to-end", () => {
 			universe: UNIVERSE_TRAP,
 		};
 
-		const persisted: ResourceCurrentState<"developerProduct"> = {
+		const persistedProduct: ResourceCurrentState<"developerProduct"> = {
 			key: asResourceKey("gem-pack"),
 			name: "Gem Pack",
 			description: "Old description before edit.",
@@ -196,7 +217,7 @@ describe("developer-products pipeline end-to-end", () => {
 			price: undefined,
 		};
 
-		const ops = diff(desiredResult.data, [persisted]);
+		const ops = diff(desiredResult.data, [persistedProduct, UNIVERSE_ADOPTED]);
 
 		expect(ops.map((op) => op.type).filter((type) => type !== "noop")).toStrictEqual([
 			"update",


### PR DESCRIPTION
## Summary

Fixes #256. Two coordinated changes to the diff and merge layers so a config like `universe: { universeId }` plus `places: { main: ... }` produces a state file that records both resources independently.

- **Composite `(kind, key)` keying.** Both `diff.currentByKey` and `mergeResources` now key resources by the `(kind, key)` pair instead of `key` alone. A `place` and a `universe` declared at the same key (canonically `"main"`) are independent slots. Cross-kind same-key entries no longer collide in the merge map and no longer produce spurious cross-kind `update` ops in the diff.
- **Universe identity is itself managed.** Drops the noop short-circuit for universe-only-id configs. The universe driver's existing read-only GET path (`hasUniverseLevelUpdate` is false) now populates the snapshot with `outputs.rootPlaceId`. `hasNoManagedFields`, `IDENTITY_KEYS`, and the now-unused `SOCIAL_LINK_FIELD_SET` are removed — the helper could only ever return true for universe-only-id, and that case no longer short-circuits.

The on-disk state format is unchanged; only the in-memory keying and the diff's universe handling change. State files written before this PR continue to parse, and historical state could never have contained the colliding `(universe-main, place-main)` pair (the bug masked it).

## Why this matters

Today, the canonical "deploy-only, no resource management" config (the anime-rush shape) leaves `universe` out of state entirely. That breaks:

- **Auditability** — the state file alone does not reveal which universe a deploy targeted.
- **Multi-environment coherence** — production and staging state files are indistinguishable when only the universeId differs.
- **Drift detection** — a future config edit that swaps `universeId` is invisible because there is nothing in state to compare against.

After this PR, the state file records `{ kind: "universe", key: "main", universeId, outputs: { rootPlaceId } }` for every deploy whose config declares a universe, regardless of whether other fields are managed.

## Out of scope

[ADR-019](docs/adr/019-state-data-model-and-diff-algebra.md) is the on-point ADR for the diff/state contract. Two amendments are warranted (universe identity is managed; resources are keyed by `(kind, key)`) but those will land as a separate collaborative pass per the project's ADR process — not auto-generated.

## Test plan

- [x] `pnpm test` (1036 passed, 10 skipped)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `pnpm gen:example-tests`
- [x] `pnpm mutate:changed` (100% mutation score on touched `src/**` files, no surviving mutants)
- [ ] Manual: deploy the issue's example config end-to-end against a real gist + Open Cloud and confirm the persisted JSON matches the issue's "Expected" shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)