### PR TITLE
ci: grant openapi-drift workflow actions write to dispatch ci.yaml

### DIFF
--- a/.github/workflows/openapi-drift.yaml
+++ b/.github/workflows/openapi-drift.yaml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 


### PR DESCRIPTION
## Summary

- Adds `actions: write` to the `openapi-drift` workflow's `permissions:` block so its `gh workflow run ci.yaml --ref \"\$DRIFT_BRANCH\"` step can call the `workflow_dispatch` API.

## Context

The scheduled run [#24980804045](https://github.com/christopher-buss/bedrock/actions/runs/24980804045) failed first at PR creation (fixed by enabling repo-level "Allow GitHub Actions to create and approve pull requests"), then on re-run at the dispatch step with:

```
HTTP 403: Resource not accessible by integration
(https://api.github.com/repos/christopher-buss/bedrock/actions/workflows/ci.yaml)
```

The workflow's `permissions:` block grants `contents: write` and `pull-requests: write`, but `gh workflow run` calls the `workflow_dispatch` API which requires `actions: write`. Without it the step 403s, no `Build & Test` checks attach to the drift PR, and the subsequent auto-merge step is skipped (the previous step's failure short-circuits the job). That left PR #265 with only third-party checks (CodeRabbit, Vercel) and no spec-conformance gate.

The drift PR is meant to surface fixture/parser breakage when the upstream OpenAPI spec changes shape. The vendored JSON drives Ajv-compiled validators in `tests/conformance/_helpers.ts`, the conformance specs across all four resources, and the `FakeHttpClient` contract layer that gates every integration spec — so `Build & Test` *is* the meaningful drift gate, provided it actually attaches.

## Test plan

- [ ] Manually dispatch `ci.yaml` against `automation/refresh-openapi-spec` to confirm the spec-consuming tests pass against the current vendored snapshot.
- [ ] After merge, dispatch `openapi-drift.yaml` (`gh workflow run openapi-drift.yaml --ref main`) and confirm the "Trigger CI on the drift branch" step now succeeds and a `Build & Test` check attaches to PR #265.
- [ ] Confirm the "Enable auto-merge on the drift PR" step also runs (no longer short-circuited by the prior step's failure).