### PR TITLE
feat(core): migrate mantle universe interpretive folds

### DIFF
--- a/packages/bedrock/src/core/migrate/fold-display-name.ts
+++ b/packages/bedrock/src/core/migrate/fold-display-name.ts
@@ -1,6 +1,9 @@
 import {
+	ambiguousWarning,
+	blockedWarning,
 	EMPTY_FRAGMENT,
 	type FoldFragment,
+	interpretiveWarning,
 	isObjectPayload,
 	mergeFragment,
 } from "./fold-universe-shared.ts";
@@ -39,11 +42,10 @@ function blockedFragment(key: string): FoldFragment {
 	return {
 		entryFragment: {},
 		warnings: [
-			{
-				kind: "blocked",
-				mantlePath: `${PLACE_CONFIGURATION_KIND}_${key}.name`,
-				reason: "non-start placeConfiguration.name has no Open Cloud equivalent",
-			},
+			blockedWarning(
+				`${PLACE_CONFIGURATION_KIND}_${key}.name`,
+				"non-start placeConfiguration.name has no Open Cloud equivalent",
+			),
 		],
 	};
 }
@@ -52,12 +54,11 @@ function interpretiveFragment(named: NamedPlaceConfig): FoldFragment {
 	return {
 		entryFragment: { displayName: named.name },
 		warnings: [
-			{
+			interpretiveWarning({
 				bedrockPath: "universe.displayName",
-				kind: "interpretive",
 				mantlePath: `${PLACE_CONFIGURATION_KIND}_${named.key}.name`,
 				rule: "start-place-name-to-display-name",
-			},
+			}),
 		],
 	};
 }
@@ -65,11 +66,10 @@ function interpretiveFragment(named: NamedPlaceConfig): FoldFragment {
 const AMBIGUOUS_MULTIPLE_STARTS: FoldFragment = {
 	entryFragment: {},
 	warnings: [
-		{
-			hint: "Multiple place_<k> resources have inputs.isStart=true; pick one as the canonical start place.",
-			kind: "ambiguous",
-			mantlePath: "place_*.isStart",
-		},
+		ambiguousWarning(
+			"place_*.isStart",
+			"Multiple place_<k> resources have inputs.isStart=true; pick one as the canonical start place.",
+		),
 	],
 };
 

--- a/packages/bedrock/src/core/migrate/fold-display-name.ts
+++ b/packages/bedrock/src/core/migrate/fold-display-name.ts
@@ -1,0 +1,124 @@
+import {
+	EMPTY_FRAGMENT,
+	type FoldFragment,
+	isObjectPayload,
+	mergeFragment,
+} from "./fold-universe-shared.ts";
+import type { MantleResource } from "./types.ts";
+
+const PLACE_KIND = "place";
+const PLACE_CONFIGURATION_KIND = "placeConfiguration";
+
+interface NamedPlaceConfig {
+	readonly key: string;
+	readonly name: string;
+}
+
+function readPlaceConfigName(resource: MantleResource): NamedPlaceConfig | undefined {
+	if (!isObjectPayload(resource.inputs)) {
+		return undefined;
+	}
+
+	const { name } = resource.inputs;
+	return typeof name === "string" ? { key: resource.key, name } : undefined;
+}
+
+function isStartPlace(resource: MantleResource): boolean {
+	if (resource.kind !== PLACE_KIND || !isObjectPayload(resource.inputs)) {
+		return false;
+	}
+
+	return resource.inputs["isStart"] === true;
+}
+
+function startKeys(resources: ReadonlyArray<MantleResource>): ReadonlyArray<string> {
+	return resources.filter(isStartPlace).map((resource) => resource.key);
+}
+
+function blockedFragment(key: string): FoldFragment {
+	return {
+		entryFragment: {},
+		warnings: [
+			{
+				kind: "blocked",
+				mantlePath: `${PLACE_CONFIGURATION_KIND}_${key}.name`,
+				reason: "non-start placeConfiguration.name has no Open Cloud equivalent",
+			},
+		],
+	};
+}
+
+function interpretiveFragment(named: NamedPlaceConfig): FoldFragment {
+	return {
+		entryFragment: { displayName: named.name },
+		warnings: [
+			{
+				bedrockPath: "universe.displayName",
+				kind: "interpretive",
+				mantlePath: `${PLACE_CONFIGURATION_KIND}_${named.key}.name`,
+				rule: "start-place-name-to-display-name",
+			},
+		],
+	};
+}
+
+const AMBIGUOUS_MULTIPLE_STARTS: FoldFragment = {
+	entryFragment: {},
+	warnings: [
+		{
+			hint: "Multiple place_<k> resources have inputs.isStart=true; pick one as the canonical start place.",
+			kind: "ambiguous",
+			mantlePath: "place_*.isStart",
+		},
+	],
+};
+
+/**
+ * Fold the start place's `placeConfiguration_<k>.name` into
+ * `universe.displayName`. Non-start places' names emit `blocked` warnings;
+ * multiple `isStart: true` places emit one `ambiguous` warning and skip
+ * the displayName mapping (every placeConfiguration name is blocked in
+ * that case).
+ *
+ * @param resources - Mantle resource list for one environment.
+ * @returns The folded displayName plus per-rule diagnostics.
+ */
+export function foldDisplayName(resources: ReadonlyArray<MantleResource>): FoldFragment {
+	const namedConfigs = resources
+		.filter((resource) => resource.kind === PLACE_CONFIGURATION_KIND)
+		.flatMap((resource) => {
+			const named = readPlaceConfigName(resource);
+			return named === undefined ? [] : [named];
+		});
+
+	const starts = startKeys(resources);
+	if (starts.length >= 2) {
+		return mergeFragment(AMBIGUOUS_MULTIPLE_STARTS, foldAllBlocked(namedConfigs));
+	}
+
+	const [startKey] = starts;
+	if (startKey === undefined) {
+		return foldAllBlocked(namedConfigs);
+	}
+
+	return foldFromSingleStart(startKey, namedConfigs);
+}
+
+function foldFromSingleStart(
+	startKey: string,
+	namedConfigs: ReadonlyArray<NamedPlaceConfig>,
+): FoldFragment {
+	return namedConfigs.reduce<FoldFragment>((accumulator, named) => {
+		return mergeFragment(
+			accumulator,
+			named.key === startKey ? interpretiveFragment(named) : blockedFragment(named.key),
+		);
+	}, EMPTY_FRAGMENT);
+}
+
+function foldAllBlocked(namedConfigs: ReadonlyArray<NamedPlaceConfig>): FoldFragment {
+	return namedConfigs.reduce<FoldFragment>(
+		(accumulator, named) => mergeFragment(accumulator, blockedFragment(named.key)),
+		EMPTY_FRAGMENT,
+	);
+}

--- a/packages/bedrock/src/core/migrate/fold-social-links.ts
+++ b/packages/bedrock/src/core/migrate/fold-social-links.ts
@@ -1,7 +1,9 @@
 import type { SocialLinkField } from "../resources.ts";
 import {
+	blockedWarning,
 	EMPTY_FRAGMENT,
 	type FoldFragment,
+	interpretiveWarning,
 	isObjectPayload,
 	mergeFragment,
 } from "./fold-universe-shared.ts";
@@ -49,12 +51,11 @@ function knownFragment(known: KnownSocialLink): FoldFragment {
 	return {
 		entryFragment: { [known.field]: { title: known.title, uri: known.url } },
 		warnings: [
-			{
+			interpretiveWarning({
 				bedrockPath: `universe.${known.field}`,
-				kind: "interpretive",
 				mantlePath: known.mantlePath,
 				rule: "domain-to-field",
-			},
+			}),
 		],
 	};
 }
@@ -63,8 +64,10 @@ function mapSocialLink(resource: MantleResource): FoldFragment {
 	const mantlePath = `${SOCIAL_LINK_KIND}_${resource.key}`;
 	const field = SOCIAL_LINK_DOMAIN_TO_FIELD[resource.key];
 	if (field === undefined) {
-		const reason = `Unknown socialLink domain: ${resource.key}`;
-		return { entryFragment: {}, warnings: [{ kind: "blocked", mantlePath, reason }] };
+		return {
+			entryFragment: {},
+			warnings: [blockedWarning(mantlePath, `Unknown socialLink domain: ${resource.key}`)],
+		};
 	}
 
 	if (!isObjectPayload(resource.inputs)) {

--- a/packages/bedrock/src/core/migrate/fold-social-links.ts
+++ b/packages/bedrock/src/core/migrate/fold-social-links.ts
@@ -1,0 +1,80 @@
+import type { SocialLinkField } from "../resources.ts";
+import {
+	EMPTY_FRAGMENT,
+	type FoldFragment,
+	isObjectPayload,
+	mergeFragment,
+} from "./fold-universe-shared.ts";
+import type { MantleResource } from "./types.ts";
+
+const SOCIAL_LINK_KIND = "socialLink";
+
+const SOCIAL_LINK_DOMAIN_TO_FIELD: Readonly<Record<string, SocialLinkField>> = {
+	"discord.gg": "discordSocialLink",
+	"facebook.com": "facebookSocialLink",
+	"guilded.gg": "guildedSocialLink",
+	"roblox.com": "robloxGroupSocialLink",
+	"twitch.tv": "twitchSocialLink",
+	"twitter.com": "twitterSocialLink",
+	"www.roblox.com": "robloxGroupSocialLink",
+	"youtube.com": "youtubeSocialLink",
+};
+
+interface KnownSocialLink {
+	readonly field: SocialLinkField;
+	readonly mantlePath: string;
+	readonly title: string;
+	readonly url: string;
+}
+
+/**
+ * Fold every `socialLink_<domain>` Mantle resource into the matching
+ * `universe.<field>SocialLink` entry. Unknown domains emit a `blocked`
+ * warning and are dropped from the output. Malformed payloads (non-string
+ * `title` or `url`) drop silently per the established convention.
+ *
+ * @param resources - Mantle resource list for one environment.
+ * @returns The folded social-link entries plus per-rule diagnostics.
+ */
+export function foldSocialLinks(resources: ReadonlyArray<MantleResource>): FoldFragment {
+	return resources
+		.filter((resource) => resource.kind === SOCIAL_LINK_KIND)
+		.reduce<FoldFragment>(
+			(accumulator, resource) => mergeFragment(accumulator, mapSocialLink(resource)),
+			EMPTY_FRAGMENT,
+		);
+}
+
+function knownFragment(known: KnownSocialLink): FoldFragment {
+	return {
+		entryFragment: { [known.field]: { title: known.title, uri: known.url } },
+		warnings: [
+			{
+				bedrockPath: `universe.${known.field}`,
+				kind: "interpretive",
+				mantlePath: known.mantlePath,
+				rule: "domain-to-field",
+			},
+		],
+	};
+}
+
+function mapSocialLink(resource: MantleResource): FoldFragment {
+	const mantlePath = `${SOCIAL_LINK_KIND}_${resource.key}`;
+	const field = SOCIAL_LINK_DOMAIN_TO_FIELD[resource.key];
+	if (field === undefined) {
+		const reason = `Unknown socialLink domain: ${resource.key}`;
+		return { entryFragment: {}, warnings: [{ kind: "blocked", mantlePath, reason }] };
+	}
+
+	if (!isObjectPayload(resource.inputs)) {
+		return EMPTY_FRAGMENT;
+	}
+
+	const { title, url } = resource.inputs;
+	if (typeof title !== "string" || typeof url !== "string") {
+		return EMPTY_FRAGMENT;
+	}
+
+	return knownFragment({ field, mantlePath, title, url });
+}

--- a/packages/bedrock/src/core/migrate/fold-universe-shared.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe-shared.ts
@@ -17,6 +17,19 @@ export interface FoldFragment {
 export const EMPTY_FRAGMENT: FoldFragment = { entryFragment: {}, warnings: [] };
 
 /**
+ * Required fields for an `interpretive` warning, gathered as a single
+ * argument so this builder stays under the project's max-params cap.
+ */
+interface InterpretiveWarningSpec {
+	/** Path the migrator wrote in the bedrock config. */
+	readonly bedrockPath: string;
+	/** Resource-rooted Mantle path the rule consumed. */
+	readonly mantlePath: string;
+	/** Stable rule identifier audited in the migration report. */
+	readonly rule: string;
+}
+
+/**
  * Narrow a value to a plain object payload (rejects arrays, null, primitives).
  *
  * @param value - Value to test.
@@ -39,4 +52,44 @@ export function mergeFragment(left: FoldFragment, right: FoldFragment): FoldFrag
 		entryFragment: { ...left.entryFragment, ...right.entryFragment },
 		warnings: [...left.warnings, ...right.warnings],
 	};
+}
+
+/**
+ * Build an `interpretive` `MigrationWarning`. Used by every fold rule that
+ * applies a documented mapping; the report consumer narrows on `kind`.
+ *
+ * @param spec - The bedrock path, mantle path, and rule identifier.
+ * @returns A `MigrationWarning` with `kind: "interpretive"`.
+ */
+export function interpretiveWarning(spec: InterpretiveWarningSpec): MigrationWarning {
+	return {
+		bedrockPath: spec.bedrockPath,
+		kind: "interpretive",
+		mantlePath: spec.mantlePath,
+		rule: spec.rule,
+	};
+}
+
+/**
+ * Build a `blocked` `MigrationWarning`. Used when no Open Cloud writable
+ * endpoint exists for the field the migrator encountered.
+ *
+ * @param mantlePath - Resource-rooted Mantle path of the blocked field.
+ * @param reason - Human-readable reason describing what is unsupported.
+ * @returns A `MigrationWarning` with `kind: "blocked"`.
+ */
+export function blockedWarning(mantlePath: string, reason: string): MigrationWarning {
+	return { kind: "blocked", mantlePath, reason };
+}
+
+/**
+ * Build an `ambiguous` `MigrationWarning`. Used when a value is mappable
+ * but unsafe to act on without user input; the hint guides the next step.
+ *
+ * @param mantlePath - Resource-rooted Mantle path of the ambiguous field.
+ * @param hint - Human-readable suggestion for resolving the ambiguity.
+ * @returns A `MigrationWarning` with `kind: "ambiguous"`.
+ */
+export function ambiguousWarning(mantlePath: string, hint: string): MigrationWarning {
+	return { hint, kind: "ambiguous", mantlePath };
 }

--- a/packages/bedrock/src/core/migrate/fold-universe-shared.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe-shared.ts
@@ -1,0 +1,42 @@
+import type { UniverseEntry } from "../schema.ts";
+import type { MigrationWarning } from "./migration-report.ts";
+
+/**
+ * Output of one fold rule contributing to the eventual `UniverseEntry`.
+ * Fragments compose by spreading `entryFragment` into the final entry and
+ * concatenating `warnings`.
+ */
+export interface FoldFragment {
+	/** Subset of universe fields this rule populated (empty when the rule did not fire). */
+	readonly entryFragment: Partial<UniverseEntry>;
+	/** Diagnostics this rule emitted. */
+	readonly warnings: ReadonlyArray<MigrationWarning>;
+}
+
+/** Sentinel value for fold rules that produced neither output nor warnings. */
+export const EMPTY_FRAGMENT: FoldFragment = { entryFragment: {}, warnings: [] };
+
+/**
+ * Narrow a value to a plain object payload (rejects arrays, null, primitives).
+ *
+ * @param value - Value to test.
+ * @returns `true` when `value` is a plain object record.
+ */
+export function isObjectPayload(value: unknown): value is Record<string, unknown> {
+	return Object.prototype.toString.call(value) === "[object Object]";
+}
+
+/**
+ * Combine two fragments, with the right-hand side overriding overlapping
+ * `entryFragment` keys and its `warnings` appended after the left's.
+ *
+ * @param left - Earlier fragment.
+ * @param right - Later fragment whose entry-fragment keys win on conflict.
+ * @returns The merged fragment.
+ */
+export function mergeFragment(left: FoldFragment, right: FoldFragment): FoldFragment {
+	return {
+		entryFragment: { ...left.entryFragment, ...right.entryFragment },
+		warnings: [...left.warnings, ...right.warnings],
+	};
+}

--- a/packages/bedrock/src/core/migrate/fold-universe.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.spec.ts
@@ -364,4 +364,132 @@ describe(foldUniverse, () => {
 			expect(result.warnings).toStrictEqual([]);
 		});
 	});
+
+	describe("privateServerPrice fold", () => {
+		it.for<[label: string, price: number]>([
+			["a non-zero price", 25],
+			["a zero price", 0],
+		])("should fold %s into privateServerPriceRobux", ([, price]) => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({
+					allowPrivateServers: true,
+					privateServerPrice: price,
+				}),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({
+				privateServerPriceRobux: price,
+				universeId: "1",
+			});
+		});
+
+		it("should emit one interpretive warning when private servers are priced", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({
+					allowPrivateServers: true,
+					privateServerPrice: 50,
+				}),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.warnings).toStrictEqual([
+				{
+					bedrockPath: "universe.privateServerPriceRobux",
+					kind: "interpretive",
+					mantlePath: "experienceConfiguration_singleton.privateServerPrice",
+					rule: "private-servers-priced",
+				},
+			]);
+		});
+
+		it("should omit privateServerPriceRobux when allowPrivateServers is false", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({
+					allowPrivateServers: false,
+					privateServerPrice: 25,
+				}),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+		});
+
+		it("should emit one interpretive omission warning when private servers are disabled", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ allowPrivateServers: false }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.warnings).toStrictEqual([
+				{
+					bedrockPath: "universe.privateServerPriceRobux",
+					kind: "interpretive",
+					mantlePath: "experienceConfiguration_singleton.allowPrivateServers",
+					rule: "private-servers-disabled-omitted",
+				},
+			]);
+		});
+
+		it("should leave the entry untouched when allowPrivateServers is true but the price is missing", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ allowPrivateServers: true }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should leave the entry untouched when the price is non-numeric", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({
+					allowPrivateServers: true,
+					privateServerPrice: "free",
+				}),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should leave the entry untouched when allowPrivateServers is missing", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ privateServerPrice: 25 }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+	});
 });

--- a/packages/bedrock/src/core/migrate/fold-universe.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.spec.ts
@@ -37,6 +37,16 @@ function spatialVoice(inputs: unknown): MantleResource {
 	};
 }
 
+function experienceActivation(inputs: unknown): MantleResource {
+	return {
+		key: "singleton",
+		dependencies: [],
+		inputs,
+		kind: "experienceActivation",
+		outputs: undefined,
+	};
+}
+
 describe(foldUniverse, () => {
 	it("should map experience.outputs.assetId to universe.universeId", () => {
 		expect.assertions(1);
@@ -555,6 +565,149 @@ describe(foldUniverse, () => {
 			const result = foldUniverse([
 				experience(DEFAULT_EXPERIENCE_OUTPUTS),
 				spatialVoice({ enabled: "yes" }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+	});
+
+	describe("visibility cross-fold", () => {
+		it.for<[label: string, isFriendsOnly: boolean | undefined]>([
+			["isFriendsOnly false", false],
+			["isFriendsOnly undefined", undefined],
+		])("should set visibility to public when isActive is true and %s", ([, isFriendsOnly]) => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceActivation({ isActive: true }),
+				experienceConfiguration({ isFriendsOnly }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({
+				universeId: "1",
+				visibility: "public",
+			});
+		});
+
+		it("should emit one interpretive warning for the active-public combo", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceActivation({ isActive: true }),
+				experienceConfiguration({ isFriendsOnly: false }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.warnings).toStrictEqual([
+				{
+					bedrockPath: "universe.visibility",
+					kind: "interpretive",
+					mantlePath: "experienceActivation_singleton.isActive",
+					rule: "active-public-combo",
+				},
+			]);
+		});
+
+		it("should set visibility to public when experienceConfiguration is absent and isActive is true", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceActivation({ isActive: true }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({
+				universeId: "1",
+				visibility: "public",
+			});
+		});
+
+		it("should omit visibility and emit ambiguous when isActive is false", () => {
+			expect.assertions(4);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceActivation({ isActive: false }),
+				experienceConfiguration({ isFriendsOnly: false }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toHaveLength(1);
+
+			const [warning] = result.warnings;
+			assert(warning?.kind === "ambiguous");
+
+			expect(warning.mantlePath).toBe("experienceActivation_singleton.isActive");
+			expect(warning.hint).toMatch(/dashboard/i);
+		});
+
+		it("should omit visibility and emit blocked when isFriendsOnly is true", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceActivation({ isActive: true }),
+				experienceConfiguration({ isFriendsOnly: true }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([
+				{
+					kind: "blocked",
+					mantlePath: "experienceConfiguration_singleton.isFriendsOnly",
+					reason: "isFriendsOnly has no Open Cloud equivalent",
+				},
+			]);
+		});
+
+		it("should leave the entry untouched when experienceActivation is absent", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ isFriendsOnly: false }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should leave the entry untouched when experienceActivation.isActive is non-boolean", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceActivation({ isActive: "maybe" }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should leave the entry untouched when experienceActivation inputs is not an object", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceActivation("not-an-object"),
 			]);
 
 			assert(result !== undefined);

--- a/packages/bedrock/src/core/migrate/fold-universe.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.spec.ts
@@ -27,6 +27,16 @@ function experienceConfiguration(inputs: unknown): MantleResource {
 	};
 }
 
+function spatialVoice(inputs: unknown): MantleResource {
+	return {
+		key: "singleton",
+		dependencies: [],
+		inputs,
+		kind: "spatialVoice",
+		outputs: undefined,
+	};
+}
+
 describe(foldUniverse, () => {
 	it("should map experience.outputs.assetId to universe.universeId", () => {
 		expect.assertions(1);
@@ -65,7 +75,7 @@ describe(foldUniverse, () => {
 		expect(result.outputs.rootPlaceId).toBe("17613681043");
 	});
 
-	it("should emit no warnings in the skeleton", () => {
+	it("should emit no warnings when only the experience resource is present", () => {
 		expect.assertions(1);
 
 		const result = foldUniverse([
@@ -77,25 +87,6 @@ describe(foldUniverse, () => {
 		expect(result.warnings).toStrictEqual([]);
 	});
 
-	it("should ignore other Mantle kinds and only consume experience", () => {
-		expect.assertions(1);
-
-		const result = foldUniverse([
-			{
-				key: "singleton",
-				dependencies: [],
-				inputs: { enabled: true },
-				kind: "spatialVoice",
-				outputs: undefined,
-			},
-			experience({ assetId: 1, startPlaceId: 2 }),
-		]);
-
-		assert(result !== undefined);
-
-		expect(result.entry).toStrictEqual({ universeId: "1" });
-	});
-
 	it("should return undefined when no experience resource is present", () => {
 		expect.assertions(1);
 
@@ -103,8 +94,8 @@ describe(foldUniverse, () => {
 			{
 				key: "singleton",
 				dependencies: [],
-				inputs: { enabled: true },
-				kind: "spatialVoice",
+				inputs: { filePath: "icon.png" },
+				kind: "experienceIcon",
 				outputs: undefined,
 			},
 		]);
@@ -484,6 +475,86 @@ describe(foldUniverse, () => {
 			const result = foldUniverse([
 				experience(DEFAULT_EXPERIENCE_OUTPUTS),
 				experienceConfiguration({ privateServerPrice: 25 }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+	});
+
+	describe("voiceChat fold", () => {
+		it.for<[label: string, enabled: boolean]>([
+			["enabled true", true],
+			["enabled false", false],
+		])("should fold spatialVoice with %s into voiceChatEnabled", ([, enabled]) => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				spatialVoice({ enabled }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({
+				universeId: "1",
+				voiceChatEnabled: enabled,
+			});
+		});
+
+		it("should emit one interpretive warning when voice chat is folded", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				spatialVoice({ enabled: true }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.warnings).toStrictEqual([
+				{
+					bedrockPath: "universe.voiceChatEnabled",
+					kind: "interpretive",
+					mantlePath: "spatialVoice_singleton.enabled",
+					rule: "voice-chat-enabled",
+				},
+			]);
+		});
+
+		it("should leave the entry untouched when no spatialVoice resource is present", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([experience(DEFAULT_EXPERIENCE_OUTPUTS)]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should leave the entry untouched when spatialVoice inputs is not an object", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				spatialVoice("not-an-object"),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should leave the entry untouched when spatialVoice.enabled is non-boolean", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				spatialVoice({ enabled: "yes" }),
 			]);
 
 			assert(result !== undefined);

--- a/packages/bedrock/src/core/migrate/fold-universe.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.spec.ts
@@ -1,5 +1,6 @@
 import { assert, describe, expect, it } from "vitest";
 
+import type { SocialLinkField } from "../resources.ts";
 import { foldUniverse } from "./fold-universe.ts";
 import type { MantleResource } from "./types.ts";
 
@@ -44,6 +45,16 @@ function experienceActivation(inputs: unknown): MantleResource {
 		inputs,
 		kind: "experienceActivation",
 		outputs: undefined,
+	};
+}
+
+function socialLink(domain: string, inputs: unknown): MantleResource {
+	return {
+		key: domain,
+		dependencies: [],
+		inputs,
+		kind: "socialLink",
+		outputs: { assetId: 1234567890 },
 	};
 }
 
@@ -709,6 +720,171 @@ describe(foldUniverse, () => {
 				experience(DEFAULT_EXPERIENCE_OUTPUTS),
 				experienceActivation("not-an-object"),
 			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+	});
+
+	describe("socialLink fold", () => {
+		it.for<[label: string, domain: string, field: SocialLinkField]>([
+			["facebook", "facebook.com", "facebookSocialLink"],
+			["twitter", "twitter.com", "twitterSocialLink"],
+			["youtube", "youtube.com", "youtubeSocialLink"],
+			["twitch", "twitch.tv", "twitchSocialLink"],
+			["discord", "discord.gg", "discordSocialLink"],
+			["roblox group via roblox.com", "roblox.com", "robloxGroupSocialLink"],
+			["roblox group via www.roblox.com", "www.roblox.com", "robloxGroupSocialLink"],
+			["guilded", "guilded.gg", "guildedSocialLink"],
+		])("should fold the %s domain into the matching universe field", ([, domain, field]) => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				socialLink(domain, {
+					linkType: "Discord",
+					title: "Join us",
+					url: `https://${domain}/example`,
+				}),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({
+				[field]: { title: "Join us", uri: `https://${domain}/example` },
+				universeId: "1",
+			});
+		});
+
+		it("should rename mantle 'url' onto bedrock 'uri' on the SocialLink", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				socialLink("discord.gg", {
+					linkType: "Discord",
+					title: "Join our Discord",
+					url: "https://discord.gg/example",
+				}),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry.discordSocialLink).toStrictEqual({
+				title: "Join our Discord",
+				uri: "https://discord.gg/example",
+			});
+		});
+
+		it("should emit one interpretive warning per matched social link", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				socialLink("discord.gg", {
+					linkType: "Discord",
+					title: "Join our Discord",
+					url: "https://discord.gg/example",
+				}),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.warnings).toStrictEqual([
+				{
+					bedrockPath: "universe.discordSocialLink",
+					kind: "interpretive",
+					mantlePath: "socialLink_discord.gg",
+					rule: "domain-to-field",
+				},
+			]);
+		});
+
+		it("should drop unknown-domain socialLink resources and emit blocked", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				socialLink("tiktok.com", {
+					linkType: "TikTok",
+					title: "Follow us",
+					url: "https://tiktok.com/example",
+				}),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([
+				{
+					kind: "blocked",
+					mantlePath: "socialLink_tiktok.com",
+					reason: "Unknown socialLink domain: tiktok.com",
+				},
+			]);
+		});
+
+		it("should fold multiple known-domain socialLink resources into distinct fields", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				socialLink("discord.gg", {
+					linkType: "Discord",
+					title: "Discord",
+					url: "https://discord.gg/a",
+				}),
+				socialLink("twitter.com", {
+					linkType: "Twitter",
+					title: "Twitter",
+					url: "https://twitter.com/a",
+				}),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({
+				discordSocialLink: { title: "Discord", uri: "https://discord.gg/a" },
+				twitterSocialLink: { title: "Twitter", uri: "https://twitter.com/a" },
+				universeId: "1",
+			});
+		});
+
+		it("should drop a socialLink resource whose title or url is non-string", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				socialLink("discord.gg", { linkType: "Discord", title: 1, url: "https://x" }),
+				socialLink("twitter.com", { linkType: "Twitter", title: "x", url: 2 }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should drop a socialLink resource whose inputs is not an object", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				socialLink("discord.gg", "not-an-object"),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should leave the entry untouched when no socialLink resources are present", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([experience(DEFAULT_EXPERIENCE_OUTPUTS)]);
 
 			assert(result !== undefined);
 

--- a/packages/bedrock/src/core/migrate/fold-universe.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.spec.ts
@@ -911,6 +911,39 @@ describe(foldUniverse, () => {
 			expect(result.entry).toStrictEqual({ universeId: "1" });
 			expect(result.warnings).toStrictEqual([]);
 		});
+
+		it("should let the later resource win when two domains map to the same universe field", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				socialLink("roblox.com", {
+					linkType: "RobloxGroup",
+					title: "Bare",
+					url: "https://roblox.com/group/1",
+				}),
+				socialLink("www.roblox.com", {
+					linkType: "RobloxGroup",
+					title: "WWW",
+					url: "https://www.roblox.com/group/1",
+				}),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry.robloxGroupSocialLink).toStrictEqual({
+				title: "WWW",
+				uri: "https://www.roblox.com/group/1",
+			});
+			expect(
+				result.warnings.filter((warning) => {
+					return (
+						warning.kind === "interpretive" &&
+						warning.bedrockPath === "universe.robloxGroupSocialLink"
+					);
+				}),
+			).toHaveLength(2);
+		});
 	});
 
 	describe("displayName cross-fold", () => {

--- a/packages/bedrock/src/core/migrate/fold-universe.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.spec.ts
@@ -58,6 +58,26 @@ function socialLink(domain: string, inputs: unknown): MantleResource {
 	};
 }
 
+function place(key: string, inputs: unknown): MantleResource {
+	return {
+		key,
+		dependencies: [],
+		inputs,
+		kind: "place",
+		outputs: { assetId: 17613681043 },
+	};
+}
+
+function placeConfiguration(key: string, inputs: unknown): MantleResource {
+	return {
+		key,
+		dependencies: [],
+		inputs,
+		kind: "placeConfiguration",
+		outputs: undefined,
+	};
+}
+
 describe(foldUniverse, () => {
 	it("should map experience.outputs.assetId to universe.universeId", () => {
 		expect.assertions(1);
@@ -890,6 +910,200 @@ describe(foldUniverse, () => {
 
 			expect(result.entry).toStrictEqual({ universeId: "1" });
 			expect(result.warnings).toStrictEqual([]);
+		});
+	});
+
+	describe("displayName cross-fold", () => {
+		it("should fold the start place's placeConfiguration.name into universe.displayName", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				place("start", { isStart: true }),
+				placeConfiguration("start", { name: "My Place" }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({
+				displayName: "My Place",
+				universeId: "1",
+			});
+		});
+
+		it("should emit one interpretive warning for the displayName mapping", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				place("start", { isStart: true }),
+				placeConfiguration("start", { name: "My Place" }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.warnings).toStrictEqual([
+				{
+					bedrockPath: "universe.displayName",
+					kind: "interpretive",
+					mantlePath: "placeConfiguration_start.name",
+					rule: "start-place-name-to-display-name",
+				},
+			]);
+		});
+
+		it("should emit blocked for non-start placeConfiguration.name and not include it in displayName", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				place("start", { isStart: true }),
+				place("lobby", { isStart: false }),
+				placeConfiguration("start", { name: "My Place" }),
+				placeConfiguration("lobby", { name: "Lobby" }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry.displayName).toBe("My Place");
+			expect(result.warnings).toIncludeAllPartialMembers([
+				{
+					kind: "blocked",
+					mantlePath: "placeConfiguration_lobby.name",
+					reason: "non-start placeConfiguration.name has no Open Cloud equivalent",
+				},
+			]);
+		});
+
+		it("should leave displayName untouched when no places have isStart true", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				place("start", { isStart: false }),
+				placeConfiguration("start", { name: "My Place" }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry.displayName).toBeNil();
+			expect(result.warnings).toStrictEqual([
+				{
+					kind: "blocked",
+					mantlePath: "placeConfiguration_start.name",
+					reason: "non-start placeConfiguration.name has no Open Cloud equivalent",
+				},
+			]);
+		});
+
+		it("should not treat isStart=true on a non-place resource as a start place", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ isStart: true }),
+				place("start", { isStart: true }),
+				placeConfiguration("start", { name: "My Place" }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry.displayName).toBe("My Place");
+			expect(result.warnings).toStrictEqual([
+				{
+					bedrockPath: "universe.displayName",
+					kind: "interpretive",
+					mantlePath: "placeConfiguration_start.name",
+					rule: "start-place-name-to-display-name",
+				},
+			]);
+		});
+
+		it("should leave displayName untouched when no placeConfiguration matches the start key", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				place("start", { isStart: true }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should omit displayName and emit ambiguous when multiple places have isStart true", () => {
+			expect.assertions(3);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				place("start", { isStart: true }),
+				place("alt-start", { isStart: true }),
+				placeConfiguration("start", { name: "Primary" }),
+				placeConfiguration("alt-start", { name: "Alternate" }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry.displayName).toBeNil();
+			expect(result.warnings).toIncludeAllPartialMembers([
+				{
+					kind: "ambiguous",
+					mantlePath: "place_*.isStart",
+				},
+			]);
+			expect(result.warnings.filter((warning) => warning.kind === "blocked")).toHaveLength(2);
+		});
+
+		it("should silently skip a placeConfiguration whose name is non-string", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				place("start", { isStart: true }),
+				placeConfiguration("start", { name: 42 }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should silently skip a placeConfiguration whose inputs is not an object", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				place("start", { isStart: true }),
+				placeConfiguration("start", "not-an-object"),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should silently skip a place resource whose inputs is not an object", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				place("start", "not-an-object"),
+				placeConfiguration("start", { name: "My Place" }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toIncludeAllPartialMembers([
+				{
+					kind: "blocked",
+					mantlePath: "placeConfiguration_start.name",
+				},
+			]);
 		});
 	});
 });

--- a/packages/bedrock/src/core/migrate/fold-universe.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.spec.ts
@@ -13,6 +13,20 @@ function experience(outputs: unknown): MantleResource {
 	};
 }
 
+const DEFAULT_EXPERIENCE_OUTPUTS = { assetId: 1, startPlaceId: 2 };
+
+type DeviceFlag = "consoleEnabled" | "desktopEnabled" | "mobileEnabled" | "tabletEnabled";
+
+function experienceConfiguration(inputs: unknown): MantleResource {
+	return {
+		key: "singleton",
+		dependencies: [],
+		inputs,
+		kind: "experienceConfiguration",
+		outputs: undefined,
+	};
+}
+
 describe(foldUniverse, () => {
 	it("should map experience.outputs.assetId to universe.universeId", () => {
 		expect.assertions(1);
@@ -137,5 +151,217 @@ describe(foldUniverse, () => {
 		expect(
 			foldUniverse([experience({ assetId: { nested: 1 }, startPlaceId: 2 })]),
 		).toBeUndefined();
+	});
+
+	describe("playableDevices fold", () => {
+		it.for<[label: string, device: string, flag: DeviceFlag]>([
+			["desktop", "Computer", "desktopEnabled"],
+			["console", "Console", "consoleEnabled"],
+			["mobile", "Phone", "mobileEnabled"],
+			["tablet", "Tablet", "tabletEnabled"],
+		])("should fold the %s device into its enabled flag", ([, device, flag]) => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ playableDevices: [device] }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry[flag]).toBeTrue();
+			expect(result.entry).toStrictEqual({ [flag]: true, universeId: "1" });
+		});
+
+		it("should fold every known device into its enabled flag for the full list", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({
+					playableDevices: ["Computer", "Console", "Phone", "Tablet"],
+				}),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({
+				consoleEnabled: true,
+				desktopEnabled: true,
+				mobileEnabled: true,
+				tabletEnabled: true,
+				universeId: "1",
+			});
+		});
+
+		it("should leave other device flags omitted for a subset list", () => {
+			expect.assertions(3);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ playableDevices: ["Computer"] }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry.desktopEnabled).toBeTrue();
+			expect(result.entry.consoleEnabled).toBeNil();
+			expect(result.entry.mobileEnabled).toBeNil();
+		});
+
+		it("should emit one interpretive warning per matched device flag", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ playableDevices: ["Computer", "Console"] }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.warnings).toHaveLength(2);
+			expect(result.warnings).toIncludeAllPartialMembers([
+				{
+					bedrockPath: "universe.desktopEnabled",
+					kind: "interpretive",
+					mantlePath: "experienceConfiguration_singleton.playableDevices",
+					rule: "list-to-flag",
+				},
+				{
+					bedrockPath: "universe.consoleEnabled",
+					kind: "interpretive",
+					mantlePath: "experienceConfiguration_singleton.playableDevices",
+					rule: "list-to-flag",
+				},
+			]);
+		});
+
+		it("should emit a blocked warning for an unknown device string", () => {
+			expect.assertions(3);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ playableDevices: ["Toaster"] }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toHaveLength(1);
+
+			const [warning] = result.warnings;
+			assert(warning?.kind === "blocked");
+
+			expect(warning).toStrictEqual({
+				kind: "blocked",
+				mantlePath: "experienceConfiguration_singleton.playableDevices",
+				reason: "Unknown playableDevices value: Toaster",
+			});
+		});
+
+		it("should emit a blocked warning for a non-string entry in playableDevices", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ playableDevices: [42] }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.warnings).toHaveLength(1);
+
+			const [warning] = result.warnings;
+			assert(warning?.kind === "blocked");
+
+			expect(warning.reason).toMatch(/Unknown playableDevices value/);
+		});
+
+		it("should fold known devices and warn on unknowns in a mixed list", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({
+					playableDevices: ["Computer", "Toaster", "Tablet"],
+				}),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({
+				desktopEnabled: true,
+				tabletEnabled: true,
+				universeId: "1",
+			});
+			expect(result.warnings).toHaveLength(3);
+		});
+
+		it("should leave the entry untouched when no experienceConfiguration is present", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([experience(DEFAULT_EXPERIENCE_OUTPUTS)]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should ignore an experienceConfiguration whose inputs is not an object", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration("not-an-object"),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should ignore an experienceConfiguration whose playableDevices is not an array", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ playableDevices: "Computer" }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should ignore an experienceConfiguration with no playableDevices field", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ genre: "All" }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should produce no warnings when playableDevices is an empty array", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ playableDevices: [] }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
 	});
 });

--- a/packages/bedrock/src/core/migrate/fold-universe.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.ts
@@ -6,6 +6,7 @@ import type { MantleResource } from "./types.ts";
 
 const EXPERIENCE_KIND = "experience";
 const EXPERIENCE_CONFIGURATION_KIND = "experienceConfiguration";
+const SPATIAL_VOICE_KIND = "spatialVoice";
 
 const PLAYABLE_DEVICE_TO_FLAG: Readonly<
 	Record<string, "consoleEnabled" | "desktopEnabled" | "mobileEnabled" | "tabletEnabled">
@@ -72,6 +73,7 @@ export function foldUniverse(
 	const fragments: ReadonlyArray<FoldFragment> = [
 		foldPlayableDevices(resources),
 		foldPrivateServers(resources),
+		foldVoiceChat(resources),
 	];
 
 	const entry: UniverseEntry = fragments.reduce<UniverseEntry>(
@@ -194,6 +196,30 @@ function pricedPrivateServersFragment(price: number): FoldFragment {
 				kind: "interpretive",
 				mantlePath: "experienceConfiguration_singleton.privateServerPrice",
 				rule: "private-servers-priced",
+			},
+		],
+	};
+}
+
+function foldVoiceChat(resources: ReadonlyArray<MantleResource>): FoldFragment {
+	const voice = resources.find((resource) => resource.kind === SPATIAL_VOICE_KIND);
+	if (voice === undefined || !isObjectPayload(voice.inputs)) {
+		return EMPTY_FRAGMENT;
+	}
+
+	const { enabled } = voice.inputs;
+	if (typeof enabled !== "boolean") {
+		return EMPTY_FRAGMENT;
+	}
+
+	return {
+		entryFragment: { voiceChatEnabled: enabled },
+		warnings: [
+			{
+				bedrockPath: "universe.voiceChatEnabled",
+				kind: "interpretive",
+				mantlePath: "spatialVoice_singleton.enabled",
+				rule: "voice-chat-enabled",
 			},
 		],
 	};

--- a/packages/bedrock/src/core/migrate/fold-universe.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.ts
@@ -5,6 +5,7 @@ import type { MigrationWarning } from "./migration-report.ts";
 import type { MantleResource } from "./types.ts";
 
 const EXPERIENCE_KIND = "experience";
+const EXPERIENCE_ACTIVATION_KIND = "experienceActivation";
 const EXPERIENCE_CONFIGURATION_KIND = "experienceConfiguration";
 const SPATIAL_VOICE_KIND = "spatialVoice";
 
@@ -74,6 +75,7 @@ export function foldUniverse(
 		foldPlayableDevices(resources),
 		foldPrivateServers(resources),
 		foldVoiceChat(resources),
+		foldVisibility(resources),
 	];
 
 	const entry: UniverseEntry = fragments.reduce<UniverseEntry>(
@@ -199,6 +201,78 @@ function pricedPrivateServersFragment(price: number): FoldFragment {
 			},
 		],
 	};
+}
+
+const VISIBILITY_PUBLIC_FRAGMENT: FoldFragment = {
+	entryFragment: { visibility: "public" },
+	warnings: [
+		{
+			bedrockPath: "universe.visibility",
+			kind: "interpretive",
+			mantlePath: "experienceActivation_singleton.isActive",
+			rule: "active-public-combo",
+		},
+	],
+};
+
+const VISIBILITY_AMBIGUOUS: FoldFragment = {
+	entryFragment: {},
+	warnings: [
+		{
+			hint: "Set visibility manually or deactivate the universe in the Roblox dashboard; auto-mapping isActive=false to visibility=private would kick live players.",
+			kind: "ambiguous",
+			mantlePath: "experienceActivation_singleton.isActive",
+		},
+	],
+};
+
+const VISIBILITY_FRIENDS_BLOCKED: FoldFragment = {
+	entryFragment: {},
+	warnings: [
+		{
+			kind: "blocked",
+			mantlePath: "experienceConfiguration_singleton.isFriendsOnly",
+			reason: "isFriendsOnly has no Open Cloud equivalent",
+		},
+	],
+};
+
+function readIsActive(resources: ReadonlyArray<MantleResource>): boolean | undefined {
+	const activation = resources.find((resource) => resource.kind === EXPERIENCE_ACTIVATION_KIND);
+	if (activation === undefined || !isObjectPayload(activation.inputs)) {
+		return undefined;
+	}
+
+	const { isActive } = activation.inputs;
+	return typeof isActive === "boolean" ? isActive : undefined;
+}
+
+function readIsFriendsOnly(resources: ReadonlyArray<MantleResource>): boolean | undefined {
+	const config = resources.find((resource) => resource.kind === EXPERIENCE_CONFIGURATION_KIND);
+	if (config === undefined || !isObjectPayload(config.inputs)) {
+		return undefined;
+	}
+
+	const { isFriendsOnly } = config.inputs;
+	return typeof isFriendsOnly === "boolean" ? isFriendsOnly : undefined;
+}
+
+function foldVisibility(resources: ReadonlyArray<MantleResource>): FoldFragment {
+	const isActive = readIsActive(resources);
+	if (isActive === undefined) {
+		return EMPTY_FRAGMENT;
+	}
+
+	if (!isActive) {
+		return VISIBILITY_AMBIGUOUS;
+	}
+
+	const isFriendsOnly = readIsFriendsOnly(resources);
+	if (isFriendsOnly === true) {
+		return VISIBILITY_FRIENDS_BLOCKED;
+	}
+
+	return VISIBILITY_PUBLIC_FRAGMENT;
 }
 
 function foldVoiceChat(resources: ReadonlyArray<MantleResource>): FoldFragment {

--- a/packages/bedrock/src/core/migrate/fold-universe.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.ts
@@ -1,6 +1,13 @@
 import { asRobloxAssetId } from "../../types/ids.ts";
 import type { UniverseOutputs } from "../resources.ts";
 import type { UniverseEntry } from "../schema.ts";
+import { foldSocialLinks } from "./fold-social-links.ts";
+import {
+	EMPTY_FRAGMENT,
+	type FoldFragment,
+	isObjectPayload,
+	mergeFragment,
+} from "./fold-universe-shared.ts";
 import type { MigrationWarning } from "./migration-report.ts";
 import type { MantleResource } from "./types.ts";
 
@@ -17,11 +24,6 @@ const PLAYABLE_DEVICE_TO_FLAG: Readonly<
 	Phone: "mobileEnabled",
 	Tablet: "tabletEnabled",
 };
-
-interface FoldFragment {
-	readonly entryFragment: Partial<UniverseEntry>;
-	readonly warnings: ReadonlyArray<MigrationWarning>;
-}
 
 /**
  * Output of folding the experience-related Mantle resources of one
@@ -76,6 +78,7 @@ export function foldUniverse(
 		foldPrivateServers(resources),
 		foldVoiceChat(resources),
 		foldVisibility(resources),
+		foldSocialLinks(resources),
 	];
 
 	const entry: UniverseEntry = fragments.reduce<UniverseEntry>(
@@ -102,10 +105,6 @@ function coerceRobloxId(value: unknown): string | undefined {
 	}
 
 	return undefined;
-}
-
-function isObjectPayload(value: unknown): value is Record<string, unknown> {
-	return Object.prototype.toString.call(value) === "[object Object]";
 }
 
 function readExperienceOutputs(resource: MantleResource): ExperienceOutputs | undefined {
@@ -150,13 +149,6 @@ function mapPlayableDevice(raw: unknown): FoldFragment {
 				rule: "list-to-flag",
 			},
 		],
-	};
-}
-
-function mergeFragment(left: FoldFragment, right: FoldFragment): FoldFragment {
-	return {
-		entryFragment: { ...left.entryFragment, ...right.entryFragment },
-		warnings: [...left.warnings, ...right.warnings],
 	};
 }
 
@@ -316,5 +308,3 @@ function foldPrivateServers(resources: ReadonlyArray<MantleResource>): FoldFragm
 
 	return pricedPrivateServersFragment(privateServerPrice);
 }
-
-const EMPTY_FRAGMENT: FoldFragment = { entryFragment: {}, warnings: [] };

--- a/packages/bedrock/src/core/migrate/fold-universe.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.ts
@@ -35,15 +35,15 @@ const PLAYABLE_DEVICE_TO_FLAG: Readonly<
  *
  * `entry` populates the bedrock `Config.universe` block. `outputs`
  * populates the matching `BedrockState` resource's `outputs` field.
- * `warnings` accumulates per-rule diagnostics; the skeleton emits an
- * empty list because no interpretive rules have landed yet.
+ * `warnings` carries per-rule diagnostics that the migration report
+ * presents to the user.
  */
 interface UniverseFoldResult {
 	/** Bedrock `Config.universe` block populated from the experience resource. */
 	readonly entry: UniverseEntry;
 	/** Roblox-assigned identifiers carried into `BedrockState.resources[*].outputs`. */
 	readonly outputs: UniverseOutputs;
-	/** Per-rule diagnostics; empty in the skeleton, populated as rules land. */
+	/** Per-rule diagnostics emitted while folding this environment's resources. */
 	readonly warnings: ReadonlyArray<MigrationWarning>;
 }
 

--- a/packages/bedrock/src/core/migrate/fold-universe.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.ts
@@ -1,6 +1,7 @@
 import { asRobloxAssetId } from "../../types/ids.ts";
 import type { UniverseOutputs } from "../resources.ts";
 import type { UniverseEntry } from "../schema.ts";
+import { foldDisplayName } from "./fold-display-name.ts";
 import { foldSocialLinks } from "./fold-social-links.ts";
 import {
 	EMPTY_FRAGMENT,
@@ -79,6 +80,7 @@ export function foldUniverse(
 		foldVoiceChat(resources),
 		foldVisibility(resources),
 		foldSocialLinks(resources),
+		foldDisplayName(resources),
 	];
 
 	const entry: UniverseEntry = fragments.reduce<UniverseEntry>(

--- a/packages/bedrock/src/core/migrate/fold-universe.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.ts
@@ -5,6 +5,21 @@ import type { MigrationWarning } from "./migration-report.ts";
 import type { MantleResource } from "./types.ts";
 
 const EXPERIENCE_KIND = "experience";
+const EXPERIENCE_CONFIGURATION_KIND = "experienceConfiguration";
+
+const PLAYABLE_DEVICE_TO_FLAG: Readonly<
+	Record<string, "consoleEnabled" | "desktopEnabled" | "mobileEnabled" | "tabletEnabled">
+> = {
+	Computer: "desktopEnabled",
+	Console: "consoleEnabled",
+	Phone: "mobileEnabled",
+	Tablet: "tabletEnabled",
+};
+
+interface FoldFragment {
+	readonly entryFragment: Partial<UniverseEntry>;
+	readonly warnings: ReadonlyArray<MigrationWarning>;
+}
 
 /**
  * Output of folding the experience-related Mantle resources of one
@@ -33,13 +48,6 @@ interface ExperienceOutputs {
  * Fold the universe-contributing Mantle resources of one environment
  * into a `UniverseEntry` plus matching `UniverseOutputs`.
  *
- * Skeleton: only the `experience_singleton` resource is consumed.
- * `experience.outputs.assetId` becomes `universe.universeId`;
- * `experience.outputs.startPlaceId` becomes the bedrock state's
- * `outputs.rootPlaceId`. Future slices fold `experienceConfiguration`,
- * `experienceActivation`, `spatialVoice`, `socialLink_*`, and the start
- * place's `placeConfiguration.name` into the same entry.
- *
  * Returns `undefined` when no `experience_singleton` resource is present;
  * the caller treats that as "this environment has no universe to migrate"
  * and omits the `universe` field from the resulting `Config`.
@@ -61,10 +69,19 @@ export function foldUniverse(
 		return undefined;
 	}
 
+	const fragments: ReadonlyArray<FoldFragment> = [foldPlayableDevices(resources)];
+
+	const entry: UniverseEntry = fragments.reduce<UniverseEntry>(
+		(accumulator, fragment) => ({ ...accumulator, ...fragment.entryFragment }),
+		{ universeId: outputs.assetId },
+	);
+
+	const warnings = fragments.flatMap((fragment) => fragment.warnings);
+
 	return {
-		entry: { universeId: outputs.assetId },
+		entry,
 		outputs: { rootPlaceId: asRobloxAssetId(outputs.startPlaceId) },
-		warnings: [],
+		warnings,
 	};
 }
 
@@ -80,17 +97,77 @@ function coerceRobloxId(value: unknown): string | undefined {
 	return undefined;
 }
 
+function isObjectPayload(value: unknown): value is Record<string, unknown> {
+	return Object.prototype.toString.call(value) === "[object Object]";
+}
+
 function readExperienceOutputs(resource: MantleResource): ExperienceOutputs | undefined {
 	const raw = resource.outputs;
-	if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+	if (!isObjectPayload(raw)) {
 		return undefined;
 	}
 
-	const assetId = coerceRobloxId((raw as { assetId?: unknown }).assetId);
-	const startPlaceId = coerceRobloxId((raw as { startPlaceId?: unknown }).startPlaceId);
+	const assetId = coerceRobloxId(raw["assetId"]);
+	const startPlaceId = coerceRobloxId(raw["startPlaceId"]);
 	if (assetId === undefined || startPlaceId === undefined) {
 		return undefined;
 	}
 
 	return { assetId, startPlaceId };
 }
+
+const PLAYABLE_DEVICES_PATH = "experienceConfiguration_singleton.playableDevices";
+
+function mapPlayableDevice(raw: unknown): FoldFragment {
+	const flag = typeof raw === "string" ? PLAYABLE_DEVICE_TO_FLAG[raw] : undefined;
+	if (flag === undefined) {
+		return {
+			entryFragment: {},
+			warnings: [
+				{
+					kind: "blocked",
+					mantlePath: PLAYABLE_DEVICES_PATH,
+					reason: `Unknown playableDevices value: ${String(raw)}`,
+				},
+			],
+		};
+	}
+
+	return {
+		entryFragment: { [flag]: true },
+		warnings: [
+			{
+				bedrockPath: `universe.${flag}`,
+				kind: "interpretive",
+				mantlePath: PLAYABLE_DEVICES_PATH,
+				rule: "list-to-flag",
+			},
+		],
+	};
+}
+
+function mergeFragment(left: FoldFragment, right: FoldFragment): FoldFragment {
+	return {
+		entryFragment: { ...left.entryFragment, ...right.entryFragment },
+		warnings: [...left.warnings, ...right.warnings],
+	};
+}
+
+function foldPlayableDevices(resources: ReadonlyArray<MantleResource>): FoldFragment {
+	const config = resources.find((resource) => resource.kind === EXPERIENCE_CONFIGURATION_KIND);
+	if (config === undefined || !isObjectPayload(config.inputs)) {
+		return EMPTY_FRAGMENT;
+	}
+
+	const { playableDevices } = config.inputs;
+	if (!Array.isArray(playableDevices)) {
+		return EMPTY_FRAGMENT;
+	}
+
+	return playableDevices.reduce<FoldFragment>(
+		(accumulator, raw) => mergeFragment(accumulator, mapPlayableDevice(raw)),
+		EMPTY_FRAGMENT,
+	);
+}
+
+const EMPTY_FRAGMENT: FoldFragment = { entryFragment: {}, warnings: [] };

--- a/packages/bedrock/src/core/migrate/fold-universe.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.ts
@@ -4,8 +4,11 @@ import type { UniverseEntry } from "../schema.ts";
 import { foldDisplayName } from "./fold-display-name.ts";
 import { foldSocialLinks } from "./fold-social-links.ts";
 import {
+	ambiguousWarning,
+	blockedWarning,
 	EMPTY_FRAGMENT,
 	type FoldFragment,
+	interpretiveWarning,
 	isObjectPayload,
 	mergeFragment,
 } from "./fold-universe-shared.ts";
@@ -132,11 +135,10 @@ function mapPlayableDevice(raw: unknown): FoldFragment {
 		return {
 			entryFragment: {},
 			warnings: [
-				{
-					kind: "blocked",
-					mantlePath: PLAYABLE_DEVICES_PATH,
-					reason: `Unknown playableDevices value: ${String(raw)}`,
-				},
+				blockedWarning(
+					PLAYABLE_DEVICES_PATH,
+					`Unknown playableDevices value: ${String(raw)}`,
+				),
 			],
 		};
 	}
@@ -144,12 +146,11 @@ function mapPlayableDevice(raw: unknown): FoldFragment {
 	return {
 		entryFragment: { [flag]: true },
 		warnings: [
-			{
+			interpretiveWarning({
 				bedrockPath: `universe.${flag}`,
-				kind: "interpretive",
 				mantlePath: PLAYABLE_DEVICES_PATH,
 				rule: "list-to-flag",
-			},
+			}),
 		],
 	};
 }
@@ -174,12 +175,11 @@ function foldPlayableDevices(resources: ReadonlyArray<MantleResource>): FoldFrag
 const PRIVATE_SERVERS_DISABLED: FoldFragment = {
 	entryFragment: {},
 	warnings: [
-		{
+		interpretiveWarning({
 			bedrockPath: "universe.privateServerPriceRobux",
-			kind: "interpretive",
 			mantlePath: "experienceConfiguration_singleton.allowPrivateServers",
 			rule: "private-servers-disabled-omitted",
-		},
+		}),
 	],
 };
 
@@ -187,12 +187,11 @@ function pricedPrivateServersFragment(price: number): FoldFragment {
 	return {
 		entryFragment: { privateServerPriceRobux: price },
 		warnings: [
-			{
+			interpretiveWarning({
 				bedrockPath: "universe.privateServerPriceRobux",
-				kind: "interpretive",
 				mantlePath: "experienceConfiguration_singleton.privateServerPrice",
 				rule: "private-servers-priced",
-			},
+			}),
 		],
 	};
 }
@@ -200,34 +199,31 @@ function pricedPrivateServersFragment(price: number): FoldFragment {
 const VISIBILITY_PUBLIC_FRAGMENT: FoldFragment = {
 	entryFragment: { visibility: "public" },
 	warnings: [
-		{
+		interpretiveWarning({
 			bedrockPath: "universe.visibility",
-			kind: "interpretive",
 			mantlePath: "experienceActivation_singleton.isActive",
 			rule: "active-public-combo",
-		},
+		}),
 	],
 };
 
 const VISIBILITY_AMBIGUOUS: FoldFragment = {
 	entryFragment: {},
 	warnings: [
-		{
-			hint: "Set visibility manually or deactivate the universe in the Roblox dashboard; auto-mapping isActive=false to visibility=private would kick live players.",
-			kind: "ambiguous",
-			mantlePath: "experienceActivation_singleton.isActive",
-		},
+		ambiguousWarning(
+			"experienceActivation_singleton.isActive",
+			"Set visibility manually or deactivate the universe in the Roblox dashboard; auto-mapping isActive=false to visibility=private would kick live players.",
+		),
 	],
 };
 
 const VISIBILITY_FRIENDS_BLOCKED: FoldFragment = {
 	entryFragment: {},
 	warnings: [
-		{
-			kind: "blocked",
-			mantlePath: "experienceConfiguration_singleton.isFriendsOnly",
-			reason: "isFriendsOnly has no Open Cloud equivalent",
-		},
+		blockedWarning(
+			"experienceConfiguration_singleton.isFriendsOnly",
+			"isFriendsOnly has no Open Cloud equivalent",
+		),
 	],
 };
 
@@ -283,12 +279,11 @@ function foldVoiceChat(resources: ReadonlyArray<MantleResource>): FoldFragment {
 	return {
 		entryFragment: { voiceChatEnabled: enabled },
 		warnings: [
-			{
+			interpretiveWarning({
 				bedrockPath: "universe.voiceChatEnabled",
-				kind: "interpretive",
 				mantlePath: "spatialVoice_singleton.enabled",
 				rule: "voice-chat-enabled",
-			},
+			}),
 		],
 	};
 }

--- a/packages/bedrock/src/core/migrate/fold-universe.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.ts
@@ -69,7 +69,10 @@ export function foldUniverse(
 		return undefined;
 	}
 
-	const fragments: ReadonlyArray<FoldFragment> = [foldPlayableDevices(resources)];
+	const fragments: ReadonlyArray<FoldFragment> = [
+		foldPlayableDevices(resources),
+		foldPrivateServers(resources),
+	];
 
 	const entry: UniverseEntry = fragments.reduce<UniverseEntry>(
 		(accumulator, fragment) => ({ ...accumulator, ...fragment.entryFragment }),
@@ -168,6 +171,50 @@ function foldPlayableDevices(resources: ReadonlyArray<MantleResource>): FoldFrag
 		(accumulator, raw) => mergeFragment(accumulator, mapPlayableDevice(raw)),
 		EMPTY_FRAGMENT,
 	);
+}
+
+const PRIVATE_SERVERS_DISABLED: FoldFragment = {
+	entryFragment: {},
+	warnings: [
+		{
+			bedrockPath: "universe.privateServerPriceRobux",
+			kind: "interpretive",
+			mantlePath: "experienceConfiguration_singleton.allowPrivateServers",
+			rule: "private-servers-disabled-omitted",
+		},
+	],
+};
+
+function pricedPrivateServersFragment(price: number): FoldFragment {
+	return {
+		entryFragment: { privateServerPriceRobux: price },
+		warnings: [
+			{
+				bedrockPath: "universe.privateServerPriceRobux",
+				kind: "interpretive",
+				mantlePath: "experienceConfiguration_singleton.privateServerPrice",
+				rule: "private-servers-priced",
+			},
+		],
+	};
+}
+
+function foldPrivateServers(resources: ReadonlyArray<MantleResource>): FoldFragment {
+	const config = resources.find((resource) => resource.kind === EXPERIENCE_CONFIGURATION_KIND);
+	if (config === undefined || !isObjectPayload(config.inputs)) {
+		return EMPTY_FRAGMENT;
+	}
+
+	const { allowPrivateServers, privateServerPrice } = config.inputs;
+	if (allowPrivateServers === false) {
+		return PRIVATE_SERVERS_DISABLED;
+	}
+
+	if (allowPrivateServers !== true || typeof privateServerPrice !== "number") {
+		return EMPTY_FRAGMENT;
+	}
+
+	return pricedPrivateServersFragment(privateServerPrice);
 }
 
 const EMPTY_FRAGMENT: FoldFragment = { entryFragment: {}, warnings: [] };

--- a/packages/bedrock/tests/fixtures/roblox-ts-example.mantle-state.yml
+++ b/packages/bedrock/tests/fixtures/roblox-ts-example.mantle-state.yml
@@ -199,6 +199,17 @@ environments:
           assetId: 17622418492
       dependencies:
         - badge_1-example
+    - id: socialLink_discord.gg
+      inputs:
+        socialLink:
+          title: Join our Discord
+          url: https://discord.gg/example
+          linkType: Discord
+      outputs:
+        socialLink:
+          assetId: 4567890123
+      dependencies:
+        - experience_singleton
   production:
     - id: experience_singleton
       inputs:
@@ -405,3 +416,25 @@ environments:
           assetId: 17834657184
       dependencies:
         - badge_1-example
+    - id: socialLink_discord.gg
+      inputs:
+        socialLink:
+          title: Join our Discord
+          url: https://discord.gg/example
+          linkType: Discord
+      outputs:
+        socialLink:
+          assetId: 4567890456
+      dependencies:
+        - experience_singleton
+    - id: socialLink_twitter.com
+      inputs:
+        socialLink:
+          title: Follow us on Twitter
+          url: https://twitter.com/example
+          linkType: Twitter
+      outputs:
+        socialLink:
+          assetId: 4567890457
+      dependencies:
+        - experience_singleton

--- a/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
@@ -219,4 +219,110 @@ describe(migrateMantleState, () => {
 		expect(ambiguous[0].hint).toContain("missing-icon.png");
 		expect(result.data.summary.ambiguousCount).toBeGreaterThanOrEqual(1);
 	});
+
+	it("should fold every interpretive universe rule for the production primary", async () => {
+		expect.assertions(1);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			primaryEnvironment: "production",
+			stateFilePath: REAL_FIXTURE,
+		});
+
+		assert(result.success);
+
+		expect(result.data.config.universe).toMatchObject({
+			consoleEnabled: true,
+			desktopEnabled: true,
+			discordSocialLink: { title: "Join our Discord", uri: "https://discord.gg/example" },
+			displayName: "roblox-ts Project Template",
+			mobileEnabled: true,
+			privateServerPriceRobux: 0,
+			tabletEnabled: true,
+			twitterSocialLink: {
+				title: "Follow us on Twitter",
+				uri: "https://twitter.com/example",
+			},
+			universeId: "6110424408",
+			visibility: "public",
+			voiceChatEnabled: true,
+		});
+	});
+
+	it("should fold the development primary into a separate universe shape with visibility omitted", async () => {
+		expect.assertions(3);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			primaryEnvironment: "development",
+			stateFilePath: REAL_FIXTURE,
+		});
+
+		assert(result.success);
+
+		expect(result.data.config.universe).toMatchObject({
+			consoleEnabled: true,
+			desktopEnabled: true,
+			discordSocialLink: { title: "Join our Discord", uri: "https://discord.gg/example" },
+			displayName: "[DEVELOPMENT] roblox-ts Project Template",
+			mobileEnabled: true,
+			privateServerPriceRobux: 0,
+			tabletEnabled: true,
+			universeId: "6031475575",
+			voiceChatEnabled: true,
+		});
+
+		expect(result.data.config.universe?.visibility).toBeUndefined();
+		expect(result.data.config.universe?.twitterSocialLink).toBeUndefined();
+	});
+
+	it("should emit an ambiguous warning rooted at development.experienceActivation_singleton.isActive", async () => {
+		expect.assertions(2);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			primaryEnvironment: "production",
+			stateFilePath: REAL_FIXTURE,
+		});
+
+		assert(result.success);
+
+		const ambiguous = result.data.warnings.find((warning) => {
+			return (
+				warning.kind === "ambiguous" &&
+				warning.mantlePath === "development.experienceActivation_singleton.isActive"
+			);
+		});
+		assert(ambiguous?.kind === "ambiguous");
+
+		expect(ambiguous.hint).toMatch(/dashboard/i);
+		expect(result.data.summary.ambiguousCount).toBeGreaterThanOrEqual(1);
+	});
+
+	it("should report interpretive warnings for every universe fold rule applied", async () => {
+		expect.assertions(2);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			primaryEnvironment: "production",
+			stateFilePath: REAL_FIXTURE,
+		});
+
+		assert(result.success);
+
+		const interpretiveRules = result.data.warnings
+			.filter((warning) => warning.kind === "interpretive")
+			.map((warning) => warning.rule);
+
+		expect(interpretiveRules).toIncludeAllMembers([
+			"active-public-combo",
+			"domain-to-field",
+			"list-to-flag",
+			"private-servers-priced",
+			"start-place-name-to-display-name",
+			"voice-chat-enabled",
+		]);
+
+		expect(result.data.summary.interpretiveCount).toBeGreaterThan(0);
+	});
 });

--- a/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
@@ -231,7 +231,7 @@ describe(migrateMantleState, () => {
 
 		assert(result.success);
 
-		expect(result.data.config.universe).toMatchObject({
+		expect(result.data.config.universe).toStrictEqual({
 			consoleEnabled: true,
 			desktopEnabled: true,
 			discordSocialLink: { title: "Join our Discord", uri: "https://discord.gg/example" },
@@ -250,7 +250,7 @@ describe(migrateMantleState, () => {
 	});
 
 	it("should fold the development primary into a separate universe shape with visibility omitted", async () => {
-		expect.assertions(3);
+		expect.assertions(1);
 
 		const result = await migrateMantleState({
 			configFormat: "typescript",
@@ -260,7 +260,7 @@ describe(migrateMantleState, () => {
 
 		assert(result.success);
 
-		expect(result.data.config.universe).toMatchObject({
+		expect(result.data.config.universe).toStrictEqual({
 			consoleEnabled: true,
 			desktopEnabled: true,
 			discordSocialLink: { title: "Join our Discord", uri: "https://discord.gg/example" },
@@ -271,9 +271,6 @@ describe(migrateMantleState, () => {
 			universeId: "6031475575",
 			voiceChatEnabled: true,
 		});
-
-		expect(result.data.config.universe?.visibility).toBeUndefined();
-		expect(result.data.config.universe?.twitterSocialLink).toBeUndefined();
 	});
 
 	it("should emit an ambiguous warning rooted at development.experienceActivation_singleton.isActive", async () => {


### PR DESCRIPTION
## Summary

- Wire the six interpretive fold rules from PRD #103 into `migrateMantleState`'s universe path so a freshly-migrated config matches the user's deployed reality across all of `playableDevices`, `allowPrivateServers + privateServerPrice`, `spatialVoice.enabled`, the `experienceActivation.isActive + experienceConfiguration.isFriendsOnly` cross-fold, the 8-domain → 7-field `socialLink_<domain>` table, and the start place's `placeConfiguration_<k>.name`.
- Each rule emits the matching `MigrationWarning` (`interpretive` per applied mapping; `blocked` for unknown device strings, unknown social-link domains, non-start `placeConfiguration.name`, and the friends-only visibility combo; `ambiguous` for `isActive: false` and the multi-`isStart` case) so every decision is auditable in the report.
- Centralize `interpretiveWarning`, `blockedWarning`, and `ambiguousWarning` builders in `fold-universe-shared.ts`; per-rule logic lives in `fold-universe.ts` (orchestrator + simple singletons), `fold-social-links.ts`, and `fold-display-name.ts`. Mantle's wire field `url` is renamed to bedrock's `uri` at the social-link boundary; mantle's `linkType` discriminator is ignored because the resource id's domain is authoritative.
- Extend `roblox-ts-example.mantle-state.yml` with `socialLink_<domain>` resources matching mantle's wire shape verbatim (PascalCase `linkType`, integer `outputs.socialLink.assetId`, dependencies on `experience_singleton`); both envs share a Discord link, production carries an extra Twitter link to exercise per-env divergence.

Closes #206.

## Test plan

- [x] `pnpm --filter @bedrock/core test` (1210 pass, 73 new fold + 4 new integration tests)
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] `pnpm mutate:changed` (100% mutation score on touched files)
- [x] Integration tests exercise both primary environments end-to-end and assert that warnings carry every interpretive rule plus the `development.experienceActivation_singleton.isActive` ambiguous

## Notes for reviewers

- Per-env universe overlay factorization is **not** wired in this PR. `buildEnvironmentEntry` in `migrate-mantle-state.ts` only builds a `places` overlay, so `selectEnvironment(config, env)` returns the primary's universe values for every env. The new e2e tests work around this by calling `migrateMantleState` twice with different `primaryEnvironment` values; wiring the universe overlay is a follow-up task.
- For social-link resources whose key is in `SOCIAL_LINK_DOMAIN_TO_FIELD` but where multiple domains map to the same field (`roblox.com` and `www.roblox.com` both route to `robloxGroupSocialLink`), last-write-wins. Real Mantle states do not produce this duplicate, so no warning is emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)