### PR TITLE
feat(core): emit blocked warnings for legacy fields in mantle migrator

### DIFF
--- a/packages/bedrock/src/core/migrate/fold-blocked-experience-fields.ts
+++ b/packages/bedrock/src/core/migrate/fold-blocked-experience-fields.ts
@@ -1,4 +1,9 @@
-import { blockedWarning, type FoldFragment, isObjectPayload } from "./fold-universe-shared.ts";
+import {
+	type BlockedFieldRule,
+	blockedWarning,
+	type FoldFragment,
+	isObjectPayload,
+} from "./fold-universe-shared.ts";
 import type { MigrationWarning } from "./migration-report.ts";
 import type { MantleResource } from "./types.ts";
 
@@ -7,11 +12,6 @@ const EXPERIENCE_CONFIGURATION_KIND = "experienceConfiguration";
 const UNIVERSE_AVATAR_PREFIX = "universeAvatar";
 const UNIVERSE_AVATAR_REASON = "avatar configuration has no Open Cloud equivalent";
 const GROUP_ID_REASON = "Open Cloud does not support transferring experience ownership";
-
-interface BlockedFieldRule {
-	readonly field: string;
-	readonly reason: string;
-}
 
 /**
  * `experienceConfiguration_singleton` fields with no Open Cloud writable

--- a/packages/bedrock/src/core/migrate/fold-blocked-experience-fields.ts
+++ b/packages/bedrock/src/core/migrate/fold-blocked-experience-fields.ts
@@ -8,6 +8,8 @@ import type { MigrationWarning } from "./migration-report.ts";
 import type { MantleResource } from "./types.ts";
 
 const EXPERIENCE_CONFIGURATION_KIND = "experienceConfiguration";
+const UNIVERSE_AVATAR_PREFIX = "universeAvatar";
+const UNIVERSE_AVATAR_REASON = "avatar configuration has no Open Cloud equivalent";
 
 interface BlockedFieldRule {
 	readonly field: string;
@@ -58,7 +60,7 @@ export function foldBlockedExperienceFields(
 	}
 
 	const { inputs } = config;
-	const warnings: ReadonlyArray<MigrationWarning> = BLOCKED_FIELDS.flatMap((rule) => {
+	const staticWarnings: ReadonlyArray<MigrationWarning> = BLOCKED_FIELDS.flatMap((rule) => {
 		if (inputs[rule.field] === undefined) {
 			return [];
 		}
@@ -66,5 +68,11 @@ export function foldBlockedExperienceFields(
 		return [blockedWarning(`experienceConfiguration_singleton.${rule.field}`, rule.reason)];
 	});
 
-	return { entryFragment: {}, warnings };
+	const avatarWarnings: ReadonlyArray<MigrationWarning> = Object.keys(inputs)
+		.filter((key) => key.startsWith(UNIVERSE_AVATAR_PREFIX) && inputs[key] !== undefined)
+		.map((key) =>
+			blockedWarning(`experienceConfiguration_singleton.${key}`, UNIVERSE_AVATAR_REASON),
+		);
+
+	return { entryFragment: {}, warnings: [...staticWarnings, ...avatarWarnings] };
 }

--- a/packages/bedrock/src/core/migrate/fold-blocked-experience-fields.ts
+++ b/packages/bedrock/src/core/migrate/fold-blocked-experience-fields.ts
@@ -1,0 +1,70 @@
+import {
+	blockedWarning,
+	EMPTY_FRAGMENT,
+	type FoldFragment,
+	isObjectPayload,
+} from "./fold-universe-shared.ts";
+import type { MigrationWarning } from "./migration-report.ts";
+import type { MantleResource } from "./types.ts";
+
+const EXPERIENCE_CONFIGURATION_KIND = "experienceConfiguration";
+
+interface BlockedFieldRule {
+	readonly field: string;
+	readonly reason: string;
+}
+
+/**
+ * `experienceConfiguration_singleton` fields with no Open Cloud writable
+ * endpoint. `isFriendsOnly` is intentionally omitted: `foldVisibility`
+ * already owns it, and listing it here would double-emit when
+ * `experienceActivation_singleton.isActive` is `true` and the cross-fold
+ * blocks the public-friends combo.
+ */
+const BLOCKED_FIELDS: ReadonlyArray<BlockedFieldRule> = [
+	{ field: "genre", reason: "Roblox does not expose `genre` via Open Cloud" },
+	{ field: "isForSale", reason: "paid-access flag has no Open Cloud equivalent" },
+	{ field: "price", reason: "paid-access flag has no Open Cloud equivalent" },
+	{
+		field: "studioAccessToApisAllowed",
+		reason: "Open Cloud does not currently expose a write endpoint for studio API access",
+	},
+	{
+		field: "permissions",
+		reason: "experienceConfiguration.permissions has no Open Cloud equivalent",
+	},
+	{ field: "isArchived", reason: "isArchived has no Open Cloud equivalent" },
+];
+
+/**
+ * Emit one `blocked` `MigrationWarning` per non-`undefined` field of
+ * `experienceConfiguration_singleton.inputs` that has no Open Cloud
+ * writable endpoint. The Mantle null sentinel (`~`) is normalized to
+ * `undefined` by `parseState`, so absent and null fields both skip.
+ *
+ * Returns `EMPTY_FRAGMENT` when no `experienceConfiguration` resource is
+ * present or its `inputs` payload is not a plain object. The fragment's
+ * `entryFragment` is always empty; this fold contributes only warnings.
+ *
+ * @param resources - Mantle resource list for one environment.
+ * @returns A fragment whose warnings list every blocked field present.
+ */
+export function foldBlockedExperienceFields(
+	resources: ReadonlyArray<MantleResource>,
+): FoldFragment {
+	const config = resources.find((resource) => resource.kind === EXPERIENCE_CONFIGURATION_KIND);
+	if (config === undefined || !isObjectPayload(config.inputs)) {
+		return EMPTY_FRAGMENT;
+	}
+
+	const { inputs } = config;
+	const warnings: ReadonlyArray<MigrationWarning> = BLOCKED_FIELDS.flatMap((rule) => {
+		if (inputs[rule.field] === undefined) {
+			return [];
+		}
+
+		return [blockedWarning(`experienceConfiguration_singleton.${rule.field}`, rule.reason)];
+	});
+
+	return { entryFragment: {}, warnings };
+}

--- a/packages/bedrock/src/core/migrate/fold-blocked-experience-fields.ts
+++ b/packages/bedrock/src/core/migrate/fold-blocked-experience-fields.ts
@@ -1,15 +1,12 @@
-import {
-	blockedWarning,
-	EMPTY_FRAGMENT,
-	type FoldFragment,
-	isObjectPayload,
-} from "./fold-universe-shared.ts";
+import { blockedWarning, type FoldFragment, isObjectPayload } from "./fold-universe-shared.ts";
 import type { MigrationWarning } from "./migration-report.ts";
 import type { MantleResource } from "./types.ts";
 
+const EXPERIENCE_KIND = "experience";
 const EXPERIENCE_CONFIGURATION_KIND = "experienceConfiguration";
 const UNIVERSE_AVATAR_PREFIX = "universeAvatar";
 const UNIVERSE_AVATAR_REASON = "avatar configuration has no Open Cloud equivalent";
+const GROUP_ID_REASON = "Open Cloud does not support transferring experience ownership";
 
 interface BlockedFieldRule {
 	readonly field: string;
@@ -39,14 +36,16 @@ const BLOCKED_FIELDS: ReadonlyArray<BlockedFieldRule> = [
 ];
 
 /**
- * Emit one `blocked` `MigrationWarning` per non-`undefined` field of
- * `experienceConfiguration_singleton.inputs` that has no Open Cloud
- * writable endpoint. The Mantle null sentinel (`~`) is normalized to
- * `undefined` by `parseState`, so absent and null fields both skip.
+ * Emit one `blocked` `MigrationWarning` per non-`undefined` legacy-only
+ * field on the experience-side Mantle resources: every entry in the
+ * static `BLOCKED_FIELDS` table on `experienceConfiguration_singleton`,
+ * any key under the `universeAvatar` prefix, and `groupId` on
+ * `experience_singleton`. The Mantle null sentinel (`~`) is normalized
+ * to `undefined` by `parseState`, so absent and null fields both skip.
  *
- * Returns `EMPTY_FRAGMENT` when no `experienceConfiguration` resource is
- * present or its `inputs` payload is not a plain object. The fragment's
- * `entryFragment` is always empty; this fold contributes only warnings.
+ * The fragment's `entryFragment` is always empty; this fold contributes
+ * only warnings, and the `warnings` array is empty when none of the
+ * watched resources have a populated blocked field.
  *
  * @param resources - Mantle resource list for one environment.
  * @returns A fragment whose warnings list every blocked field present.
@@ -54,25 +53,52 @@ const BLOCKED_FIELDS: ReadonlyArray<BlockedFieldRule> = [
 export function foldBlockedExperienceFields(
 	resources: ReadonlyArray<MantleResource>,
 ): FoldFragment {
-	const config = resources.find((resource) => resource.kind === EXPERIENCE_CONFIGURATION_KIND);
-	if (config === undefined || !isObjectPayload(config.inputs)) {
-		return EMPTY_FRAGMENT;
+	return {
+		entryFragment: {},
+		warnings: [...configurationWarnings(resources), ...groupIdWarnings(resources)],
+	};
+}
+
+function groupIdWarnings(
+	resources: ReadonlyArray<MantleResource>,
+): ReadonlyArray<MigrationWarning> {
+	const experience = resources.find((resource) => resource.kind === EXPERIENCE_KIND);
+	if (
+		experience === undefined ||
+		!isObjectPayload(experience.inputs) ||
+		experience.inputs["groupId"] === undefined
+	) {
+		return [];
 	}
 
-	const { inputs } = config;
-	const staticWarnings: ReadonlyArray<MigrationWarning> = BLOCKED_FIELDS.flatMap((rule) => {
+	return [blockedWarning("experience_singleton.groupId", GROUP_ID_REASON)];
+}
+
+function staticFieldWarnings(inputs: Record<string, unknown>): ReadonlyArray<MigrationWarning> {
+	return BLOCKED_FIELDS.flatMap((rule) => {
 		if (inputs[rule.field] === undefined) {
 			return [];
 		}
 
 		return [blockedWarning(`experienceConfiguration_singleton.${rule.field}`, rule.reason)];
 	});
+}
 
-	const avatarWarnings: ReadonlyArray<MigrationWarning> = Object.keys(inputs)
+function avatarFieldWarnings(inputs: Record<string, unknown>): ReadonlyArray<MigrationWarning> {
+	return Object.keys(inputs)
 		.filter((key) => key.startsWith(UNIVERSE_AVATAR_PREFIX) && inputs[key] !== undefined)
 		.map((key) =>
 			blockedWarning(`experienceConfiguration_singleton.${key}`, UNIVERSE_AVATAR_REASON),
 		);
+}
 
-	return { entryFragment: {}, warnings: [...staticWarnings, ...avatarWarnings] };
+function configurationWarnings(
+	resources: ReadonlyArray<MantleResource>,
+): ReadonlyArray<MigrationWarning> {
+	const config = resources.find((resource) => resource.kind === EXPERIENCE_CONFIGURATION_KIND);
+	if (config === undefined || !isObjectPayload(config.inputs)) {
+		return [];
+	}
+
+	return [...staticFieldWarnings(config.inputs), ...avatarFieldWarnings(config.inputs)];
 }

--- a/packages/bedrock/src/core/migrate/fold-blocked-place-fields.ts
+++ b/packages/bedrock/src/core/migrate/fold-blocked-place-fields.ts
@@ -1,0 +1,70 @@
+import { blockedWarning, isObjectPayload } from "./fold-universe-shared.ts";
+import type { MigrationWarning } from "./migration-report.ts";
+import type { MantleResource } from "./types.ts";
+
+const PLACE_CONFIGURATION_KIND = "placeConfiguration";
+
+interface BlockedFieldRule {
+	readonly field: string;
+	readonly reason: string;
+}
+
+/**
+ * `placeConfiguration_<k>` fields with no Open Cloud writable endpoint.
+ * `name` is intentionally omitted: `foldDisplayName` already owns it
+ * (start-place name folds into `universe.displayName`; non-start names
+ * already emit a blocked warning).
+ */
+const BLOCKED_FIELDS: ReadonlyArray<BlockedFieldRule> = [
+	{
+		field: "description",
+		reason: "placeConfiguration.description has no Open Cloud equivalent",
+	},
+	{
+		field: "maxPlayerCount",
+		reason: "placeConfiguration.maxPlayerCount has no Open Cloud equivalent",
+	},
+	{
+		field: "allowCopying",
+		reason: "placeConfiguration.allowCopying has no Open Cloud equivalent",
+	},
+	{
+		field: "socialSlotType",
+		reason: "placeConfiguration social-slot config has no Open Cloud equivalent",
+	},
+	{
+		field: "customSocialSlotsCount",
+		reason: "placeConfiguration social-slot config has no Open Cloud equivalent",
+	},
+];
+
+/**
+ * Emit one `blocked` `MigrationWarning` per non-`undefined` legacy-only
+ * field on every `placeConfiguration_<k>` resource. The Mantle null
+ * sentinel (`~`) is normalized to `undefined` by `parseState`, so absent
+ * and null fields both skip.
+ *
+ * @param resources - Mantle resource list for one environment.
+ * @returns One warning per blocked field present, ordered by resource
+ *   list then by the static field table.
+ */
+export function foldBlockedPlaceFields(
+	resources: ReadonlyArray<MantleResource>,
+): ReadonlyArray<MigrationWarning> {
+	return resources.flatMap((resource) => {
+		if (resource.kind !== PLACE_CONFIGURATION_KIND || !isObjectPayload(resource.inputs)) {
+			return [];
+		}
+
+		const { key, inputs } = resource;
+		return BLOCKED_FIELDS.flatMap((rule) => {
+			if (inputs[rule.field] === undefined) {
+				return [];
+			}
+
+			return [
+				blockedWarning(`${PLACE_CONFIGURATION_KIND}_${key}.${rule.field}`, rule.reason),
+			];
+		});
+	});
+}

--- a/packages/bedrock/src/core/migrate/fold-blocked-place-fields.ts
+++ b/packages/bedrock/src/core/migrate/fold-blocked-place-fields.ts
@@ -1,13 +1,8 @@
-import { blockedWarning, isObjectPayload } from "./fold-universe-shared.ts";
+import { type BlockedFieldRule, blockedWarning, isObjectPayload } from "./fold-universe-shared.ts";
 import type { MigrationWarning } from "./migration-report.ts";
 import type { MantleResource } from "./types.ts";
 
 const PLACE_CONFIGURATION_KIND = "placeConfiguration";
-
-interface BlockedFieldRule {
-	readonly field: string;
-	readonly reason: string;
-}
 
 /**
  * `placeConfiguration_<k>` fields with no Open Cloud writable endpoint.

--- a/packages/bedrock/src/core/migrate/fold-places.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.spec.ts
@@ -45,6 +45,16 @@ function defaultPlaceFile(key: string): MantleResource {
 	});
 }
 
+function placeConfiguration(key: string, inputs: unknown): MantleResource {
+	return {
+		key,
+		dependencies: [],
+		inputs,
+		kind: "placeConfiguration",
+		outputs: undefined,
+	};
+}
+
 describe(foldPlaces, () => {
 	it("should fold a matched place and placeFile pair into one entry", () => {
 		expect.assertions(2);
@@ -276,5 +286,119 @@ describe(foldPlaces, () => {
 		expect(start.placeId).toBe("17613681043");
 		expect(lobby.placeId).toBe("17613681044");
 		expect(lobby.entry).toStrictEqual({ filePath: "lobby.rbxl" });
+	});
+
+	describe("blocked placeConfiguration fields", () => {
+		it.for<[label: string, field: string, value: unknown, reason: string]>([
+			[
+				"description",
+				"description",
+				"A project template",
+				"placeConfiguration.description has no Open Cloud equivalent",
+			],
+			[
+				"maxPlayerCount",
+				"maxPlayerCount",
+				700,
+				"placeConfiguration.maxPlayerCount has no Open Cloud equivalent",
+			],
+			[
+				"allowCopying",
+				"allowCopying",
+				true,
+				"placeConfiguration.allowCopying has no Open Cloud equivalent",
+			],
+			[
+				"socialSlotType",
+				"socialSlotType",
+				"Automatic",
+				"placeConfiguration social-slot config has no Open Cloud equivalent",
+			],
+			[
+				"customSocialSlotsCount",
+				"customSocialSlotsCount",
+				4,
+				"placeConfiguration social-slot config has no Open Cloud equivalent",
+			],
+		])("should emit a blocked warning when %s is set", ([, field, value, reason]) => {
+			expect.assertions(1);
+
+			const result = foldPlaces([placeConfiguration("start", { [field]: value })]);
+
+			expect(result.warnings).toStrictEqual([
+				{
+					kind: "blocked",
+					mantlePath: `placeConfiguration_start.${field}`,
+					reason,
+				},
+			]);
+		});
+
+		it("should emit no warning for a tracked field whose value is undefined", () => {
+			expect.assertions(1);
+
+			const result = foldPlaces([
+				placeConfiguration("start", {
+					allowCopying: undefined,
+					description: undefined,
+				}),
+			]);
+
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should emit one warning per tracked field per placeConfiguration resource", () => {
+			expect.assertions(1);
+
+			const result = foldPlaces([
+				placeConfiguration("start", {
+					allowCopying: true,
+					description: "Start place",
+					maxPlayerCount: 50,
+				}),
+				placeConfiguration("lobby", { socialSlotType: "Empty" }),
+			]);
+
+			expect(result.warnings).toIncludeAllPartialMembers([
+				{ kind: "blocked", mantlePath: "placeConfiguration_start.description" },
+				{ kind: "blocked", mantlePath: "placeConfiguration_start.maxPlayerCount" },
+				{ kind: "blocked", mantlePath: "placeConfiguration_start.allowCopying" },
+				{ kind: "blocked", mantlePath: "placeConfiguration_lobby.socialSlotType" },
+			]);
+		});
+
+		it("should emit no blocked warning when no placeConfiguration resource is present", () => {
+			expect.assertions(1);
+
+			const result = foldPlaces([
+				place({ key: "start", outputs: { assetId: 17613681043 } }),
+				defaultPlaceFile("start"),
+			]);
+
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should skip a placeConfiguration whose inputs is not an object", () => {
+			expect.assertions(1);
+
+			const result = foldPlaces([placeConfiguration("start", "not-an-object")]);
+
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should not emit a blocked warning for the name field (foldDisplayName owns it)", () => {
+			expect.assertions(1);
+
+			const result = foldPlaces([placeConfiguration("start", { name: "My Place" })]);
+
+			expect(
+				result.warnings.filter((warning) => {
+					return (
+						warning.kind === "blocked" &&
+						warning.mantlePath === "placeConfiguration_start.name"
+					);
+				}),
+			).toStrictEqual([]);
+		});
 	});
 });

--- a/packages/bedrock/src/core/migrate/fold-places.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.ts
@@ -1,6 +1,7 @@
 import { isSha256Hex, type Sha256Hex } from "../../types/ids.ts";
 import type { PlaceOutputs } from "../resources.ts";
 import type { PlaceEntry } from "../schema.ts";
+import { foldBlockedPlaceFields } from "./fold-blocked-place-fields.ts";
 import type { MigrationWarning } from "./migration-report.ts";
 import type { MantleResource } from "./types.ts";
 
@@ -99,7 +100,7 @@ export function foldPlaces(resources: ReadonlyArray<MantleResource>): PlaceFoldR
 		}
 	}
 
-	return { entries, warnings };
+	return { entries, warnings: [...warnings, ...foldBlockedPlaceFields(resources)] };
 }
 
 function bucketByKind(resources: ReadonlyArray<MantleResource>): {

--- a/packages/bedrock/src/core/migrate/fold-universe-shared.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe-shared.ts
@@ -17,6 +17,19 @@ export interface FoldFragment {
 export const EMPTY_FRAGMENT: FoldFragment = { entryFragment: {}, warnings: [] };
 
 /**
+ * One row in a static blocked-field table: the Mantle field name and the
+ * upstream limitation reason that the migrator surfaces verbatim in the
+ * warning's `reason` slot. Used by folds that emit one `blocked`
+ * `MigrationWarning` per non-`undefined` legacy-only field.
+ */
+export interface BlockedFieldRule {
+	/** Mantle input key to test for non-`undefined`. */
+	readonly field: string;
+	/** Human-readable reason naming the upstream limitation. */
+	readonly reason: string;
+}
+
+/**
  * Required fields for an `interpretive` warning, gathered as a single
  * argument so this builder stays under the project's max-params cap.
  */

--- a/packages/bedrock/src/core/migrate/fold-universe.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.spec.ts
@@ -1309,5 +1309,71 @@ describe(foldUniverse, () => {
 
 			expect(result.warnings).toStrictEqual([]);
 		});
+
+		it("should emit a blocked warning when experience.inputs.groupId is set", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				{
+					key: "singleton",
+					dependencies: [],
+					inputs: { groupId: 12345 },
+					kind: "experience",
+					outputs: DEFAULT_EXPERIENCE_OUTPUTS,
+				},
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.warnings).toStrictEqual([
+				{
+					kind: "blocked",
+					mantlePath: "experience_singleton.groupId",
+					reason: "Open Cloud does not support transferring experience ownership",
+				},
+			]);
+		});
+
+		it("should not emit a groupId blocked warning when groupId is undefined", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([experience(DEFAULT_EXPERIENCE_OUTPUTS)]);
+
+			assert(result !== undefined);
+
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should read groupId from the experience resource even when other resources precede it", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experienceConfiguration({ allowPrivateServers: undefined }),
+				{
+					key: "singleton",
+					dependencies: [],
+					inputs: { groupId: 12345 },
+					kind: "experience",
+					outputs: DEFAULT_EXPERIENCE_OUTPUTS,
+				},
+			]);
+
+			assert(result !== undefined);
+
+			const groupIdBlocked = result.warnings.filter((warning) => {
+				return (
+					warning.kind === "blocked" &&
+					warning.mantlePath === "experience_singleton.groupId"
+				);
+			});
+
+			expect(groupIdBlocked).toHaveLength(1);
+
+			assert(groupIdBlocked[0]?.kind === "blocked");
+
+			expect(groupIdBlocked[0].reason).toBe(
+				"Open Cloud does not support transferring experience ownership",
+			);
+		});
 	});
 });

--- a/packages/bedrock/src/core/migrate/fold-universe.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.spec.ts
@@ -373,7 +373,7 @@ describe(foldUniverse, () => {
 
 			const result = foldUniverse([
 				experience(DEFAULT_EXPERIENCE_OUTPUTS),
-				experienceConfiguration({ genre: "All" }),
+				experienceConfiguration({ allowPrivateServers: undefined }),
 			]);
 
 			assert(result !== undefined);
@@ -1137,6 +1137,125 @@ describe(foldUniverse, () => {
 					mantlePath: "placeConfiguration_start.name",
 				},
 			]);
+		});
+	});
+
+	describe("blocked experienceConfiguration fields fold", () => {
+		it.for<[label: string, field: string, value: unknown, reason: string]>([
+			["genre", "genre", "All", "Roblox does not expose `genre` via Open Cloud"],
+			["isForSale", "isForSale", false, "paid-access flag has no Open Cloud equivalent"],
+			["price", "price", 25, "paid-access flag has no Open Cloud equivalent"],
+			[
+				"studioAccessToApisAllowed",
+				"studioAccessToApisAllowed",
+				true,
+				"Open Cloud does not currently expose a write endpoint for studio API access",
+			],
+			[
+				"permissions",
+				"permissions",
+				{ IsThirdPartyTeleportAllowed: false },
+				"experienceConfiguration.permissions has no Open Cloud equivalent",
+			],
+			["isArchived", "isArchived", false, "isArchived has no Open Cloud equivalent"],
+		])("should emit a blocked warning when %s is set", ([, field, value, reason]) => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ [field]: value }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.warnings).toStrictEqual([
+				{
+					kind: "blocked",
+					mantlePath: `experienceConfiguration_singleton.${field}`,
+					reason,
+				},
+			]);
+		});
+
+		it("should emit no warning for a tracked field whose value is undefined", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ genre: undefined, isArchived: undefined }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should emit one warning per tracked field when several are populated together", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({
+					genre: "All",
+					isArchived: false,
+					isForSale: false,
+				}),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.warnings).toIncludeAllPartialMembers([
+				{ kind: "blocked", mantlePath: "experienceConfiguration_singleton.genre" },
+				{ kind: "blocked", mantlePath: "experienceConfiguration_singleton.isForSale" },
+				{ kind: "blocked", mantlePath: "experienceConfiguration_singleton.isArchived" },
+			]);
+		});
+
+		it("should emit no warning when no experienceConfiguration is present", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([experience(DEFAULT_EXPERIENCE_OUTPUTS)]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should emit no warning when experienceConfiguration inputs is not an object", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration("not-an-object"),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should not double-emit a blocked for isFriendsOnly when foldVisibility owns it", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceActivation({ isActive: true }),
+				experienceConfiguration({ isFriendsOnly: true }),
+			]);
+
+			assert(result !== undefined);
+
+			const friendsOnlyBlocked = result.warnings.filter((warning) => {
+				return (
+					warning.kind === "blocked" &&
+					warning.mantlePath === "experienceConfiguration_singleton.isFriendsOnly"
+				);
+			});
+
+			expect(friendsOnlyBlocked).toHaveLength(1);
 		});
 	});
 });

--- a/packages/bedrock/src/core/migrate/fold-universe.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.spec.ts
@@ -1257,5 +1257,57 @@ describe(foldUniverse, () => {
 
 			expect(friendsOnlyBlocked).toHaveLength(1);
 		});
+
+		it.for<[label: string, key: string]>([
+			["universeAvatarType", "universeAvatarType"],
+			["universeAvatarMinScales", "universeAvatarMinScales"],
+			["universeAvatarMaxScales", "universeAvatarMaxScales"],
+			["universeAvatarAssetOverrides", "universeAvatarAssetOverrides"],
+			["a forward-looking universeAvatarFoo", "universeAvatarFoo"],
+		])("should emit a blocked warning for the %s glob match", ([, key]) => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ [key]: "PlayerChoice" }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.warnings).toStrictEqual([
+				{
+					kind: "blocked",
+					mantlePath: `experienceConfiguration_singleton.${key}`,
+					reason: "avatar configuration has no Open Cloud equivalent",
+				},
+			]);
+		});
+
+		it("should not glob-match keys that lack the universeAvatar prefix", () => {
+			expect.assertions(2);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ universeAnimationType: "PlayerChoice" }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).toStrictEqual({ universeId: "1" });
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should skip a universeAvatar key whose value is undefined", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceConfiguration({ universeAvatarType: undefined }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.warnings).toStrictEqual([]);
+		});
 	});
 });

--- a/packages/bedrock/src/core/migrate/fold-universe.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.ts
@@ -1,6 +1,7 @@
 import { asRobloxAssetId } from "../../types/ids.ts";
 import type { UniverseOutputs } from "../resources.ts";
 import type { UniverseEntry } from "../schema.ts";
+import { foldBlockedExperienceFields } from "./fold-blocked-experience-fields.ts";
 import { foldDisplayName } from "./fold-display-name.ts";
 import { foldSocialLinks } from "./fold-social-links.ts";
 import {
@@ -77,14 +78,7 @@ export function foldUniverse(
 		return undefined;
 	}
 
-	const fragments: ReadonlyArray<FoldFragment> = [
-		foldPlayableDevices(resources),
-		foldPrivateServers(resources),
-		foldVoiceChat(resources),
-		foldVisibility(resources),
-		foldSocialLinks(resources),
-		foldDisplayName(resources),
-	];
+	const fragments = collectUniverseFragments(resources);
 
 	const entry: UniverseEntry = fragments.reduce<UniverseEntry>(
 		(accumulator, fragment) => ({ ...accumulator, ...fragment.entryFragment }),
@@ -98,6 +92,20 @@ export function foldUniverse(
 		outputs: { rootPlaceId: asRobloxAssetId(outputs.startPlaceId) },
 		warnings,
 	};
+}
+
+function collectUniverseFragments(
+	resources: ReadonlyArray<MantleResource>,
+): ReadonlyArray<FoldFragment> {
+	return [
+		foldPlayableDevices(resources),
+		foldPrivateServers(resources),
+		foldVoiceChat(resources),
+		foldVisibility(resources),
+		foldSocialLinks(resources),
+		foldDisplayName(resources),
+		foldBlockedExperienceFields(resources),
+	];
 }
 
 function coerceRobloxId(value: unknown): string | undefined {

--- a/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
@@ -473,4 +473,88 @@ describe(migrateMantleState, () => {
 
 		expect(result.data.summary.interpretiveCount).toBeGreaterThan(0);
 	});
+
+	it("should emit one blocked warning per legacy field per environment in the real fixture", async () => {
+		expect.assertions(3);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			primaryEnvironment: "production",
+			stateFilePath: REAL_FIXTURE,
+		});
+
+		assert(result.success);
+
+		const blocked = result.data.warnings.filter((warning) => warning.kind === "blocked");
+
+		// 9 experienceConfiguration fields (genre, isForSale,
+		// studioAccessToApisAllowed, permissions, isArchived, universeAvatarType,
+		// universeAvatarMinScales, universeAvatarMaxScales,
+		// universeAvatarAssetOverrides) plus 4 placeConfiguration fields
+		// (description, maxPlayerCount, allowCopying, socialSlotType) per
+		// environment. price and customSocialSlotsCount use the null sentinel;
+		// isFriendsOnly is owned by foldVisibility; experience.groupId is null in
+		// both environments.
+		expect(blocked).toHaveLength(26);
+		expect(result.data.summary.blockedCount).toBe(26);
+
+		const paths = blocked.map((warning) => warning.mantlePath);
+
+		expect(paths).toIncludeAllMembers([
+			"development.experienceConfiguration_singleton.genre",
+			"production.experienceConfiguration_singleton.genre",
+			"production.experienceConfiguration_singleton.universeAvatarType",
+			"production.placeConfiguration_start.description",
+			"production.placeConfiguration_start.allowCopying",
+		]);
+	});
+
+	it("should root every blocked warning's mantlePath at an environment name", async () => {
+		expect.assertions(2);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			primaryEnvironment: "production",
+			stateFilePath: REAL_FIXTURE,
+		});
+
+		assert(result.success);
+
+		const paths = result.data.warnings
+			.filter((warning) => warning.kind === "blocked")
+			.map((warning) => warning.mantlePath);
+		const missingPrefix = paths.filter(
+			(path) => !path.startsWith("development.") && !path.startsWith("production."),
+		);
+
+		expect(missingPrefix).toStrictEqual([]);
+		expect(paths.length).toBeGreaterThan(0);
+	});
+
+	it("should suppress blocked emission for fields owned by interpretive folds or set to the null sentinel", async () => {
+		expect.assertions(3);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			primaryEnvironment: "production",
+			stateFilePath: REAL_FIXTURE,
+		});
+
+		assert(result.success);
+
+		const paths = result.data.warnings
+			.filter((warning) => warning.kind === "blocked")
+			.map((warning) => warning.mantlePath);
+
+		// isFriendsOnly: foldVisibility owns it (production sets isFriendsOnly:
+		// false + isActive: true → public visibility, no blocked).
+		expect(paths.filter((path) => path.endsWith(".isFriendsOnly"))).toStrictEqual([]);
+
+		// customSocialSlotsCount and price use the YAML null sentinel (~) so
+		// parseState strips them to undefined before the fold runs.
+		expect(paths.filter((path) => path.endsWith(".customSocialSlotsCount"))).toStrictEqual([]);
+
+		// experience.groupId is also null in both environments.
+		expect(paths.filter((path) => path.endsWith(".groupId"))).toStrictEqual([]);
+	});
 });

--- a/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
@@ -487,14 +487,9 @@ describe(migrateMantleState, () => {
 
 		const blocked = result.data.warnings.filter((warning) => warning.kind === "blocked");
 
-		// 9 experienceConfiguration fields (genre, isForSale,
-		// studioAccessToApisAllowed, permissions, isArchived, universeAvatarType,
-		// universeAvatarMinScales, universeAvatarMaxScales,
-		// universeAvatarAssetOverrides) plus 4 placeConfiguration fields
-		// (description, maxPlayerCount, allowCopying, socialSlotType) per
-		// environment. price and customSocialSlotsCount use the null sentinel;
-		// isFriendsOnly is owned by foldVisibility; experience.groupId is null in
-		// both environments.
+		// 13 fields per environment × 2 environments. Excluded: price and
+		// customSocialSlotsCount (null sentinel); isFriendsOnly (foldVisibility
+		// owns it); experience.groupId (null in both environments).
 		expect(blocked).toHaveLength(26);
 		expect(result.data.summary.blockedCount).toBe(26);
 


### PR DESCRIPTION
## Summary

Adds the fourth `MigrationWarning` kind — `blocked` — for every Mantle field that has no Open Cloud writable equivalent. After this slice, the migration report is honest about what cannot follow when a Mantle user runs `migrateMantleState`.

## Closes

- Closes #208

## Changes

### New folds

- **`foldBlockedExperienceFields`** (`packages/bedrock/src/core/migrate/fold-blocked-experience-fields.ts`) — emits one blocked warning per non-`undefined` field on `experience_singleton.inputs.groupId` and `experienceConfiguration_singleton.inputs.{genre, isForSale, price, studioAccessToApisAllowed, permissions, isArchived}`, plus a `universeAvatar*` prefix glob. Wired into `foldUniverse`.
- **`foldBlockedPlaceFields`** (`packages/bedrock/src/core/migrate/fold-blocked-place-fields.ts`) — emits one blocked warning per non-`undefined` field on every `placeConfiguration_<k>.inputs.{description, maxPlayerCount, allowCopying, socialSlotType, customSocialSlotsCount}`. Wired into `foldPlaces`.

### Suppression of cross-fold owned fields

`isFriendsOnly` is intentionally absent from the new tables — `foldVisibility` already owns its blocked emission (when `isActive: true` and `isFriendsOnly: true`). The new folds skip it by design, satisfying AC #2 without runtime suppression logic. The same holds for `placeConfiguration.name` (owned by `foldDisplayName`).

### Null-sentinel handling

`parseState.stripNulls` already normalizes YAML `~` to `undefined`. The new folds simply test `value !== undefined`, so absent and null fields both skip — no special sentinel handling needed.

### Reasons

Each warning's `reason` slot names the upstream limitation concretely, e.g.:

- `experienceConfiguration_singleton.genre` → "Roblox does not expose \`genre\` via Open Cloud"
- `experienceConfiguration_singleton.studioAccessToApisAllowed` → "Open Cloud does not currently expose a write endpoint for studio API access"
- `experience_singleton.groupId` → "Open Cloud does not support transferring experience ownership"
- `experienceConfiguration_singleton.universeAvatar*` → "avatar configuration has no Open Cloud equivalent"
- `placeConfiguration_<k>.allowCopying` → "placeConfiguration.allowCopying has no Open Cloud equivalent"

### Shared `BlockedFieldRule` type

Both new fold modules use the same field-table shape, so `BlockedFieldRule` is exported from `fold-universe-shared.ts` alongside the existing warning builders.

## Commits (TDD slices)

- `e26ed1d` `feat(core): emit blocked warnings for legacy experience-config fields` — static `experienceConfiguration` fields.
- `ee2fe8e` `feat(core): emit blocked warnings for universe-avatar fields in migrator` — `universeAvatar*` prefix glob.
- `6d573f9` `feat(core): emit blocked warning for experience.group-id in migrator` — `experience_singleton.groupId` emission.
- `34821bc` `feat(core): emit blocked warnings for legacy place-config fields` — `placeConfiguration` fields.
- `766e300` `test(core): assert mantle-migrator blocked-warning shape end-to-end` — integration assertion against `roblox-ts-example.mantle-state.yml`.
- `63ecc7e` `refactor(core): share blocked-field-rule type across migrator folds` — extract `BlockedFieldRule` to shared.

Each slice landed as its own commit per the project's TDD cadence; tests and production code shipped together (RED+GREEN), with mutation testing enforcing 100% kill rate on every step.

## Test plan

- [x] Per-field unit tests in `fold-universe.spec.ts` for every blocked experience-side field, including the `universeAvatar*` glob (with a forward-looking `universeAvatarFoo` to prove the prefix match) and a "key with no `universeAvatar` prefix" negative case.
- [x] `groupId` test that places a non-`experience` resource first to exercise the kind filter (and prove the `find` predicate isn't trivially mutable to `true`).
- [x] Suppression test asserting only one blocked warning fires for `isFriendsOnly` when both the visibility cross-fold and the new fold see the field.
- [x] Per-field unit tests in `fold-places.spec.ts` for every blocked place-config field, plus a multi-place test asserting one warning per field per resource.
- [x] Integration assertion in `tests/integration/migrate-mantle-state.spec.ts` against the canonical fixture: exact blocked count (26 = 13 per env × 2 envs), env-prefixing of every `mantlePath`, and explicit suppression checks for `isFriendsOnly`, `customSocialSlotsCount`, and `groupId`.
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`, `pnpm gen:example-tests` all pass.
- [x] `pnpm mutate:changed` reports 100% mutation score across the four touched source files (40/40 mutants killed).

## Reviewer notes

- The PRD lists `placeConfiguration.{description, maxPlayerCount}` as blocked. #277 added `description` and `serverSize` (== Mantle's `maxPlayerCount`) to `PlaceEntry`, but did not yet wire a Mantle-side interpretive fold from those keys. This PR follows the issue's literal AC and emits `blocked` for both. A future slice that adds the interpretive fold will move them out of the table — the same precedent used for `isFriendsOnly` (owned by `foldVisibility`, excluded from this PR's tables).
- The duplication of `EXPERIENCE_KIND` / `EXPERIENCE_CONFIGURATION_KIND` between `fold-blocked-experience-fields.ts` and `fold-universe.ts` mirrors the existing pattern (also duplicated between `fold-display-name.ts` and `fold-places.ts`). Centralising those constants is a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)