### PR TITLE
feat(core): add place support to migrate-mantle-state

### DIFF
--- a/packages/bedrock/src/core/migrate/build-state.spec.ts
+++ b/packages/bedrock/src/core/migrate/build-state.spec.ts
@@ -4,14 +4,28 @@ import { asRobloxAssetId } from "../../types/ids.ts";
 import { UNIVERSE_SINGLETON_KEY } from "../resources.ts";
 import { buildState } from "./build-state.ts";
 import type { EnvironmentFoldResult } from "./fold-environment.ts";
+import type { PlaceFoldEntry } from "./fold-places.ts";
+
+const VALID_HASH = "908498abb7f4fca2b7d2b050bfe7c48c009202fabd85f489b03bb19ac6e0b1d9";
 
 const FOLDED_UNIVERSE: EnvironmentFoldResult = {
+	places: new Map(),
 	universe: {
 		entry: { universeId: "6031475575" },
 		outputs: { rootPlaceId: asRobloxAssetId("17613681043") },
 	},
 	warnings: [],
 };
+
+function placeFold(overrides: Partial<PlaceFoldEntry> = {}): PlaceFoldEntry {
+	return {
+		entry: { filePath: "place.rbxl" },
+		fileHash: VALID_HASH,
+		outputs: { versionNumber: 53 },
+		placeId: "17613681043",
+		...overrides,
+	};
+}
 
 describe(buildState, () => {
 	it("should set the schema version literal to 1", () => {
@@ -90,8 +104,65 @@ describe(buildState, () => {
 	it("should emit an empty resources array when the fold yielded no universe", () => {
 		expect.assertions(1);
 
-		const state = buildState("production", { universe: undefined, warnings: [] });
+		const state = buildState("production", {
+			places: new Map(),
+			universe: undefined,
+			warnings: [],
+		});
 
 		expect(state.resources).toStrictEqual([]);
+	});
+
+	it("should emit one place ResourceCurrentState per folded place entry", () => {
+		expect.assertions(5);
+
+		const state = buildState("production", {
+			places: new Map([["start", placeFold()]]),
+			universe: undefined,
+			warnings: [],
+		});
+
+		expect(state.resources).toHaveLength(1);
+
+		const [resource] = state.resources;
+		assert(resource !== undefined);
+		assert(resource.kind === "place");
+
+		expect(resource.key).toBe("start");
+		expect(resource.placeId).toBe("17613681043");
+		expect(resource.filePath).toBe("place.rbxl");
+		expect(resource.outputs.versionNumber).toBe(53);
+	});
+
+	it("should preserve the Mantle-recorded fileHash on the place resource", () => {
+		expect.assertions(1);
+
+		const state = buildState("production", {
+			places: new Map([["start", placeFold()]]),
+			universe: undefined,
+			warnings: [],
+		});
+
+		const [resource] = state.resources;
+		assert(resource !== undefined);
+		assert(resource.kind === "place");
+
+		expect(resource.fileHash).toBe(VALID_HASH);
+	});
+
+	it("should emit place resources after the universe resource", () => {
+		expect.assertions(2);
+
+		const state = buildState("production", {
+			places: new Map([["start", placeFold()]]),
+			universe: FOLDED_UNIVERSE.universe,
+			warnings: [],
+		});
+
+		expect(state.resources).toHaveLength(2);
+		expect(state.resources.map((resource) => resource.kind)).toStrictEqual([
+			"universe",
+			"place",
+		]);
 	});
 });

--- a/packages/bedrock/src/core/migrate/build-state.spec.ts
+++ b/packages/bedrock/src/core/migrate/build-state.spec.ts
@@ -1,12 +1,12 @@
 import { assert, describe, expect, it } from "vitest";
 
-import { asRobloxAssetId } from "../../types/ids.ts";
+import { asRobloxAssetId, asSha256Hex } from "../../types/ids.ts";
 import { UNIVERSE_SINGLETON_KEY } from "../resources.ts";
 import { buildState } from "./build-state.ts";
 import type { EnvironmentFoldResult } from "./fold-environment.ts";
 import type { PlaceFoldEntry } from "./fold-places.ts";
 
-const VALID_HASH = "908498abb7f4fca2b7d2b050bfe7c48c009202fabd85f489b03bb19ac6e0b1d9";
+const VALID_HASH = asSha256Hex("908498abb7f4fca2b7d2b050bfe7c48c009202fabd85f489b03bb19ac6e0b1d9");
 
 const FOLDED_UNIVERSE: EnvironmentFoldResult = {
 	places: new Map(),

--- a/packages/bedrock/src/core/migrate/build-state.ts
+++ b/packages/bedrock/src/core/migrate/build-state.ts
@@ -1,4 +1,4 @@
-import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../../types/ids.ts";
+import { asResourceKey, asRobloxAssetId } from "../../types/ids.ts";
 import {
 	type ResourceCurrentState,
 	UNIVERSE_SINGLETON_KEY,
@@ -65,7 +65,7 @@ function universeResource(
 function placeResource(key: string, fold: PlaceFoldEntry): ResourceCurrentState<"place"> {
 	return {
 		key: asResourceKey(key),
-		fileHash: asSha256Hex(fold.fileHash),
+		fileHash: fold.fileHash,
 		filePath: fold.entry.filePath,
 		kind: "place",
 		outputs: fold.outputs,

--- a/packages/bedrock/src/core/migrate/build-state.ts
+++ b/packages/bedrock/src/core/migrate/build-state.ts
@@ -1,4 +1,4 @@
-import { asRobloxAssetId } from "../../types/ids.ts";
+import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../../types/ids.ts";
 import {
 	type ResourceCurrentState,
 	UNIVERSE_SINGLETON_KEY,
@@ -7,28 +7,39 @@ import {
 import type { UniverseEntry } from "../schema.ts";
 import type { BedrockState } from "../state.ts";
 import type { EnvironmentFoldResult } from "./fold-environment.ts";
+import type { PlaceFoldEntry } from "./fold-places.ts";
 
 /**
  * Compose one environment's folded data into the on-disk `BedrockState`
  * snapshot the migrator's caller writes per environment.
  *
- * Skeleton: only universe folding is wired. The resulting state carries
- * one `kind: "universe"` resource whose declared fields mirror the folded
- * `UniverseEntry` and whose `outputs` carries the Roblox-assigned
- * `rootPlaceId` recovered from Mantle. Future slices append game-pass and
- * place resources alongside.
+ * Skeleton: universe and place folds are wired. The resulting state
+ * carries one `kind: "universe"` resource (when an experience folded) and
+ * one `kind: "place"` resource per matched place pair, in declaration
+ * order. Each resource's declared fields mirror its fold output and the
+ * `outputs` field carries the Mantle-recorded identifiers (universe
+ * `rootPlaceId`, place `versionNumber`). Future slices append game-pass
+ * resources alongside.
  *
  * @param environment - Environment name; written verbatim onto the state.
  * @param folded - Per-kind fold results for this environment.
  * @returns A `BedrockState` populated with one resource per folded kind.
  */
 export function buildState(environment: string, folded: EnvironmentFoldResult): BedrockState {
-	const resources: ReadonlyArray<ResourceCurrentState> =
+	const universeResources: ReadonlyArray<ResourceCurrentState> =
 		folded.universe === undefined
 			? []
 			: [universeResource(folded.universe.entry, folded.universe.outputs)];
 
-	return { environment, resources, version: 1 };
+	const placeResources: ReadonlyArray<ResourceCurrentState> = [...folded.places.entries()].map(
+		([key, entry]) => placeResource(key, entry),
+	);
+
+	return {
+		environment,
+		resources: [...universeResources, ...placeResources],
+		version: 1,
+	};
 }
 
 function universeResource(
@@ -48,5 +59,16 @@ function universeResource(
 		visibility: entry.visibility,
 		voiceChatEnabled: entry.voiceChatEnabled,
 		vrEnabled: entry.vrEnabled,
+	};
+}
+
+function placeResource(key: string, fold: PlaceFoldEntry): ResourceCurrentState<"place"> {
+	return {
+		key: asResourceKey(key),
+		fileHash: asSha256Hex(fold.fileHash),
+		filePath: fold.entry.filePath,
+		kind: "place",
+		outputs: fold.outputs,
+		placeId: asRobloxAssetId(fold.placeId),
 	};
 }

--- a/packages/bedrock/src/core/migrate/fold-environment.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-environment.spec.ts
@@ -3,6 +3,8 @@ import { assert, describe, expect, it } from "vitest";
 import { foldEnvironment } from "./fold-environment.ts";
 import type { MantleResource } from "./types.ts";
 
+const VALID_HASH = "908498abb7f4fca2b7d2b050bfe7c48c009202fabd85f489b03bb19ac6e0b1d9";
+
 function experience(): MantleResource {
 	return {
 		key: "singleton",
@@ -27,7 +29,7 @@ function placeFile(): MantleResource {
 	return {
 		key: "start",
 		dependencies: [],
-		inputs: { fileHash: "h1", filePath: "place.rbxl" },
+		inputs: { fileHash: VALID_HASH, filePath: "place.rbxl" },
 		kind: "placeFile",
 		outputs: { version: 53 },
 	};

--- a/packages/bedrock/src/core/migrate/fold-environment.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-environment.spec.ts
@@ -13,6 +13,26 @@ function experience(): MantleResource {
 	};
 }
 
+function place(): MantleResource {
+	return {
+		key: "start",
+		dependencies: [],
+		inputs: { isStart: true },
+		kind: "place",
+		outputs: { assetId: 17613681043 },
+	};
+}
+
+function placeFile(): MantleResource {
+	return {
+		key: "start",
+		dependencies: [],
+		inputs: { fileHash: "h1", filePath: "place.rbxl" },
+		kind: "placeFile",
+		outputs: { version: 53 },
+	};
+}
+
 describe(foldEnvironment, () => {
 	it("should expose the folded universe entry when an experience is present", () => {
 		expect.assertions(1);
@@ -56,5 +76,38 @@ describe(foldEnvironment, () => {
 		const result = foldEnvironment([]);
 
 		expect(result.warnings).toStrictEqual([]);
+	});
+
+	it("should expose folded place entries when a matched place pair is present", () => {
+		expect.assertions(2);
+
+		const result = foldEnvironment([experience(), place(), placeFile()]);
+
+		const start = result.places.get("start");
+		assert(start !== undefined);
+
+		expect(start.entry).toStrictEqual({ filePath: "place.rbxl" });
+		expect(start.placeId).toBe("17613681043");
+	});
+
+	it("should expose an empty places map when no place resources are present", () => {
+		expect.assertions(1);
+
+		const result = foldEnvironment([experience()]);
+
+		expect(result.places.size).toBe(0);
+	});
+
+	it("should aggregate place ambiguous warnings into the warnings list", () => {
+		expect.assertions(2);
+
+		const result = foldEnvironment([experience(), place()]);
+
+		expect(result.warnings).toHaveLength(1);
+
+		const [warning] = result.warnings;
+		assert(warning?.kind === "ambiguous");
+
+		expect(warning.mantlePath).toBe("place_start");
 	});
 });

--- a/packages/bedrock/src/core/migrate/fold-environment.ts
+++ b/packages/bedrock/src/core/migrate/fold-environment.ts
@@ -1,5 +1,6 @@
 import type { UniverseOutputs } from "../resources.ts";
 import type { UniverseEntry } from "../schema.ts";
+import { foldPlaces, type PlaceFoldEntry } from "./fold-places.ts";
 import { foldUniverse } from "./fold-universe.ts";
 import type { MigrationWarning } from "./migration-report.ts";
 import type { MantleResource } from "./types.ts";
@@ -10,10 +11,16 @@ import type { MantleResource } from "./types.ts";
  * an experience resource yields `universe: undefined`, signalling that
  * the bedrock `Config` for this environment carries no `universe` block.
  *
- * Skeleton: only the universe branch is wired. Future slices add `places`,
- * `passes`, and the deferred / blocked / interpretive warning categories.
+ * `places` is always present (potentially empty) so the orchestrator does
+ * not have to special-case "no places" against "places not yet wired";
+ * orphan resources surface as `ambiguous` warnings on `warnings`.
+ *
+ * Skeleton: universe and place branches are wired. Future slices add
+ * `passes` and the deferred / blocked / interpretive warning categories.
  */
 export interface EnvironmentFoldResult {
+	/** Folded place entries for this environment, keyed by Mantle's place key. */
+	readonly places: ReadonlyMap<string, PlaceFoldEntry>;
 	/** Folded universe data for this environment, or `undefined` when no experience is present. */
 	readonly universe:
 		| undefined
@@ -28,8 +35,8 @@ export interface EnvironmentFoldResult {
 /**
  * Orchestrate the per-kind folds for one Mantle environment, gathering
  * the results and warnings into a single `EnvironmentFoldResult`. Pure;
- * delegates to `foldUniverse` and (in future slices) the matching place,
- * pass, and unsupported folders.
+ * delegates to `foldUniverse`, `foldPlaces`, and (in future slices) the
+ * matching pass and unsupported folders.
  *
  * @param resources - Mantle resource list for one environment.
  * @returns The folded per-kind data plus aggregated warnings.
@@ -41,7 +48,9 @@ export function foldEnvironment(resources: ReadonlyArray<MantleResource>): Envir
 			? undefined
 			: { entry: universeResult.entry, outputs: universeResult.outputs };
 
-	const warnings = universeResult?.warnings ?? [];
+	const placesResult = foldPlaces(resources);
 
-	return { universe, warnings };
+	const warnings = [...(universeResult?.warnings ?? []), ...placesResult.warnings];
+
+	return { places: placesResult.entries, universe, warnings };
 }

--- a/packages/bedrock/src/core/migrate/fold-places.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.spec.ts
@@ -1,0 +1,264 @@
+import { assert, describe, expect, it } from "vitest";
+
+import { foldPlaces } from "./fold-places.ts";
+import type { MantleResource } from "./types.ts";
+
+const VALID_HASH = "908498abb7f4fca2b7d2b050bfe7c48c009202fabd85f489b03bb19ac6e0b1d9";
+
+interface PlaceArgs {
+	readonly key: string;
+	readonly inputs?: unknown;
+	readonly outputs: unknown;
+}
+
+interface PlaceFileArgs {
+	readonly key: string;
+	readonly inputs: unknown;
+	readonly outputs: unknown;
+}
+
+function place({ key, inputs = { isStart: false }, outputs }: PlaceArgs): MantleResource {
+	return {
+		key,
+		dependencies: [],
+		inputs,
+		kind: "place",
+		outputs,
+	};
+}
+
+function placeFile({ key, inputs, outputs }: PlaceFileArgs): MantleResource {
+	return {
+		key,
+		dependencies: [],
+		inputs,
+		kind: "placeFile",
+		outputs,
+	};
+}
+
+function defaultPlaceFile(key: string): MantleResource {
+	return placeFile({
+		key,
+		inputs: { fileHash: VALID_HASH, filePath: "place.rbxl" },
+		outputs: { version: 53 },
+	});
+}
+
+describe(foldPlaces, () => {
+	it("should fold a matched place and placeFile pair into one entry", () => {
+		expect.assertions(2);
+
+		const result = foldPlaces([
+			place({ key: "start", outputs: { assetId: 17613681043 } }),
+			defaultPlaceFile("start"),
+		]);
+
+		const entry = result.entries.get("start");
+		assert(entry !== undefined);
+
+		expect(entry.entry).toStrictEqual({ filePath: "place.rbxl" });
+		expect(entry.placeId).toBe("17613681043");
+	});
+
+	it("should accept a string-formatted place assetId", () => {
+		expect.assertions(1);
+
+		const result = foldPlaces([
+			place({ key: "start", outputs: { assetId: "17613681043" } }),
+			defaultPlaceFile("start"),
+		]);
+
+		const entry = result.entries.get("start");
+		assert(entry !== undefined);
+
+		expect(entry.placeId).toBe("17613681043");
+	});
+
+	it("should record the placeFile version number in outputs", () => {
+		expect.assertions(1);
+
+		const result = foldPlaces([
+			place({ key: "start", outputs: { assetId: 17613681043 } }),
+			defaultPlaceFile("start"),
+		]);
+
+		const entry = result.entries.get("start");
+		assert(entry !== undefined);
+
+		expect(entry.outputs).toStrictEqual({ versionNumber: 53 });
+	});
+
+	it("should propagate the Mantle-recorded fileHash on the matched entry", () => {
+		expect.assertions(1);
+
+		const result = foldPlaces([
+			place({ key: "start", outputs: { assetId: 17613681043 } }),
+			defaultPlaceFile("start"),
+		]);
+
+		const entry = result.entries.get("start");
+		assert(entry !== undefined);
+
+		expect(entry.fileHash).toBe(VALID_HASH);
+	});
+
+	it("should emit no warnings when every place has a matching placeFile", () => {
+		expect.assertions(1);
+
+		const result = foldPlaces([
+			place({ key: "start", outputs: { assetId: 17613681043 } }),
+			defaultPlaceFile("start"),
+		]);
+
+		expect(result.warnings).toStrictEqual([]);
+	});
+
+	it("should ignore non-place and non-placeFile resources", () => {
+		expect.assertions(2);
+
+		const result = foldPlaces([
+			{
+				key: "singleton",
+				dependencies: [],
+				inputs: { groupId: undefined },
+				kind: "experience",
+				outputs: { assetId: 6031475575, startPlaceId: 17613681043 },
+			},
+			place({ key: "start", outputs: { assetId: 17613681043 } }),
+			defaultPlaceFile("start"),
+		]);
+
+		expect([...result.entries.keys()]).toStrictEqual(["start"]);
+		expect(result.warnings).toStrictEqual([]);
+	});
+
+	it("should return an empty entries map when no place resources are present", () => {
+		expect.assertions(2);
+
+		const result = foldPlaces([]);
+
+		expect(result.entries.size).toBe(0);
+		expect(result.warnings).toStrictEqual([]);
+	});
+
+	it("should emit an ambiguous warning when a place has no matching placeFile", () => {
+		expect.assertions(4);
+
+		const result = foldPlaces([place({ key: "orphan", outputs: { assetId: 17613681043 } })]);
+
+		expect(result.entries.size).toBe(0);
+		expect(result.warnings).toHaveLength(1);
+
+		const [warning] = result.warnings;
+		assert(warning?.kind === "ambiguous");
+
+		expect(warning.mantlePath).toBe("place_orphan");
+		expect(warning.hint).toMatch(/verify your mantle state/i);
+	});
+
+	it("should emit an ambiguous warning when a placeFile has no matching place", () => {
+		expect.assertions(3);
+
+		const result = foldPlaces([
+			placeFile({
+				key: "orphan",
+				inputs: { fileHash: VALID_HASH, filePath: "place.rbxl" },
+				outputs: { version: 1 },
+			}),
+		]);
+
+		expect(result.entries.size).toBe(0);
+		expect(result.warnings).toHaveLength(1);
+
+		const [warning] = result.warnings;
+		assert(warning?.kind === "ambiguous");
+
+		expect(warning.mantlePath).toBe("placeFile_orphan");
+	});
+
+	it("should pair only the matched key when one of two places lacks a placeFile", () => {
+		expect.assertions(3);
+
+		const result = foldPlaces([
+			place({ key: "start", outputs: { assetId: 1 } }),
+			place({ key: "lobby", outputs: { assetId: 2 } }),
+			defaultPlaceFile("start"),
+		]);
+
+		expect([...result.entries.keys()]).toStrictEqual(["start"]);
+		expect(result.warnings).toHaveLength(1);
+
+		const [warning] = result.warnings;
+		assert(warning?.kind === "ambiguous");
+
+		expect(warning.mantlePath).toBe("place_lobby");
+	});
+
+	it("should not produce an entry when place outputs declares a non-integer assetId", () => {
+		expect.assertions(2);
+
+		const result = foldPlaces([
+			place({ key: "start", outputs: { assetId: 1.5 } }),
+			defaultPlaceFile("start"),
+		]);
+
+		expect(result.entries.size).toBe(0);
+		expect(result.warnings).toStrictEqual([]);
+	});
+
+	it("should not produce an entry when place outputs is undefined", () => {
+		expect.assertions(2);
+
+		const result = foldPlaces([
+			place({ key: "start", outputs: undefined }),
+			defaultPlaceFile("start"),
+		]);
+
+		expect(result.entries.size).toBe(0);
+		expect(result.warnings).toStrictEqual([]);
+	});
+
+	it("should not produce an entry when place outputs is null", () => {
+		expect.assertions(2);
+
+		const result = foldPlaces([
+			// eslint-disable-next-line unicorn/no-null -- exercising the null guard against direct callers that bypass parseState's null normalization
+			place({ key: "start", outputs: null }),
+			defaultPlaceFile("start"),
+		]);
+
+		expect(result.entries.size).toBe(0);
+		expect(result.warnings).toStrictEqual([]);
+	});
+
+	it("should fold multiple matched place pairs in one environment", () => {
+		expect.assertions(4);
+
+		const result = foldPlaces([
+			place({ key: "start", outputs: { assetId: 17613681043 } }),
+			place({ key: "lobby", outputs: { assetId: 17613681044 } }),
+			placeFile({
+				key: "start",
+				inputs: { fileHash: VALID_HASH, filePath: "start.rbxl" },
+				outputs: { version: 53 },
+			}),
+			placeFile({
+				key: "lobby",
+				inputs: { fileHash: VALID_HASH, filePath: "lobby.rbxl" },
+				outputs: { version: 7 },
+			}),
+		]);
+
+		expect(result.entries.size).toBe(2);
+
+		const start = result.entries.get("start");
+		const lobby = result.entries.get("lobby");
+		assert(start !== undefined);
+		assert(lobby !== undefined);
+
+		expect(start.placeId).toBe("17613681043");
+		expect(lobby.placeId).toBe("17613681044");
+		expect(lobby.entry).toStrictEqual({ filePath: "lobby.rbxl" });
+	});
+});

--- a/packages/bedrock/src/core/migrate/fold-places.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.spec.ts
@@ -219,6 +219,22 @@ describe(foldPlaces, () => {
 		expect(result.warnings).toStrictEqual([]);
 	});
 
+	it("should not produce an entry when placeFile inputs carries a malformed fileHash", () => {
+		expect.assertions(2);
+
+		const result = foldPlaces([
+			place({ key: "start", outputs: { assetId: 17613681043 } }),
+			placeFile({
+				key: "start",
+				inputs: { fileHash: "abc", filePath: "place.rbxl" },
+				outputs: { version: 53 },
+			}),
+		]);
+
+		expect(result.entries.size).toBe(0);
+		expect(result.warnings).toStrictEqual([]);
+	});
+
 	it("should not produce an entry when place outputs is null", () => {
 		expect.assertions(2);
 

--- a/packages/bedrock/src/core/migrate/fold-places.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.ts
@@ -1,3 +1,4 @@
+import { isSha256Hex, type Sha256Hex } from "../../types/ids.ts";
 import type { PlaceOutputs } from "../resources.ts";
 import type { PlaceEntry } from "../schema.ts";
 import type { MigrationWarning } from "./migration-report.ts";
@@ -23,7 +24,7 @@ export interface PlaceFoldEntry {
 	/** Bedrock root `Config.places.<key>` body (currently `filePath` only). */
 	readonly entry: PlaceEntry;
 	/** Mantle-recorded SHA-256 hex digest of the place file (fallback for hash recomputation). */
-	readonly fileHash: string;
+	readonly fileHash: Sha256Hex;
 	/** Roblox-assigned identifiers carried into `BedrockState.resources[*].outputs`. */
 	readonly outputs: PlaceOutputs;
 	/** Roblox-assigned place ID copied from `place_<key>.outputs.assetId`. */
@@ -49,7 +50,7 @@ interface PlaceOutputsRaw {
 }
 
 interface PlaceFileInputsRaw {
-	readonly fileHash: string;
+	readonly fileHash: Sha256Hex;
 	readonly filePath: string;
 }
 
@@ -64,6 +65,12 @@ interface PlaceFileOutputsRaw {
  * either side emits an `ambiguous` warning carrying the orphan's
  * `mantlePath` and a hint instructing the user to verify their Mantle
  * state.
+ *
+ * Matched pairs whose payloads fail shape validation (missing or
+ * non-numeric `assetId`, missing `filePath`, malformed `fileHash`, etc.)
+ * are dropped silently rather than surfacing as warnings, mirroring the
+ * malformed-input handling in `foldUniverse`. A `malformed` warning kind
+ * spanning the per-kind folds is left to a follow-up slice.
  *
  * @param resources - Mantle resource list for one environment.
  * @returns The folded entries plus orphan warnings.
@@ -149,7 +156,7 @@ function readPlaceFileInputs(resource: MantleResource): PlaceFileInputsRaw | und
 	}
 
 	const { fileHash, filePath } = inputs;
-	if (typeof filePath !== "string" || typeof fileHash !== "string") {
+	if (typeof filePath !== "string" || typeof fileHash !== "string" || !isSha256Hex(fileHash)) {
 		return undefined;
 	}
 
@@ -191,7 +198,7 @@ function mergeMatchedPair(
 
 function orphanWarning(kind: string, key: string): MigrationWarning {
 	return {
-		hint: "Verify your Mantle state file: a place_<k> resource must be paired with a matching placeFile_<k> resource.",
+		hint: "Verify your Mantle state file: each place_<k> resource must be paired with a matching placeFile_<k>, and vice versa.",
 		kind: "ambiguous",
 		mantlePath: `${kind}_${key}`,
 	};

--- a/packages/bedrock/src/core/migrate/fold-places.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.ts
@@ -37,7 +37,7 @@ export interface PlaceFoldEntry {
  * versa) emit one `ambiguous` warning each instead of being projected into
  * `entries`.
  */
-export interface PlaceFoldResult {
+interface PlaceFoldResult {
 	/** Folded entries keyed by Mantle's place key (the suffix after the first `_`). */
 	readonly entries: ReadonlyMap<string, PlaceFoldEntry>;
 	/** Per-rule diagnostics: orphan resources surface as `ambiguous` warnings. */

--- a/packages/bedrock/src/core/migrate/fold-places.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.ts
@@ -1,0 +1,198 @@
+import type { PlaceOutputs } from "../resources.ts";
+import type { PlaceEntry } from "../schema.ts";
+import type { MigrationWarning } from "./migration-report.ts";
+import type { MantleResource } from "./types.ts";
+
+const PLACE_KIND = "place";
+const PLACE_FILE_KIND = "placeFile";
+
+/**
+ * Folded place data for one Mantle resource key.
+ *
+ * `entry` populates the bedrock root `Config.places.<key>` block (currently
+ * just `filePath`). `placeId` is the Roblox-assigned place ID Mantle stored
+ * under `place_<k>.outputs.assetId`; the migrator threads it onto the
+ * matching per-environment overlay (`environments[env].places.<key>`).
+ * `fileHash` is the SHA-256 digest Mantle recorded under
+ * `placeFile_<k>.inputs.fileHash`; the shell consumes it as the fallback
+ * value when the migrator cannot recompute the hash from disk. `outputs`
+ * carries the auto-incrementing publish version number Mantle stored under
+ * `placeFile_<k>.outputs.version`.
+ */
+export interface PlaceFoldEntry {
+	/** Bedrock root `Config.places.<key>` body (currently `filePath` only). */
+	readonly entry: PlaceEntry;
+	/** Mantle-recorded SHA-256 hex digest of the place file (fallback for hash recomputation). */
+	readonly fileHash: string;
+	/** Roblox-assigned identifiers carried into `BedrockState.resources[*].outputs`. */
+	readonly outputs: PlaceOutputs;
+	/** Roblox-assigned place ID copied from `place_<key>.outputs.assetId`. */
+	readonly placeId: string;
+}
+
+/**
+ * Output of folding the place-related Mantle resources of one environment
+ * into bedrock's `places` shape. Each Mantle place key produces one entry
+ * in `entries`; orphans (a `place_<k>` without a `placeFile_<k>`, or vice
+ * versa) emit one `ambiguous` warning each instead of being projected into
+ * `entries`.
+ */
+export interface PlaceFoldResult {
+	/** Folded entries keyed by Mantle's place key (the suffix after the first `_`). */
+	readonly entries: ReadonlyMap<string, PlaceFoldEntry>;
+	/** Per-rule diagnostics: orphan resources surface as `ambiguous` warnings. */
+	readonly warnings: ReadonlyArray<MigrationWarning>;
+}
+
+interface PlaceOutputsRaw {
+	readonly assetId: string;
+}
+
+interface PlaceFileInputsRaw {
+	readonly fileHash: string;
+	readonly filePath: string;
+}
+
+interface PlaceFileOutputsRaw {
+	readonly version: number;
+}
+
+/**
+ * Fold the place-related Mantle resources of one environment into a map of
+ * `PlaceFoldEntry` plus accompanying warnings. Pairs each `place_<k>`
+ * with the matching `placeFile_<k>` by key; an unmatched resource on
+ * either side emits an `ambiguous` warning carrying the orphan's
+ * `mantlePath` and a hint instructing the user to verify their Mantle
+ * state.
+ *
+ * @param resources - Mantle resource list for one environment.
+ * @returns The folded entries plus orphan warnings.
+ */
+export function foldPlaces(resources: ReadonlyArray<MantleResource>): PlaceFoldResult {
+	const { placeFiles, places } = bucketByKind(resources);
+	const entries = new Map<string, PlaceFoldEntry>();
+	const warnings: Array<MigrationWarning> = [];
+
+	for (const [key, placeResource] of places) {
+		const fileResource = placeFiles.get(key);
+		if (fileResource === undefined) {
+			warnings.push(orphanWarning(PLACE_KIND, key));
+			continue;
+		}
+
+		const folded = mergeMatchedPair(placeResource, fileResource);
+		if (folded !== undefined) {
+			entries.set(key, folded);
+		}
+	}
+
+	for (const [key] of placeFiles) {
+		if (!places.has(key)) {
+			warnings.push(orphanWarning(PLACE_FILE_KIND, key));
+		}
+	}
+
+	return { entries, warnings };
+}
+
+function bucketByKind(resources: ReadonlyArray<MantleResource>): {
+	readonly placeFiles: Map<string, MantleResource>;
+	readonly places: Map<string, MantleResource>;
+} {
+	const places = new Map<string, MantleResource>();
+	const placeFiles = new Map<string, MantleResource>();
+	for (const resource of resources) {
+		if (resource.kind === PLACE_KIND) {
+			places.set(resource.key, resource);
+		} else if (resource.kind === PLACE_FILE_KIND) {
+			placeFiles.set(resource.key, resource);
+		}
+	}
+
+	return { placeFiles, places };
+}
+
+function coerceRobloxId(value: unknown): string | undefined {
+	if (typeof value === "string") {
+		return value;
+	}
+
+	if (Number.isInteger(value)) {
+		return String(value);
+	}
+
+	return undefined;
+}
+
+function isObjectPayload(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readPlaceOutputs(resource: MantleResource): PlaceOutputsRaw | undefined {
+	const { outputs } = resource;
+	if (!isObjectPayload(outputs)) {
+		return undefined;
+	}
+
+	const assetId = coerceRobloxId(outputs["assetId"]);
+	if (assetId === undefined) {
+		return undefined;
+	}
+
+	return { assetId };
+}
+
+function readPlaceFileInputs(resource: MantleResource): PlaceFileInputsRaw | undefined {
+	const { inputs } = resource;
+	if (!isObjectPayload(inputs)) {
+		return undefined;
+	}
+
+	const { fileHash, filePath } = inputs;
+	if (typeof filePath !== "string" || typeof fileHash !== "string") {
+		return undefined;
+	}
+
+	return { fileHash, filePath };
+}
+
+function readPlaceFileOutputs(resource: MantleResource): PlaceFileOutputsRaw | undefined {
+	const { outputs } = resource;
+	if (!isObjectPayload(outputs)) {
+		return undefined;
+	}
+
+	const { version } = outputs;
+	if (typeof version !== "number") {
+		return undefined;
+	}
+
+	return { version };
+}
+
+function mergeMatchedPair(
+	placeResource: MantleResource,
+	fileResource: MantleResource,
+): PlaceFoldEntry | undefined {
+	const placeOutputs = readPlaceOutputs(placeResource);
+	const fileInputs = readPlaceFileInputs(fileResource);
+	const fileOutputs = readPlaceFileOutputs(fileResource);
+	if (placeOutputs === undefined || fileInputs === undefined || fileOutputs === undefined) {
+		return undefined;
+	}
+
+	return {
+		entry: { filePath: fileInputs.filePath },
+		fileHash: fileInputs.fileHash,
+		outputs: { versionNumber: fileOutputs.version },
+		placeId: placeOutputs.assetId,
+	};
+}
+
+function orphanWarning(kind: string, key: string): MigrationWarning {
+	return {
+		hint: "Verify your Mantle state file: a place_<k> resource must be paired with a matching placeFile_<k> resource.",
+		kind: "ambiguous",
+		mantlePath: `${kind}_${key}`,
+	};
+}

--- a/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
@@ -2,6 +2,9 @@ import { assert, describe, expect, it } from "vitest";
 
 import { migrateMantleState } from "./migrate-mantle-state.ts";
 
+const VALID_HASH = "908498abb7f4fca2b7d2b050bfe7c48c009202fabd85f489b03bb19ac6e0b1d9";
+const PROD_HASH = "804a980a447b7fb258cb2d64b8e3e4bbf323ea76b203510457a14cfd536c1970";
+
 const SINGLE_ENV_YAML = `
 version: "6"
 environments:
@@ -14,6 +17,182 @@ environments:
         experience:
           assetId: 6031475575
           startPlaceId: 17613681043
+      dependencies: []
+`;
+
+const SINGLE_ENV_WITH_PLACE_YAML = `
+version: "6"
+environments:
+  production:
+    - id: experience_singleton
+      inputs:
+        experience:
+          groupId: ~
+      outputs:
+        experience:
+          assetId: 6031475575
+          startPlaceId: 17613681043
+      dependencies: []
+    - id: place_start
+      inputs:
+        place:
+          isStart: true
+      outputs:
+        place:
+          assetId: 17613681043
+      dependencies:
+        - experience_singleton
+    - id: placeFile_start
+      inputs:
+        placeFile:
+          filePath: place.rbxl
+          fileHash: ${VALID_HASH}
+      outputs:
+        placeFile:
+          version: 53
+      dependencies:
+        - place_start
+        - experience_singleton
+`;
+
+const TWO_ENV_PLACE_YAML = `
+version: "6"
+environments:
+  development:
+    - id: experience_singleton
+      inputs:
+        experience:
+          groupId: ~
+      outputs:
+        experience:
+          assetId: 1111111111
+          startPlaceId: 2222222222
+      dependencies: []
+    - id: place_start
+      inputs:
+        place:
+          isStart: true
+      outputs:
+        place:
+          assetId: 2222222222
+      dependencies: []
+    - id: placeFile_start
+      inputs:
+        placeFile:
+          filePath: place.rbxl
+          fileHash: ${VALID_HASH}
+      outputs:
+        placeFile:
+          version: 7
+      dependencies: []
+  production:
+    - id: experience_singleton
+      inputs:
+        experience:
+          groupId: ~
+      outputs:
+        experience:
+          assetId: 6031475575
+          startPlaceId: 17613681043
+      dependencies: []
+    - id: place_start
+      inputs:
+        place:
+          isStart: true
+      outputs:
+        place:
+          assetId: 17613681043
+      dependencies: []
+    - id: placeFile_start
+      inputs:
+        placeFile:
+          filePath: place.rbxlx
+          fileHash: ${PROD_HASH}
+      outputs:
+        placeFile:
+          version: 12
+      dependencies: []
+`;
+
+const TWO_ENV_PLACE_SAME_PATH_YAML = `
+version: "6"
+environments:
+  development:
+    - id: experience_singleton
+      inputs:
+        experience:
+          groupId: ~
+      outputs:
+        experience:
+          assetId: 1111111111
+          startPlaceId: 2222222222
+      dependencies: []
+    - id: place_start
+      inputs:
+        place:
+          isStart: true
+      outputs:
+        place:
+          assetId: 2222222222
+      dependencies: []
+    - id: placeFile_start
+      inputs:
+        placeFile:
+          filePath: place.rbxl
+          fileHash: ${VALID_HASH}
+      outputs:
+        placeFile:
+          version: 7
+      dependencies: []
+  production:
+    - id: experience_singleton
+      inputs:
+        experience:
+          groupId: ~
+      outputs:
+        experience:
+          assetId: 6031475575
+          startPlaceId: 17613681043
+      dependencies: []
+    - id: place_start
+      inputs:
+        place:
+          isStart: true
+      outputs:
+        place:
+          assetId: 17613681043
+      dependencies: []
+    - id: placeFile_start
+      inputs:
+        placeFile:
+          filePath: place.rbxl
+          fileHash: ${VALID_HASH}
+      outputs:
+        placeFile:
+          version: 12
+      dependencies: []
+`;
+
+const ORPHAN_PLACE_YAML = `
+version: "6"
+environments:
+  production:
+    - id: experience_singleton
+      inputs:
+        experience:
+          groupId: ~
+      outputs:
+        experience:
+          assetId: 6031475575
+          startPlaceId: 17613681043
+      dependencies: []
+    - id: place_orphan
+      inputs:
+        place:
+          isStart: false
+      outputs:
+        place:
+          assetId: 9999999999
       dependencies: []
 `;
 
@@ -387,5 +566,155 @@ environments:
 		});
 
 		await expect(promise).rejects.toBe(numeric);
+	});
+
+	it("should fold a matched place pair into the root config places block", async () => {
+		expect.assertions(1);
+
+		const result = await migrateMantleState({
+			outputFormat: "typescript",
+			readFile: fakeReadFile(SINGLE_ENV_WITH_PLACE_YAML),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		expect(result.data.config.places).toStrictEqual({ start: { filePath: "place.rbxl" } });
+	});
+
+	it("should put the placeId on the primary environment overlay", async () => {
+		expect.assertions(1);
+
+		const result = await migrateMantleState({
+			outputFormat: "typescript",
+			readFile: fakeReadFile(SINGLE_ENV_WITH_PLACE_YAML),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		expect(result.data.config.environments["production"]?.places).toStrictEqual({
+			start: { placeId: "17613681043" },
+		});
+	});
+
+	it("should emit a place ResourceCurrentState carrying the Mantle-recorded place version", async () => {
+		expect.assertions(4);
+
+		const result = await migrateMantleState({
+			outputFormat: "typescript",
+			readFile: fakeReadFile(SINGLE_ENV_WITH_PLACE_YAML),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		const state = result.data.statesByEnvironment["production"];
+		assert(state !== undefined);
+
+		const placeResource = state.resources.find((resource) => resource.kind === "place");
+		assert(placeResource?.kind === "place");
+
+		expect(placeResource.key).toBe("start");
+		expect(placeResource.placeId).toBe("17613681043");
+		expect(placeResource.filePath).toBe("place.rbxl");
+		expect(placeResource.outputs.versionNumber).toBe(53);
+	});
+
+	it("should emit an ambiguous warning prefixed by the environment for an orphan place", async () => {
+		expect.assertions(3);
+
+		const result = await migrateMantleState({
+			outputFormat: "typescript",
+			readFile: fakeReadFile(ORPHAN_PLACE_YAML),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		expect(result.data.warnings).toHaveLength(1);
+
+		const [warning] = result.data.warnings;
+		assert(warning?.kind === "ambiguous");
+
+		expect(warning.mantlePath).toBe("production.place_orphan");
+		expect(result.data.summary.ambiguousCount).toBe(1);
+	});
+
+	it("should override filePath on a non-primary overlay when it diverges from the primary", async () => {
+		expect.assertions(3);
+
+		const result = await migrateMantleState({
+			outputFormat: "typescript",
+			primaryEnvironment: "production",
+			readFile: fakeReadFile(TWO_ENV_PLACE_YAML),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		expect(result.data.config.places?.["start"]?.filePath).toBe("place.rbxlx");
+		expect(result.data.config.environments["production"]?.places).toStrictEqual({
+			start: { placeId: "17613681043" },
+		});
+		expect(result.data.config.environments["development"]?.places).toStrictEqual({
+			start: { filePath: "place.rbxl", placeId: "2222222222" },
+		});
+	});
+
+	it("should keep each environment's BedrockState place resource truthful to its own values", async () => {
+		expect.assertions(2);
+
+		const result = await migrateMantleState({
+			outputFormat: "typescript",
+			primaryEnvironment: "production",
+			readFile: fakeReadFile(TWO_ENV_PLACE_YAML),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		const { development, production } = result.data.statesByEnvironment;
+		assert(development !== undefined && production !== undefined);
+
+		const developmentPlace = development.resources.find(
+			(resource) => resource.kind === "place",
+		);
+		const productionPlace = production.resources.find((resource) => resource.kind === "place");
+		assert(developmentPlace?.kind === "place" && productionPlace?.kind === "place");
+
+		expect(developmentPlace.placeId).toBe("2222222222");
+		expect(productionPlace.placeId).toBe("17613681043");
+	});
+
+	it("should omit the root places block when the primary environment has no place resources", async () => {
+		expect.assertions(1);
+
+		const result = await migrateMantleState({
+			outputFormat: "typescript",
+			readFile: fakeReadFile(SINGLE_ENV_YAML),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		expect(result.data.config.places).toBeUndefined();
+	});
+
+	it("should omit filePath from a non-primary overlay when it matches the primary's filePath", async () => {
+		expect.assertions(1);
+
+		const result = await migrateMantleState({
+			outputFormat: "typescript",
+			primaryEnvironment: "production",
+			readFile: fakeReadFile(TWO_ENV_PLACE_SAME_PATH_YAML),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		expect(result.data.config.environments["development"]?.places).toStrictEqual({
+			start: { placeId: "2222222222" },
+		});
 	});
 });

--- a/packages/bedrock/src/shell/migrate-mantle-state.ts
+++ b/packages/bedrock/src/shell/migrate-mantle-state.ts
@@ -4,6 +4,7 @@ import { readFile as nodeReadFile } from "node:fs/promises";
 
 import { buildState } from "../core/migrate/build-state.ts";
 import { type EnvironmentFoldResult, foldEnvironment } from "../core/migrate/fold-environment.ts";
+import type { PlaceFoldEntry } from "../core/migrate/fold-places.ts";
 import type {
 	MigrateError,
 	MigrationReport,
@@ -13,8 +14,15 @@ import { parseState } from "../core/migrate/parse-state.ts";
 import { serializeConfig } from "../core/migrate/serialize-config.ts";
 import { summarizeWarnings } from "../core/migrate/summarize-warnings.ts";
 import type { MantleStateV6 } from "../core/migrate/types.ts";
-import { type Config, validateConfig } from "../core/schema.ts";
+import {
+	type Config,
+	type EnvironmentEntry,
+	type PlaceEntry,
+	validateConfig,
+} from "../core/schema.ts";
 import type { BedrockState } from "../core/state.ts";
+
+type PlaceOverlayEntry = NonNullable<EnvironmentEntry["places"]>[string];
 
 const FILE_MISSING_CODES = new Set(["ENOENT"]);
 
@@ -50,18 +58,28 @@ export interface MigrateMantleStateDeps {
 	readonly stateFilePath: string;
 }
 
+interface EnvironmentOverlayContext {
+	readonly fold: EnvironmentFoldResult;
+	readonly primary: EnvironmentFoldResult | undefined;
+}
+
+interface PlaceOverlayContext {
+	readonly fold: PlaceFoldEntry;
+	readonly primary: PlaceFoldEntry | undefined;
+}
+
 /**
  * Read a Mantle state file and produce a `MigrationReport` containing a
  * bedrock config, per-environment `BedrockState`s, and a structured list
  * of fields that did not migrate verbatim.
  *
- * Skeleton: handles a single-environment, universe-only state. The
- * primary environment auto-picks when only one environment is present;
- * multi-environment inputs without an explicit `primaryEnvironment`
- * return `Err({ kind: "primaryEnvironmentRequired", available })` so the
+ * Skeleton: handles single-environment or multi-environment states with
+ * universe and place resources. The primary environment auto-picks when
+ * only one environment is present; multi-environment inputs without an
+ * explicit `primaryEnvironment` return
+ * `Err({ kind: "primaryEnvironmentRequired", available })` so the
  * migrator never silently picks a winner. Future slices fold game
- * passes, places, social links, and the deferred / blocked warning
- * categories.
+ * passes, social links, and the deferred / blocked warning categories.
  *
  * @param deps - Inputs for the migration.
  * @returns `Ok` with a `MigrationReport` on success, or `Err` with a
@@ -161,16 +179,87 @@ function pickPrimary(
 	return { data: requested, success: true };
 }
 
-function buildConfig(
-	environmentNames: ReadonlyArray<string>,
+function buildRootPlaces(
 	primaryFold: EnvironmentFoldResult | undefined,
-): Config {
-	const environments = Object.fromEntries(environmentNames.map((name) => [name, {}]));
-	if (primaryFold?.universe === undefined) {
-		return { environments };
+): Record<string, PlaceEntry> | undefined {
+	if (primaryFold === undefined || primaryFold.places.size === 0) {
+		return undefined;
 	}
 
-	return { environments, universe: primaryFold.universe.entry };
+	return Object.fromEntries(
+		[...primaryFold.places.entries()].map(([key, fold]) => [key, { ...fold.entry }]),
+	);
+}
+
+function buildPlaceOverlayEntry(context: PlaceOverlayContext): PlaceOverlayEntry {
+	const { fold, primary } = context;
+	if (primary === undefined || primary.entry.filePath === fold.entry.filePath) {
+		return { placeId: fold.placeId };
+	}
+
+	return { filePath: fold.entry.filePath, placeId: fold.placeId };
+}
+
+function buildPlacesOverlay(
+	context: EnvironmentOverlayContext,
+): Record<string, PlaceOverlayEntry> | undefined {
+	const { fold, primary } = context;
+	if (fold.places.size === 0) {
+		return undefined;
+	}
+
+	const overlay: Record<string, PlaceOverlayEntry> = {};
+	for (const [key, foldEntry] of fold.places) {
+		overlay[key] = buildPlaceOverlayEntry({
+			fold: foldEntry,
+			primary: primary?.places.get(key),
+		});
+	}
+
+	return overlay;
+}
+
+function buildEnvironmentEntry(context: EnvironmentOverlayContext): EnvironmentEntry {
+	const places = buildPlacesOverlay(context);
+	if (places === undefined) {
+		return {};
+	}
+
+	return { places };
+}
+
+function buildEnvironmentEntries(
+	folds: ReadonlyMap<string, EnvironmentFoldResult>,
+	primaryName: string,
+): Record<string, EnvironmentEntry> {
+	const primaryFold = folds.get(primaryName);
+	const entries: Record<string, EnvironmentEntry> = {};
+	for (const [name, fold] of folds) {
+		entries[name] = buildEnvironmentEntry({ fold, primary: primaryFold });
+	}
+
+	return entries;
+}
+
+function buildConfig(
+	folds: ReadonlyMap<string, EnvironmentFoldResult>,
+	primaryName: string,
+): Config {
+	const primaryFold = folds.get(primaryName);
+	const environments = buildEnvironmentEntries(folds, primaryName);
+	const places = buildRootPlaces(primaryFold);
+	const universe = primaryFold?.universe?.entry;
+
+	const config: Config = { environments };
+	if (places !== undefined) {
+		config.places = places;
+	}
+
+	if (universe !== undefined) {
+		config.universe = universe;
+	}
+
+	return config;
 }
 
 function buildStatesByEnvironment(
@@ -182,6 +271,18 @@ function buildStatesByEnvironment(
 			buildState(name, folded),
 		]),
 	);
+}
+
+function prefixMantlePath(warning: MigrationWarning, environmentName: string): MigrationWarning {
+	return { ...warning, mantlePath: `${environmentName}.${warning.mantlePath}` };
+}
+
+function collectWarnings(
+	folds: ReadonlyMap<string, EnvironmentFoldResult>,
+): ReadonlyArray<MigrationWarning> {
+	return [...folds.entries()].flatMap(([name, fold]) => {
+		return fold.warnings.map((warning) => prefixMantlePath(warning, name));
+	});
 }
 
 function finalizeReport(
@@ -200,7 +301,7 @@ function finalizeReport(
 		};
 	}
 
-	const warnings: ReadonlyArray<MigrationWarning> = [];
+	const warnings = collectWarnings(folds);
 	return {
 		data: {
 			config: validated.data,
@@ -226,7 +327,7 @@ function assembleReport(
 	const folds: ReadonlyMap<string, EnvironmentFoldResult> = new Map(
 		available.map((name) => [name, foldEnvironment(state.environments[name] ?? [])]),
 	);
-	return finalizeReport(buildConfig(available, folds.get(primaryResult.data)), folds);
+	return finalizeReport(buildConfig(folds, primaryResult.data), folds);
 }
 
 function isFileMissing(err: unknown): boolean {

--- a/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
@@ -1,4 +1,4 @@
-import { loadConfig, migrateMantleState } from "@bedrock/core";
+import { loadConfig, migrateMantleState, selectEnvironment } from "@bedrock/core";
 
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -82,5 +82,54 @@ describe(migrateMantleState, () => {
 		assert(universe?.kind === "universe");
 
 		expect(universe.outputs.rootPlaceId).toBe("17834656300");
+	});
+
+	it("should round-trip the migrated places block through selectEnvironment per environment", async () => {
+		expect.assertions(4);
+
+		const result = await migrateMantleState({
+			outputFormat: "typescript",
+			primaryEnvironment: "production",
+			stateFilePath: REAL_FIXTURE,
+		});
+
+		assert(result.success);
+
+		const production = selectEnvironment(result.data.config, "production");
+		assert(production.success);
+
+		const development = selectEnvironment(result.data.config, "development");
+		assert(development.success);
+
+		expect(production.data.places?.["start"]?.placeId).toBe("17834656300");
+		expect(production.data.places?.["start"]?.filePath).toBe("place.rbxlx");
+		expect(development.data.places?.["start"]?.placeId).toBe("17613681043");
+		expect(development.data.places?.["start"]?.filePath).toBe("place.rbxl");
+	});
+
+	it("should emit one place ResourceCurrentState per environment from the real fixture", async () => {
+		expect.assertions(4);
+
+		const result = await migrateMantleState({
+			outputFormat: "typescript",
+			primaryEnvironment: "production",
+			stateFilePath: REAL_FIXTURE,
+		});
+
+		assert(result.success);
+
+		const { development, production } = result.data.statesByEnvironment;
+		assert(development !== undefined && production !== undefined);
+
+		const developmentPlace = development.resources.find(
+			(resource) => resource.kind === "place",
+		);
+		const productionPlace = production.resources.find((resource) => resource.kind === "place");
+		assert(developmentPlace?.kind === "place" && productionPlace?.kind === "place");
+
+		expect(developmentPlace.placeId).toBe("17613681043");
+		expect(developmentPlace.outputs.versionNumber).toBe(53);
+		expect(productionPlace.placeId).toBe("17834656300");
+		expect(productionPlace.outputs.versionNumber).toBe(12);
 	});
 });


### PR DESCRIPTION
## Summary

Wires `fold-places` into `fold-environment`, `build-state`, and the `migrate-mantle-state` shell so place resources round-trip through the Mantle migrator. Each Mantle environment now produces a `kind: "place"` ResourceCurrentState per matched `place_<k>` + `placeFile_<k>` pair, with `placeId`, `filePath`, `fileHash`, and `outputs.versionNumber`. Orphan place resources surface as `ambiguous` MigrationWarnings with the offending `mantlePath` and a hint to verify the Mantle state file.

Closes #202

## Test plan

- [x] `pnpm --filter=@bedrock/core test` (2033 passed)
- [x] `pnpm lint && pnpm typecheck && pnpm build`
- [x] `pnpm mutate:changed` (49 killed, 0 survived across the 3 changed src files; 100% mutation score)
- [x] Integration fixture round-trips through `loadConfig` and `selectEnvironment` per environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)