### PR TITLE
ci: deploy website on release tags, add main preview channel

### DIFF
--- a/.github/workflows/website-release.yaml
+++ b/.github/workflows/website-release.yaml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/website-release.yaml
+++ b/.github/workflows/website-release.yaml
@@ -1,0 +1,45 @@
+# Production docs deploy. Fires on a release tag matching the Changesets
+# default for `@bedrock/core`, builds TypeDoc + VitePress against the tagged
+# source, and ships the output to the production Vercel project.
+# A separate Vercel project (configured via the dashboard) tracks `main` for
+# unreleased preview docs and is not driven by this workflow.
+
+name: Website Release
+
+on:
+  push:
+    tags: ["@bedrock/core@*"]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: website-release
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy production docs
+    runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+
+      - name: Build with Vercel
+        run: vercel build --prod --token="$VERCEL_TOKEN"
+
+      - name: Deploy to production
+        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"
+    timeout-minutes: 15

--- a/apps/website/.vitepress/config.ts
+++ b/apps/website/.vitepress/config.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import process from "node:process";
 import { defineConfig } from "vitepress";
 import { tabsMarkdownPlugin } from "vitepress-plugin-tabs";
 
@@ -6,6 +7,8 @@ import { buildSidebarFromNavigation, type NavigationItem } from "./build-sidebar
 
 const navigationBedrock = loadNavigation("./docs/bedrock/api/navigation.json");
 const navigationOcale = loadNavigation("./docs/ocale/api/navigation.json");
+
+const IS_PREVIEW_CHANNEL = process.env["BEDROCK_DOCS_CHANNEL"] === "next";
 
 export default defineConfig({
 	cleanUrls: true,
@@ -25,6 +28,9 @@ export default defineConfig({
 			{ link: "/", text: "Home" },
 			{ link: "/bedrock/guide/getting-started", text: "Bedrock" },
 			{ link: "/ocale/guide/getting-started", text: "Ocale" },
+			...(IS_PREVIEW_CHANNEL
+				? [{ link: "https://bedrock-livid.vercel.app/", text: "Latest release" }]
+				: []),
 		],
 		sidebar: {
 			"/bedrock/": [
@@ -55,7 +61,7 @@ export default defineConfig({
 		},
 		socialLinks: [{ icon: "github", link: "https://github.com/christopher-buss/bedrock" }],
 	},
-	title: "Bedrock",
+	title: IS_PREVIEW_CHANNEL ? "Bedrock (preview)" : "Bedrock",
 });
 
 function toNavigationItem(value: JSONValue): NavigationItem | undefined {

--- a/docs/adr/004-documentation-site.md
+++ b/docs/adr/004-documentation-site.md
@@ -140,3 +140,18 @@ reviewing documentation changes before merge.
   `@bedrock/ocale`. URL path is now `/ocale/` (not `/open-cloud/`) and TypeDoc
   emits to `apps/website/docs/ocale/api/`. The directory `packages/open-cloud/`
   retains its original name.
+
+- **2026-04-29:** Production docs deploy on release tags, not `main`. The
+  Vercel project at `bedrock-livid.vercel.app` is driven by
+  `.github/workflows/website-release.yaml`, which fires on push of a tag
+  matching `@bedrock/core@*` (the Changesets default), checks out the tagged
+  commit, and runs `vercel pull` / `vercel build --prod` /
+  `vercel deploy --prebuilt --prod`. Required repo secrets: `VERCEL_TOKEN`,
+  `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`. The dashboard's git integration for
+  this project must have auto-deploy on `main` disabled. A second Vercel
+  project tracks `main` for previewing unreleased work; it builds with the
+  environment variable `BEDROCK_DOCS_CHANNEL=next`, which the VitePress
+  config consumes to prefix the title (`Bedrock (preview)`) and add a "Latest
+  release" link to the navbar pointing back at production. The site remains
+  single-version; a version switcher is deferred until the API stabilizes
+  at 1.0. Issue #137.


### PR DESCRIPTION
## Summary

- New `.github/workflows/website-release.yaml` deploys to the existing Vercel production project on push of a tag matching `@bedrock/core@*` (the Changesets default).
- VitePress config reads `BEDROCK_DOCS_CHANNEL=next` to mark the preview surface: title becomes `Bedrock (preview)` and a `Latest release` link appears in the navbar.
- ADR-004 amendment records the new deploy split.

## Why

Closes #137. Production docs at `bedrock-livid.vercel.app` rebuild on every push to `main`, so once `@bedrock/core` ships, readers will land on APIs that have not yet been released, and `@example` blocks (per ADR-005) calling symbols that don't exist in their installed version. ADR-017 makes every export from `packages/bedrock/src/index.ts` part of the semver contract, so the public site needs to mirror what consumers can `pnpm install` rather than the in-progress state of `main`.

The site stays single-version. A version switcher and multi-version hosting are deferred until 1.0.

## State already configured

- `bedrock` (production) Vercel project: git disconnected; only deploys via this workflow.
- `bedrock-next` (preview) Vercel project: git-connected to this repo with `BEDROCK_DOCS_CHANNEL=next`; auto-deploys on `main`.
- Repo secrets `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` set.

## Prerequisite

The workflow can't fire until Changesets is adopted and cuts the first `@bedrock/core@X.Y.Z` tag. Tracked separately. If Changesets is configured for a different tag pattern, update the `tags:` filter in `website-release.yaml`.

## Test plan

- [ ] Merge: `bedrock-next` auto-deploys; site shows `Bedrock (preview)` title and the `Latest release` navbar link.
- [ ] Merge: `bedrock` production project does *not* redeploy.
- [ ] First Changesets tag push: `website-release.yaml` fires and updates `bedrock-livid.vercel.app` against the tagged source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)