### PR TITLE
feat(core): add bedrock migrate command

### DIFF
--- a/packages/bedrock/src/cli/commands/migrate.spec.ts
+++ b/packages/bedrock/src/cli/commands/migrate.spec.ts
@@ -177,6 +177,81 @@ describe(migrateCommand, () => {
 		expect(firstCall?.getEnv("GITHUB_TOKEN")).toBe("from-process");
 	});
 
+	it("should render an io error and exit 1 when the migrator throws (e.g. EACCES)", async () => {
+		expect.assertions(3);
+
+		const migrateMantleState = vi.fn<MigrateFunc>(async () => {
+			throw new Error("EACCES: permission denied");
+		});
+		const deps = makeDeps({ migrateMantleState });
+		scriptHappyPrompts(deps);
+
+		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
+			"failed to read Mantle state file '/projects/example/.mantle-state.yml': EACCES: permission denied",
+		);
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("migrate failed");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should describe a non-Error throw value via String(value)", async () => {
+		expect.assertions(1);
+
+		const migrateMantleState = vi.fn<MigrateFunc>();
+		migrateMantleState.mockRejectedValueOnce("raw-string-failure");
+		const deps = makeDeps({ migrateMantleState });
+		scriptHappyPrompts(deps);
+
+		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
+			"failed to read Mantle state file '/projects/example/.mantle-state.yml': raw-string-failure",
+		);
+	});
+
+	it("should render an io error from the second migrator pass (multi-env retry)", async () => {
+		expect.assertions(2);
+
+		const migrateMantleState = vi
+			.fn<MigrateFunc>()
+			.mockResolvedValueOnce({
+				err: { available: ["production", "staging"], kind: "primaryEnvironmentRequired" },
+				success: false,
+			})
+			.mockRejectedValueOnce(new Error("ENOSPC: no space left on device"));
+		const deps = makeDeps({ migrateMantleState });
+		scriptHappyPrompts(deps);
+		vi.mocked(deps.migratePromptPort!.promptPrimaryEnvironment).mockResolvedValueOnce({
+			data: "production",
+			success: true,
+		});
+
+		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
+			"failed to read Mantle state file '/projects/example/.mantle-state.yml': ENOSPC: no space left on device",
+		);
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should render a config-write error and exit 1 when writeFile rejects", async () => {
+		expect.assertions(3);
+
+		const writeFile = vi.fn<WriteFileFunc>();
+		writeFile.mockRejectedValueOnce(new Error("EROFS: read-only file system"));
+		const deps = makeDeps({ writeFile });
+		scriptHappyPrompts(deps);
+
+		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
+			"config file write failed (/projects/example/bedrock.config.ts): EROFS: read-only file system",
+		);
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("migrate failed");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
 	it("should fall back to clack.text when the positional path is omitted", async () => {
 		expect.assertions(2);
 
@@ -336,20 +411,50 @@ describe(migrateCommand, () => {
 		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
 	});
 
-	it.for<{ method: "promptConfigFormat" | "promptGistId" | "promptStateBackend" }>([
-		{ method: "promptConfigFormat" },
-		{ method: "promptStateBackend" },
-		{ method: "promptGistId" },
-	])("should cancel cleanly when the user aborts $method", async ({ method }) => {
+	it("should cancel cleanly when the user aborts the config-format prompt", async () => {
 		expect.assertions(2);
 
 		const deps = makeDeps();
 		scriptHappyPrompts(deps);
-		vi.mocked(deps.migratePromptPort![method]).mockReset();
-		vi.mocked(deps.migratePromptPort![method]).mockResolvedValueOnce({
+		vi.mocked(deps.migratePromptPort!.promptConfigFormat).mockReset();
+		vi.mocked(deps.migratePromptPort!.promptConfigFormat).mockResolvedValueOnce({
 			err: { kind: "cancelled" },
 			success: false,
-		} as never);
+		});
+
+		await migrateCommand(deps)("./.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("migrate cancelled");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should cancel cleanly when the user aborts the state-backend prompt", async () => {
+		expect.assertions(2);
+
+		const deps = makeDeps();
+		scriptHappyPrompts(deps);
+		vi.mocked(deps.migratePromptPort!.promptStateBackend).mockReset();
+		vi.mocked(deps.migratePromptPort!.promptStateBackend).mockResolvedValueOnce({
+			err: { kind: "cancelled" },
+			success: false,
+		});
+
+		await migrateCommand(deps)("./.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("migrate cancelled");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should cancel cleanly when the user aborts the gist-id prompt", async () => {
+		expect.assertions(2);
+
+		const deps = makeDeps();
+		scriptHappyPrompts(deps);
+		vi.mocked(deps.migratePromptPort!.promptGistId).mockReset();
+		vi.mocked(deps.migratePromptPort!.promptGistId).mockResolvedValueOnce({
+			err: { kind: "cancelled" },
+			success: false,
+		});
 
 		await migrateCommand(deps)("./.mantle-state.yml", { from: "mantle" });
 

--- a/packages/bedrock/src/cli/commands/migrate.spec.ts
+++ b/packages/bedrock/src/cli/commands/migrate.spec.ts
@@ -1,0 +1,477 @@
+import { fakeClackPort } from "#tests/helpers/clack";
+import { fakeMigratePromptPort } from "#tests/helpers/migrate-prompt-port";
+import process from "node:process";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+
+import type { MigrationReport } from "../../core/migrate/migration-report.ts";
+import type { Config } from "../../core/schema.ts";
+import type { BedrockState, StateError } from "../../core/state.ts";
+import type { StatePort } from "../../ports/state-port.ts";
+import type { ProgDeps } from "../index.ts";
+import { migrateCommand } from "./migrate.ts";
+
+type ExitFunc = NonNullable<ProgDeps["exit"]>;
+type WriteFileFunc = NonNullable<ProgDeps["writeFile"]>;
+type MigrateFunc = NonNullable<ProgDeps["migrateMantleState"]>;
+type BuildStatePortFunc = NonNullable<ProgDeps["buildStatePort"]>;
+
+const SAMPLE_CONFIG: Config = {
+	environments: { production: {} },
+	universe: { universeId: "12345" },
+};
+
+const SAMPLE_STATE: BedrockState = { environment: "production", resources: [], version: 1 };
+
+const SAMPLE_REPORT: MigrationReport = {
+	config: SAMPLE_CONFIG,
+	configFileContent: "",
+	statesByEnvironment: { production: SAMPLE_STATE },
+	summary: { ambiguousCount: 0, blockedCount: 0, deferredCount: 0, interpretiveCount: 0 },
+	warnings: [],
+};
+
+function happyPort(write?: StatePort["write"]): StatePort {
+	return {
+		read: vi.fn<StatePort["read"]>(async () => ({ data: undefined, success: true })),
+		write: write ?? vi.fn<StatePort["write"]>(async () => ({ data: undefined, success: true })),
+	};
+}
+
+function makeWriteSpy(): StatePort["write"] {
+	const writeSpy = vi.fn<StatePort["write"]>();
+	writeSpy.mockResolvedValue({ data: undefined, success: true });
+	return writeSpy;
+}
+
+function happyPortResult(write?: StatePort["write"]): ReturnType<BuildStatePortFunc> {
+	return { data: happyPort(write), success: true };
+}
+
+function makeDeps(overrides: Partial<ProgDeps> = {}): ProgDeps {
+	const migrate = vi.fn<MigrateFunc>();
+	migrate.mockResolvedValue({ data: SAMPLE_REPORT, success: true });
+	const writeFile = vi.fn<WriteFileFunc>();
+	writeFile.mockResolvedValue();
+	return {
+		buildStatePort: vi.fn<BuildStatePortFunc>(() => ({ data: happyPort(), success: true })),
+		clack: fakeClackPort(),
+		exit: vi.fn<ExitFunc>(),
+		migrateMantleState: migrate,
+		migratePromptPort: fakeMigratePromptPort(),
+		writeFile,
+		...overrides,
+	};
+}
+
+function scriptHappyPrompts(deps: ProgDeps): void {
+	const port = deps.migratePromptPort;
+	if (port === undefined) {
+		throw new Error("migratePromptPort missing in deps");
+	}
+
+	vi.mocked(port.promptStateFilePath).mockResolvedValueOnce({
+		data: "./.mantle-state.yml",
+		success: true,
+	});
+	vi.mocked(port.promptConfigFormat).mockResolvedValueOnce({ data: "typescript", success: true });
+	vi.mocked(port.promptStateBackend).mockResolvedValueOnce({ data: "gist", success: true });
+	vi.mocked(port.promptGistId).mockResolvedValueOnce({ data: "abc123", success: true });
+}
+
+describe(migrateCommand, () => {
+	it("should surface a parse error and exit 1 when --from is missing", async () => {
+		expect.assertions(3);
+
+		const deps = makeDeps();
+
+		await migrateCommand(deps)(undefined, {});
+
+		expect(deps.clack?.logError).toHaveBeenCalledOnce();
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("migrate failed");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should reject an unknown --from source with the unknownSource diagnostic", async () => {
+		expect.assertions(2);
+
+		const deps = makeDeps();
+
+		await migrateCommand(deps)(undefined, { from: "universe" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
+			"unknown migration source 'universe' (supported: mantle)",
+		);
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should call the migrator once with the picked format and resolved path", async () => {
+		expect.assertions(3);
+
+		const deps = makeDeps();
+		scriptHappyPrompts(deps);
+
+		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.intro).toHaveBeenCalledExactlyOnceWith("bedrock migrate");
+		expect(deps.migrateMantleState).toHaveBeenCalledExactlyOnceWith({
+			configFormat: "typescript",
+			stateFilePath: "/projects/example/.mantle-state.yml",
+		});
+
+		const firstCallDeps = vi.mocked(deps.migrateMantleState!).mock.calls[0]?.[0];
+
+		expect(Object.hasOwn(firstCallDeps ?? {}, "primaryEnvironment")).toBeFalse();
+	});
+
+	it("should write each environment's state through the StatePort and log per-env success", async () => {
+		expect.assertions(3);
+
+		const writeSpy = makeWriteSpy();
+		const buildStatePort = vi.fn<BuildStatePortFunc>(() => happyPortResult(writeSpy));
+		const deps = makeDeps({ buildStatePort });
+		scriptHappyPrompts(deps);
+
+		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
+
+		expect(writeSpy).toHaveBeenCalledExactlyOnceWith(SAMPLE_STATE);
+		expect(deps.clack?.logSuccess).toHaveBeenCalledWith("production: 0 resources migrated");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(0);
+	});
+
+	it("should write the bedrock config beside the state file and log the path", async () => {
+		expect.assertions(3);
+
+		const writeFile = vi.fn<WriteFileFunc>();
+		writeFile.mockResolvedValue();
+		const deps = makeDeps({ writeFile });
+		scriptHappyPrompts(deps);
+
+		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
+
+		expect(writeFile).toHaveBeenCalledExactlyOnceWith(
+			"/projects/example/bedrock.config.ts",
+			expect.any(String),
+		);
+		expect(deps.clack?.logSuccess).toHaveBeenCalledWith(
+			"wrote /projects/example/bedrock.config.ts",
+		);
+		expect(deps.clack?.outro).toHaveBeenCalledExactlyOnceWith("migrate succeeded");
+	});
+
+	it("should pass process.env through getEnv when constructing the StatePort", async () => {
+		expect.assertions(1);
+
+		onTestFinished(() => {
+			vi.unstubAllEnvs();
+		});
+		vi.stubEnv("GITHUB_TOKEN", "from-process");
+
+		const buildStatePort = vi.fn<BuildStatePortFunc>(() => happyPortResult());
+		const deps = makeDeps({ buildStatePort });
+		scriptHappyPrompts(deps);
+
+		await migrateCommand(deps)("./.mantle-state.yml", { from: "mantle" });
+
+		const firstCall = vi.mocked(buildStatePort).mock.calls[0]?.[0];
+
+		expect(firstCall?.getEnv("GITHUB_TOKEN")).toBe("from-process");
+	});
+
+	it("should fall back to clack.text when the positional path is omitted", async () => {
+		expect.assertions(2);
+
+		const deps = makeDeps();
+		scriptHappyPrompts(deps);
+
+		await migrateCommand(deps)(undefined, { from: "mantle" });
+
+		expect(deps.migratePromptPort?.promptStateFilePath).toHaveBeenCalledOnce();
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(0);
+	});
+
+	it("should re-run the migrator with the picked primary env on multi-env state", async () => {
+		expect.assertions(3);
+
+		const migrateMantleState = vi
+			.fn<MigrateFunc>()
+			.mockResolvedValueOnce({
+				err: { available: ["production", "staging"], kind: "primaryEnvironmentRequired" },
+				success: false,
+			})
+			.mockResolvedValueOnce({ data: SAMPLE_REPORT, success: true });
+		const deps = makeDeps({ migrateMantleState });
+		scriptHappyPrompts(deps);
+		vi.mocked(deps.migratePromptPort!.promptPrimaryEnvironment).mockResolvedValueOnce({
+			data: "production",
+			success: true,
+		});
+
+		await migrateCommand(deps)("./.mantle-state.yml", { from: "mantle" });
+
+		expect(migrateMantleState).toHaveBeenCalledTimes(2);
+		expect(migrateMantleState).toHaveBeenLastCalledWith(
+			expect.objectContaining({ primaryEnvironment: "production" }),
+		);
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(0);
+	});
+
+	it("should render the migrator error and exit 1 on a non-recoverable failure", async () => {
+		expect.assertions(3);
+
+		const migrateMantleState = vi.fn<MigrateFunc>(async () => {
+			return {
+				err: { kind: "stateFileNotFound", path: "./.mantle-state.yml" },
+				success: false,
+			};
+		});
+		const deps = makeDeps({ migrateMantleState });
+		scriptHappyPrompts(deps);
+
+		await migrateCommand(deps)("./.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
+			"Mantle state file not found at './.mantle-state.yml'",
+		);
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("migrate failed");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should render the migrator error from the second pass when re-runs fail", async () => {
+		expect.assertions(2);
+
+		const migrateMantleState = vi
+			.fn<MigrateFunc>()
+			.mockResolvedValueOnce({
+				err: { available: ["production", "staging"], kind: "primaryEnvironmentRequired" },
+				success: false,
+			})
+			.mockResolvedValueOnce({
+				err: {
+					available: ["production", "staging"],
+					kind: "primaryEnvironmentNotFound",
+					primary: "ghost",
+				},
+				success: false,
+			});
+		const deps = makeDeps({ migrateMantleState });
+		scriptHappyPrompts(deps);
+		vi.mocked(deps.migratePromptPort!.promptPrimaryEnvironment).mockResolvedValueOnce({
+			data: "ghost",
+			success: true,
+		});
+
+		await migrateCommand(deps)("./.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
+			"primary environment 'ghost' not found (available: production, staging)",
+		);
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should render the buildStatePort error when constructing the StatePort fails", async () => {
+		expect.assertions(2);
+
+		const buildStatePort = vi.fn<BuildStatePortFunc>(() => {
+			return {
+				err: {
+					kind: "missingCredential",
+					purpose: "stateBackend",
+					variable: "GITHUB_TOKEN",
+				},
+				success: false,
+			};
+		});
+		const deps = makeDeps({ buildStatePort });
+		scriptHappyPrompts(deps);
+
+		await migrateCommand(deps)("./.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
+			"missing credential: environment variable GITHUB_TOKEN is not set",
+		);
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should render the unsupportedBackend error from buildStatePort", async () => {
+		expect.assertions(1);
+
+		const buildStatePort = vi.fn<BuildStatePortFunc>(() => {
+			return {
+				err: { backend: "s3", hint: "pass a custom statePort", kind: "unsupportedBackend" },
+				success: false,
+			};
+		});
+		const deps = makeDeps({ buildStatePort });
+		scriptHappyPrompts(deps);
+
+		await migrateCommand(deps)("./.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
+			"unsupported state backend 's3' (pass a custom statePort)",
+		);
+	});
+
+	it("should render the state-write error and exit 1 when statePort.write fails", async () => {
+		expect.assertions(2);
+
+		const stateError: StateError = {
+			file: "state.json",
+			kind: "stateError",
+			reason: "auth 401",
+		};
+		const writeSpy: StatePort["write"] = vi
+			.fn<StatePort["write"]>()
+			.mockResolvedValueOnce({ err: stateError, success: false });
+		const buildStatePort = vi.fn<BuildStatePortFunc>(() => {
+			return { data: happyPort(writeSpy), success: true };
+		});
+		const deps = makeDeps({ buildStatePort });
+		scriptHappyPrompts(deps);
+
+		await migrateCommand(deps)("./.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
+			"state write failed for 'production' (state.json): auth 401",
+		);
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it.for<{ method: "promptConfigFormat" | "promptGistId" | "promptStateBackend" }>([
+		{ method: "promptConfigFormat" },
+		{ method: "promptStateBackend" },
+		{ method: "promptGistId" },
+	])("should cancel cleanly when the user aborts $method", async ({ method }) => {
+		expect.assertions(2);
+
+		const deps = makeDeps();
+		scriptHappyPrompts(deps);
+		vi.mocked(deps.migratePromptPort![method]).mockReset();
+		vi.mocked(deps.migratePromptPort![method]).mockResolvedValueOnce({
+			err: { kind: "cancelled" },
+			success: false,
+		} as never);
+
+		await migrateCommand(deps)("./.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("migrate cancelled");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should cancel cleanly when the user aborts the path prompt", async () => {
+		expect.assertions(2);
+
+		const deps = makeDeps();
+		vi.mocked(deps.migratePromptPort!.promptStateFilePath).mockResolvedValueOnce({
+			err: { kind: "cancelled" },
+			success: false,
+		});
+
+		await migrateCommand(deps)(undefined, { from: "mantle" });
+
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("migrate cancelled");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should cancel cleanly when the user aborts the primary-env prompt", async () => {
+		expect.assertions(1);
+
+		const migrateMantleState = vi.fn<MigrateFunc>(async () => {
+			return {
+				err: { available: ["production", "staging"], kind: "primaryEnvironmentRequired" },
+				success: false,
+			};
+		});
+		const deps = makeDeps({ migrateMantleState });
+		scriptHappyPrompts(deps);
+		vi.mocked(deps.migratePromptPort!.promptPrimaryEnvironment).mockResolvedValueOnce({
+			err: { kind: "cancelled" },
+			success: false,
+		});
+
+		await migrateCommand(deps)("./.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("migrate cancelled");
+	});
+
+	it("should skip every warning category whose summary count is zero", async () => {
+		expect.assertions(1);
+
+		const deps = makeDeps();
+		scriptHappyPrompts(deps);
+
+		await migrateCommand(deps)("./.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.logMessage).not.toHaveBeenCalled();
+	});
+
+	it("should render every warning category present in the report summary", async () => {
+		expect.assertions(4);
+
+		const reportWithWarnings: MigrationReport = {
+			...SAMPLE_REPORT,
+			summary: {
+				ambiguousCount: 4,
+				blockedCount: 3,
+				deferredCount: 2,
+				interpretiveCount: 1,
+			},
+		};
+		const migrateMantleState = vi.fn<MigrateFunc>(async () => {
+			return { data: reportWithWarnings, success: true };
+		});
+		const deps = makeDeps({ migrateMantleState });
+		scriptHappyPrompts(deps);
+
+		await migrateCommand(deps)("./.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.logMessage).toHaveBeenCalledWith("interpretive mappings: 1");
+		expect(deps.clack?.logMessage).toHaveBeenCalledWith("deferred fields: 2");
+		expect(deps.clack?.logMessage).toHaveBeenCalledWith("blocked fields: 3");
+		expect(deps.clack?.logMessage).toHaveBeenCalledWith("ambiguous fields: 4");
+	});
+
+	it("should write a yaml config when the user picks yaml format", async () => {
+		expect.assertions(1);
+
+		const writeFile = vi.fn<WriteFileFunc>(async () => {});
+		const deps = makeDeps({ writeFile });
+		vi.mocked(deps.migratePromptPort!.promptStateFilePath).mockResolvedValueOnce({
+			data: "/projects/example/.mantle-state.yml",
+			success: true,
+		});
+		vi.mocked(deps.migratePromptPort!.promptConfigFormat).mockResolvedValueOnce({
+			data: "yaml",
+			success: true,
+		});
+		vi.mocked(deps.migratePromptPort!.promptStateBackend).mockResolvedValueOnce({
+			data: "gist",
+			success: true,
+		});
+		vi.mocked(deps.migratePromptPort!.promptGistId).mockResolvedValueOnce({
+			data: "abc",
+			success: true,
+		});
+
+		await migrateCommand(deps)(undefined, { from: "mantle" });
+
+		expect(writeFile).toHaveBeenCalledExactlyOnceWith(
+			"/projects/example/bedrock.config.yaml",
+			expect.any(String),
+		);
+	});
+
+	it("should default to process.exit when no exit slot is provided", async () => {
+		expect.assertions(1);
+
+		onTestFinished(() => {
+			exitSpy.mockRestore();
+		});
+		const exitSpy = vi
+			.spyOn(process, "exit")
+			.mockImplementation((() => {}) as typeof process.exit);
+
+		await migrateCommand({ clack: fakeClackPort() })(undefined, {});
+
+		expect(exitSpy).toHaveBeenCalledExactlyOnceWith(1);
+	});
+});

--- a/packages/bedrock/src/cli/commands/migrate.ts
+++ b/packages/bedrock/src/cli/commands/migrate.ts
@@ -24,12 +24,22 @@ import {
 	renderBuildStatePortError,
 	renderMigrateError,
 	renderMigrateParseError,
+	renderMigrationSummary,
 	renderStateWriteError,
 } from "../render.ts";
 
 const FAILED_OUTRO = "migrate failed";
 
 const CANCELLED_OUTRO = "migrate cancelled";
+
+/**
+ * Sentinel returned by inner orchestration helpers when they could not
+ * produce a `MigrationReport`. `cancelled` means the user aborted a
+ * prompt; `rendered` means the failure was already described to the
+ * user via `renderMigrateError` and the caller should exit
+ * unconditionally without re-rendering.
+ */
+type MigrateRunError = "cancelled" | "rendered";
 
 interface ResolvedMigrate {
 	readonly buildStatePort: typeof defaultBuildStatePort;
@@ -109,10 +119,15 @@ function cancel(resolved: ResolvedMigrate): number {
 	return EXIT_ERROR;
 }
 
+function failAfterRender(resolved: ResolvedMigrate): number {
+	resolved.clack.cancel(FAILED_OUTRO);
+	return EXIT_ERROR;
+}
+
 function renderedFailure(
 	err: MigrateError,
 	resolved: ResolvedMigrate,
-): Result<MigrationReport, "rendered"> {
+): Result<MigrationReport, MigrateRunError> {
 	renderMigrateError(err, resolved.clack);
 	resolved.clack.cancel(FAILED_OUTRO);
 	return { err: "rendered", success: false };
@@ -133,7 +148,7 @@ async function callMigrator(
 
 async function runMigratorWithPrompt(
 	inputs: RunMigratorInputs,
-): Promise<Result<MigrationReport, "cancelled" | "rendered">> {
+): Promise<Result<MigrationReport, MigrateRunError>> {
 	const first = await callMigrator(inputs);
 	if (first.success) {
 		return { data: first.data, success: true };
@@ -186,25 +201,6 @@ async function writeStates(inputs: WriteStatesInputs): Promise<Result<void, void
 	return { data: undefined, success: true };
 }
 
-function renderWarningSummary(report: MigrationReport, clack: ClackPort): void {
-	const { ambiguousCount, blockedCount, deferredCount, interpretiveCount } = report.summary;
-	if (interpretiveCount > 0) {
-		clack.logMessage(`interpretive mappings: ${String(interpretiveCount)}`);
-	}
-
-	if (deferredCount > 0) {
-		clack.logMessage(`deferred fields: ${String(deferredCount)}`);
-	}
-
-	if (blockedCount > 0) {
-		clack.logMessage(`blocked fields: ${String(blockedCount)}`);
-	}
-
-	if (ambiguousCount > 0) {
-		clack.logMessage(`ambiguous fields: ${String(ambiguousCount)}`);
-	}
-}
-
 async function finalize(inputs: FinalizeInputs): Promise<number> {
 	const { configFilePath, configFormat, report, resolved, stateConfig } = inputs;
 	const portResult = resolved.buildStatePort({
@@ -213,8 +209,7 @@ async function finalize(inputs: FinalizeInputs): Promise<number> {
 	});
 	if (!portResult.success) {
 		renderBuildStatePortError(portResult.err, resolved.clack);
-		resolved.clack.cancel(FAILED_OUTRO);
-		return EXIT_ERROR;
+		return failAfterRender(resolved);
 	}
 
 	const writes = await writeStates({
@@ -223,15 +218,14 @@ async function finalize(inputs: FinalizeInputs): Promise<number> {
 		statesByEnvironment: report.statesByEnvironment,
 	});
 	if (!writes.success) {
-		resolved.clack.cancel(FAILED_OUTRO);
-		return EXIT_ERROR;
+		return failAfterRender(resolved);
 	}
 
 	const enrichedConfig: Config = { ...report.config, state: stateConfig };
 	const enrichedBytes = serializeConfig({ config: enrichedConfig, configFormat });
 	await resolved.writeFile(configFilePath, enrichedBytes);
 	resolved.clack.logSuccess(`wrote ${configFilePath}`);
-	renderWarningSummary(report, resolved.clack);
+	renderMigrationSummary(report.summary, resolved.clack);
 	resolved.clack.outro("migrate succeeded");
 	return EXIT_OK;
 }
@@ -296,8 +290,7 @@ async function runMigrate(inputs: RunMigrateInputs): Promise<number> {
 	const parsed = parseMigrateOptions(rawOptions);
 	if (!parsed.success) {
 		renderMigrateParseError(parsed.err, resolved.clack);
-		resolved.clack.cancel(FAILED_OUTRO);
-		return EXIT_ERROR;
+		return failAfterRender(resolved);
 	}
 
 	const stateFilePath = await resolveStateFilePath(pathArg, resolved);

--- a/packages/bedrock/src/cli/commands/migrate.ts
+++ b/packages/bedrock/src/cli/commands/migrate.ts
@@ -1,0 +1,309 @@
+import type { Result } from "@bedrock/ocale";
+
+import { writeFile as nodeWriteFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import process from "node:process";
+
+import type { MigrateError, MigrationReport } from "../../core/migrate/migration-report.ts";
+import { serializeConfig } from "../../core/migrate/serialize-config.ts";
+import type { Config, GistStateConfig } from "../../core/schema.ts";
+import type { BedrockState, StateError } from "../../core/state.ts";
+import { buildStatePort as defaultBuildStatePort } from "../../shell/build-state-port.ts";
+import {
+	migrateMantleState as defaultMigrateMantleState,
+	type MigrateMantleStateDeps,
+} from "../../shell/migrate-mantle-state.ts";
+import { createDefaultMigratePromptPort } from "../default-migrate-prompt-port.ts";
+import { EXIT_ERROR, EXIT_OK } from "../exit-codes.ts";
+import type { ProgDeps } from "../index.ts";
+import type { MigrateConfigFormat, MigratePromptPort } from "../migrate-prompt-port.ts";
+import { parseMigrateOptions } from "../parse-migrate-options.ts";
+import {
+	type ClackPort,
+	createClackPort,
+	renderBuildStatePortError,
+	renderMigrateError,
+	renderMigrateParseError,
+	renderStateWriteError,
+} from "../render.ts";
+
+const FAILED_OUTRO = "migrate failed";
+
+const CANCELLED_OUTRO = "migrate cancelled";
+
+interface ResolvedMigrate {
+	readonly buildStatePort: typeof defaultBuildStatePort;
+	readonly clack: ClackPort;
+	readonly exit: (code: number) => void;
+	readonly migrateMantleState: typeof defaultMigrateMantleState;
+	readonly promptPort: MigratePromptPort;
+	readonly writeFile: (path: string, contents: string) => Promise<void>;
+}
+
+interface RunMigrateInputs {
+	readonly pathArg: string | undefined;
+	readonly rawOptions: Readonly<Record<string, unknown>>;
+	readonly resolved: ResolvedMigrate;
+}
+
+interface FinalizeInputs {
+	readonly configFilePath: string;
+	readonly configFormat: MigrateConfigFormat;
+	readonly report: MigrationReport;
+	readonly resolved: ResolvedMigrate;
+	readonly stateConfig: GistStateConfig;
+}
+
+interface RunMigratorInputs {
+	readonly configFormat: MigrateConfigFormat;
+	readonly resolved: ResolvedMigrate;
+	readonly stateFilePath: string;
+}
+
+interface WriteStatesInputs {
+	readonly clack: ClackPort;
+	readonly statePort: { write: (state: BedrockState) => Promise<Result<void, StateError>> };
+	readonly statesByEnvironment: Readonly<Record<string, BedrockState>>;
+}
+
+/**
+ * Build the sade action for `bedrock migrate`. The returned function
+ * consumes the optional positional path argument and the raw options
+ * object sade hands the action callback. The command parses `--from`,
+ * resolves the state file path (positional or interactive), prompts for
+ * the output config format, runs the migrator, prompts for the state
+ * backend coordinates, writes the per-environment states through the
+ * configured `StatePort`, and emits an enriched bedrock config to disk.
+ *
+ * @param deps - Dependency overrides; missing slots are default-constructed
+ *   from real implementations.
+ * @returns An async sade action that returns once `deps.exit` was invoked.
+ */
+export function migrateCommand(
+	deps: ProgDeps,
+): (
+	pathArgument: string | undefined,
+	rawOptions: Readonly<Record<string, unknown>>,
+) => Promise<void> {
+	const resolved = resolveMigrate(deps);
+	return async (pathArgument, rawOptions) => {
+		const code = await runMigrate({ pathArg: pathArgument, rawOptions, resolved });
+		resolved.exit(code);
+	};
+}
+
+function resolveMigrate(deps: ProgDeps): ResolvedMigrate {
+	return {
+		buildStatePort: deps.buildStatePort ?? defaultBuildStatePort,
+		clack: deps.clack ?? createClackPort(),
+		exit: deps.exit ?? ((code) => process.exit(code)),
+		migrateMantleState: deps.migrateMantleState ?? defaultMigrateMantleState,
+		promptPort: deps.migratePromptPort ?? createDefaultMigratePromptPort(),
+		writeFile:
+			deps.writeFile ?? (async (path, contents) => nodeWriteFile(path, contents, "utf8")),
+	};
+}
+
+function cancel(resolved: ResolvedMigrate): number {
+	resolved.clack.cancel(CANCELLED_OUTRO);
+	return EXIT_ERROR;
+}
+
+function renderedFailure(
+	err: MigrateError,
+	resolved: ResolvedMigrate,
+): Result<MigrationReport, "rendered"> {
+	renderMigrateError(err, resolved.clack);
+	resolved.clack.cancel(FAILED_OUTRO);
+	return { err: "rendered", success: false };
+}
+
+async function callMigrator(
+	inputs: RunMigratorInputs & { readonly primaryEnvironment?: string },
+): Promise<Result<MigrationReport, MigrateError>> {
+	const callDeps: MigrateMantleStateDeps = {
+		configFormat: inputs.configFormat,
+		stateFilePath: inputs.stateFilePath,
+		...(inputs.primaryEnvironment === undefined
+			? {}
+			: { primaryEnvironment: inputs.primaryEnvironment }),
+	};
+	return inputs.resolved.migrateMantleState(callDeps);
+}
+
+async function runMigratorWithPrompt(
+	inputs: RunMigratorInputs,
+): Promise<Result<MigrationReport, "cancelled" | "rendered">> {
+	const first = await callMigrator(inputs);
+	if (first.success) {
+		return { data: first.data, success: true };
+	}
+
+	if (first.err.kind !== "primaryEnvironmentRequired") {
+		return renderedFailure(first.err, inputs.resolved);
+	}
+
+	const primary = await inputs.resolved.promptPort.promptPrimaryEnvironment(first.err.available);
+	if (!primary.success) {
+		return { err: "cancelled", success: false };
+	}
+
+	const second = await callMigrator({ ...inputs, primaryEnvironment: primary.data });
+	if (!second.success) {
+		return renderedFailure(second.err, inputs.resolved);
+	}
+
+	return { data: second.data, success: true };
+}
+
+async function promptForStateConfig(
+	resolved: ResolvedMigrate,
+): Promise<Result<GistStateConfig, "cancelled">> {
+	const backend = await resolved.promptPort.promptStateBackend();
+	if (!backend.success) {
+		return { err: "cancelled", success: false };
+	}
+
+	const gistId = await resolved.promptPort.promptGistId();
+	if (!gistId.success) {
+		return { err: "cancelled", success: false };
+	}
+
+	return { data: { backend: backend.data, gistId: gistId.data }, success: true };
+}
+
+async function writeStates(inputs: WriteStatesInputs): Promise<Result<void, void>> {
+	for (const [environment, state] of Object.entries(inputs.statesByEnvironment)) {
+		const writeResult = await inputs.statePort.write(state);
+		if (!writeResult.success) {
+			renderStateWriteError({ environment, err: writeResult.err }, inputs.clack);
+			return { err: undefined, success: false };
+		}
+
+		inputs.clack.logSuccess(`${environment}: ${state.resources.length} resources migrated`);
+	}
+
+	return { data: undefined, success: true };
+}
+
+function renderWarningSummary(report: MigrationReport, clack: ClackPort): void {
+	const { ambiguousCount, blockedCount, deferredCount, interpretiveCount } = report.summary;
+	if (interpretiveCount > 0) {
+		clack.logMessage(`interpretive mappings: ${String(interpretiveCount)}`);
+	}
+
+	if (deferredCount > 0) {
+		clack.logMessage(`deferred fields: ${String(deferredCount)}`);
+	}
+
+	if (blockedCount > 0) {
+		clack.logMessage(`blocked fields: ${String(blockedCount)}`);
+	}
+
+	if (ambiguousCount > 0) {
+		clack.logMessage(`ambiguous fields: ${String(ambiguousCount)}`);
+	}
+}
+
+async function finalize(inputs: FinalizeInputs): Promise<number> {
+	const { configFilePath, configFormat, report, resolved, stateConfig } = inputs;
+	const portResult = resolved.buildStatePort({
+		getEnv: (name) => process.env[name],
+		stateConfig,
+	});
+	if (!portResult.success) {
+		renderBuildStatePortError(portResult.err, resolved.clack);
+		resolved.clack.cancel(FAILED_OUTRO);
+		return EXIT_ERROR;
+	}
+
+	const writes = await writeStates({
+		clack: resolved.clack,
+		statePort: portResult.data,
+		statesByEnvironment: report.statesByEnvironment,
+	});
+	if (!writes.success) {
+		resolved.clack.cancel(FAILED_OUTRO);
+		return EXIT_ERROR;
+	}
+
+	const enrichedConfig: Config = { ...report.config, state: stateConfig };
+	const enrichedBytes = serializeConfig({ config: enrichedConfig, configFormat });
+	await resolved.writeFile(configFilePath, enrichedBytes);
+	resolved.clack.logSuccess(`wrote ${configFilePath}`);
+	renderWarningSummary(report, resolved.clack);
+	resolved.clack.outro("migrate succeeded");
+	return EXIT_OK;
+}
+
+function configFileFor(stateFilePath: string, format: MigrateConfigFormat): string {
+	const extension = format === "typescript" ? "ts" : "yaml";
+	return join(dirname(stateFilePath), `bedrock.config.${extension}`);
+}
+
+async function runWithStateFilePath(
+	stateFilePath: string,
+	resolved: ResolvedMigrate,
+): Promise<number> {
+	const formatResult = await resolved.promptPort.promptConfigFormat();
+	if (!formatResult.success) {
+		return cancel(resolved);
+	}
+
+	const reportResult = await runMigratorWithPrompt({
+		configFormat: formatResult.data,
+		resolved,
+		stateFilePath,
+	});
+	if (!reportResult.success) {
+		return reportResult.err === "cancelled" ? cancel(resolved) : EXIT_ERROR;
+	}
+
+	const stateConfigResult = await promptForStateConfig(resolved);
+	if (!stateConfigResult.success) {
+		return cancel(resolved);
+	}
+
+	return finalize({
+		configFilePath: configFileFor(stateFilePath, formatResult.data),
+		configFormat: formatResult.data,
+		report: reportResult.data,
+		resolved,
+		stateConfig: stateConfigResult.data,
+	});
+}
+
+async function resolveStateFilePath(
+	pathArgument: string | undefined,
+	resolved: ResolvedMigrate,
+): Promise<Result<string, "cancelled">> {
+	if (pathArgument !== undefined) {
+		return { data: pathArgument, success: true };
+	}
+
+	const promptResult = await resolved.promptPort.promptStateFilePath();
+	if (!promptResult.success) {
+		return { err: "cancelled", success: false };
+	}
+
+	return { data: promptResult.data, success: true };
+}
+
+async function runMigrate(inputs: RunMigrateInputs): Promise<number> {
+	const { pathArg, rawOptions, resolved } = inputs;
+	resolved.clack.intro("bedrock migrate");
+
+	const parsed = parseMigrateOptions(rawOptions);
+	if (!parsed.success) {
+		renderMigrateParseError(parsed.err, resolved.clack);
+		resolved.clack.cancel(FAILED_OUTRO);
+		return EXIT_ERROR;
+	}
+
+	const stateFilePath = await resolveStateFilePath(pathArg, resolved);
+	if (!stateFilePath.success) {
+		return cancel(resolved);
+	}
+
+	return runWithStateFilePath(stateFilePath.data, resolved);
+}

--- a/packages/bedrock/src/cli/commands/migrate.ts
+++ b/packages/bedrock/src/cli/commands/migrate.ts
@@ -7,7 +7,6 @@ import process from "node:process";
 import type { MigrateError, MigrationReport } from "../../core/migrate/migration-report.ts";
 import { serializeConfig } from "../../core/migrate/serialize-config.ts";
 import type { Config, GistStateConfig } from "../../core/schema.ts";
-import type { BedrockState, StateError } from "../../core/state.ts";
 import { buildStatePort as defaultBuildStatePort } from "../../shell/build-state-port.ts";
 import {
 	migrateMantleState as defaultMigrateMantleState,
@@ -17,7 +16,7 @@ import { createDefaultMigratePromptPort } from "../default-migrate-prompt-port.t
 import { EXIT_ERROR, EXIT_OK } from "../exit-codes.ts";
 import type { ProgDeps } from "../index.ts";
 import type { MigrateConfigFormat, MigratePromptPort } from "../migrate-prompt-port.ts";
-import { parseMigrateOptions } from "../parse-migrate-options.ts";
+import { type MigrationSource, parseMigrateOptions } from "../parse-migrate-options.ts";
 import {
 	type ClackPort,
 	createClackPort,
@@ -70,10 +69,16 @@ interface RunMigratorInputs {
 	readonly stateFilePath: string;
 }
 
-interface WriteStatesInputs {
-	readonly clack: ClackPort;
-	readonly statePort: { write: (state: BedrockState) => Promise<Result<void, StateError>> };
-	readonly statesByEnvironment: Readonly<Record<string, BedrockState>>;
+interface MigratorIoError {
+	readonly cause: unknown;
+	readonly kind: "ioError";
+	readonly path: string;
+}
+
+interface DispatchInputs {
+	readonly resolved: ResolvedMigrate;
+	readonly source: MigrationSource;
+	readonly stateFilePath: string;
 }
 
 /**
@@ -124,6 +129,22 @@ function failAfterRender(resolved: ResolvedMigrate): number {
 	return EXIT_ERROR;
 }
 
+async function resolveStateFilePath(
+	pathArgument: string | undefined,
+	resolved: ResolvedMigrate,
+): Promise<Result<string, "cancelled">> {
+	if (pathArgument !== undefined) {
+		return { data: pathArgument, success: true };
+	}
+
+	const promptResult = await resolved.promptPort.promptStateFilePath();
+	if (!promptResult.success) {
+		return { err: "cancelled", success: false };
+	}
+
+	return { data: promptResult.data, success: true };
+}
+
 function renderedFailure(
 	err: MigrateError,
 	resolved: ResolvedMigrate,
@@ -135,7 +156,7 @@ function renderedFailure(
 
 async function callMigrator(
 	inputs: RunMigratorInputs & { readonly primaryEnvironment?: string },
-): Promise<Result<MigrationReport, MigrateError>> {
+): Promise<Result<MigrationReport, MigrateError | MigratorIoError>> {
 	const callDeps: MigrateMantleStateDeps = {
 		configFormat: inputs.configFormat,
 		stateFilePath: inputs.stateFilePath,
@@ -143,7 +164,26 @@ async function callMigrator(
 			? {}
 			: { primaryEnvironment: inputs.primaryEnvironment }),
 	};
-	return inputs.resolved.migrateMantleState(callDeps);
+	try {
+		return await inputs.resolved.migrateMantleState(callDeps);
+	} catch (err) {
+		return { err: { cause: err, kind: "ioError", path: inputs.stateFilePath }, success: false };
+	}
+}
+
+function describeUnknown(value: unknown): string {
+	return value instanceof Error ? value.message : String(value);
+}
+
+function renderIoFailure(
+	err: MigratorIoError,
+	resolved: ResolvedMigrate,
+): Result<MigrationReport, MigrateRunError> {
+	resolved.clack.logError(
+		`failed to read Mantle state file '${err.path}': ${describeUnknown(err.cause)}`,
+	);
+	resolved.clack.cancel(FAILED_OUTRO);
+	return { err: "rendered", success: false };
 }
 
 async function runMigratorWithPrompt(
@@ -152,6 +192,10 @@ async function runMigratorWithPrompt(
 	const first = await callMigrator(inputs);
 	if (first.success) {
 		return { data: first.data, success: true };
+	}
+
+	if (first.err.kind === "ioError") {
+		return renderIoFailure(first.err, inputs.resolved);
 	}
 
 	if (first.err.kind !== "primaryEnvironmentRequired") {
@@ -164,11 +208,15 @@ async function runMigratorWithPrompt(
 	}
 
 	const second = await callMigrator({ ...inputs, primaryEnvironment: primary.data });
-	if (!second.success) {
-		return renderedFailure(second.err, inputs.resolved);
+	if (second.success) {
+		return { data: second.data, success: true };
 	}
 
-	return { data: second.data, success: true };
+	if (second.err.kind === "ioError") {
+		return renderIoFailure(second.err, inputs.resolved);
+	}
+
+	return renderedFailure(second.err, inputs.resolved);
 }
 
 async function promptForStateConfig(
@@ -187,44 +235,59 @@ async function promptForStateConfig(
 	return { data: { backend: backend.data, gistId: gistId.data }, success: true };
 }
 
-async function writeStates(inputs: WriteStatesInputs): Promise<Result<void, void>> {
-	for (const [environment, state] of Object.entries(inputs.statesByEnvironment)) {
-		const writeResult = await inputs.statePort.write(state);
-		if (!writeResult.success) {
-			renderStateWriteError({ environment, err: writeResult.err }, inputs.clack);
-			return { err: undefined, success: false };
-		}
-
-		inputs.clack.logSuccess(`${environment}: ${state.resources.length} resources migrated`);
-	}
-
-	return { data: undefined, success: true };
-}
-
-async function finalize(inputs: FinalizeInputs): Promise<number> {
-	const { configFilePath, configFormat, report, resolved, stateConfig } = inputs;
+async function writeMigratedStates(inputs: FinalizeInputs): Promise<Result<void, void>> {
+	const { report, resolved, stateConfig } = inputs;
 	const portResult = resolved.buildStatePort({
 		getEnv: (name) => process.env[name],
 		stateConfig,
 	});
 	if (!portResult.success) {
 		renderBuildStatePortError(portResult.err, resolved.clack);
-		return failAfterRender(resolved);
+		return { err: undefined, success: false };
 	}
 
-	const writes = await writeStates({
-		clack: resolved.clack,
-		statePort: portResult.data,
-		statesByEnvironment: report.statesByEnvironment,
-	});
-	if (!writes.success) {
-		return failAfterRender(resolved);
+	for (const [environment, state] of Object.entries(report.statesByEnvironment)) {
+		const writeResult = await portResult.data.write(state);
+		if (!writeResult.success) {
+			renderStateWriteError({ environment, err: writeResult.err }, resolved.clack);
+			return { err: undefined, success: false };
+		}
+
+		resolved.clack.logSuccess(`${environment}: ${state.resources.length} resources migrated`);
 	}
 
+	return { data: undefined, success: true };
+}
+
+async function writeBedrockConfig(inputs: FinalizeInputs): Promise<Result<void, void>> {
+	const { configFilePath, configFormat, report, resolved, stateConfig } = inputs;
 	const enrichedConfig: Config = { ...report.config, state: stateConfig };
 	const enrichedBytes = serializeConfig({ config: enrichedConfig, configFormat });
-	await resolved.writeFile(configFilePath, enrichedBytes);
+	try {
+		await resolved.writeFile(configFilePath, enrichedBytes);
+	} catch (err) {
+		resolved.clack.logError(
+			`config file write failed (${configFilePath}): ${describeUnknown(err)}`,
+		);
+		return { err: undefined, success: false };
+	}
+
 	resolved.clack.logSuccess(`wrote ${configFilePath}`);
+	return { data: undefined, success: true };
+}
+
+async function finalize(inputs: FinalizeInputs): Promise<number> {
+	const { report, resolved } = inputs;
+	const stateWritten = await writeMigratedStates(inputs);
+	if (!stateWritten.success) {
+		return failAfterRender(resolved);
+	}
+
+	const written = await writeBedrockConfig(inputs);
+	if (!written.success) {
+		return failAfterRender(resolved);
+	}
+
 	renderMigrationSummary(report.summary, resolved.clack);
 	resolved.clack.outro("migrate succeeded");
 	return EXIT_OK;
@@ -267,20 +330,13 @@ async function runWithStateFilePath(
 	});
 }
 
-async function resolveStateFilePath(
-	pathArgument: string | undefined,
-	resolved: ResolvedMigrate,
-): Promise<Result<string, "cancelled">> {
-	if (pathArgument !== undefined) {
-		return { data: pathArgument, success: true };
-	}
-
-	const promptResult = await resolved.promptPort.promptStateFilePath();
-	if (!promptResult.success) {
-		return { err: "cancelled", success: false };
-	}
-
-	return { data: promptResult.data, success: true };
+async function dispatchBySource(inputs: DispatchInputs): Promise<number> {
+	const { resolved, source, stateFilePath } = inputs;
+	const dispatch: Record<MigrationSource, () => Promise<number>> = {
+		mantle: async () => runWithStateFilePath(stateFilePath, resolved),
+	};
+	const handler = dispatch[source];
+	return handler();
 }
 
 async function runMigrate(inputs: RunMigrateInputs): Promise<number> {
@@ -298,5 +354,9 @@ async function runMigrate(inputs: RunMigrateInputs): Promise<number> {
 		return cancel(resolved);
 	}
 
-	return runWithStateFilePath(stateFilePath.data, resolved);
+	return dispatchBySource({
+		resolved,
+		source: parsed.data.from,
+		stateFilePath: stateFilePath.data,
+	});
 }

--- a/packages/bedrock/src/cli/default-migrate-prompt-port.spec.ts
+++ b/packages/bedrock/src/cli/default-migrate-prompt-port.spec.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	createDefaultMigratePromptPort,
+	type MigratePromptClackHelpers,
+} from "./default-migrate-prompt-port.ts";
+
+const CANCEL_SENTINEL = Symbol("clack-cancel");
+
+function fakeIsCancel(value: unknown): value is symbol {
+	return value === CANCEL_SENTINEL;
+}
+
+function makeHelpers(
+	overrides: Partial<MigratePromptClackHelpers> = {},
+): MigratePromptClackHelpers {
+	return {
+		isCancel: fakeIsCancel,
+		select: vi.fn<MigratePromptClackHelpers["select"]>(),
+		text: vi.fn<MigratePromptClackHelpers["text"]>(),
+		...overrides,
+	};
+}
+
+describe(createDefaultMigratePromptPort, () => {
+	it("should resolve promptConfigFormat with the picked format", async () => {
+		expect.assertions(2);
+
+		const select = vi.fn<MigratePromptClackHelpers["select"]>(async () => "yaml");
+		const port = createDefaultMigratePromptPort(makeHelpers({ select }));
+
+		const result = await port.promptConfigFormat();
+
+		expect(result).toStrictEqual({ data: "yaml", success: true });
+		expect(select).toHaveBeenCalledExactlyOnceWith({
+			initialValue: "typescript",
+			message: "Output config format?",
+			options: [
+				{ hint: "recommended", label: "TypeScript", value: "typescript" },
+				{ label: "YAML", value: "yaml" },
+			],
+		});
+	});
+
+	it("should resolve promptStateBackend with the picked backend and forward the prompt shape", async () => {
+		expect.assertions(2);
+
+		const select = vi.fn<MigratePromptClackHelpers["select"]>(async () => "gist");
+		const port = createDefaultMigratePromptPort(makeHelpers({ select }));
+
+		const result = await port.promptStateBackend();
+
+		expect(result).toStrictEqual({ data: "gist", success: true });
+		expect(select).toHaveBeenCalledExactlyOnceWith({
+			initialValue: "gist",
+			message: "State backend?",
+			options: [{ label: "GitHub Gist", value: "gist" }],
+		});
+	});
+
+	it("should resolve promptPrimaryEnvironment with the picked env and forward the env list", async () => {
+		expect.assertions(4);
+
+		const select = vi.fn<MigratePromptClackHelpers["select"]>(async () => "production");
+		const port = createDefaultMigratePromptPort(makeHelpers({ select }));
+
+		const result = await port.promptPrimaryEnvironment(["production", "staging"]);
+
+		expect(result).toStrictEqual({ data: "production", success: true });
+		expect(select).toHaveBeenCalledExactlyOnceWith({
+			message: "Primary environment?",
+			options: [
+				{ label: "production", value: "production" },
+				{ label: "staging", value: "staging" },
+			],
+		});
+
+		const passedOptions = vi.mocked(select).mock.calls[0]?.[0];
+
+		expect(Object.hasOwn(passedOptions ?? {}, "initialValue")).toBeFalse();
+		expect(Object.hasOwn(passedOptions?.options[0] ?? {}, "hint")).toBeFalse();
+	});
+
+	it("should resolve promptStateFilePath with the typed path", async () => {
+		expect.assertions(4);
+
+		const text = vi.fn<MigratePromptClackHelpers["text"]>(async () => "./.mantle-state.yml");
+		const port = createDefaultMigratePromptPort(makeHelpers({ text }));
+
+		const result = await port.promptStateFilePath();
+
+		expect(result).toStrictEqual({ data: "./.mantle-state.yml", success: true });
+
+		const firstCall = vi.mocked(text).mock.calls[0];
+
+		expect(firstCall?.[0]?.message).toBe("Path to the Mantle state file?");
+		expect(firstCall?.[0]?.placeholder).toBe(".mantle-state.yml");
+		expect(firstCall?.[0]?.validate).toBeFunction();
+	});
+
+	it("should resolve promptGistId with the typed id and forward the prompt shape", async () => {
+		expect.assertions(4);
+
+		const text = vi.fn<MigratePromptClackHelpers["text"]>(async () => "abc123");
+		const port = createDefaultMigratePromptPort(makeHelpers({ text }));
+
+		const result = await port.promptGistId();
+
+		expect(result).toStrictEqual({ data: "abc123", success: true });
+
+		const firstCall = vi.mocked(text).mock.calls[0];
+
+		expect(firstCall?.[0]?.message).toBe("Gist ID for state storage?");
+		expect(firstCall?.[0]?.placeholder).toBe("abc123");
+		expect(firstCall?.[0]?.validate).toBeFunction();
+	});
+
+	it("should reject empty input on prompts that require a value via the validator", async () => {
+		expect.assertions(4);
+
+		const text = vi.fn<MigratePromptClackHelpers["text"]>(async () => "x");
+		const port = createDefaultMigratePromptPort(makeHelpers({ text }));
+
+		await port.promptStateFilePath();
+
+		const firstCall = vi.mocked(text).mock.calls[0];
+		const validate = firstCall?.[0]?.validate;
+
+		expect(validate?.("")).toBe("Required");
+		expect(validate?.("   ")).toBe("Required");
+		expect(validate?.(undefined)).toBe("Required");
+		expect(validate?.("path")).toBeUndefined();
+	});
+
+	it.for<{ method: "promptConfigFormat" | "promptGistId" | "promptStateBackend" }>([
+		{ method: "promptConfigFormat" },
+		{ method: "promptGistId" },
+		{ method: "promptStateBackend" },
+	])(
+		"should map a clack cancel into Err({ kind: 'cancelled' }) on $method",
+		async ({ method }) => {
+			expect.assertions(1);
+
+			const helpers = makeHelpers({
+				select: vi.fn<MigratePromptClackHelpers["select"]>(async () => CANCEL_SENTINEL),
+				text: vi.fn<MigratePromptClackHelpers["text"]>(async () => CANCEL_SENTINEL),
+			});
+			const port = createDefaultMigratePromptPort(helpers);
+
+			const result = await port[method]();
+
+			expect(result).toStrictEqual({ err: { kind: "cancelled" }, success: false });
+		},
+	);
+
+	it("should map a clack cancel into Err({ kind: 'cancelled' }) on promptPrimaryEnvironment", async () => {
+		expect.assertions(1);
+
+		const select = vi.fn<MigratePromptClackHelpers["select"]>(async () => CANCEL_SENTINEL);
+		const port = createDefaultMigratePromptPort(makeHelpers({ select }));
+
+		const result = await port.promptPrimaryEnvironment(["production"]);
+
+		expect(result).toStrictEqual({ err: { kind: "cancelled" }, success: false });
+	});
+
+	it("should map a clack cancel into Err({ kind: 'cancelled' }) on promptStateFilePath", async () => {
+		expect.assertions(1);
+
+		const text = vi.fn<MigratePromptClackHelpers["text"]>(async () => CANCEL_SENTINEL);
+		const port = createDefaultMigratePromptPort(makeHelpers({ text }));
+
+		const result = await port.promptStateFilePath();
+
+		expect(result).toStrictEqual({ err: { kind: "cancelled" }, success: false });
+	});
+
+	it("should default to real clack helpers when none are injected", () => {
+		expect.assertions(1);
+
+		const port = createDefaultMigratePromptPort();
+
+		expect(port.promptConfigFormat).toBeFunction();
+	});
+});

--- a/packages/bedrock/src/cli/default-migrate-prompt-port.ts
+++ b/packages/bedrock/src/cli/default-migrate-prompt-port.ts
@@ -1,0 +1,171 @@
+import {
+	isCancel as defaultIsCancel,
+	select as defaultSelect,
+	text as defaultText,
+	type SelectOptions,
+	type TextOptions,
+} from "@clack/prompts";
+
+import type {
+	MigrateConfigFormat,
+	MigratePromptPort,
+	MigratePromptResult,
+	MigrateStateBackend,
+} from "./migrate-prompt-port.ts";
+
+/**
+ * Test seam for {@link createDefaultMigratePromptPort}. Production callers
+ * omit `helpers` and the port delegates straight to `@clack/prompts`;
+ * tests substitute scripted, non-generic stand-ins so each prompt method
+ * can be exercised without spawning a real terminal.
+ *
+ * Slot signatures use clack's own types pinned to `string`-valued options
+ * so a `vi.fn` instance is assignable: vitest cannot construct a `Mock`
+ * that satisfies a polymorphic `<Value>(...)` signature, but it can
+ * satisfy this concrete shape.
+ */
+export interface MigratePromptClackHelpers {
+	/** Cancel predicate; defaults to `@clack/prompts`'s `isCancel`. */
+	readonly isCancel: (value: unknown) => value is symbol;
+	/** Select-prompt fn; defaults to `@clack/prompts`'s `select`. */
+	readonly select: (options: SelectOptions<string>) => Promise<string | symbol>;
+	/** Text-prompt fn; defaults to `@clack/prompts`'s `text`. */
+	readonly text: (options: TextOptions) => Promise<string | symbol>;
+}
+
+const FORMAT_OPTIONS: ReadonlyArray<{ hint?: string; label: string; value: MigrateConfigFormat }> =
+	[
+		{ hint: "recommended", label: "TypeScript", value: "typescript" },
+		{ label: "YAML", value: "yaml" },
+	];
+
+const BACKEND_OPTIONS: ReadonlyArray<{ label: string; value: MigrateStateBackend }> = [
+	{ label: "GitHub Gist", value: "gist" },
+];
+
+const defaultHelpers: MigratePromptClackHelpers = {
+	isCancel: defaultIsCancel,
+	select: defaultSelect,
+	text: defaultText,
+};
+
+interface FromSelectInputs<T extends string> {
+	readonly initialValue?: T;
+	readonly message: string;
+	readonly options: ReadonlyArray<{ hint?: string; label: string; value: T }>;
+}
+
+/**
+ * Construct a `MigratePromptPort` whose methods delegate to
+ * `@clack/prompts`. Each prompt translates clack's cancel sentinel into
+ * a typed `Err({ kind: "cancelled" })` so the migrate command branches
+ * on `Result` like every other shell call.
+ *
+ * @param helpers - Test-only seam for swapping the three clack
+ *   primitives. Production callers omit this argument.
+ * @returns A live `MigratePromptPort` ready to drive interactively.
+ */
+export function createDefaultMigratePromptPort(
+	helpers: MigratePromptClackHelpers = defaultHelpers,
+): MigratePromptPort {
+	return {
+		promptConfigFormat: async () => promptConfigFormatFrom(helpers),
+		promptGistId: async () => promptGistIdFrom(helpers),
+		promptPrimaryEnvironment: async (environments) =>
+			selectPrimaryEnvironment(helpers, environments),
+		promptStateBackend: async () => promptStateBackendFrom(helpers),
+		promptStateFilePath: async () => promptStateFilePathFrom(helpers),
+	};
+}
+
+async function fromSelect<T extends string>(
+	helpers: MigratePromptClackHelpers,
+	inputs: FromSelectInputs<T>,
+): Promise<MigratePromptResult<T>> {
+	const result = await helpers.select({
+		message: inputs.message,
+		options: inputs.options.map((option) => {
+			return {
+				...(option.hint === undefined ? {} : { hint: option.hint }),
+				label: option.label,
+				value: option.value,
+			};
+		}),
+		...(inputs.initialValue === undefined ? {} : { initialValue: inputs.initialValue }),
+	});
+	if (helpers.isCancel(result)) {
+		return { err: { kind: "cancelled" }, success: false };
+	}
+
+	return { data: result as T, success: true };
+}
+
+async function promptConfigFormatFrom(
+	helpers: MigratePromptClackHelpers,
+): Promise<MigratePromptResult<MigrateConfigFormat>> {
+	return fromSelect(helpers, {
+		initialValue: "typescript",
+		message: "Output config format?",
+		options: FORMAT_OPTIONS,
+	});
+}
+
+function validateNonEmpty(value: string | undefined): string | undefined {
+	if (value === undefined || value.trim() === "") {
+		return "Required";
+	}
+
+	return undefined;
+}
+
+async function fromText(
+	helpers: MigratePromptClackHelpers,
+	options: TextOptions,
+): Promise<MigratePromptResult<string>> {
+	const result = await helpers.text(options);
+	if (helpers.isCancel(result)) {
+		return { err: { kind: "cancelled" }, success: false };
+	}
+
+	return { data: result, success: true };
+}
+
+async function promptGistIdFrom(
+	helpers: MigratePromptClackHelpers,
+): Promise<MigratePromptResult<string>> {
+	return fromText(helpers, {
+		message: "Gist ID for state storage?",
+		placeholder: "abc123",
+		validate: validateNonEmpty,
+	});
+}
+
+async function selectPrimaryEnvironment(
+	helpers: MigratePromptClackHelpers,
+	environments: ReadonlyArray<string>,
+): Promise<MigratePromptResult<string>> {
+	return fromSelect(helpers, {
+		message: "Primary environment?",
+		options: environments.map((name) => ({ label: name, value: name })),
+	});
+}
+
+async function promptStateBackendFrom(
+	helpers: MigratePromptClackHelpers,
+): Promise<MigratePromptResult<MigrateStateBackend>> {
+	return fromSelect(helpers, {
+		initialValue: "gist",
+		message: "State backend?",
+		options: BACKEND_OPTIONS,
+	});
+}
+
+async function promptStateFilePathFrom(
+	helpers: MigratePromptClackHelpers,
+): Promise<MigratePromptResult<string>> {
+	return fromText(helpers, {
+		message: "Path to the Mantle state file?",
+		placeholder: ".mantle-state.yml",
+		validate: validateNonEmpty,
+	});
+}

--- a/packages/bedrock/src/cli/index.spec-d.ts
+++ b/packages/bedrock/src/cli/index.spec-d.ts
@@ -1,24 +1,37 @@
 import type { Sade } from "sade";
 import { describe, expectTypeOf, it } from "vitest";
 
+import type { buildStatePort } from "../shell/build-state-port.ts";
 import type { deploy } from "../shell/deploy.ts";
 import type { loadConfig } from "../shell/load-config.ts";
+import type { migrateMantleState } from "../shell/migrate-mantle-state.ts";
 import type { previewDiff } from "../shell/preview-diff.ts";
 import type { ProgDeps } from "./index.ts";
 import { createProg } from "./index.ts";
+import type { MigratePromptPort } from "./migrate-prompt-port.ts";
 import type { ClackPort } from "./render.ts";
 
-describe("ProgDeps", () => {
-	it("should expose exactly the five injection slots", () => {
+describe("ProgDeps shape", () => {
+	it("should expose exactly the configured injection slots", () => {
 		expectTypeOf<keyof ProgDeps>().toEqualTypeOf<
-			"clack" | "deploy" | "exit" | "loadConfig" | "previewDiff"
+			| "buildStatePort"
+			| "clack"
+			| "deploy"
+			| "exit"
+			| "loadConfig"
+			| "migrateMantleState"
+			| "migratePromptPort"
+			| "previewDiff"
+			| "writeFile"
 		>();
 	});
 
 	it("should mark every slot as optional so an empty deps object satisfies ProgDeps", () => {
 		expectTypeOf<Record<string, never>>().toExtend<ProgDeps>();
 	});
+});
 
+describe("ProgDeps deploy/diff slots", () => {
 	it("should accept the real deploy signature in the deploy slot", () => {
 		expectTypeOf<NonNullable<ProgDeps["deploy"]>>().toEqualTypeOf<typeof deploy>();
 	});
@@ -30,7 +43,35 @@ describe("ProgDeps", () => {
 	it("should accept the real loadConfig signature in the loadConfig slot", () => {
 		expectTypeOf<NonNullable<ProgDeps["loadConfig"]>>().toEqualTypeOf<typeof loadConfig>();
 	});
+});
 
+describe("ProgDeps migrate slots", () => {
+	it("should accept the real buildStatePort signature in the buildStatePort slot", () => {
+		expectTypeOf<NonNullable<ProgDeps["buildStatePort"]>>().toEqualTypeOf<
+			typeof buildStatePort
+		>();
+	});
+
+	it("should accept the real migrateMantleState signature in the migrateMantleState slot", () => {
+		expectTypeOf<NonNullable<ProgDeps["migrateMantleState"]>>().toEqualTypeOf<
+			typeof migrateMantleState
+		>();
+	});
+
+	it("should accept the MigratePromptPort interface in the migratePromptPort slot", () => {
+		expectTypeOf<
+			NonNullable<ProgDeps["migratePromptPort"]>
+		>().toEqualTypeOf<MigratePromptPort>();
+	});
+
+	it("should accept a (path, contents) writeFile signature in the writeFile slot", () => {
+		expectTypeOf<NonNullable<ProgDeps["writeFile"]>>().toEqualTypeOf<
+			(path: string, contents: string) => Promise<void>
+		>();
+	});
+});
+
+describe("ProgDeps render slots", () => {
 	it("should accept the ClackPort interface in the clack slot", () => {
 		expectTypeOf<NonNullable<ProgDeps["clack"]>>().toEqualTypeOf<ClackPort>();
 	});

--- a/packages/bedrock/src/cli/index.ts
+++ b/packages/bedrock/src/cli/index.ts
@@ -51,7 +51,7 @@ export interface ProgDeps {
  *   resolves its own defaults from any omitted slots.
  * @returns A configured sade program with the bedrock name, description, and
  *   the currently installed `@bedrock/core` version, plus the registered
- *   `deploy` and `diff` commands.
+ *   `deploy`, `diff`, and `migrate` commands.
  */
 export function createProg(deps: ProgDeps = {}): Sade {
 	const prog = sade(PROGRAM_NAME).describe(PROGRAM_DESCRIBE).version(manifest.version);

--- a/packages/bedrock/src/cli/index.ts
+++ b/packages/bedrock/src/cli/index.ts
@@ -2,11 +2,15 @@ import sade from "sade";
 import type { Sade } from "sade";
 
 import manifest from "../../package.json" with { type: "json" };
+import type { buildStatePort as defaultBuildStatePort } from "../shell/build-state-port.ts";
 import type { deploy as defaultDeploy } from "../shell/deploy.ts";
 import type { loadConfig as defaultLoadConfig } from "../shell/load-config.ts";
+import type { migrateMantleState as defaultMigrateMantleState } from "../shell/migrate-mantle-state.ts";
 import type { previewDiff as defaultPreviewDiff } from "../shell/preview-diff.ts";
 import { deployCommand } from "./commands/deploy.ts";
 import { diffCommand } from "./commands/diff.ts";
+import { migrateCommand } from "./commands/migrate.ts";
+import type { MigratePromptPort } from "./migrate-prompt-port.ts";
 import type { ClackPort } from "./render.ts";
 
 export { createClackPort } from "./render.ts";
@@ -19,6 +23,8 @@ const PROGRAM_DESCRIBE = "Infrastructure-as-Code deployment tool for Roblox";
  * command actions resolve a real default when a slot is omitted.
  */
 export interface ProgDeps {
+	/** Builds a `StatePort` from a resolved state config; defaults to the public `buildStatePort`. */
+	readonly buildStatePort?: typeof defaultBuildStatePort;
 	/** Output port; defaults to a real `@clack/prompts` adapter inside command actions. */
 	readonly clack?: ClackPort;
 	/** Reconciles config to live state; defaults to the public `deploy`. */
@@ -27,8 +33,14 @@ export interface ProgDeps {
 	readonly exit?: (code: number) => void;
 	/** Project config loader; defaults to the public `loadConfig`. */
 	readonly loadConfig?: typeof defaultLoadConfig;
+	/** Mantle state migrator; defaults to the public `migrateMantleState`. */
+	readonly migrateMantleState?: typeof defaultMigrateMantleState;
+	/** Domain-specific prompt port for the migrate command; defaults to `createDefaultMigratePromptPort()`. */
+	readonly migratePromptPort?: MigratePromptPort;
 	/** Read-only preview of operations; defaults to the internal `previewDiff` shell helper. */
 	readonly previewDiff?: typeof defaultPreviewDiff;
+	/** File-write seam used by the migrate command to emit the bedrock config file; defaults to `node:fs/promises.writeFile`. */
+	readonly writeFile?: (path: string, contents: string) => Promise<void>;
 }
 
 /**
@@ -59,6 +71,11 @@ export function createProg(deps: ProgDeps = {}): Sade {
 		.option("--api-key", "Override the ROBLOX_API_KEY environment variable")
 		.option("--github-token", "Override the GITHUB_TOKEN environment variable")
 		.action(diffCommand(deps));
+
+	prog.command("migrate [stateFilePath]")
+		.describe("Translate a state file from another tool into a bedrock project")
+		.option("--from", "Source format to migrate from (mantle)")
+		.action(migrateCommand(deps));
 
 	return prog;
 }

--- a/packages/bedrock/src/cli/migrate-prompt-port.ts
+++ b/packages/bedrock/src/cli/migrate-prompt-port.ts
@@ -1,0 +1,59 @@
+import type { Result } from "@bedrock/ocale";
+
+/**
+ * Output config format the user picks via `MigratePromptPort.promptConfigFormat`.
+ * The migrator already supports both formats; this union just constrains
+ * the choices the prompt offers.
+ */
+export type MigrateConfigFormat = "typescript" | "yaml";
+
+/**
+ * State backend kind the user picks via `MigratePromptPort.promptStateBackend`.
+ * Single-option today; the union exists so adding a new backend kind widens
+ * one tuple without reshaping the prompt port.
+ */
+export type MigrateStateBackend = "gist";
+
+/**
+ * Failure surfaced when the user aborts a `MigratePromptPort` prompt
+ * (Ctrl-C, Esc). Plain data; narrow on `kind`.
+ */
+export interface MigratePromptCancelled {
+	/** Literal discriminator for narrowing. */
+	readonly kind: "cancelled";
+}
+
+/**
+ * Result returned by every method on {@link MigratePromptPort}.
+ *
+ * @template T - The data type returned on a successful prompt.
+ */
+export type MigratePromptResult<T> = Result<T, MigratePromptCancelled>;
+
+/**
+ * Domain-specific prompt port the `bedrock migrate` command renders
+ * through. Each method is purpose-built (no generic `select` or `text`),
+ * which keeps tests free of the vitest/generics mocking quirk and lets
+ * the command body read top-to-bottom without inline option arrays.
+ *
+ * Real production implementations call `@clack/prompts` underneath; tests
+ * inject `fakeMigratePromptPort()` and script `mockResolvedValueOnce`
+ * answers per scenario.
+ */
+export interface MigratePromptPort {
+	/** Pick the output `bedrock.config.*` format. */
+	promptConfigFormat(): Promise<MigratePromptResult<MigrateConfigFormat>>;
+	/** Ask for the GitHub Gist ID that will hold the migrated state files. */
+	promptGistId(): Promise<MigratePromptResult<string>>;
+	/**
+	 * Pick the primary environment from a Mantle state file that declares
+	 * more than one. Caller passes the available environment names.
+	 */
+	promptPrimaryEnvironment(
+		environments: ReadonlyArray<string>,
+	): Promise<MigratePromptResult<string>>;
+	/** Pick the state backend kind. */
+	promptStateBackend(): Promise<MigratePromptResult<MigrateStateBackend>>;
+	/** Ask for the path to the input Mantle state file. */
+	promptStateFilePath(): Promise<MigratePromptResult<string>>;
+}

--- a/packages/bedrock/src/cli/migrate-prompt-port.ts
+++ b/packages/bedrock/src/cli/migrate-prompt-port.ts
@@ -15,15 +15,6 @@ export type MigrateConfigFormat = "typescript" | "yaml";
 export type MigrateStateBackend = "gist";
 
 /**
- * Failure surfaced when the user aborts a `MigratePromptPort` prompt
- * (Ctrl-C, Esc). Plain data; narrow on `kind`.
- */
-export interface MigratePromptCancelled {
-	/** Literal discriminator for narrowing. */
-	readonly kind: "cancelled";
-}
-
-/**
  * Result returned by every method on {@link MigratePromptPort}.
  *
  * @template T - The data type returned on a successful prompt.
@@ -56,4 +47,13 @@ export interface MigratePromptPort {
 	promptStateBackend(): Promise<MigratePromptResult<MigrateStateBackend>>;
 	/** Ask for the path to the input Mantle state file. */
 	promptStateFilePath(): Promise<MigratePromptResult<string>>;
+}
+
+/**
+ * Failure surfaced when the user aborts a `MigratePromptPort` prompt
+ * (Ctrl-C, Esc). Plain data; narrow on `kind`.
+ */
+interface MigratePromptCancelled {
+	/** Literal discriminator for narrowing. */
+	readonly kind: "cancelled";
 }

--- a/packages/bedrock/src/cli/parse-migrate-options.spec.ts
+++ b/packages/bedrock/src/cli/parse-migrate-options.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	type ParseMigrateError,
+	parseMigrateOptions,
+	SUPPORTED_MIGRATION_SOURCES,
+} from "./parse-migrate-options.ts";
+
+describe(parseMigrateOptions, () => {
+	it("should return Ok with the parsed source on --from mantle", () => {
+		expect.assertions(1);
+
+		const result = parseMigrateOptions({ from: "mantle" });
+
+		expect(result).toStrictEqual({ data: { from: "mantle" }, success: true });
+	});
+
+	it("should ignore the sade-reserved underscore positional bag", () => {
+		expect.assertions(1);
+
+		const result = parseMigrateOptions({ _: ["./.mantle-state.yml"], from: "mantle" });
+
+		expect(result).toStrictEqual({ data: { from: "mantle" }, success: true });
+	});
+
+	it.for<{ expected: ParseMigrateError; label: string; rawOptions: Record<string, unknown> }>([
+		{
+			expected: { flag: "from", kind: "missingRequired" },
+			label: "missing --from",
+			rawOptions: {},
+		},
+		{
+			expected: { flag: "from", kind: "invalidValue" },
+			label: "non-string --from",
+			rawOptions: { from: false },
+		},
+		{
+			expected: {
+				kind: "unknownSource",
+				received: "universe",
+				supported: SUPPORTED_MIGRATION_SOURCES,
+			},
+			label: "--from value outside SUPPORTED_MIGRATION_SOURCES",
+			rawOptions: { from: "universe" },
+		},
+		{
+			expected: { flag: "verbose", kind: "unknownFlag" },
+			label: "unknown flag",
+			rawOptions: { from: "mantle", verbose: true },
+		},
+	])("should reject $label with the matching error variant", ({ expected, rawOptions }) => {
+		expect.assertions(1);
+
+		const result = parseMigrateOptions(rawOptions);
+
+		expect(result).toStrictEqual({ err: expected, success: false });
+	});
+});

--- a/packages/bedrock/src/cli/parse-migrate-options.ts
+++ b/packages/bedrock/src/cli/parse-migrate-options.ts
@@ -29,7 +29,7 @@ export type ParseMigrateError =
 	| {
 			readonly kind: "unknownSource";
 			readonly received: string;
-			readonly supported: ReadonlyArray<MigrationSource>;
+			readonly supported: ReadonlyArray<string>;
 	  };
 
 const RECOGNIZED_FLAGS: ReadonlySet<string> = new Set(["from"]);

--- a/packages/bedrock/src/cli/parse-migrate-options.ts
+++ b/packages/bedrock/src/cli/parse-migrate-options.ts
@@ -1,0 +1,84 @@
+import type { Result } from "@bedrock/ocale";
+
+import type { ParseOptionsError } from "./parse-options.ts";
+
+/**
+ * Sources `bedrock migrate --from <source>` accepts. Today only `"mantle"`
+ * is wired up; widening this tuple turns on additional sources without
+ * touching the parser.
+ */
+export const SUPPORTED_MIGRATION_SOURCES = ["mantle"] as const;
+
+/** One element of {@link SUPPORTED_MIGRATION_SOURCES}. */
+export type MigrationSource = (typeof SUPPORTED_MIGRATION_SOURCES)[number];
+
+/** Typed shape the migrate command consumes after `--from` has been validated. */
+export interface MigrateOptions {
+	/** Validated source to migrate from. */
+	readonly from: MigrationSource;
+}
+
+/**
+ * Failure surfaced by `parseMigrateOptions`. Reuses the three flag-shape
+ * variants from `ParseOptionsError` (so the existing `renderParseError`
+ * messages stay consistent) and adds `unknownSource` for `--from` values
+ * outside {@link SUPPORTED_MIGRATION_SOURCES}.
+ */
+export type ParseMigrateError =
+	| ParseOptionsError
+	| {
+			readonly kind: "unknownSource";
+			readonly received: string;
+			readonly supported: ReadonlyArray<MigrationSource>;
+	  };
+
+const RECOGNIZED_FLAGS: ReadonlySet<string> = new Set(["from"]);
+
+const SADE_RESERVED: ReadonlySet<string> = new Set(["--", "_", "h", "help", "v", "version"]);
+
+/**
+ * Translate the raw sade options POJO into a typed `MigrateOptions`. The
+ * positional `<stateFilePath>` argument is not handled here: sade hands
+ * positional values to the action callback ahead of the options object,
+ * and the migrate command falls back to an interactive prompt when it
+ * is absent. This parser only covers the `--from` flag.
+ *
+ * @param rawOptions - The options object sade hands the action callback.
+ * @returns `Ok(MigrateOptions)` on success, or `Err(ParseMigrateError)`
+ *   describing the offending flag or value.
+ */
+export function parseMigrateOptions(
+	rawOptions: Readonly<Record<string, unknown>>,
+): Result<MigrateOptions, ParseMigrateError> {
+	for (const key of Object.keys(rawOptions)) {
+		if (!RECOGNIZED_FLAGS.has(key) && !SADE_RESERVED.has(key)) {
+			return { err: { flag: key, kind: "unknownFlag" }, success: false };
+		}
+	}
+
+	const fromRaw = rawOptions["from"];
+	if (fromRaw === undefined) {
+		return { err: { flag: "from", kind: "missingRequired" }, success: false };
+	}
+
+	if (typeof fromRaw !== "string") {
+		return { err: { flag: "from", kind: "invalidValue" }, success: false };
+	}
+
+	if (!isMigrationSource(fromRaw)) {
+		return {
+			err: {
+				kind: "unknownSource",
+				received: fromRaw,
+				supported: SUPPORTED_MIGRATION_SOURCES,
+			},
+			success: false,
+		};
+	}
+
+	return { data: { from: fromRaw }, success: true };
+}
+
+function isMigrationSource(value: string): value is MigrationSource {
+	return (SUPPORTED_MIGRATION_SOURCES as ReadonlyArray<string>).includes(value);
+}

--- a/packages/bedrock/src/cli/parse-migrate-options.ts
+++ b/packages/bedrock/src/cli/parse-migrate-options.ts
@@ -9,15 +9,6 @@ import type { ParseOptionsError } from "./parse-options.ts";
  */
 export const SUPPORTED_MIGRATION_SOURCES = ["mantle"] as const;
 
-/** One element of {@link SUPPORTED_MIGRATION_SOURCES}. */
-export type MigrationSource = (typeof SUPPORTED_MIGRATION_SOURCES)[number];
-
-/** Typed shape the migrate command consumes after `--from` has been validated. */
-export interface MigrateOptions {
-	/** Validated source to migrate from. */
-	readonly from: MigrationSource;
-}
-
 /**
  * Failure surfaced by `parseMigrateOptions`. Reuses the three flag-shape
  * variants from `ParseOptionsError` (so the existing `renderParseError`
@@ -31,6 +22,15 @@ export type ParseMigrateError =
 			readonly received: string;
 			readonly supported: ReadonlyArray<string>;
 	  };
+
+/** One element of {@link SUPPORTED_MIGRATION_SOURCES}. */
+type MigrationSource = (typeof SUPPORTED_MIGRATION_SOURCES)[number];
+
+/** Typed shape the migrate command consumes after `--from` has been validated. */
+interface MigrateOptions {
+	/** Validated source to migrate from. */
+	readonly from: MigrationSource;
+}
 
 const RECOGNIZED_FLAGS: ReadonlySet<string> = new Set(["from"]);
 

--- a/packages/bedrock/src/cli/parse-migrate-options.ts
+++ b/packages/bedrock/src/cli/parse-migrate-options.ts
@@ -24,7 +24,7 @@ export type ParseMigrateError =
 	  };
 
 /** One element of {@link SUPPORTED_MIGRATION_SOURCES}. */
-type MigrationSource = (typeof SUPPORTED_MIGRATION_SOURCES)[number];
+export type MigrationSource = (typeof SUPPORTED_MIGRATION_SOURCES)[number];
 
 /** Typed shape the migrate command consumes after `--from` has been validated. */
 interface MigrateOptions {

--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -6,10 +6,22 @@ import { Buffer } from "node:buffer";
 import process from "node:process";
 import { describe, expect, it, vi } from "vitest";
 
+import type { MigrateError } from "../core/migrate/migration-report.ts";
+import type { MissingCredentialError, UnsupportedBackendError } from "../shell/build-state-port.ts";
 import type { DeployError } from "../shell/deploy.ts";
 import { asResourceKey } from "../types/ids.ts";
+import type { ParseMigrateError } from "./parse-migrate-options.ts";
 import type { ParseOptionsError } from "./parse-options.ts";
-import { type ClackPort, createClackPort, renderDeployError, renderParseError } from "./render.ts";
+import {
+	type ClackPort,
+	createClackPort,
+	renderBuildStatePortError,
+	renderDeployError,
+	renderMigrateError,
+	renderMigrateParseError,
+	renderParseError,
+	renderStateWriteError,
+} from "./render.ts";
 
 interface CapturedOutput {
 	readonly text: string;
@@ -305,5 +317,133 @@ describe(renderParseError, () => {
 		renderParseError(err, port);
 
 		expect(port.logError).toHaveBeenCalledExactlyOnceWith(expected);
+	});
+});
+
+describe(renderMigrateParseError, () => {
+	it.for<{ err: ParseMigrateError; expected: string }>([
+		{
+			err: { flag: "from", kind: "missingRequired" },
+			expected: "missing required flag --from",
+		},
+		{
+			err: {
+				kind: "unknownSource",
+				received: "x",
+				supported: ["mantle", "universe"],
+			},
+			expected: "unknown migration source 'x' (supported: mantle, universe)",
+		},
+	])(
+		"should render $err.kind via logError with a migrate-specific message",
+		({ err, expected }) => {
+			expect.assertions(1);
+
+			const port = fakeClackPort();
+
+			renderMigrateParseError(err, port);
+
+			expect(port.logError).toHaveBeenCalledExactlyOnceWith(expected);
+		},
+	);
+});
+
+describe(renderMigrateError, () => {
+	it.for<{ err: MigrateError; expected: string }>([
+		{
+			err: { kind: "stateFileNotFound", path: "./.mantle-state.yml" },
+			expected: "Mantle state file not found at './.mantle-state.yml'",
+		},
+		{
+			err: {
+				kind: "stateParseFailed",
+				path: "./.mantle-state.yml",
+				reason: "unexpected end of stream",
+			},
+			expected:
+				"Mantle state file at './.mantle-state.yml' could not be parsed: unexpected end of stream",
+		},
+		{
+			err: {
+				found: "5",
+				kind: "unsupportedMantleStateVersion",
+				supported: ["6", "7"],
+			},
+			expected: "unsupported Mantle state version '5' (supported: 6, 7)",
+		},
+		{
+			err: { available: ["production", "staging"], kind: "primaryEnvironmentRequired" },
+			expected: "primary environment required (available: production, staging)",
+		},
+		{
+			err: {
+				available: ["production", "staging"],
+				kind: "primaryEnvironmentNotFound",
+				primary: "ghost",
+			},
+			expected: "primary environment 'ghost' not found (available: production, staging)",
+		},
+		{
+			err: {
+				cause: { kind: "fileNotFound", searchedFrom: "/projects/example" },
+				kind: "internalError",
+				reason: "config validation failed",
+			},
+			expected:
+				"migrate internal error: config validation failed (no bedrock config under /projects/example)",
+		},
+	])("should render $err.kind via logError with a kind-specific message", ({ err, expected }) => {
+		expect.assertions(1);
+
+		const port = fakeClackPort();
+
+		renderMigrateError(err, port);
+
+		expect(port.logError).toHaveBeenCalledExactlyOnceWith(expected);
+	});
+});
+
+describe(renderBuildStatePortError, () => {
+	it.for<{ err: MissingCredentialError | UnsupportedBackendError; expected: string }>([
+		{
+			err: { kind: "missingCredential", purpose: "stateBackend", variable: "GITHUB_TOKEN" },
+			expected: "missing credential: environment variable GITHUB_TOKEN is not set",
+		},
+		{
+			err: { backend: "s3", hint: "pass a custom statePort", kind: "unsupportedBackend" },
+			expected: "unsupported state backend 's3' (pass a custom statePort)",
+		},
+	])("should render $err.kind via logError with a kind-specific message", ({ err, expected }) => {
+		expect.assertions(1);
+
+		const port = fakeClackPort();
+
+		renderBuildStatePortError(err, port);
+
+		expect(port.logError).toHaveBeenCalledExactlyOnceWith(expected);
+	});
+});
+
+describe(renderStateWriteError, () => {
+	it("should render the environment, file path, and reason in one logError line", () => {
+		expect.assertions(1);
+
+		const port = fakeClackPort();
+
+		renderStateWriteError(
+			{
+				environment: "production",
+				err: {
+					file: "gist:abc/state.production.json",
+					kind: "stateError",
+					reason: "auth 401",
+				},
+			},
+			port,
+		);
+
+		expect(port.logError).toHaveBeenCalledExactlyOnceWith(
+			"state write failed for 'production' (gist:abc/state.production.json): auth 401",
+		);
 	});
 });

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -293,9 +293,12 @@ function migrateErrorMessage(err: MigrateError): string {
 }
 
 function buildStatePortErrorMessage(err: MissingCredentialError | UnsupportedBackendError): string {
-	if (err.kind === "missingCredential") {
-		return `missing credential: environment variable ${err.variable} is not set`;
+	switch (err.kind) {
+		case "missingCredential": {
+			return `missing credential: environment variable ${err.variable} is not set`;
+		}
+		case "unsupportedBackend": {
+			return `unsupported state backend '${err.backend}' (${err.hint})`;
+		}
 	}
-
-	return `unsupported state backend '${err.backend}' (${err.hint})`;
 }

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -30,7 +30,7 @@ export interface ClackPort {
 }
 
 /** Inputs for {@link renderStateWriteError}. */
-export interface StateWriteErrorRender {
+interface StateWriteErrorRender {
 	/** Environment whose state could not be written. */
 	readonly environment: string;
 	/** The state-error returned by the adapter. */

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -1,10 +1,13 @@
 import { cancel, intro, log, outro } from "@clack/prompts";
 
 import type { ConfigError } from "../core/config-error.ts";
+import type { MigrateError } from "../core/migrate/migration-report.ts";
 import type { StateError } from "../core/state.ts";
 import type { ApplyError } from "../shell/apply-ops.ts";
 import type { BuildDesiredError } from "../shell/build-desired.ts";
+import type { MissingCredentialError, UnsupportedBackendError } from "../shell/build-state-port.ts";
 import type { DeployError } from "../shell/deploy.ts";
+import type { ParseMigrateError } from "./parse-migrate-options.ts";
 import type { ParseOptionsError } from "./parse-options.ts";
 
 /**
@@ -24,6 +27,14 @@ export interface ClackPort {
 	logSuccess(message: string): void;
 	/** Close the current framed section with a final message. */
 	outro(message: string): void;
+}
+
+/** Inputs for {@link renderStateWriteError}. */
+export interface StateWriteErrorRender {
+	/** Environment whose state could not be written. */
+	readonly environment: string;
+	/** The state-error returned by the adapter. */
+	readonly err: StateError;
 }
 
 /**
@@ -77,6 +88,56 @@ export function createClackPort(): ClackPort {
 			outro(message);
 		},
 	};
+}
+
+/**
+ * Render a `ParseMigrateError` to the supplied `ClackPort`. Reuses
+ * `parseErrorMessage` for the three flag-shape variants and adds a
+ * dedicated message for `unknownSource` listing the supported sources.
+ * @param err - The parse error to describe.
+ * @param port - The output port the diagnostic is written to.
+ */
+export function renderMigrateParseError(err: ParseMigrateError, port: ClackPort): void {
+	port.logError(migrateParseErrorMessage(err));
+}
+
+/**
+ * Render a `MigrateError` to the supplied `ClackPort` as a single error
+ * line. Each variant points at the offending Mantle state file path,
+ * primary-environment input, or wrapped `ConfigError` so the reader can
+ * act without inspecting the raw error object.
+ * @param err - The migrate error to describe.
+ * @param port - The output port the diagnostic is written to.
+ */
+export function renderMigrateError(err: MigrateError, port: ClackPort): void {
+	port.logError(migrateErrorMessage(err));
+}
+
+/**
+ * Render a `MissingCredentialError` or `UnsupportedBackendError`
+ * surfaced when the migrate command tried to default-construct the
+ * configured `StatePort` and was missing its inputs.
+ * @param err - The error returned by `buildStatePort`.
+ * @param port - The output port the diagnostic is written to.
+ */
+export function renderBuildStatePortError(
+	err: MissingCredentialError | UnsupportedBackendError,
+	port: ClackPort,
+): void {
+	port.logError(buildStatePortErrorMessage(err));
+}
+
+/**
+ * Render a `StateError` produced when the migrator wrote a per-environment
+ * state through the `StatePort`. Names the environment alongside the
+ * adapter's failure reason so the reader knows which write failed.
+ * @param input - Environment + state-error to describe.
+ * @param port - The output port the diagnostic is written to.
+ */
+export function renderStateWriteError(input: StateWriteErrorRender, port: ClackPort): void {
+	port.logError(
+		`state write failed for '${input.environment}' (${input.err.file}): ${input.err.reason}`,
+	);
 }
 
 function applyCauseDetail(cause: ApplyError): string {
@@ -172,4 +233,43 @@ function parseErrorMessage(err: ParseOptionsError): string {
 			return `unknown flag '--${err.flag}'`;
 		}
 	}
+}
+
+function migrateParseErrorMessage(err: ParseMigrateError): string {
+	if (err.kind === "unknownSource") {
+		return `unknown migration source '${err.received}' (supported: ${err.supported.join(", ")})`;
+	}
+
+	return parseErrorMessage(err);
+}
+
+function migrateErrorMessage(err: MigrateError): string {
+	switch (err.kind) {
+		case "internalError": {
+			return `migrate internal error: ${err.reason} (${configErrorDetail(err.cause)})`;
+		}
+		case "primaryEnvironmentNotFound": {
+			return `primary environment '${err.primary}' not found (available: ${err.available.join(", ")})`;
+		}
+		case "primaryEnvironmentRequired": {
+			return `primary environment required (available: ${err.available.join(", ")})`;
+		}
+		case "stateFileNotFound": {
+			return `Mantle state file not found at '${err.path}'`;
+		}
+		case "stateParseFailed": {
+			return `Mantle state file at '${err.path}' could not be parsed: ${err.reason}`;
+		}
+		case "unsupportedMantleStateVersion": {
+			return `unsupported Mantle state version '${err.found}' (supported: ${err.supported.join(", ")})`;
+		}
+	}
+}
+
+function buildStatePortErrorMessage(err: MissingCredentialError | UnsupportedBackendError): string {
+	if (err.kind === "missingCredential") {
+		return `missing credential: environment variable ${err.variable} is not set`;
+	}
+
+	return `unsupported state backend '${err.backend}' (${err.hint})`;
 }

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -1,7 +1,7 @@
 import { cancel, intro, log, outro } from "@clack/prompts";
 
 import type { ConfigError } from "../core/config-error.ts";
-import type { MigrateError } from "../core/migrate/migration-report.ts";
+import type { MigrateError, MigrationSummary } from "../core/migrate/migration-report.ts";
 import type { StateError } from "../core/state.ts";
 import type { ApplyError } from "../shell/apply-ops.ts";
 import type { BuildDesiredError } from "../shell/build-desired.ts";
@@ -125,6 +125,32 @@ export function renderBuildStatePortError(
 	port: ClackPort,
 ): void {
 	port.logError(buildStatePortErrorMessage(err));
+}
+
+/** Pairing of a migration warning kind with the per-line label rendered by {@link renderMigrationSummary}. */
+const MIGRATION_SUMMARY_LINES: ReadonlyArray<{
+	readonly count: keyof MigrationSummary;
+	readonly label: string;
+}> = [
+	{ count: "interpretiveCount", label: "interpretive mappings" },
+	{ count: "deferredCount", label: "deferred fields" },
+	{ count: "blockedCount", label: "blocked fields" },
+	{ count: "ambiguousCount", label: "ambiguous fields" },
+];
+
+/**
+ * Render every non-zero `MigrationSummary` count to the supplied
+ * `ClackPort` as a single message line. Categories with a zero count
+ * are skipped so a clean migration produces no output.
+ * @param summary - Aggregate counts from a `MigrationReport`.
+ * @param port - The output port the lines are written to.
+ */
+export function renderMigrationSummary(summary: MigrationSummary, port: ClackPort): void {
+	for (const { count, label } of MIGRATION_SUMMARY_LINES) {
+		if (summary[count] > 0) {
+			port.logMessage(`${label}: ${String(summary[count])}`);
+		}
+	}
 }
 
 /**

--- a/packages/bedrock/src/core/migrate/migration-report.ts
+++ b/packages/bedrock/src/core/migrate/migration-report.ts
@@ -90,7 +90,7 @@ export type MigrateError =
 	| {
 			readonly found: string;
 			readonly kind: "unsupportedMantleStateVersion";
-			readonly supported: ReadonlyArray<"6">;
+			readonly supported: ReadonlyArray<string>;
 	  }
 	| { readonly kind: "stateFileNotFound"; readonly path: string }
 	| { readonly kind: "stateParseFailed"; readonly path: string; readonly reason: string };

--- a/packages/bedrock/src/shell/migrate-mantle-state.spec-d.ts
+++ b/packages/bedrock/src/shell/migrate-mantle-state.spec-d.ts
@@ -169,10 +169,10 @@ describe("MigrateError - state-file variants", () => {
 });
 
 describe("MigrateError - environment-selection variants", () => {
-	it("should lock unsupportedMantleStateVersion's supported list to the v6 literal", () => {
+	it("should expose unsupportedMantleStateVersion's supported list as a string list", () => {
 		expectTypeOf<
 			Extract<MigrateError, { kind: "unsupportedMantleStateVersion" }>["supported"]
-		>().toEqualTypeOf<ReadonlyArray<"6">>();
+		>().toEqualTypeOf<ReadonlyArray<string>>();
 		expectTypeOf<
 			Extract<MigrateError, { kind: "unsupportedMantleStateVersion" }>["found"]
 		>().toEqualTypeOf<string>();

--- a/packages/bedrock/tests/helpers/migrate-prompt-port.ts
+++ b/packages/bedrock/tests/helpers/migrate-prompt-port.ts
@@ -1,0 +1,22 @@
+import type { MigratePromptPort } from "#src/cli/migrate-prompt-port";
+import { vi } from "vitest";
+
+/**
+ * Build a `MigratePromptPort` whose five methods are independent
+ * `vi.fn()` spies. Tests script answers per scenario via
+ * `mockResolvedValueOnce({ data: ..., success: true })` (or the
+ * `cancelled` Err shape). Used by `migrate.spec.ts` to drive the
+ * full prompt sequence without touching real `@clack/prompts`.
+ *
+ * @returns A `MigratePromptPort` whose every method is a fresh
+ *   `vi.fn()` instance.
+ */
+export function fakeMigratePromptPort(): MigratePromptPort {
+	return {
+		promptConfigFormat: vi.fn<MigratePromptPort["promptConfigFormat"]>(),
+		promptGistId: vi.fn<MigratePromptPort["promptGistId"]>(),
+		promptPrimaryEnvironment: vi.fn<MigratePromptPort["promptPrimaryEnvironment"]>(),
+		promptStateBackend: vi.fn<MigratePromptPort["promptStateBackend"]>(),
+		promptStateFilePath: vi.fn<MigratePromptPort["promptStateFilePath"]>(),
+	};
+}

--- a/packages/bedrock/tests/integration/cli/index.spec.ts
+++ b/packages/bedrock/tests/integration/cli/index.spec.ts
@@ -157,4 +157,22 @@ describe("cli program factory", () => {
 			expect(captured).toContain("GITHUB_TOKEN");
 		}
 	});
+
+	it("should describe the migrate subcommand and its --from flag in 'migrate --help' output", () => {
+		expect.assertions(3);
+
+		const prog = createProg();
+
+		const collect = startCapture();
+		try {
+			prog.parse(["node", "bedrock", "migrate", "--help"]);
+		} finally {
+			const { stdout } = collect();
+			const captured = stdout.join("");
+
+			expect(captured).toContain("Translate a state file from another tool");
+			expect(captured).toContain("--from");
+			expect(captured).toContain("Source format to migrate from");
+		}
+	});
 });


### PR DESCRIPTION
## Summary

Adds `bedrock migrate --from mantle [stateFilePath]`, the first-pass CLI command for translating an existing Mantle project's state into a fresh bedrock project. The migrator core (`migrateMantleState`) already shipped in earlier slices; this PR is the thin CLI seam plus the prompt port that drives it interactively.

The command is built so adding a future `--from universe` source widens one tuple (`SUPPORTED_MIGRATION_SOURCES`) without reshaping the surface.

## What changed

- **`bedrock migrate --from <source> [stateFilePath]`** registered under `createProg`. `--from` is validated against `SUPPORTED_MIGRATION_SOURCES`; unknown values surface a typed `unknownSource` error listing the supported names. The positional path is optional — when omitted, a `clack.text` prompt asks for it with `.mantle-state.yml` as the placeholder default.
- **`MigratePromptPort`** — domain-specific prompt port with five concrete (non-generic) methods: `promptStateFilePath`, `promptConfigFormat`, `promptPrimaryEnvironment`, `promptStateBackend`, `promptGistId`. Each returns `Result<T, { kind: "cancelled" }>` so the command branches on `Result` like every other shell call.
- **`createDefaultMigratePromptPort`** wraps `@clack/prompts` and translates the cancel sentinel into the typed `Err`. A `MigratePromptClackHelpers` test seam swaps the three clack primitives so each prompt's options, validators, and cancel paths get exercised without spawning a real terminal.
- **State writes go through the configured `StatePort`** (`buildStatePort`), built from the user's interactive answers. The migrated states are byte-identical to a fresh deploy result. The emitted `bedrock.config.{ts,yaml}` is enriched with the chosen state backend block and re-serialised through `serializeConfig` before hitting disk.
- **Multi-environment recovery** — when the input declares more than one environment, the first migrator pass fails with `primaryEnvironmentRequired`; the command catches that, prompts for a primary from the available list, and re-runs the migrator with the picked value.
- **Render** gains `renderMigrateParseError`, `renderMigrateError`, `renderBuildStatePortError`, `renderStateWriteError`, and `renderMigrationSummary` so every error path the new command can hit produces a prescriptive single-line diagnostic, and warning-summary lines render via a small lookup table.
- **`ProgDeps`** gains `buildStatePort`, `migrateMantleState`, `migratePromptPort`, and `writeFile` slots, with the matching `spec-d.ts` pinning their shapes.
- **`tests/helpers/migrate-prompt-port.ts`** exposes a `fakeMigratePromptPort` whose five methods are independent `vi.fn()` spies tests script per scenario.

## Why

Bedrock's Mantle migrator (`migrateMantleState`) has been built up over the last few slices but had no user-facing entry point. This PR closes that loop so a Mantle user can run a single command and end up with a working bedrock project — config file on disk, per-environment states already in their Gist.

## Test plan

- [x] Unit tests cover every `migrateCommand` path: parse error, unknown source, happy path, positional vs. interactive path, multi-env primary prompt, every `MigrateError` variant, `buildStatePort` failure, state-write failure, every prompt cancel, summary rendering, default `process.exit` fallback.
- [x] Unit tests cover every `MigratePromptPort` real-clack delegation: each prompt's option list, validator, and cancel path.
- [x] `parseMigrateOptions` covers happy path, missing `--from`, non-string `--from`, unknown source, unknown flag.
- [x] `render.spec.ts` exhaustively covers `renderMigrateError`, `renderMigrateParseError`, `renderBuildStatePortError`, `renderStateWriteError`, and `renderMigrationSummary`.
- [x] Integration test asserts `bedrock migrate --help` describes the command and names the `--from` flag.
- [x] `pnpm test`, `pnpm typecheck`, `pnpm lint`, `pnpm build`, `pnpm mutate:changed` all green; mutation score 100% on every touched `src/cli/**` file.
- [ ] End-to-end smoke against a real Mantle state file with a fresh Gist target — out of scope for this PR; will land alongside the `--from universe` slice.

## Out of scope (followups)

- `--force` overwrite for an existing `bedrock.config.*` file.
- Auto-creating a Gist when the user has no `gistId` yet.
- Backend kinds beyond `gist`.
- `--from universe` — the parser already rejects it cleanly, so when the universe migrator lands, only the union widens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Bedrock Migration Command - Code Review (finalized)

Overall verdict: Approve with minor follow-ups. The PR implements the migrate CLI, prompt port, parse/render helpers, and comprehensive tests while largely adhering to Bedrock's FCIS+Ports architecture and project standards.

Files confirmed present (key changed files): packages/bedrock/src/cli/{default-migrate-prompt-port.ts,default-migrate-prompt-port.spec.ts,index.ts,index.spec-d.ts,migrate-prompt-port.ts,parse-migrate-options.ts,parse-migrate-options.spec.ts,render.ts,render.spec.ts}, packages/bedrock/src/core/migrate/migration-report.ts, packages/bedrock/src/shell/migrate-mantle-state.spec-d.ts, packages/bedrock/tests/helpers/migrate-prompt-port.ts, packages/bedrock/tests/integration/cli/index.spec.ts.

Findings mapped to review checklist:

1) Architecture (FCIS + Ports)
- Compliant: Core remains pure; shell (migrateCommand) orchestrates using injected ports/adapters.
- MigratePromptPort and createDefaultMigratePromptPort are well-scoped ports/adapters with a test seam.
- No direct I/O in core; readFile and state writers are injected.

2) Testing (TDD)
- Satisfactory: Tests cover parser, prompt port, renderers, and command orchestration including happy, error, cancellation, and multi-env retry flows.
- Action: Ensure CI enforces the repo's 100% coverage requirement; current tests appear exhaustive but CI verification is required.

3) Test Isolation
- Good: Unit tests isolate parser/prompt; command tests use fakeMigratePromptPort and injected deps, matching layer isolation guidelines.
- Note: For any future HTTP-backed adapters (e.g., Gist), ensure nock-based adapter tests.

4) Security & Constraints
- Good: No secrets written to persisted state; credentials are passed via getEnv and not persisted.
- parseMigrateOptions includes validation and rejects unknown flags.

5) Code Quality
- TypeScript strictness preserved; discriminated unions and typed Result<E> patterns used throughout.
- Error rendering is explicit and avoids double-rendering via sentinel logic.

6) Notable changes & behavior
- parse-migrate-options introduces unknownSource error and supported sources tuple.
- migrateCommand handles primary-environment-required by prompting and re-running migrator; writes per-env state via buildStatePort and writes bedrock.config.{ts|yaml} using serializeConfig.
- Tests assert process.exit fallback when deps.exit absent and validate cancel behavior for every prompt.

7) Minor recommendations (actionable)
- Confirm CI enforces 100% coverage; add any missing edge-case tests if coverage falls short.
- Add brief docs/README note about the new migrate command and the default .mantle-state.yml placeholder.
- Consider a one-line JSDoc in migrateCommand explaining the primary-environment re-run semantics.
- Document the expected values for unsupportedMantleStateVersion.supported (the widening to string is fine but a comment helps future maintainers).

Conclusion
- The implementation is consistent with Bedrock architecture, well-tested, and secure. Merge after confirming coverage gating and adding the small documentation/JSDoc items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->