### PR TITLE
test(core): namespace luau bootstrap temp dirs by process id

### DIFF
--- a/packages/bedrock/src/shell/load-config-internal.ts
+++ b/packages/bedrock/src/shell/load-config-internal.ts
@@ -1,1 +1,17 @@
 export const LUAU_BOOTSTRAP_TEMP_PREFIX = "bedrock-luau-bootstrap-";
+
+/**
+ * Build the `mkdtempSync` prefix used for Luau bootstrap directories.
+ *
+ * Namespacing the temp directory by `process.pid` keeps parallel vitest
+ * workers from observing each other's in-flight bootstrap dirs through the
+ * shared `tmpdir()`, which would otherwise race the cleanup test's readdir
+ * snapshot.
+ * @param pid - Process id to embed in the prefix; pass `process.pid` from
+ * production callers.
+ * @returns The full prefix to pass to `mkdtempSync`, including the trailing
+ * separator that `mkdtempSync` appends its random suffix to.
+ */
+export function bootstrapDirectoryPrefix(pid: number): string {
+	return `${LUAU_BOOTSTRAP_TEMP_PREFIX}${pid}-`;
+}

--- a/packages/bedrock/src/shell/load-config-internal.ts
+++ b/packages/bedrock/src/shell/load-config-internal.ts
@@ -3,10 +3,10 @@ const LUAU_BOOTSTRAP_TEMP_PREFIX = "bedrock-luau-bootstrap-";
 /**
  * Build the `mkdtempSync` prefix used for Luau bootstrap directories.
  *
- * Namespacing the temp directory by `process.pid` keeps parallel vitest
- * workers from observing each other's in-flight bootstrap dirs through the
- * shared `tmpdir()`, which would otherwise race the cleanup test's readdir
- * snapshot.
+ * Embedding `process.pid` scopes the directory to its creator. Concurrent
+ * processes share `tmpdir()`, so without a pid component they would observe
+ * each other's in-flight bootstrap dirs whenever any caller scans the temp
+ * directory.
  * @param pid - Process id to embed in the prefix; pass `process.pid` from
  * production callers.
  * @returns The full prefix to pass to `mkdtempSync`, including the trailing

--- a/packages/bedrock/src/shell/load-config-internal.ts
+++ b/packages/bedrock/src/shell/load-config-internal.ts
@@ -1,4 +1,4 @@
-export const LUAU_BOOTSTRAP_TEMP_PREFIX = "bedrock-luau-bootstrap-";
+const LUAU_BOOTSTRAP_TEMP_PREFIX = "bedrock-luau-bootstrap-";
 
 /**
  * Build the `mkdtempSync` prefix used for Luau bootstrap directories.

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import process from "node:process";
 import { assert, describe, expect, it } from "vitest";
 
-import { LUAU_BOOTSTRAP_TEMP_PREFIX } from "./load-config-internal.ts";
+import { bootstrapDirectoryPrefix } from "./load-config-internal.ts";
 import { loadConfig } from "./load-config.ts";
 
 async function withTemporaryDirectory<T>(run: (directory: string) => Promise<T>): Promise<T> {
@@ -23,7 +23,8 @@ function writeFixtureConfig(directory: string, lines: ReadonlyArray<string>): vo
 }
 
 function readBootstrapDirectories(): Array<string> {
-	return readdirSync(tmpdir()).filter((entry) => entry.startsWith(LUAU_BOOTSTRAP_TEMP_PREFIX));
+	const selfPrefix = bootstrapDirectoryPrefix(process.pid);
+	return readdirSync(tmpdir()).filter((entry) => entry.startsWith(selfPrefix));
 }
 
 async function expectParseFailed(filename: string, contents: string): Promise<void> {
@@ -753,5 +754,19 @@ describe(loadConfig, () => {
 
 			expect(second.data.passes!["vip-pass"]!.price).toBe(500);
 		});
+	});
+});
+
+describe(bootstrapDirectoryPrefix, () => {
+	it("should embed the supplied pid between the shared prefix and a trailing separator", () => {
+		expect.assertions(1);
+
+		expect(bootstrapDirectoryPrefix(12_345)).toBe("bedrock-luau-bootstrap-12345-");
+	});
+
+	it("should produce distinct prefixes for distinct process ids so parallel workers cannot collide", () => {
+		expect.assertions(1);
+
+		expect(bootstrapDirectoryPrefix(1)).not.toBe(bootstrapDirectoryPrefix(2));
 	});
 });

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -9,7 +9,7 @@ import process from "node:process";
 
 import type { ConfigError } from "../core/config-error.ts";
 import { type Config, validateConfig } from "../core/schema.ts";
-import { LUAU_BOOTSTRAP_TEMP_PREFIX } from "./load-config-internal.ts";
+import { bootstrapDirectoryPrefix } from "./load-config-internal.ts";
 
 /**
  * Options for {@link loadConfig}. Matches a subset of c12's loader options;
@@ -345,7 +345,7 @@ async function evaluateLuauConfig(absPath: string): Promise<Record<string, unkno
 	const cwd = dirname(absPath);
 	const base = basename(absPath);
 
-	const bootstrapDirectory = mkdtempSync(join(tmpdir(), LUAU_BOOTSTRAP_TEMP_PREFIX));
+	const bootstrapDirectory = mkdtempSync(join(tmpdir(), bootstrapDirectoryPrefix(process.pid)));
 	try {
 		const bootstrapPath = join(bootstrapDirectory, "bootstrap.luau");
 		writeFileSync(bootstrapPath, LUTE_BOOTSTRAP_LUAU);


### PR DESCRIPTION
## Summary

Fixes #292. The `should remove the bootstrap temp directory after evaluating a Luau config` test in `load-config.spec.ts` flaked when run alongside other spec files because vitest workers share `tmpdir()` and two spec files exercise the Luau path: `load-config.spec.ts` and the `it.for(SUPPORTED_FORMATS)` row in `config-pipeline.spec.ts` that runs the Luau fixture when `HAS_LUTE` is true. Worker A's `before/after` snapshot of `tmpdir()` could observe Worker B's in-flight `bedrock-luau-bootstrap-XXXXXX` directory and attribute it as a leak even though Worker B's own `finally` block cleaned it up moments later.

The issue body's hypothesis pointed at c12 fanning out resolver calls concurrently. c12 actually invokes resolvers strictly sequentially (a `for...of` loop with `await` over both the main config and any extends), so the suggested polling fix would have masked the symptom and left the cross-worker race in place.

## Fix

Tag each bootstrap directory with the creating worker's pid: `bedrock-luau-bootstrap-{pid}-XXXXXX`. The shared helper `bootstrapDirectoryPrefix(pid)` lives in `load-config-internal.ts` so production and the test helper read from the same source. The cleanup test now filters by the local pid, so each worker only sees its own directories.

The cleanup assertion still catches a real `evaluateLuauConfig` finally-block regression: any directory it forgets to remove carries this process's pid and remains in scope of the filter. Two unit tests on `bootstrapDirectoryPrefix` kill mutants that would otherwise drop the pid or trailing separator and let the cleanup test pass vacuously.

## Verification

- `pnpm --filter '@bedrock/core' test -- --run` passed 10/10 consecutive runs.
- `pnpm typecheck`, `pnpm lint`, `pnpm build`, `pnpm gen:example-tests`, `pnpm lint:unused`, `pnpm mutate:changed` all green. Mutation score on `load-config-internal.ts`: 100%.

## Test plan

- [ ] Reviewer runs `pnpm --filter '@bedrock/core' test -- --run` a few times and confirms no flake.
- [ ] Confirm the cleanup test still observes a deliberate regression: temporarily comment out the `rmSync` in `evaluateLuauConfig` and verify the test fails with a leaked-dir assertion before reverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)