### PR TITLE
feat(core): retry gist requests on conflict and transient errors

### DIFF
--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -22,6 +22,7 @@
 		"arktype": "catalog:runtime"
 	},
 	"devDependencies": {
+		"@bedrock/testing": "workspace:*",
 		"@bedrock/typescript-config": "workspace:*",
 		"@bedrock/vite-config": "workspace:*",
 		"typescript": "catalog:tsc",

--- a/apps/e2e/tests/helpers/prune-state-gist.spec.ts
+++ b/apps/e2e/tests/helpers/prune-state-gist.spec.ts
@@ -217,4 +217,31 @@ describe(pruneStateGist, () => {
 		expect(sleepFake.calls).toStrictEqual([1000, 2000, 4000]);
 		expect(warnSpy).toHaveBeenCalledWith("pruneStateGist: prune failed with status 409");
 	});
+
+	it.for<[number]>([[401], [403], [404], [422]])(
+		"should not retry the list GET on %i and surface the warn in a single attempt",
+		async ([status]) => {
+			expect.assertions(2);
+
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+			onTestFinished(() => {
+				warnSpy.mockRestore();
+			});
+
+			const { calls, fetchFn } = fakeFetchSequence([new Response("", { status })]);
+			const sleepFake = fakeSleep();
+
+			await pruneStateGist({
+				fetch: fetchFn,
+				filenamePrefix: "state.smoke-",
+				gistId: GIST_ID,
+				keep: 3,
+				sleep: sleepFake.sleep,
+				token: TOKEN,
+			});
+
+			expect(calls).toHaveLength(1);
+			expect(sleepFake.calls).toStrictEqual([]);
+		},
+	);
 });

--- a/apps/e2e/tests/helpers/prune-state-gist.spec.ts
+++ b/apps/e2e/tests/helpers/prune-state-gist.spec.ts
@@ -215,7 +215,9 @@ describe(pruneStateGist, () => {
 
 		expect(calls).toHaveLength(5);
 		expect(sleepFake.calls).toStrictEqual([1000, 2000, 4000]);
-		expect(warnSpy).toHaveBeenCalledWith("pruneStateGist: prune failed with status 409");
+		expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
+			"pruneStateGist: prune failed with status 409",
+		);
 	});
 
 	it.for<[number]>([[401], [403], [404], [422]])(

--- a/apps/e2e/tests/helpers/prune-state-gist.spec.ts
+++ b/apps/e2e/tests/helpers/prune-state-gist.spec.ts
@@ -1,6 +1,45 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
 
-import { selectFilesToDelete } from "./prune-state-gist.ts";
+import { pruneStateGist, selectFilesToDelete } from "./prune-state-gist.ts";
+
+interface FakeFetch {
+	readonly calls: Array<{ readonly init: RequestInit | undefined; readonly url: string }>;
+	readonly fetchFn: (input: string, init?: RequestInit) => Promise<Response>;
+}
+
+interface FakeSleep {
+	readonly calls: Array<number>;
+	readonly sleep: (ms: number) => Promise<void>;
+}
+
+function fakeFetchSequence(responses: ReadonlyArray<Response>): FakeFetch {
+	const calls: Array<{ init: RequestInit | undefined; url: string }> = [];
+	let index = 0;
+	async function fetchFunc(input: string, init?: RequestInit): Promise<Response> {
+		calls.push({ init, url: input });
+		const response = responses[index];
+		if (response === undefined) {
+			throw new Error(`fakeFetchSequence: no response queued for call ${String(index + 1)}`);
+		}
+
+		index += 1;
+		return response;
+	}
+
+	return { calls, fetchFn: fetchFunc };
+}
+
+function fakeSleep(): FakeSleep {
+	const calls: Array<number> = [];
+	async function sleep(ms: number): Promise<void> {
+		calls.push(ms);
+	}
+
+	return { calls, sleep };
+}
+
+const TOKEN = "ghp_x";
+const GIST_ID = "abc123";
 
 describe(selectFilesToDelete, () => {
 	it.for<[label: string, input: ReadonlyArray<string>]>([
@@ -49,5 +88,133 @@ describe(selectFilesToDelete, () => {
 		expect(selectFilesToDelete(filenames, "state.smoke-", 3)).toStrictEqual([
 			"state.smoke-1737900000001.json",
 		]);
+	});
+});
+
+describe(pruneStateGist, () => {
+	it("should retry the list GET on 409 and succeed on the second attempt", async () => {
+		expect.assertions(2);
+
+		const { calls, fetchFn } = fakeFetchSequence([
+			new Response("", { status: 409 }),
+			new Response(
+				JSON.stringify({
+					files: { "state.smoke-1.json": {}, "state.smoke-2.json": {} },
+				}),
+				{ status: 200 },
+			),
+		]);
+		const sleepFake = fakeSleep();
+
+		await pruneStateGist({
+			fetch: fetchFn,
+			filenamePrefix: "state.smoke-",
+			gistId: GIST_ID,
+			keep: 3,
+			sleep: sleepFake.sleep,
+			token: TOKEN,
+		});
+
+		expect(calls).toHaveLength(2);
+		expect(sleepFake.calls).toStrictEqual([1000]);
+	});
+
+	it("should warn once after exhausting the list retry budget on persistent 409", async () => {
+		expect.assertions(3);
+
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		onTestFinished(() => {
+			warnSpy.mockRestore();
+		});
+
+		const { calls, fetchFn } = fakeFetchSequence([
+			new Response("", { status: 409 }),
+			new Response("", { status: 409 }),
+			new Response("", { status: 409 }),
+			new Response("", { status: 409 }),
+		]);
+		const sleepFake = fakeSleep();
+
+		await pruneStateGist({
+			fetch: fetchFn,
+			filenamePrefix: "state.smoke-",
+			gistId: GIST_ID,
+			keep: 3,
+			sleep: sleepFake.sleep,
+			token: TOKEN,
+		});
+
+		expect(calls).toHaveLength(4);
+		expect(sleepFake.calls).toStrictEqual([1000, 2000, 4000]);
+		expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
+			"pruneStateGist: list failed with status 409",
+		);
+	});
+
+	it("should retry the prune PATCH on 409 and succeed on the second attempt", async () => {
+		expect.assertions(3);
+
+		const filesNeedingPrune = {
+			"state.smoke-1.json": {},
+			"state.smoke-2.json": {},
+			"state.smoke-3.json": {},
+			"state.smoke-4.json": {},
+		};
+		const { calls, fetchFn } = fakeFetchSequence([
+			new Response(JSON.stringify({ files: filesNeedingPrune }), { status: 200 }),
+			new Response("", { status: 409 }),
+			new Response("", { status: 200 }),
+		]);
+		const sleepFake = fakeSleep();
+
+		await pruneStateGist({
+			fetch: fetchFn,
+			filenamePrefix: "state.smoke-",
+			gistId: GIST_ID,
+			keep: 3,
+			sleep: sleepFake.sleep,
+			token: TOKEN,
+		});
+
+		expect(calls).toHaveLength(3);
+		expect(calls[1]?.init?.method).toBe("PATCH");
+		expect(sleepFake.calls).toStrictEqual([1000]);
+	});
+
+	it("should warn once after exhausting the prune retry budget on persistent 409", async () => {
+		expect.assertions(3);
+
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+		onTestFinished(() => {
+			warnSpy.mockRestore();
+		});
+
+		const filesNeedingPrune = {
+			"state.smoke-1.json": {},
+			"state.smoke-2.json": {},
+			"state.smoke-3.json": {},
+			"state.smoke-4.json": {},
+		};
+		const { calls, fetchFn } = fakeFetchSequence([
+			new Response(JSON.stringify({ files: filesNeedingPrune }), { status: 200 }),
+			new Response("", { status: 409 }),
+			new Response("", { status: 409 }),
+			new Response("", { status: 409 }),
+			new Response("", { status: 409 }),
+		]);
+		const sleepFake = fakeSleep();
+
+		await pruneStateGist({
+			fetch: fetchFn,
+			filenamePrefix: "state.smoke-",
+			gistId: GIST_ID,
+			keep: 3,
+			sleep: sleepFake.sleep,
+			token: TOKEN,
+		});
+
+		expect(calls).toHaveLength(5);
+		expect(sleepFake.calls).toStrictEqual([1000, 2000, 4000]);
+		expect(warnSpy).toHaveBeenCalledWith("pruneStateGist: prune failed with status 409");
 	});
 });

--- a/apps/e2e/tests/helpers/prune-state-gist.spec.ts
+++ b/apps/e2e/tests/helpers/prune-state-gist.spec.ts
@@ -241,7 +241,7 @@ describe(pruneStateGist, () => {
 			});
 
 			expect(calls).toHaveLength(1);
-			expect(sleepFake.calls).toStrictEqual([]);
+			expect(sleepFake.calls).toBeEmpty();
 		},
 	);
 });

--- a/apps/e2e/tests/helpers/prune-state-gist.ts
+++ b/apps/e2e/tests/helpers/prune-state-gist.ts
@@ -6,18 +6,37 @@ const gistResponse = type({
 	},
 });
 
+const MAX_RETRIES = 3;
+const RETRYABLE_STATUSES: ReadonlySet<number> = new Set([409, 502, 503, 504]);
+
 /**
  * Options controlling a smoke-test gist prune call.
  */
 export interface PruneStateGistOptions {
+	/** Injection seam for tests; defaults to `globalThis.fetch`. */
+	readonly fetch?: Fetch | undefined;
 	/** Filename prefix (e.g. `state.cli-smoke-`) that scopes the prune. */
 	readonly filenamePrefix: string;
 	/** Identifier of the gist holding smoke-test state files. */
 	readonly gistId: string;
 	/** Number of newest matching files to retain. */
 	readonly keep: number;
+	/**
+	 * Injection seam for retry backoff timing; defaults to a `setTimeout`-based
+	 * promise. Tests pass a fake to keep retry assertions deterministic.
+	 */
+	readonly sleep?: ((ms: number) => Promise<void>) | undefined;
 	/** GitHub token with write access to the gist. */
 	readonly token: string;
+}
+
+type Fetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+interface PruneRequestContext {
+	readonly fetchFn: Fetch;
+	readonly headers: Record<string, string>;
+	readonly sleep: (ms: number) => Promise<void>;
+	readonly url: string;
 }
 
 /**
@@ -49,21 +68,38 @@ export function selectFilesToDelete(
  * @param options - Prune target, retention count, and credentials.
  */
 export async function pruneStateGist(options: PruneStateGistOptions): Promise<void> {
-	const { filenamePrefix, gistId, keep, token } = options;
-	const url = `https://api.github.com/gists/${gistId}`;
-	const headers = gistHeaders(token);
+	const {
+		fetch: fetchFunc = globalThis.fetch.bind(globalThis),
+		filenamePrefix,
+		gistId,
+		keep,
+		sleep = defaultSleep,
+		token,
+	} = options;
+	const ctx: PruneRequestContext = {
+		fetchFn: fetchFunc,
+		headers: gistHeaders(token),
+		sleep,
+		url: `https://api.github.com/gists/${gistId}`,
+	};
 
 	try {
-		const filenames = await listGistFilenames(url, headers);
+		const filenames = await listGistFilenames(ctx);
 		const toDelete = selectFilesToDelete(filenames, filenamePrefix, keep);
 		if (toDelete.length === 0) {
 			return;
 		}
 
-		await deleteGistFiles(url, headers, toDelete);
+		await deleteGistFiles(ctx, toDelete);
 	} catch (err) {
 		console.warn(`pruneStateGist: ${String(err)}`);
 	}
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+	await new Promise<void>((resolve) => {
+		setTimeout(resolve, ms);
+	});
 }
 
 function gistHeaders(token: string): Record<string, string> {
@@ -75,18 +111,43 @@ function gistHeaders(token: string): Record<string, string> {
 	};
 }
 
+function isRetryableStatus(status: number): boolean {
+	return RETRYABLE_STATUSES.has(status);
+}
+
+function backoffMs(attempt: number): number {
+	return 1000 * 2 ** attempt;
+}
+
+async function withRetry(
+	sleep: (ms: number) => Promise<void>,
+	operation: () => Promise<Response>,
+): Promise<Response> {
+	let response = await operation();
+	for (let attempt = 0; attempt < MAX_RETRIES; attempt += 1) {
+		if (response.ok || !isRetryableStatus(response.status)) {
+			return response;
+		}
+
+		await sleep(backoffMs(attempt));
+		response = await operation();
+	}
+
+	return response;
+}
+
 /**
  * GET the gist and return the filenames currently stored in it. Returns an
  * empty list when the request fails or the response shape is unexpected.
- * @param url - The full gist URL (including ID).
- * @param headers - Authenticated request headers from {@link gistHeaders}.
+ * @param ctx - Pre-resolved fetch implementation, retry sleep, gist URL, and request headers.
  * @returns Filenames present in the gist, or `[]` on error.
  */
-async function listGistFilenames(
-	url: string,
-	headers: Record<string, string>,
-): Promise<ReadonlyArray<string>> {
-	const response = await fetch(url, { headers });
+async function listGistFilenames(ctx: PruneRequestContext): Promise<ReadonlyArray<string>> {
+	async function sendList(): Promise<Response> {
+		return ctx.fetchFn(ctx.url, { headers: ctx.headers });
+	}
+
+	const response = await withRetry(ctx.sleep, sendList);
 	if (!response.ok) {
 		console.warn(`pruneStateGist: list failed with status ${String(response.status)}`);
 		return [];
@@ -103,20 +164,20 @@ async function listGistFilenames(
 
 /**
  * PATCH the gist to delete every named file in a single request.
- * @param url - The full gist URL (including ID).
- * @param headers - Authenticated request headers from {@link gistHeaders}.
+ * @param ctx - Pre-resolved fetch implementation, retry sleep, gist URL, and request headers.
  * @param names - Filenames to delete; must be non-empty.
  */
 async function deleteGistFiles(
-	url: string,
-	headers: Record<string, string>,
+	ctx: PruneRequestContext,
 	names: ReadonlyArray<string>,
 ): Promise<void> {
 	const filesPayload = Object.fromEntries(names.map((name): [string, null] => [name, null]));
-	const response = await fetch(url, {
-		body: JSON.stringify({ files: filesPayload }),
-		headers: { ...headers, "Content-Type": "application/json" },
-		method: "PATCH",
+	const response = await withRetry(ctx.sleep, async () => {
+		return ctx.fetchFn(ctx.url, {
+			body: JSON.stringify({ files: filesPayload }),
+			headers: { ...ctx.headers, "Content-Type": "application/json" },
+			method: "PATCH",
+		});
 	});
 	if (!response.ok) {
 		console.warn(`pruneStateGist: prune failed with status ${String(response.status)}`);

--- a/apps/e2e/tests/helpers/prune-state-gist.ts
+++ b/apps/e2e/tests/helpers/prune-state-gist.ts
@@ -136,12 +136,6 @@ async function withRetry(
 	return response;
 }
 
-/**
- * GET the gist and return the filenames currently stored in it. Returns an
- * empty list when the request fails or the response shape is unexpected.
- * @param ctx - Pre-resolved fetch implementation, retry sleep, gist URL, and request headers.
- * @returns Filenames present in the gist, or `[]` on error.
- */
 async function listGistFilenames(ctx: PruneRequestContext): Promise<ReadonlyArray<string>> {
 	async function sendList(): Promise<Response> {
 		return ctx.fetchFn(ctx.url, { headers: ctx.headers });
@@ -149,6 +143,8 @@ async function listGistFilenames(ctx: PruneRequestContext): Promise<ReadonlyArra
 
 	const response = await withRetry(ctx.sleep, sendList);
 	if (!response.ok) {
+		// Return [] rather than throwing so a transient gist hiccup cannot flip
+		// an otherwise-passing smoke test to failed.
 		console.warn(`pruneStateGist: list failed with status ${String(response.status)}`);
 		return [];
 	}
@@ -162,23 +158,18 @@ async function listGistFilenames(ctx: PruneRequestContext): Promise<ReadonlyArra
 	return Object.keys(parsed.files);
 }
 
-/**
- * PATCH the gist to delete every named file in a single request.
- * @param ctx - Pre-resolved fetch implementation, retry sleep, gist URL, and request headers.
- * @param names - Filenames to delete; must be non-empty.
- */
 async function deleteGistFiles(
 	ctx: PruneRequestContext,
 	names: ReadonlyArray<string>,
 ): Promise<void> {
 	const filesPayload = Object.fromEntries(names.map((name): [string, null] => [name, null]));
-	const response = await withRetry(ctx.sleep, async () => {
-		return ctx.fetchFn(ctx.url, {
-			body: JSON.stringify({ files: filesPayload }),
-			headers: { ...ctx.headers, "Content-Type": "application/json" },
-			method: "PATCH",
-		});
-	});
+	const body = JSON.stringify({ files: filesPayload });
+	const headers = { ...ctx.headers, "Content-Type": "application/json" };
+	async function sendDelete(): Promise<Response> {
+		return ctx.fetchFn(ctx.url, { body, headers, method: "PATCH" });
+	}
+
+	const response = await withRetry(ctx.sleep, sendDelete);
 	if (!response.ok) {
 		console.warn(`pruneStateGist: prune failed with status ${String(response.status)}`);
 	}

--- a/apps/e2e/tests/vitest-jest-extended.d.ts
+++ b/apps/e2e/tests/vitest-jest-extended.d.ts
@@ -1,0 +1,1 @@
+import "@bedrock/testing/jest-extended";

--- a/apps/e2e/vitest.config.ts
+++ b/apps/e2e/vitest.config.ts
@@ -6,8 +6,6 @@ import { mergeConfig } from "vite-plus";
 // is tighter than publish-round-trip latency under retry. Coverage thresholds
 // from the shared config are not meaningful here: this package has no
 // production source, only scenario tests, so forcing 100 % would block CI.
-// Jest-extended matchers are not wired in because the e2e package does not
-// depend on @bedrock/testing.
 //
 // The `ssr.resolve.conditions` override mirrors packages/bedrock/vite.config.ts:
 // workspace imports such as `@bedrock/core` must resolve via the `source`
@@ -24,7 +22,6 @@ export default mergeConfig(sharedConfig, {
 		coverage: {
 			thresholds: undefined,
 		},
-		setupFiles: [],
 		testTimeout: 60_000,
 	},
 });

--- a/packages/bedrock/src/adapters/gist-state-adapter.spec-d.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.spec-d.ts
@@ -1,0 +1,18 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import type { GistStateAdapterDeps } from "./gist-state-adapter.ts";
+
+describe("GistStateAdapterDeps", () => {
+	it("should expose sleep as an optional injection seam", () => {
+		expectTypeOf<GistStateAdapterDeps>()
+			.toHaveProperty("sleep")
+			.toEqualTypeOf<((ms: number) => Promise<void>) | undefined>();
+	});
+
+	it("should be constructible without sleep when the production default is desired", () => {
+		expectTypeOf<{
+			readonly gistId: string;
+			readonly token: string;
+		}>().toExtend<GistStateAdapterDeps>();
+	});
+});

--- a/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
@@ -658,5 +658,34 @@ describe(createGistStateAdapter, () => {
 				expect(sleepFake.calls).toBeEmpty();
 			},
 		);
+
+		it.for<[number]>([[502], [503], [504]])(
+			"should retry the PATCH on %i and succeed on the second attempt",
+			async ([status]) => {
+				expect.assertions(3);
+
+				const { calls, fetchFn } = fakeFetchSequence([
+					emptyResponse(status),
+					emptyResponse(200),
+				]);
+				const sleepFake = fakeSleep();
+				const port = createGistStateAdapter({
+					fetch: fetchFn,
+					gistId: GIST_ID,
+					sleep: sleepFake.sleep,
+					token: TOKEN,
+				});
+
+				const result = await port.write({
+					environment: "production",
+					resources: [],
+					version: 1,
+				});
+
+				expect(result.success).toBeTrue();
+				expect(calls).toHaveLength(2);
+				expect(sleepFake.calls).toStrictEqual([1000]);
+			},
+		);
 	});
 });

--- a/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
@@ -417,6 +417,31 @@ describe(createGistStateAdapter, () => {
 
 			expect(result.data).toStrictEqual(state);
 		});
+
+		it.for<[number]>([[502], [503], [504]])(
+			"should retry the read GET on %i and succeed on the second attempt",
+			async ([status]) => {
+				expect.assertions(3);
+
+				const { calls, fetchFn } = fakeFetchSequence([
+					emptyResponse(status),
+					okJson({ files: {} }),
+				]);
+				const sleepFake = fakeSleep();
+				const port = createGistStateAdapter({
+					fetch: fetchFn,
+					gistId: GIST_ID,
+					sleep: sleepFake.sleep,
+					token: TOKEN,
+				});
+
+				const result = await port.read("production");
+
+				expect(result.success).toBeTrue();
+				expect(calls).toHaveLength(2);
+				expect(sleepFake.calls).toStrictEqual([1000]);
+			},
+		);
 	});
 
 	describe("write", () => {

--- a/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
@@ -625,5 +625,38 @@ describe(createGistStateAdapter, () => {
 			expect(result.success).toBeTrue();
 			expect(calls).toHaveLength(2);
 		});
+
+		it.for<[number, RegExp]>([
+			[401, /auth failed/u],
+			[403, /auth failed/u],
+			[404, /not found/u],
+			[422, /invalid PATCH body/u],
+		])(
+			"should not retry write on %i and surface the error in a single attempt",
+			async ([status, reasonPattern]) => {
+				expect.assertions(3);
+
+				const { calls, fetchFn } = fakeFetch(() => emptyResponse(status));
+				const sleepFake = fakeSleep();
+				const port = createGistStateAdapter({
+					fetch: fetchFn,
+					gistId: GIST_ID,
+					sleep: sleepFake.sleep,
+					token: TOKEN,
+				});
+
+				const result = await port.write({
+					environment: "production",
+					resources: [],
+					version: 1,
+				});
+
+				assert(!result.success);
+
+				expect(result.err.reason).toMatch(reasonPattern);
+				expect(calls).toHaveLength(1);
+				expect(sleepFake.calls).toBeEmpty();
+			},
+		);
 	});
 });

--- a/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
@@ -1,4 +1,4 @@
-import { assert, describe, expect, it } from "vitest";
+import { assert, describe, expect, it, onTestFinished, vi } from "vitest";
 
 import { serializeStateFile } from "../core/state-file.ts";
 import type { BedrockState } from "../core/state.ts";
@@ -10,6 +10,11 @@ const TOKEN = "ghp_example_token";
 interface FakeFetch {
 	readonly calls: Array<Request>;
 	readonly fetchFn: GistFetch;
+}
+
+interface FakeSleep {
+	readonly calls: Array<number>;
+	readonly sleep: (ms: number) => Promise<void>;
 }
 
 function fakeFetch(responder: (request: Request) => Promise<Response> | Response): FakeFetch {
@@ -24,6 +29,28 @@ function fakeFetch(responder: (request: Request) => Promise<Response> | Response
 	}
 
 	return { calls, fetchFn: fetchFunc };
+}
+
+function fakeFetchSequence(responses: ReadonlyArray<Response>): FakeFetch {
+	let index = 0;
+	return fakeFetch(() => {
+		const response = responses[index];
+		if (response === undefined) {
+			throw new Error(`fakeFetchSequence: no response queued for call ${String(index + 1)}`);
+		}
+
+		index += 1;
+		return response;
+	});
+}
+
+function fakeSleep(): FakeSleep {
+	const calls: Array<number> = [];
+	async function sleep(ms: number): Promise<void> {
+		calls.push(ms);
+	}
+
+	return { calls, sleep };
 }
 
 function okJson(body: unknown): Response {
@@ -510,6 +537,93 @@ describe(createGistStateAdapter, () => {
 			assert(!result.success);
 
 			expect(result.err.reason).toMatch(/network error/u);
+		});
+
+		it("should retry the PATCH on 409 and succeed on the second attempt", async () => {
+			expect.assertions(3);
+
+			const { calls, fetchFn } = fakeFetchSequence([emptyResponse(409), emptyResponse(200)]);
+			const sleepFake = fakeSleep();
+			const port = createGistStateAdapter({
+				fetch: fetchFn,
+				gistId: GIST_ID,
+				sleep: sleepFake.sleep,
+				token: TOKEN,
+			});
+
+			const result = await port.write({
+				environment: "production",
+				resources: [],
+				version: 1,
+			});
+
+			expect(result.success).toBeTrue();
+			expect(calls).toHaveLength(2);
+			expect(sleepFake.calls).toStrictEqual([1000]);
+		});
+
+		it("should err with the github-returned-409 reason after exhausting the retry budget", async () => {
+			expect.assertions(4);
+
+			const { calls, fetchFn } = fakeFetchSequence([
+				emptyResponse(409),
+				emptyResponse(409),
+				emptyResponse(409),
+				emptyResponse(409),
+			]);
+			const sleepFake = fakeSleep();
+			const port = createGistStateAdapter({
+				fetch: fetchFn,
+				gistId: GIST_ID,
+				sleep: sleepFake.sleep,
+				token: TOKEN,
+			});
+
+			const result = await port.write({
+				environment: "production",
+				resources: [],
+				version: 1,
+			});
+
+			assert(!result.success);
+
+			expect(result.err.reason).toMatch(/github returned 409/u);
+			expect(result.err.file).toBe(`gist:${GIST_ID}/state.production.json`);
+			expect(calls).toHaveLength(4);
+			expect(sleepFake.calls).toStrictEqual([1000, 2000, 4000]);
+		});
+
+		it("should sleep using setTimeout by default when sleep is not injected", async () => {
+			expect.assertions(3);
+
+			vi.useFakeTimers();
+			onTestFinished(() => {
+				vi.useRealTimers();
+			});
+
+			const { calls, fetchFn } = fakeFetchSequence([emptyResponse(409), emptyResponse(200)]);
+			const port = createGistStateAdapter({
+				fetch: fetchFn,
+				gistId: GIST_ID,
+				token: TOKEN,
+			});
+
+			const writePromise = port.write({
+				environment: "production",
+				resources: [],
+				version: 1,
+			});
+
+			await vi.advanceTimersByTimeAsync(0);
+
+			expect(calls).toHaveLength(1);
+
+			await vi.advanceTimersByTimeAsync(1000);
+
+			const result = await writePromise;
+
+			expect(result.success).toBeTrue();
+			expect(calls).toHaveLength(2);
 		});
 	});
 });

--- a/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
@@ -204,6 +204,39 @@ describe(createGistStateAdapter, () => {
 			expect(result.err.reason).toMatch(/network error/u);
 		});
 
+		it("should err with a network-error reason when the raw_url fetch throws", async () => {
+			expect.assertions(2);
+
+			const { fetchFn } = fakeFetch((request) => {
+				if (request.url.startsWith("https://api.github.com")) {
+					return okJson({
+						files: {
+							"state.production.json": {
+								content: "",
+								raw_url: "https://gist.example/raw/abc",
+								size: 2_000_000,
+								truncated: true,
+							},
+						},
+					});
+				}
+
+				throw new Error("connection reset");
+			});
+			const port = createGistStateAdapter({
+				fetch: fetchFn,
+				gistId: GIST_ID,
+				token: TOKEN,
+			});
+
+			const result = await port.read("production");
+
+			assert(!result.success);
+
+			expect(result.err.reason).toMatch(/network error/u);
+			expect(result.err.file).toBe(`gist:${GIST_ID}/state.production.json`);
+		});
+
 		it("should err with a github-returned-<status> reason on 500", async () => {
 			expect.assertions(2);
 

--- a/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
@@ -286,7 +286,13 @@ describe(createGistStateAdapter, () => {
 
 				return emptyResponse(503);
 			});
-			const port = createGistStateAdapter({ fetch: fetchFn, gistId: GIST_ID, token: TOKEN });
+			const sleepFake = fakeSleep();
+			const port = createGistStateAdapter({
+				fetch: fetchFn,
+				gistId: GIST_ID,
+				sleep: sleepFake.sleep,
+				token: TOKEN,
+			});
 
 			const result = await port.read("production");
 
@@ -439,6 +445,47 @@ describe(createGistStateAdapter, () => {
 
 				expect(result.success).toBeTrue();
 				expect(calls).toHaveLength(2);
+				expect(sleepFake.calls).toStrictEqual([1000]);
+			},
+		);
+
+		it.for<[number]>([[502], [503], [504]])(
+			"should retry the raw_url fetch on %i and succeed on the second attempt",
+			async ([status]) => {
+				expect.assertions(3);
+
+				const state: BedrockState = {
+					environment: "production",
+					resources: [],
+					version: 1,
+				};
+				const content = serializeStateFile(state);
+				const { calls, fetchFn } = fakeFetchSequence([
+					okJson({
+						files: {
+							"state.production.json": {
+								content: "",
+								raw_url: "https://gist.example/raw/abc",
+								size: 2_000_000,
+								truncated: true,
+							},
+						},
+					}),
+					emptyResponse(status),
+					new Response(content, { status: 200 }),
+				]);
+				const sleepFake = fakeSleep();
+				const port = createGistStateAdapter({
+					fetch: fetchFn,
+					gistId: GIST_ID,
+					sleep: sleepFake.sleep,
+					token: TOKEN,
+				});
+
+				const result = await port.read("production");
+
+				expect(result.success).toBeTrue();
+				expect(calls).toHaveLength(3);
 				expect(sleepFake.calls).toStrictEqual([1000]);
 			},
 		);

--- a/packages/bedrock/src/adapters/gist-state-adapter.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.ts
@@ -150,15 +150,6 @@ function toGistFile(entry: unknown): GistFile | undefined {
 	return { content, isTruncated, rawUrl, size };
 }
 
-function buildHeaders(token: string): Headers {
-	const headers = new Headers();
-	headers.set("Accept", "application/vnd.github+json");
-	headers.set("Authorization", `Bearer ${token}`);
-	headers.set("User-Agent", USER_AGENT);
-	headers.set("X-GitHub-Api-Version", GITHUB_API_VERSION);
-	return headers;
-}
-
 function mapHttpError({ file, gistId, status }: HttpFailure): StateError {
 	if (status === 404) {
 		return { file, kind: "stateError", reason: `gist ${gistId} not found: check gistId` };
@@ -176,16 +167,54 @@ function networkError(error: unknown, file: string): StateError {
 	return { file, kind: "stateError", reason: `network error: ${message}` };
 }
 
+function buildHeaders(token: string): Headers {
+	const headers = new Headers();
+	headers.set("Accept", "application/vnd.github+json");
+	headers.set("Authorization", `Bearer ${token}`);
+	headers.set("User-Agent", USER_AGENT);
+	headers.set("X-GitHub-Api-Version", GITHUB_API_VERSION);
+	return headers;
+}
+
+async function sendGet(ctx: AdapterContext): Promise<Response> {
+	return ctx.fetchFn(`${GITHUB_API_BASE}/gists/${ctx.gistId}`, {
+		headers: buildHeaders(ctx.token),
+		method: "GET",
+	});
+}
+
+function isRetryableStatus(status: number): boolean {
+	return RETRYABLE_STATUSES.has(status);
+}
+
+function backoffMs(attempt: number): number {
+	return 1000 * 2 ** attempt;
+}
+
+async function withRetry(
+	ctx: AdapterContext,
+	operation: () => Promise<Response>,
+): Promise<Response> {
+	let response = await operation();
+	for (let attempt = 0; attempt < MAX_RETRIES; attempt += 1) {
+		if (response.ok || !isRetryableStatus(response.status)) {
+			return response;
+		}
+
+		await ctx.sleep(backoffMs(attempt));
+		response = await operation();
+	}
+
+	return response;
+}
+
 async function fetchGistBody(
 	ctx: AdapterContext,
 	file: string,
 ): Promise<Result<Record<string, unknown>, StateError>> {
 	let response: Response;
 	try {
-		response = await ctx.fetchFn(`${GITHUB_API_BASE}/gists/${ctx.gistId}`, {
-			headers: buildHeaders(ctx.token),
-			method: "GET",
-		});
+		response = await withRetry(ctx, async () => sendGet(ctx));
 	} catch (err) {
 		return { err: networkError(err, file), success: false };
 	}
@@ -258,31 +287,6 @@ async function sendPatch(ctx: AdapterContext, body: string): Promise<Response> {
 		headers,
 		method: "PATCH",
 	});
-}
-
-function isRetryableStatus(status: number): boolean {
-	return RETRYABLE_STATUSES.has(status);
-}
-
-function backoffMs(attempt: number): number {
-	return 1000 * 2 ** attempt;
-}
-
-async function withRetry(
-	ctx: AdapterContext,
-	operation: () => Promise<Response>,
-): Promise<Response> {
-	let response = await operation();
-	for (let attempt = 0; attempt < MAX_RETRIES; attempt += 1) {
-		if (response.ok || !isRetryableStatus(response.status)) {
-			return response;
-		}
-
-		await ctx.sleep(backoffMs(attempt));
-		response = await operation();
-	}
-
-	return response;
 }
 
 async function writePath(

--- a/packages/bedrock/src/adapters/gist-state-adapter.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.ts
@@ -9,6 +9,8 @@ const GITHUB_API_BASE = "https://api.github.com";
 const GITHUB_API_VERSION = "2026-03-10";
 const USER_AGENT = "bedrock";
 const MAX_INLINE_BYTES = 10_000_000;
+const MAX_RETRIES = 3;
+const RETRYABLE_STATUSES: ReadonlySet<number> = new Set([409]);
 
 /**
  * Minimal `fetch`-compatible signature the adapter needs, narrower than
@@ -28,6 +30,11 @@ export interface GistStateAdapterDeps {
 	readonly fetch?: GistFetch | undefined;
 	/** ID of an existing GitHub Gist that holds this project's state files. */
 	readonly gistId: string;
+	/**
+	 * Injection seam for retry backoff timing; defaults to a `setTimeout`-based
+	 * promise. Tests pass a fake to keep retry assertions deterministic.
+	 */
+	readonly sleep?: ((ms: number) => Promise<void>) | undefined;
 	/** GitHub token (fine-grained PAT or classic PAT) with gist read/write scope. */
 	readonly token: string;
 }
@@ -35,6 +42,7 @@ export interface GistStateAdapterDeps {
 interface AdapterContext {
 	readonly fetchFn: GistFetch;
 	readonly gistId: string;
+	readonly sleep: (ms: number) => Promise<void>;
 	readonly token: string;
 }
 
@@ -91,6 +99,7 @@ export function createGistStateAdapter(deps: GistStateAdapterDeps): StatePort {
 	const ctx: AdapterContext = {
 		fetchFn: deps.fetch ?? globalThis.fetch.bind(globalThis),
 		gistId: deps.gistId,
+		sleep: deps.sleep ?? defaultSleep,
 		token: deps.token,
 	};
 
@@ -112,6 +121,12 @@ export function createGistStateAdapter(deps: GistStateAdapterDeps): StatePort {
 			return writePath(ctx, state);
 		},
 	};
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+	await new Promise<void>((resolve) => {
+		setTimeout(resolve, ms);
+	});
 }
 
 function fileLabel(gistId: string, environment: string): string {
@@ -245,6 +260,31 @@ async function sendPatch(ctx: AdapterContext, body: string): Promise<Response> {
 	});
 }
 
+function isRetryableStatus(status: number): boolean {
+	return RETRYABLE_STATUSES.has(status);
+}
+
+function backoffMs(attempt: number): number {
+	return 1000 * 2 ** attempt;
+}
+
+async function withRetry(
+	ctx: AdapterContext,
+	operation: () => Promise<Response>,
+): Promise<Response> {
+	let response = await operation();
+	for (let attempt = 0; attempt < MAX_RETRIES; attempt += 1) {
+		if (response.ok || !isRetryableStatus(response.status)) {
+			return response;
+		}
+
+		await ctx.sleep(backoffMs(attempt));
+		response = await operation();
+	}
+
+	return response;
+}
+
 async function writePath(
 	ctx: AdapterContext,
 	state: BedrockState,
@@ -256,7 +296,7 @@ async function writePath(
 
 	let response: Response;
 	try {
-		response = await sendPatch(ctx, body);
+		response = await withRetry(ctx, async () => sendPatch(ctx, body));
 	} catch (err) {
 		return { err: networkError(err, file), success: false };
 	}

--- a/packages/bedrock/src/adapters/gist-state-adapter.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.ts
@@ -10,7 +10,7 @@ const GITHUB_API_VERSION = "2026-03-10";
 const USER_AGENT = "bedrock";
 const MAX_INLINE_BYTES = 10_000_000;
 const MAX_RETRIES = 3;
-const RETRYABLE_STATUSES: ReadonlySet<number> = new Set([409]);
+const RETRYABLE_STATUSES: ReadonlySet<number> = new Set([409, 502, 503, 504]);
 
 /**
  * Minimal `fetch`-compatible signature the adapter needs, narrower than

--- a/packages/bedrock/src/adapters/gist-state-adapter.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.ts
@@ -60,9 +60,10 @@ interface HttpFailure {
 }
 
 interface ReadContentParameters {
-	readonly ctx: AdapterContext;
 	readonly entry: GistFile;
+	readonly fetchFn: GistFetch;
 	readonly file: string;
+	readonly sleep: (ms: number) => Promise<void>;
 }
 
 /**
@@ -192,7 +193,7 @@ function backoffMs(attempt: number): number {
 }
 
 async function withRetry(
-	ctx: AdapterContext,
+	sleep: (ms: number) => Promise<void>,
 	operation: () => Promise<Response>,
 ): Promise<Response> {
 	let response = await operation();
@@ -201,7 +202,7 @@ async function withRetry(
 			return response;
 		}
 
-		await ctx.sleep(backoffMs(attempt));
+		await sleep(backoffMs(attempt));
 		response = await operation();
 	}
 
@@ -214,7 +215,7 @@ async function fetchGistBody(
 ): Promise<Result<Record<string, unknown>, StateError>> {
 	let response: Response;
 	try {
-		response = await withRetry(ctx, async () => sendGet(ctx));
+		response = await withRetry(ctx.sleep, async () => sendGet(ctx));
 	} catch (err) {
 		return { err: networkError(err, file), success: false };
 	}
@@ -235,9 +236,10 @@ function stateErr<T>(file: string, reason: string): Result<T, StateError> {
 }
 
 async function readGistContent({
-	ctx,
 	entry,
+	fetchFn,
 	file,
+	sleep,
 }: ReadContentParameters): Promise<Result<BedrockState | undefined, StateError>> {
 	if (entry.size > MAX_INLINE_BYTES) {
 		return stateErr(file, `state file too large: ${entry.size} bytes`);
@@ -249,7 +251,7 @@ async function readGistContent({
 		}
 
 		const { rawUrl } = entry;
-		const rawResponse = await withRetry(ctx, async () => ctx.fetchFn(rawUrl));
+		const rawResponse = await withRetry(sleep, async () => fetchFn(rawUrl));
 		if (!rawResponse.ok) {
 			return stateErr(file, `raw_url fetch returned ${rawResponse.status}`);
 		}
@@ -277,7 +279,7 @@ async function readPath(
 		return { data: undefined, success: true };
 	}
 
-	return readGistContent({ ctx, entry, file });
+	return readGistContent({ entry, fetchFn: ctx.fetchFn, file, sleep: ctx.sleep });
 }
 
 async function sendPatch(ctx: AdapterContext, body: string): Promise<Response> {
@@ -301,7 +303,7 @@ async function writePath(
 
 	let response: Response;
 	try {
-		response = await withRetry(ctx, async () => sendPatch(ctx, body));
+		response = await withRetry(ctx.sleep, async () => sendPatch(ctx, body));
 	} catch (err) {
 		return { err: networkError(err, file), success: false };
 	}

--- a/packages/bedrock/src/adapters/gist-state-adapter.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.ts
@@ -251,7 +251,13 @@ async function readGistContent({
 		}
 
 		const { rawUrl } = entry;
-		const rawResponse = await withRetry(sleep, async () => fetchFn(rawUrl));
+		let rawResponse: Response;
+		try {
+			rawResponse = await withRetry(sleep, async () => fetchFn(rawUrl));
+		} catch (err) {
+			return { err: networkError(err, file), success: false };
+		}
+
 		if (!rawResponse.ok) {
 			return stateErr(file, `raw_url fetch returned ${rawResponse.status}`);
 		}

--- a/packages/bedrock/src/adapters/gist-state-adapter.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.ts
@@ -60,8 +60,8 @@ interface HttpFailure {
 }
 
 interface ReadContentParameters {
+	readonly ctx: AdapterContext;
 	readonly entry: GistFile;
-	readonly fetchFn: GistFetch;
 	readonly file: string;
 }
 
@@ -235,8 +235,8 @@ function stateErr<T>(file: string, reason: string): Result<T, StateError> {
 }
 
 async function readGistContent({
+	ctx,
 	entry,
-	fetchFn,
 	file,
 }: ReadContentParameters): Promise<Result<BedrockState | undefined, StateError>> {
 	if (entry.size > MAX_INLINE_BYTES) {
@@ -248,7 +248,8 @@ async function readGistContent({
 			return stateErr(file, "truncated gist file missing raw_url");
 		}
 
-		const rawResponse = await fetchFn(entry.rawUrl);
+		const { rawUrl } = entry;
+		const rawResponse = await withRetry(ctx, async () => ctx.fetchFn(rawUrl));
 		if (!rawResponse.ok) {
 			return stateErr(file, `raw_url fetch returned ${rawResponse.status}`);
 		}
@@ -276,7 +277,7 @@ async function readPath(
 		return { data: undefined, success: true };
 	}
 
-	return readGistContent({ entry, fetchFn: ctx.fetchFn, file });
+	return readGistContent({ ctx, entry, file });
 }
 
 async function sendPatch(ctx: AdapterContext, body: string): Promise<Response> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,9 @@ importers:
         specifier: catalog:runtime
         version: 2.2.0
     devDependencies:
+      '@bedrock/testing':
+        specifier: workspace:*
+        version: link:../../packages/testing
       '@bedrock/typescript-config':
         specifier: workspace:*
         version: link:../../packages/typescript-config


### PR DESCRIPTION
## Summary

- `gist-state-adapter.ts` retries write PATCH, read GET, and raw_url GET on `{409, 502, 503, 504}` with exponential backoff (1s → 2s → 4s, three retries). Auth errors (`401`, `403`), `404`, and `422` fail through unchanged in a single attempt.
- `GistStateAdapterDeps` gains an optional `sleep?` injection seam alongside `fetch?`. Production defaults to a `setTimeout`-based promise; tests pass a fake recorder for deterministic delay assertions.
- `pruneStateGist` smoke-test helper gets the same retry treatment for both its list GET and prune PATCH, plus optional `fetch?` / `sleep?` seams. Failures still surface via a single `console.warn` after the budget exhausts, not per attempt.

## Why

Closes the recurring smoke flake in [run 25084924870](https://github.com/christopher-buss/bedrock/actions/runs/25084924870/job/73566037351), where three smoke specs run in parallel against the same `BEDROCK_TEST_GIST_ID` and GitHub serializes gist PATCH operations at the resource level — only one PATCH against a given gist runs at a time and the loser receives `409 Conflict`. The same shape will hit real users running concurrent deploys to *different* environments through the same gist (e.g. `staging` and `production` from two CI workflows): different state files, same backend resource, same 409.

This is backend-layer resilience, not domain-level locking. Same-environment concurrent deploys still race with last-writer-wins semantics; a per-environment lock primitive on `StatePort` is a separate decision worth its own ADR if real users ever ask for it. Mirrors the policy shape of `@bedrock/ocale`'s internal retry helpers without sharing code (those helpers are `internal/` and tied to ocale-specific error types).

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm test` 2136 pass / 14 skipped
- [x] `pnpm build` clean
- [x] `MUTATE_BASE_REF=origin/main pnpm mutate:changed` 100% mutation score on `gist-state-adapter.ts` (21/21 killed, 0 survived)
- [ ] Smoke workflow on this PR runs all three smoke specs in parallel against the shared gist with no `state write failed` or `pruneStateGist: prune failed with status 409` lines surfacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)