### PR TITLE
feat(core): manage display-name, description, server-size on places

### DIFF
--- a/packages/bedrock/src/adapters/place-driver.example.spec.ts
+++ b/packages/bedrock/src/adapters/place-driver.example.spec.ts
@@ -51,6 +51,8 @@ it('Example 2', () => {
   })
   return driver
     .create({
+      description: undefined,
+      displayName: undefined,
       fileHash: asSha256Hex(
         'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
       ),
@@ -58,6 +60,7 @@ it('Example 2', () => {
       key: asResourceKey('start-place'),
       kind: 'place',
       placeId: asRobloxAssetId('4711'),
+      serverSize: undefined,
     })
     .then((result) => {
       expect(result.success).toBeTrue()

--- a/packages/bedrock/src/adapters/place-driver.spec.ts
+++ b/packages/bedrock/src/adapters/place-driver.spec.ts
@@ -1,6 +1,6 @@
 import { ApiError } from "@bedrock/ocale";
 import { PlacesClient } from "@bedrock/ocale/places";
-import { createFakeHttpClient } from "@bedrock/ocale/testing";
+import { createFakeHttpClient, validPlaceBody } from "@bedrock/ocale/testing";
 
 import { placeCurrent, placeDesired } from "#tests/helpers/resources";
 import type { Except } from "type-fest";
@@ -135,5 +135,102 @@ describe(createPlaceDriver, () => {
 
 		expect(result.data.outputs.versionNumber).toBe(7);
 		expect(http.requests).toHaveLength(1);
+	});
+
+	it("should issue a PATCH with displayName only after publish when only displayName is declared", async () => {
+		expect.assertions(4);
+
+		const { driver, http } = makeDriver();
+		http.mockResponse({ body: { versionNumber: 1 }, status: 200 });
+		http.mockResponse({
+			body: validPlaceBody({ displayName: "Lobby" }),
+			status: 200,
+		});
+
+		const result = await driver.create(placeDesired({ displayName: "Lobby" }));
+
+		assert(result.success);
+
+		expect(http.requests).toHaveLength(2);
+		expect(http.requests[1]!.request.method).toBe("PATCH");
+		expect(http.requests[1]!.request.url).toBe(
+			`/cloud/v2/universes/${UNIVERSE_ID}/places/${PLACE_ID}?updateMask=displayName`,
+		);
+		expect(http.requests[1]!.request.body).toStrictEqual({ displayName: "Lobby" });
+	});
+
+	it("should forward every declared metadata field in the PATCH body and updateMask", async () => {
+		expect.assertions(2);
+
+		const { driver, http } = makeDriver();
+		http.mockResponse({ body: { versionNumber: 1 }, status: 200 });
+		http.mockResponse({
+			body: validPlaceBody({
+				description: "Updated body.",
+				displayName: "Lobby v2",
+				serverSize: 25,
+			}),
+			status: 200,
+		});
+
+		assert(driver.update !== undefined);
+
+		await driver.update(
+			placeCurrent(),
+			placeDesired({
+				description: "Updated body.",
+				displayName: "Lobby v2",
+				serverSize: 25,
+			}),
+		);
+
+		expect(http.requests[1]!.request.url).toBe(
+			`/cloud/v2/universes/${UNIVERSE_ID}/places/${PLACE_ID}?updateMask=displayName,description,serverSize`,
+		);
+		expect(http.requests[1]!.request.body).toStrictEqual({
+			description: "Updated body.",
+			displayName: "Lobby v2",
+			serverSize: 25,
+		});
+	});
+
+	it("should still PATCH metadata when only description differs and the file hash is unchanged", async () => {
+		expect.assertions(3);
+
+		const { driver, http } = makeDriver();
+		http.mockResponse({ body: { versionNumber: 2 }, status: 200 });
+		http.mockResponse({
+			body: validPlaceBody({ description: "Updated body." }),
+			status: 200,
+		});
+
+		assert(driver.update !== undefined);
+
+		await driver.update(placeCurrent(), placeDesired({ description: "Updated body." }));
+
+		expect(http.requests).toHaveLength(2);
+		expect(http.requests[1]!.request.url).toBe(
+			`/cloud/v2/universes/${UNIVERSE_ID}/places/${PLACE_ID}?updateMask=description`,
+		);
+		expect(http.requests[1]!.request.body).toStrictEqual({ description: "Updated body." });
+	});
+
+	it("should surface a Result.err when the metadata PATCH fails after a successful publish", async () => {
+		expect.assertions(2);
+
+		const { driver, http } = makeDriver();
+		http.mockResponse({ body: { versionNumber: 1 }, status: 200 });
+		http.mockApiError({
+			code: "INVALID_ARGUMENT",
+			message: "displayName too long",
+			statusCode: 400,
+		});
+
+		const result = await driver.create(placeDesired({ displayName: "X" }));
+
+		assert(!result.success);
+
+		expect(http.requests).toHaveLength(2);
+		expect(result.err.message).toContain("displayName too long");
 	});
 });

--- a/packages/bedrock/src/adapters/place-driver.spec.ts
+++ b/packages/bedrock/src/adapters/place-driver.spec.ts
@@ -33,7 +33,7 @@ function makeDriver(overrides?: Partial<Except<PlaceDriverDeps, "client">>) {
 
 describe(createPlaceDriver, () => {
 	it("should publish an rbxl place and return a PlaceOutputs-shaped current state", async () => {
-		expect.assertions(1);
+		expect.assertions(2);
 
 		const { driver, http } = makeDriver();
 		http.mockResponse({ body: { versionNumber: 3 }, status: 200 });
@@ -47,6 +47,7 @@ describe(createPlaceDriver, () => {
 			...desired,
 			outputs: { versionNumber: 3 },
 		});
+		expect(http.requests).toHaveLength(1);
 	});
 
 	it("should POST to the place publish endpoint with content-type application/octet-stream for rbxl", async () => {

--- a/packages/bedrock/src/adapters/place-driver.ts
+++ b/packages/bedrock/src/adapters/place-driver.ts
@@ -1,7 +1,8 @@
 import { ApiError, type OpenCloudError, type Result } from "@bedrock/ocale";
-import type { PlacesClient } from "@bedrock/ocale/places";
+import type { PlacesClient, UpdatePlaceParameters } from "@bedrock/ocale/places";
 
-import type { PlaceDesiredState, ResourceCurrentState } from "../core/resources.ts";
+import type { PlaceDesiredState, PlaceOutputs, ResourceCurrentState } from "../core/resources.ts";
+import { PLACE_MANAGED_METADATA_FIELDS } from "../core/resources.ts";
 import type { ResourceDriver } from "../ports/resource-driver.ts";
 import type { RobloxAssetId } from "../types/ids.ts";
 
@@ -98,6 +99,8 @@ export interface PlaceDriverDeps {
  *
  * return driver
  *     .create({
+ *         description: undefined,
+ *         displayName: undefined,
  *         fileHash: asSha256Hex(
  *             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
  *         ),
@@ -105,6 +108,7 @@ export interface PlaceDriverDeps {
  *         key: asResourceKey("start-place"),
  *         kind: "place",
  *         placeId: asRobloxAssetId("4711"),
+ *         serverSize: undefined,
  *     })
  *     .then((result) => {
  *         expect(result.success).toBeTrue();
@@ -125,6 +129,25 @@ export function createPlaceDriver(deps: PlaceDriverDeps): ResourceDriver<"place"
 	};
 }
 
+function buildMetadataParameters(
+	universeId: RobloxAssetId,
+	desired: PlaceDesiredState,
+): undefined | UpdatePlaceParameters {
+	const metadata = PLACE_MANAGED_METADATA_FIELDS.reduce<Partial<UpdatePlaceParameters>>(
+		(accumulator, field) => {
+			const value = desired[field];
+			return value === undefined ? accumulator : { ...accumulator, [field]: value };
+		},
+		{},
+	);
+
+	if (Object.keys(metadata).length === 0) {
+		return undefined;
+	}
+
+	return { ...metadata, placeId: desired.placeId, universeId };
+}
+
 function detectFormat(filePath: string): "rbxl" | "rbxlx" | undefined {
 	if (filePath.endsWith(".rbxlx")) {
 		return "rbxlx";
@@ -137,10 +160,10 @@ function detectFormat(filePath: string): "rbxl" | "rbxlx" | undefined {
 	return undefined;
 }
 
-async function publishPlace(
+async function publishVersion(
 	deps: PlaceDriverDeps,
 	desired: PlaceDesiredState,
-): Promise<Result<ResourceCurrentState<"place">, OpenCloudError>> {
+): Promise<Result<PlaceOutputs, OpenCloudError>> {
 	const format = detectFormat(desired.filePath);
 	if (format === undefined) {
 		return {
@@ -153,7 +176,7 @@ async function publishPlace(
 	}
 
 	const body = await deps.readFile(desired.filePath);
-	const result = await deps.client.publish({
+	return deps.client.publish({
 		// Narrows `Uint8Array<ArrayBufferLike>` to `Uint8Array<ArrayBuffer>`
 		// so the ocale wire type rejects SharedArrayBuffer at the call site.
 		body: Uint8Array.from(body),
@@ -161,12 +184,24 @@ async function publishPlace(
 		placeId: desired.placeId,
 		universeId: deps.universeId,
 	});
-	if (!result.success) {
-		return result;
+}
+
+async function publishPlace(
+	deps: PlaceDriverDeps,
+	desired: PlaceDesiredState,
+): Promise<Result<ResourceCurrentState<"place">, OpenCloudError>> {
+	const publishResult = await publishVersion(deps, desired);
+	if (!publishResult.success) {
+		return publishResult;
 	}
 
-	return {
-		data: { ...desired, outputs: { versionNumber: result.data.versionNumber } },
-		success: true,
-	};
+	const metadataParameters = buildMetadataParameters(deps.universeId, desired);
+	if (metadataParameters !== undefined) {
+		const metadataResult = await deps.client.update(metadataParameters);
+		if (!metadataResult.success) {
+			return metadataResult;
+		}
+	}
+
+	return { data: { ...desired, outputs: publishResult.data }, success: true };
 }

--- a/packages/bedrock/src/cli/commands/diff.spec.ts
+++ b/packages/bedrock/src/cli/commands/diff.spec.ts
@@ -51,10 +51,13 @@ function createGamePassOp(key: string): Operation {
 function updatePlaceOp(key: string): Operation {
 	const desired = {
 		key: asResourceKey(key),
+		description: undefined,
+		displayName: undefined,
 		fileHash: SAMPLE_HASH,
 		filePath: "places/start.rbxl",
 		kind: "place" as const,
 		placeId: asResourceKey("4711") as never,
+		serverSize: undefined,
 	};
 	return {
 		key: asResourceKey(key),

--- a/packages/bedrock/src/core/diff.spec.ts
+++ b/packages/bedrock/src/core/diff.spec.ts
@@ -16,6 +16,7 @@ import { diff } from "./diff.ts";
 import { SOCIAL_LINK_FIELDS, UNIVERSE_SINGLETON_KEY } from "./resources.ts";
 import type {
 	GamePassDesiredState,
+	PlaceDesiredState,
 	ResourceCurrentState,
 	UniverseDesiredState,
 } from "./resources.ts";
@@ -300,6 +301,35 @@ describe(diff, () => {
 				{ key: PLACE_KEY, current: currentEntry, desired: desiredEntry, type: "update" },
 			]);
 		});
+
+		it.for<
+			[
+				label: string,
+				desiredOverrides: Partial<PlaceDesiredState>,
+				currentOverrides: Partial<ResourceCurrentState<"place">>,
+			]
+		>([
+			["displayName", { displayName: "Lobby v2" }, { displayName: "Lobby" }],
+			["description", { description: "Updated body." }, { description: "Original body." }],
+			["serverSize", { serverSize: 25 }, { serverSize: 50 }],
+		])(
+			"should emit an update op when the place %s differs",
+			([, desiredOverrides, currentOverrides]) => {
+				expect.assertions(1);
+
+				const desiredEntry = placeDesired(desiredOverrides);
+				const currentEntry = placeCurrent(currentOverrides);
+
+				expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
+					{
+						key: PLACE_KEY,
+						current: currentEntry,
+						desired: desiredEntry,
+						type: "update",
+					},
+				]);
+			},
+		);
 
 		it("should emit a create op when the place is absent from current state", () => {
 			expect.assertions(1);

--- a/packages/bedrock/src/core/flatten.example.spec.ts
+++ b/packages/bedrock/src/core/flatten.example.spec.ts
@@ -27,12 +27,16 @@ it('Example 1', () => {
 
 it('Example 2', () => {
   const input: PlaceDesiredInput = {
+    description: undefined,
+    displayName: 'Start Place',
     filePath: 'places/start.rbxl',
     key: asResourceKey('start-place'),
     kind: 'place',
     placeId: asRobloxAssetId('4711'),
+    serverSize: 50,
   }
   expect(input.kind).toBe('place')
+  expect(input.displayName).toBe('Start Place')
 })
 
 it('Example 3', () => {

--- a/packages/bedrock/src/core/flatten.spec.ts
+++ b/packages/bedrock/src/core/flatten.spec.ts
@@ -96,9 +96,12 @@ describe(flattenConfig, () => {
 		expect(flattenConfig(config)).toStrictEqual([
 			{
 				key: asResourceKey("start-place"),
+				description: undefined,
+				displayName: undefined,
 				filePath: "places/start.rbxl",
 				kind: "place",
 				placeId: asRobloxAssetId("4711"),
+				serverSize: undefined,
 			},
 		]);
 	});

--- a/packages/bedrock/src/core/flatten.ts
+++ b/packages/bedrock/src/core/flatten.ts
@@ -44,9 +44,9 @@ export interface GamePassDesiredInput extends Readonly<GamePassEntry> {
 /**
  * Pre-I/O place input the flattener emits. Carries the resolved place
  * fields (`filePath` from the root, `placeId` from the per-environment
- * overlay) plus the tag discriminator and the `ResourceKey`-branded key,
- * so `buildDesired` can consume a flat tagged list and layer on the
- * SHA-256 file digest.
+ * overlay) plus the optional metadata fields and the tag discriminator and
+ * the `ResourceKey`-branded key, so `buildDesired` can consume a flat
+ * tagged list and layer on the SHA-256 file digest.
  *
  * @example
  *
@@ -54,24 +54,34 @@ export interface GamePassDesiredInput extends Readonly<GamePassEntry> {
  * import { asResourceKey, asRobloxAssetId, type PlaceDesiredInput } from "@bedrock/core";
  *
  * const input: PlaceDesiredInput = {
+ *     description: undefined,
+ *     displayName: "Start Place",
  *     filePath: "places/start.rbxl",
  *     key: asResourceKey("start-place"),
  *     kind: "place",
  *     placeId: asRobloxAssetId("4711"),
+ *     serverSize: 50,
  * };
  *
  * expect(input.kind).toBe("place");
+ * expect(input.displayName).toBe("Start Place");
  * ```
  */
 export interface PlaceDesiredInput {
 	/** User-supplied handle, already validated against the `ResourceKey` brand. */
 	readonly key: ResourceKey;
+	/** User-facing place description; `undefined` leaves the server value untouched. */
+	readonly description: string | undefined;
+	/** User-facing place name; `undefined` leaves the server value untouched. */
+	readonly displayName: string | undefined;
 	/** Path to the `.rbxl` or `.rbxlx` file; read by `buildDesired`. */
 	readonly filePath: string;
 	/** Discriminator tag for the `ResourceDesiredInput` union. */
 	readonly kind: "place";
 	/** Existing Roblox place ID, validated and branded at flatten time. */
 	readonly placeId: RobloxAssetId;
+	/** Maximum players per server; `undefined` leaves the server value untouched. */
+	readonly serverSize: number | undefined;
 }
 
 /**

--- a/packages/bedrock/src/core/kinds/place.spec.ts
+++ b/packages/bedrock/src/core/kinds/place.spec.ts
@@ -21,15 +21,47 @@ describe("placeKind", () => {
 				placeKind.flatten({
 					environments: { production: {} },
 					places: {
+						"start-place": {
+							description: "The lobby place.",
+							displayName: "Start Place",
+							filePath: "places/start.rbxl",
+							placeId: "4711",
+							serverSize: 50,
+						},
+					},
+				}),
+			).toStrictEqual([
+				{
+					key: asResourceKey("start-place"),
+					description: "The lobby place.",
+					displayName: "Start Place",
+					filePath: "places/start.rbxl",
+					kind: "place",
+					placeId: asRobloxAssetId("4711"),
+					serverSize: 50,
+				},
+			]);
+		});
+
+		it("should propagate undefined for metadata fields the user did not declare", () => {
+			expect.assertions(1);
+
+			expect(
+				placeKind.flatten({
+					environments: { production: {} },
+					places: {
 						"start-place": { filePath: "places/start.rbxl", placeId: "4711" },
 					},
 				}),
 			).toStrictEqual([
 				{
 					key: asResourceKey("start-place"),
+					description: undefined,
+					displayName: undefined,
 					filePath: "places/start.rbxl",
 					kind: "place",
 					placeId: asRobloxAssetId("4711"),
+					serverSize: undefined,
 				},
 			]);
 		});
@@ -49,9 +81,12 @@ describe("placeKind", () => {
 			const result = await placeKind.normalize(
 				{
 					key: asResourceKey("start-place"),
+					description: undefined,
+					displayName: undefined,
 					filePath: "places/start.rbxl",
 					kind: "place",
 					placeId: asRobloxAssetId("4711"),
+					serverSize: undefined,
 				},
 				{ readFile: async () => bytes },
 			);
@@ -61,15 +96,42 @@ describe("placeKind", () => {
 			expect(result.data.fileHash).toHaveLength(64);
 		});
 
+		it("should propagate declared metadata fields onto the desired state", async () => {
+			expect.assertions(3);
+
+			const bytes = new Uint8Array([0x3c, 0x72, 0x6f, 0x62]);
+			const result = await placeKind.normalize(
+				{
+					key: asResourceKey("start-place"),
+					description: "Lobby description.",
+					displayName: "Start Place",
+					filePath: "places/start.rbxl",
+					kind: "place",
+					placeId: asRobloxAssetId("4711"),
+					serverSize: 50,
+				},
+				{ readFile: async () => bytes },
+			);
+
+			assert(result.success);
+
+			expect(result.data.displayName).toBe("Start Place");
+			expect(result.data.description).toBe("Lobby description.");
+			expect(result.data.serverSize).toBe(50);
+		});
+
 		it("should surface a fileReadFailed error when readFile rejects", async () => {
 			expect.assertions(1);
 
 			const result = await placeKind.normalize(
 				{
 					key: asResourceKey("start-place"),
+					description: undefined,
+					displayName: undefined,
 					filePath: "places/start.rbxl",
 					kind: "place",
 					placeId: asRobloxAssetId("4711"),
+					serverSize: undefined,
 				},
 				{
 					readFile: async () => {
@@ -105,7 +167,67 @@ describe("placeKind", () => {
 
 			expect(placeKind.fieldsEqual(placeDesired(), placeCurrent(overrides))).toBeFalse();
 		});
+
+		it.for<
+			[
+				label: string,
+				desiredOverrides: Partial<PlaceDesiredStateOnly>,
+				currentOverrides: Partial<ResourceCurrentStatePlace>,
+			]
+		>([
+			["displayName", { displayName: "New Name" }, { displayName: "Old Name" }],
+			["description", { description: "New body." }, { description: "Old body." }],
+			["serverSize", { serverSize: 25 }, { serverSize: 50 }],
+		])(
+			"should return false when desired declares a different %s than current",
+			([, desiredOverrides, currentOverrides]) => {
+				expect.assertions(1);
+
+				expect(
+					placeKind.fieldsEqual(
+						placeDesired(desiredOverrides),
+						placeCurrent(currentOverrides),
+					),
+				).toBeFalse();
+			},
+		);
+
+		it.for<[label: string, currentOverrides: Partial<ResourceCurrentStatePlace>]>([
+			["displayName", { displayName: "Server Owned" }],
+			["description", { description: "Server owned body." }],
+			["serverSize", { serverSize: 100 }],
+		])(
+			"should return true when desired leaves %s unmanaged but current carries a value",
+			([, currentOverrides]) => {
+				expect.assertions(1);
+
+				expect(
+					placeKind.fieldsEqual(placeDesired(), placeCurrent(currentOverrides)),
+				).toBeTrue();
+			},
+		);
+
+		it.for<
+			[
+				label: string,
+				overrides: Partial<PlaceDesiredStateOnly> & Partial<ResourceCurrentStatePlace>,
+			]
+		>([
+			["displayName", { displayName: "Lobby" }],
+			["description", { description: "Lobby body." }],
+			["serverSize", { serverSize: 50 }],
+		])(
+			"should return true when desired declares %s and current carries the same value",
+			([, overrides]) => {
+				expect.assertions(1);
+
+				expect(
+					placeKind.fieldsEqual(placeDesired(overrides), placeCurrent(overrides)),
+				).toBeTrue();
+			},
+		);
 	});
 });
 
 type ResourceCurrentStatePlace = Parameters<typeof placeKind.fieldsEqual>[1];
+type PlaceDesiredStateOnly = Parameters<typeof placeKind.fieldsEqual>[0];

--- a/packages/bedrock/src/core/kinds/place.ts
+++ b/packages/bedrock/src/core/kinds/place.ts
@@ -4,24 +4,32 @@ import { type } from "arktype";
 
 import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../../types/ids.ts";
 import type { PlaceDesiredInput } from "../flatten.ts";
+import { PLACE_MANAGED_METADATA_FIELDS } from "../resources.ts";
 import type { PlaceDesiredState, ResourceCurrentState } from "../resources.ts";
+import { OPTIONAL_POSITIVE_INTEGER } from "../schema.ts";
 import type { ResolvedConfig } from "../schema.ts";
 import { sha256Hex } from "./hash.ts";
 import type { BuildDesiredError, KindIo, ResourceKindModule } from "./module.ts";
 import { readBytes } from "./read-bytes.ts";
 
 const entrySchema = type({
-	filePath: "string",
-	placeId: "string.digits",
+	"description?": "string | undefined",
+	"displayName?": "string | undefined",
+	"filePath": "string",
+	"placeId": "string.digits",
+	"serverSize?": OPTIONAL_POSITIVE_INTEGER,
 }).onUndeclaredKey("reject");
 
 function flatten(config: ResolvedConfig): ReadonlyArray<PlaceDesiredInput> {
 	return Object.entries(config.places ?? {}).map<PlaceDesiredInput>(([key, entry]) => {
 		return {
 			key: asResourceKey(key),
+			description: entry.description,
+			displayName: entry.displayName,
 			filePath: entry.filePath,
 			kind: "place",
 			placeId: asRobloxAssetId(entry.placeId),
+			serverSize: entry.serverSize,
 		};
 	});
 }
@@ -38,21 +46,31 @@ async function normalize(
 	return {
 		data: {
 			key: input.key,
+			description: input.description,
+			displayName: input.displayName,
 			fileHash: asSha256Hex(await sha256Hex(read.data)),
 			filePath: input.filePath,
 			kind: "place",
 			placeId: input.placeId,
+			serverSize: input.serverSize,
 		},
 		success: true,
 	};
 }
 
 function fieldsEqual(desired: PlaceDesiredState, current: ResourceCurrentState<"place">): boolean {
-	return (
-		desired.fileHash === current.fileHash &&
-		desired.filePath === current.filePath &&
-		desired.placeId === current.placeId
-	);
+	if (
+		desired.fileHash !== current.fileHash ||
+		desired.filePath !== current.filePath ||
+		desired.placeId !== current.placeId
+	) {
+		return false;
+	}
+
+	return PLACE_MANAGED_METADATA_FIELDS.every((field) => {
+		const desiredValue = desired[field];
+		return desiredValue === undefined || desiredValue === current[field];
+	});
 }
 
 /**

--- a/packages/bedrock/src/core/migrate/build-state.ts
+++ b/packages/bedrock/src/core/migrate/build-state.ts
@@ -93,11 +93,14 @@ function universeResource(
 function placeResource(key: string, fold: PlaceFoldEntry): ResourceCurrentState<"place"> {
 	return {
 		key: asResourceKey(key),
+		description: undefined,
+		displayName: undefined,
 		fileHash: fold.fileHash,
 		filePath: fold.entry.filePath,
 		kind: "place",
 		outputs: fold.outputs,
 		placeId: asRobloxAssetId(fold.placeId),
+		serverSize: undefined,
 	};
 }
 

--- a/packages/bedrock/src/core/resources.example.spec.ts
+++ b/packages/bedrock/src/core/resources.example.spec.ts
@@ -31,6 +31,8 @@ it('Example 1', () => {
 
 it('Example 2', () => {
   const place: PlaceDesiredState = {
+    description: undefined,
+    displayName: 'Start Place',
     fileHash: asSha256Hex(
       'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
     ),
@@ -38,9 +40,12 @@ it('Example 2', () => {
     key: asResourceKey('start-place'),
     kind: 'place',
     placeId: asRobloxAssetId('4711'),
+    serverSize: 50,
   }
   expect(place.kind).toBe('place')
-  expect(place.placeId).toBe('4711')
+  expect(place.displayName).toBe('Start Place')
+  expect(place.description).toBeUndefined()
+  expect(place.serverSize).toBe(50)
 })
 
 it('Example 3', () => {

--- a/packages/bedrock/src/core/resources.spec-d.ts
+++ b/packages/bedrock/src/core/resources.spec-d.ts
@@ -22,10 +22,13 @@ import type { UniverseVisibility } from "./schema.ts";
 
 interface ExpectedPlaceDesiredState {
 	readonly key: ResourceKey;
+	readonly description: string | undefined;
+	readonly displayName: string | undefined;
 	readonly fileHash: Sha256Hex;
 	readonly filePath: string;
 	readonly kind: "place";
 	readonly placeId: RobloxAssetId;
+	readonly serverSize: number | undefined;
 }
 
 interface ExpectedPlaceOutputs {

--- a/packages/bedrock/src/core/resources.ts
+++ b/packages/bedrock/src/core/resources.ts
@@ -69,7 +69,9 @@ export interface GamePassDesiredState {
  * places; the user supplies the existing place ID per entry. `filePath` and
  * `fileHash` describe the local file the driver publishes; `buildDesired`
  * computes `fileHash` from the file bytes so `diff` can detect drift without
- * re-uploading unchanged content.
+ * re-uploading unchanged content. `displayName`, `description`, and
+ * `serverSize` are optional metadata fields routed through
+ * `PlacesClient.update`; `undefined` leaves the server value untouched.
  *
  * @example
  *
@@ -82,6 +84,8 @@ export interface GamePassDesiredState {
  * } from "@bedrock/core";
  *
  * const place: PlaceDesiredState = {
+ *     description: undefined,
+ *     displayName: "Start Place",
  *     fileHash: asSha256Hex(
  *         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
  *     ),
@@ -89,15 +93,22 @@ export interface GamePassDesiredState {
  *     key: asResourceKey("start-place"),
  *     kind: "place",
  *     placeId: asRobloxAssetId("4711"),
+ *     serverSize: 50,
  * };
  *
  * expect(place.kind).toBe("place");
- * expect(place.placeId).toBe("4711");
+ * expect(place.displayName).toBe("Start Place");
+ * expect(place.description).toBeUndefined();
+ * expect(place.serverSize).toBe(50);
  * ```
  */
 export interface PlaceDesiredState {
 	/** User-supplied key; stable across deploys; used to correlate desired with current. */
 	readonly key: ResourceKey;
+	/** User-facing place description; `undefined` leaves the server value untouched. */
+	readonly description: string | undefined;
+	/** User-facing place name; `undefined` leaves the server value untouched. */
+	readonly displayName: string | undefined;
 	/** SHA-256 hex digest of the place file, computed by `buildDesired` in shell. */
 	readonly fileHash: Sha256Hex;
 	/** Path to the `.rbxl` or `.rbxlx` file on disk, relative to the config file. */
@@ -106,7 +117,21 @@ export interface PlaceDesiredState {
 	readonly kind: "place";
 	/** Existing Roblox place ID; Open Cloud cannot create places, so this is an input, not an output. */
 	readonly placeId: RobloxAssetId;
+	/** Maximum players per server; positive integer. `undefined` leaves the server value untouched. */
+	readonly serverSize: number | undefined;
 }
+
+/**
+ * Ordered list of optional metadata fields the driver routes through
+ * `PlacesClient.update`. Iterated by `placeKind.fieldsEqual` and the place
+ * driver's parameter translator so drift detection and the constructed
+ * `updateMask` cannot drift apart.
+ */
+export const PLACE_MANAGED_METADATA_FIELDS = [
+	"displayName",
+	"description",
+	"serverSize",
+] as const satisfies ReadonlyArray<keyof PlaceDesiredState>;
 
 /**
  * Roblox-returned value produced by publishing a place version. The publish

--- a/packages/bedrock/src/core/schema.spec-d.ts
+++ b/packages/bedrock/src/core/schema.spec-d.ts
@@ -94,13 +94,20 @@ describe("EnvironmentEntry overlay derivation", () => {
 });
 
 describe("PlaceEntry / ResolvedPlaceEntry split", () => {
-	it("should expose only filePath at the root PlaceEntry level", () => {
-		expectTypeOf<keyof PlaceEntry>().toEqualTypeOf<"filePath">();
+	it("should expose filePath plus the optional metadata fields at the root PlaceEntry level", () => {
+		expectTypeOf<keyof PlaceEntry>().toEqualTypeOf<
+			"description" | "displayName" | "filePath" | "serverSize"
+		>();
 		expectTypeOf<PlaceEntry["filePath"]>().toEqualTypeOf<string>();
+		expectTypeOf<PlaceEntry["displayName"]>().toEqualTypeOf<string | undefined>();
+		expectTypeOf<PlaceEntry["description"]>().toEqualTypeOf<string | undefined>();
+		expectTypeOf<PlaceEntry["serverSize"]>().toEqualTypeOf<number | undefined>();
 	});
 
-	it("should expose filePath and placeId on ResolvedPlaceEntry as the post-merge invariant", () => {
-		expectTypeOf<keyof ResolvedPlaceEntry>().toEqualTypeOf<"filePath" | "placeId">();
+	it("should add placeId on ResolvedPlaceEntry as the post-merge invariant alongside the metadata fields", () => {
+		expectTypeOf<keyof ResolvedPlaceEntry>().toEqualTypeOf<
+			"description" | "displayName" | "filePath" | "placeId" | "serverSize"
+		>();
 		expectTypeOf<ResolvedPlaceEntry["filePath"]>().toEqualTypeOf<string>();
 		expectTypeOf<ResolvedPlaceEntry["placeId"]>().toEqualTypeOf<string>();
 	});

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -457,6 +457,117 @@ describe(validateConfig, () => {
 		]);
 	});
 
+	it("should accept a root places entry that declares displayName, description, and serverSize", () => {
+		expect.assertions(3);
+
+		const result = validateConfig(
+			{
+				environments: MinEnvironments,
+				places: {
+					"start-place": {
+						description: "The lobby place.",
+						displayName: "Start Place",
+						filePath: "places/start.rbxl",
+						serverSize: 50,
+					},
+				},
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.places!["start-place"]!.displayName).toBe("Start Place");
+		expect(result.data.places!["start-place"]!.description).toBe("The lobby place.");
+		expect(result.data.places!["start-place"]!.serverSize).toBe(50);
+	});
+
+	it.for([
+		["a non-string displayName", { displayName: 42 }, "displayName"],
+		["a non-string description", { description: 99 }, "description"],
+		["a zero serverSize", { serverSize: 0 }, "serverSize"],
+		["a negative serverSize", { serverSize: -10 }, "serverSize"],
+		["a non-integer serverSize", { serverSize: 12.5 }, "serverSize"],
+	] as const)("should reject %s on a root place entry", ([, override, expectedField]) => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: MinEnvironments,
+				places: {
+					"start-place": { filePath: "places/start.rbxl", ...override },
+				},
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual(["places", "start-place", expectedField]);
+	});
+
+	it("should accept a per-environment places overlay that declares displayName, description, and serverSize", () => {
+		expect.assertions(3);
+
+		const result = validateConfig(
+			{
+				environments: {
+					staging: {
+						places: {
+							"start-place": {
+								description: "Staging lobby.",
+								displayName: "Staging Start",
+								placeId: "5555",
+								serverSize: 12,
+							},
+						},
+					},
+				},
+				places: { "start-place": { filePath: "places/start.rbxl" } },
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		const overlay = result.data.environments["staging"]?.places?.["start-place"];
+
+		expect(overlay?.displayName).toBe("Staging Start");
+		expect(overlay?.description).toBe("Staging lobby.");
+		expect(overlay?.serverSize).toBe(12);
+	});
+
+	it("should reject a non-positive serverSize on a per-environment places overlay", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: {
+					staging: {
+						places: {
+							"start-place": { placeId: "5555", serverSize: 0 },
+						},
+					},
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual([
+			"environments",
+			"staging",
+			"places",
+			"start-place",
+			"serverSize",
+		]);
+	});
+
 	it("should reject a places key that does not match the ResourceKey pattern", () => {
 		expect.assertions(1);
 

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -44,32 +44,45 @@ export interface DeveloperProductEntry {
 }
 
 /**
- * Body of a single entry under the root `places` collection. Carries only
- * the file-path that environments share. The Roblox `placeId` is
- * environment-specific and lives on each per-environment overlay so the
- * same `.rbxl` file can publish to different places across staging,
- * production, and so on.
+ * Body of a single entry under the root `places` collection. Carries the
+ * file-path environments share plus the optional Open-Cloud-supported
+ * metadata fields. The Roblox `placeId` is environment-specific and lives
+ * on each per-environment overlay so the same `.rbxl` file can publish to
+ * different places across staging, production, and so on.
  */
 export interface PlaceEntry {
+	/** User-facing description shown on the place's detail page. */
+	description?: string | undefined;
+	/** User-facing place name shown on the Roblox storefront. */
+	displayName?: string | undefined;
 	/** Path to the `.rbxl` or `.rbxlx` file; handed to `readFile` verbatim by `buildDesired`. */
 	filePath: string;
+	/** Maximum players per server; positive integer. */
+	serverSize?: number | undefined;
 }
 
 /**
  * Body of a places entry after `selectEnvironment` has merged the
- * matching per-environment overlay onto the root entry. Both fields are
- * present: `filePath` flows from the root (or an overlay override) and
- * `placeId` is supplied by the per-environment overlay.
+ * matching per-environment overlay onto the root entry. `filePath` flows
+ * from the root (or an overlay override), `placeId` is supplied by the
+ * per-environment overlay, and the optional metadata fields fall through
+ * from the root unless overridden per-environment.
  *
  * `placeId` is user-supplied because Open Cloud cannot mint places; the
  * place must already exist in Roblox before Bedrock can publish versions
  * to it.
  */
 export interface ResolvedPlaceEntry {
+	/** User-facing description shown on the place's detail page. */
+	description?: string | undefined;
+	/** User-facing place name shown on the Roblox storefront. */
+	displayName?: string | undefined;
 	/** Path to the `.rbxl` or `.rbxlx` file; handed to `readFile` verbatim by `buildDesired`. */
 	filePath: string;
 	/** Existing Roblox place ID. */
 	placeId: string;
+	/** Maximum players per server; positive integer. */
+	serverSize?: number | undefined;
 }
 
 /**
@@ -391,6 +404,15 @@ export function isGistStateConfig(config: StateConfig): config is GistStateConfi
 
 const OPTIONAL_BOOLEAN = "boolean | undefined";
 
+const OPTIONAL_STRING = "string | undefined";
+
+/**
+ * Shared arktype constraint for any optional positive-integer field.
+ * Reused by per-kind entry schemas so positive-integer fields validate
+ * identically.
+ */
+export const OPTIONAL_POSITIVE_INTEGER = "(number.integer >= 1) | undefined";
+
 /**
  * Shared arktype constraint for any optional Robux-price field. The schema
  * rejects negatives, fractional values, `NaN`, and `Infinity` at config
@@ -432,7 +454,10 @@ const productsCollection = type({
 const ROBLOX_ID_DIGITS = "string.digits";
 
 const placeEntry = type({
-	filePath: "string",
+	"description?": OPTIONAL_STRING,
+	"displayName?": OPTIONAL_STRING,
+	"filePath": "string",
+	"serverSize?": OPTIONAL_POSITIVE_INTEGER,
 }).onUndeclaredKey("reject");
 
 const placesCollection = type({
@@ -450,7 +475,7 @@ const universeEntry = type({
 	"consoleEnabled?": OPTIONAL_BOOLEAN,
 	"desktopEnabled?": OPTIONAL_BOOLEAN,
 	"discordSocialLink?": socialLinkOrUndefined,
-	"displayName?": "string | undefined",
+	"displayName?": OPTIONAL_STRING,
 	"facebookSocialLink?": socialLinkOrUndefined,
 	"guildedSocialLink?": socialLinkOrUndefined,
 	"mobileEnabled?": OPTIONAL_BOOLEAN,
@@ -497,8 +522,11 @@ const productsOverlayCollection = type({
 }).onUndeclaredKey("reject");
 
 const placeOverlay = type({
+	"description?": OPTIONAL_STRING,
+	"displayName?": OPTIONAL_STRING,
 	"filePath?": "string",
 	"placeId": ROBLOX_ID_DIGITS,
+	"serverSize?": OPTIONAL_POSITIVE_INTEGER,
 }).onUndeclaredKey("reject");
 
 const placesOverlayCollection = type({

--- a/packages/bedrock/src/index.spec-d.ts
+++ b/packages/bedrock/src/index.spec-d.ts
@@ -252,16 +252,20 @@ describe(loadConfig, () => {
 });
 
 describe("PlaceEntry", () => {
-	it("should expose only filePath at the root entry level", () => {
-		expectTypeOf<keyof PlaceEntry>().toEqualTypeOf<"filePath">();
+	it("should expose filePath plus the optional metadata fields at the root entry level", () => {
+		expectTypeOf<keyof PlaceEntry>().toEqualTypeOf<
+			"description" | "displayName" | "filePath" | "serverSize"
+		>();
 		expectTypeOf<PlaceEntry["filePath"]>().toEqualTypeOf<string>();
+		expectTypeOf<PlaceEntry["serverSize"]>().toEqualTypeOf<number | undefined>();
 	});
 });
 
 describe("ResolvedPlaceEntry", () => {
-	it("should expose filePath and placeId as the post-merge invariant", () => {
-		expectTypeOf<keyof ResolvedPlaceEntry>().toEqualTypeOf<"filePath" | "placeId">();
-		expectTypeOf<ResolvedPlaceEntry["filePath"]>().toEqualTypeOf<string>();
+	it("should add placeId as the post-merge invariant alongside the optional metadata fields", () => {
+		expectTypeOf<keyof ResolvedPlaceEntry>().toEqualTypeOf<
+			"description" | "displayName" | "filePath" | "placeId" | "serverSize"
+		>();
 		expectTypeOf<ResolvedPlaceEntry["placeId"]>().toEqualTypeOf<string>();
 	});
 });

--- a/packages/bedrock/src/shell/build-desired.spec.ts
+++ b/packages/bedrock/src/shell/build-desired.spec.ts
@@ -132,9 +132,12 @@ describe(buildDesired, () => {
 			[
 				{
 					key: asResourceKey("start-place"),
+					description: undefined,
+					displayName: undefined,
 					filePath: "places/start.rbxl",
 					kind: "place",
 					placeId: asRobloxAssetId("4711"),
+					serverSize: undefined,
 				},
 			],
 			readFile,
@@ -144,10 +147,13 @@ describe(buildDesired, () => {
 			data: [
 				{
 					key: "start-place",
+					description: undefined,
+					displayName: undefined,
 					fileHash: "039058c6f2c0cb492c533b0a4d14ef77cc0f78abccced5287d84a1a2011cfb81",
 					filePath: "places/start.rbxl",
 					kind: "place",
 					placeId: "4711",
+					serverSize: undefined,
 				},
 			],
 			success: true,
@@ -165,9 +171,12 @@ describe(buildDesired, () => {
 			[
 				{
 					key: asResourceKey("start-place"),
+					description: undefined,
+					displayName: undefined,
 					filePath: "places/start.rbxl",
 					kind: "place",
 					placeId: asRobloxAssetId("4711"),
+					serverSize: undefined,
 				},
 			],
 			readFile,
@@ -196,9 +205,12 @@ describe(buildDesired, () => {
 				gamePassInput(),
 				{
 					key: asResourceKey("start-place"),
+					description: undefined,
+					displayName: undefined,
 					filePath: "places/start.rbxl",
 					kind: "place",
 					placeId: asRobloxAssetId("4711"),
+					serverSize: undefined,
 				},
 			],
 			readFile,

--- a/packages/bedrock/tests/helpers/resources.ts
+++ b/packages/bedrock/tests/helpers/resources.ts
@@ -110,10 +110,13 @@ export function gamePassCurrent(
 export function placeDesired(overrides?: Partial<PlaceDesiredState>): PlaceDesiredState {
 	return {
 		key: asResourceKey("start-place"),
+		description: undefined,
+		displayName: undefined,
 		fileHash: PLACE_HASH,
 		filePath: "places/start.rbxl",
 		kind: "place",
 		placeId: asRobloxAssetId("4711"),
+		serverSize: undefined,
 		...overrides,
 	};
 }

--- a/packages/bedrock/tests/integration/fixtures/places-metadata/bedrock.config.ts
+++ b/packages/bedrock/tests/integration/fixtures/places-metadata/bedrock.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "@bedrock/core";
+
+export default defineConfig({
+	environments: {
+		production: {
+			places: { "start-place": { placeId: "4711" } },
+		},
+	},
+	places: {
+		"start-place": {
+			description: "The lobby place.",
+			displayName: "Start Place",
+			filePath: "places/start.rbxl",
+			serverSize: 50,
+		},
+	},
+});

--- a/packages/bedrock/tests/integration/places.spec.ts
+++ b/packages/bedrock/tests/integration/places.spec.ts
@@ -11,7 +11,7 @@ import {
 	selectEnvironment,
 } from "@bedrock/core";
 import { PlacesClient } from "@bedrock/ocale/places";
-import { createFakeHttpClient } from "@bedrock/ocale/testing";
+import { createFakeHttpClient, validPlaceBody } from "@bedrock/ocale/testing";
 
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,6 +19,7 @@ import { assert, describe, expect, it } from "vitest";
 
 const FIXTURES_ROOT = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
 const PLACES_FIXTURE_DIR = join(FIXTURES_ROOT, "places");
+const PLACES_METADATA_FIXTURE_DIR = join(FIXTURES_ROOT, "places-metadata");
 const UNIVERSE_ID = asRobloxAssetId("1234567890");
 const PLACE_ID = asRobloxAssetId("4711");
 const RBXL_BYTES = new Uint8Array([
@@ -95,5 +96,61 @@ describe("places pipeline end-to-end", () => {
 		expect(first.request.url).toBe(
 			`/universes/v1/${UNIVERSE_ID}/places/${PLACE_ID}/versions?versionType=Published`,
 		);
+	});
+
+	it("should issue a metadata PATCH after publish when displayName, description, and serverSize are declared", async () => {
+		expect.assertions(4);
+
+		const loaded = await loadConfig({ cwd: PLACES_METADATA_FIXTURE_DIR });
+		assert(loaded.success);
+
+		const resolved = selectEnvironment(loaded.data, "production");
+		assert(resolved.success);
+
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readPlaceFile);
+		assert(desiredResult.success);
+
+		const httpClient = createFakeHttpClient()
+			.mockResponse({ body: { versionNumber: 1 }, status: 200 })
+			.mockResponse({
+				body: validPlaceBody({
+					description: "The lobby place.",
+					displayName: "Start Place",
+					serverSize: 50,
+				}),
+				status: 200,
+			});
+
+		const registry: DriverRegistry = {
+			developerProduct: DEVELOPER_PRODUCT_TRAP,
+			gamePass: GAME_PASS_TRAP,
+			place: createPlaceDriver({
+				client: new PlacesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: async () => {},
+				}),
+				readFile: readPlaceFile,
+				universeId: UNIVERSE_ID,
+			}),
+			universe: UNIVERSE_TRAP,
+		};
+
+		const applyResult = await applyOps(diff(desiredResult.data, []), registry);
+
+		expect(applyResult.success).toBeTrue();
+		expect(httpClient.requests).toHaveLength(2);
+
+		const [, second] = httpClient.requests;
+		assert(second);
+
+		expect(second.request.url).toBe(
+			`/cloud/v2/universes/${UNIVERSE_ID}/places/${PLACE_ID}?updateMask=displayName,description,serverSize`,
+		);
+		expect(second.request.body).toStrictEqual({
+			description: "The lobby place.",
+			displayName: "Start Place",
+			serverSize: 50,
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Place entries can now declare `displayName`, `description`, and `serverSize`. The diff emits an update op when any of these fields drifts from current state, and the place driver follows a successful version publish with a PATCH against `/cloud/v2/universes/{universe_id}/places/{place_id}`, sending only the fields the user declared.

`undefined` (or omitted) means "unmanaged" — the field is excluded from the `updateMask` and the server value stays untouched, mirroring `UniverseDesiredState.displayName`.

`allowCopying` and `serverFill` stay out of scope per ADR-007 (cookie-only endpoints).

Closes #272.

## Test plan

- [x] Unit tests for `placeKind.flatten`, `normalize`, `fieldsEqual` covering the three new fields (declared, undeclared, drift, equal-when-declared).
- [x] Diff tests confirm an `update` op fires when any field drifts.
- [x] Place driver unit tests confirm: no PATCH when no metadata declared; PATCH with correct `updateMask` and body for partial and full declarations; `Result.err` propagation when the PATCH fails.
- [x] Integration test in `places.spec.ts` runs the full `loadConfig` to `applyOps` pipeline against a fixture declaring all three fields, asserting both the publish and PATCH requests.
- [x] Schema validation tests accept declared fields on root and per-environment overlays, reject non-string display-name/description, and reject zero/negative/non-integer `serverSize`.
- [x] Full `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`, `pnpm mutate:changed` (100% on `place.ts` and `place-driver.ts`).

## Notes

The driver always republishes the file before issuing the metadata PATCH, even when only metadata changed and `fileHash` matches. Skipping the republish on metadata-only updates is a deferred optimization; the existing `update` driver also republishes unconditionally and the `update` op carries no per-field information for the driver to discriminate on.

The new fields could overlap with `universe.displayName` for the root place (the universe driver writes `displayName` through `places.update`). Cross-validation between the two layers is a follow-up; this PR does not change universe behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)