### PR TITLE
feat(core): add filesystem tab-completion to migrate path prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 *.local.*
 .DS_Store
 .eslintcache
+.env
 
 # Testing
 coverage

--- a/packages/bedrock/src/cli/default-migrate-prompt-port.spec.ts
+++ b/packages/bedrock/src/cli/default-migrate-prompt-port.spec.ts
@@ -16,6 +16,7 @@ function makeHelpers(
 ): MigratePromptClackHelpers {
 	return {
 		isCancel: fakeIsCancel,
+		path: vi.fn<MigratePromptClackHelpers["path"]>(),
 		select: vi.fn<MigratePromptClackHelpers["select"]>(),
 		text: vi.fn<MigratePromptClackHelpers["text"]>(),
 		...overrides,
@@ -108,20 +109,20 @@ describe(createDefaultMigratePromptPort, () => {
 		expect(Object.hasOwn(passedOptions?.options[0] ?? {}, "hint")).toBeFalse();
 	});
 
-	it("should resolve promptStateFilePath with the typed path", async () => {
+	it("should resolve promptStateFilePath via the path prompt with filesystem completion", async () => {
 		expect.assertions(4);
 
-		const text = vi.fn<MigratePromptClackHelpers["text"]>(async () => "./.mantle-state.yml");
-		const port = createDefaultMigratePromptPort(makeHelpers({ text }));
+		const path = vi.fn<MigratePromptClackHelpers["path"]>(async () => "./.mantle-state.yml");
+		const port = createDefaultMigratePromptPort(makeHelpers({ path }));
 
 		const result = await port.promptStateFilePath();
 
 		expect(result).toStrictEqual({ data: "./.mantle-state.yml", success: true });
 
-		const firstCall = vi.mocked(text).mock.calls[0];
+		const firstCall = vi.mocked(path).mock.calls[0];
 
 		expect(firstCall?.[0]?.message).toBe("Path to the Mantle state file?");
-		expect(firstCall?.[0]?.placeholder).toBe(".mantle-state.yml");
+		expect(firstCall?.[0]?.initialValue).toBe(".mantle-state.yml");
 		expect(firstCall?.[0]?.validate).toBeFunction();
 	});
 
@@ -145,12 +146,12 @@ describe(createDefaultMigratePromptPort, () => {
 	it("should reject empty input on prompts that require a value via the validator", async () => {
 		expect.assertions(4);
 
-		const text = vi.fn<MigratePromptClackHelpers["text"]>(async () => "x");
-		const port = createDefaultMigratePromptPort(makeHelpers({ text }));
+		const path = vi.fn<MigratePromptClackHelpers["path"]>(async () => "x");
+		const port = createDefaultMigratePromptPort(makeHelpers({ path }));
 
 		await port.promptStateFilePath();
 
-		const firstCall = vi.mocked(text).mock.calls[0];
+		const firstCall = vi.mocked(path).mock.calls[0];
 		const validate = firstCall?.[0]?.validate;
 
 		expect(validate?.("")).toBe("Required");
@@ -194,8 +195,8 @@ describe(createDefaultMigratePromptPort, () => {
 	it("should map a clack cancel into Err({ kind: 'cancelled' }) on promptStateFilePath", async () => {
 		expect.assertions(1);
 
-		const text = vi.fn<MigratePromptClackHelpers["text"]>(async () => CANCEL_SENTINEL);
-		const port = createDefaultMigratePromptPort(makeHelpers({ text }));
+		const path = vi.fn<MigratePromptClackHelpers["path"]>(async () => CANCEL_SENTINEL);
+		const port = createDefaultMigratePromptPort(makeHelpers({ path }));
 
 		const result = await port.promptStateFilePath();
 

--- a/packages/bedrock/src/cli/default-migrate-prompt-port.ts
+++ b/packages/bedrock/src/cli/default-migrate-prompt-port.ts
@@ -1,7 +1,9 @@
 import {
 	isCancel as defaultIsCancel,
+	path as defaultPath,
 	select as defaultSelect,
 	text as defaultText,
+	type PathOptions,
 	type SelectOptions,
 	type TextOptions,
 } from "@clack/prompts";
@@ -28,6 +30,11 @@ import type { MigrationSource } from "./parse-migrate-options.ts";
 export interface MigratePromptClackHelpers {
 	/** Cancel predicate; defaults to `@clack/prompts`'s `isCancel`. */
 	readonly isCancel: (value: unknown) => value is symbol;
+	/**
+	 * Path-prompt fn with filesystem tab-completion; defaults to
+	 * `@clack/prompts`'s `path`.
+	 */
+	readonly path: (options: PathOptions) => Promise<string | symbol>;
 	/** Select-prompt fn; defaults to `@clack/prompts`'s `select`. */
 	readonly select: (options: SelectOptions<string>) => Promise<string | symbol>;
 	/** Text-prompt fn; defaults to `@clack/prompts`'s `text`. */
@@ -50,6 +57,7 @@ const SOURCE_LABELS: Record<MigrationSource, string> = {
 
 const defaultHelpers: MigratePromptClackHelpers = {
 	isCancel: defaultIsCancel,
+	path: defaultPath,
 	select: defaultSelect,
 	text: defaultText,
 };
@@ -177,12 +185,24 @@ async function promptStateBackendFrom(
 	});
 }
 
+async function fromPath(
+	helpers: MigratePromptClackHelpers,
+	options: PathOptions,
+): Promise<MigratePromptResult<string>> {
+	const result = await helpers.path(options);
+	if (helpers.isCancel(result)) {
+		return { err: { kind: "cancelled" }, success: false };
+	}
+
+	return { data: result, success: true };
+}
+
 async function promptStateFilePathFrom(
 	helpers: MigratePromptClackHelpers,
 ): Promise<MigratePromptResult<string>> {
-	return fromText(helpers, {
+	return fromPath(helpers, {
+		initialValue: ".mantle-state.yml",
 		message: "Path to the Mantle state file?",
-		placeholder: ".mantle-state.yml",
 		validate: validateNonEmpty,
 	});
 }


### PR DESCRIPTION
## Summary

- Swap the "Path to the Mantle state file?" prompt from clack's `text()` to `path()` so the user gets filesystem suggestions as they type, with arrow keys to cycle through matches.
- The `MigratePromptPort.promptStateFilePath()` signature is unchanged. Cancel-symbol contract is identical to `text()`. Only the underlying clack primitive changes.
- `.mantle-state.yml` moves from `placeholder` to `initialValue` (path() has no placeholder), so users can press Enter to accept the default or edit it.
- Tests updated to script the new `path` helper slot; behaviour assertions are otherwise the same.

Already on `@clack/prompts@1.2.0` via the runtime catalog, so no dep bump needed.

## Test Plan

- [x] `pnpm --filter @bedrock/core test` (1524 / 1524)
- [x] `pnpm typecheck`
- [x] `pnpm mutate:changed` (100% mutation score)
- [ ] Manual: run `bedrock migrate` (no positional path), confirm the prompt is pre-filled with `.mantle-state.yml`, that backspacing and typing a partial filename surfaces suggestions from cwd, and that arrows cycle matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Bedrock Architecture Review: feat(core): add filesystem tab-completion to migrate path prompt

### Architecture Compliance ✅

**Layer Placement**: Correct
- Changes are confined to the Shell/Adapter boundary (`createDefaultMigratePromptPort` is a port adapter factory)
- No business logic or pure functions touched
- No I/O violations

**FCIS Pattern**: Compliant
- Port abstraction (`MigratePromptClackHelpers`) remains clean with concrete dependency injection
- Default implementation cleanly separates concerns via helper functions (`fromPath`, `promptStateFilePathFrom`)
- No OOP ceremony, no factory classes

### Testing (TDD) ✅

**Coverage**: Complete
- Existing test suite updated to validate `path` helper invocation (line 112-127)
- All three behavior scenarios covered:
  - Successful path input with filesystem completion
  - Input validation (empty-string rejection)
  - User cancellation handling
- Test naming follows `it("should <behavior>")` convention correctly

**Test Isolation**: Proper
- Fake helpers (`fakeIsCancel`, `vi.fn` mocks) isolate from real filesystem
- No unintended I/O; test setup uses `makeHelpers()` factory with correct helper signatures
- Validator function testing (lines 146-161) correctly exercises the validation logic in isolation

**Mock Pattern**: Good
- Helper interface (`MigratePromptClackHelpers`) provides clear contract for test doubles
- Vitest `vi.fn<T>()` generic typing allows concrete mock signatures to satisfy the interface
- Cancel sentinel pattern is idiomatic and avoids ambiguity

### Code Quality ✅

**TypeScript Strictness**: Maintained
- New `path: (options: PathOptions) => Promise<string | symbol>` field in `MigratePromptClackHelpers` is explicit
- All imports pinned to clack's concrete types (`PathOptions`)
- No `any` types

**Error Handling**: Preserved
- `MigratePromptResult<T>` Result type used consistently (lines 191, 197)
- Cancel-to-`{ kind: "cancelled" }` translation identical to `fromText` pattern
- Validator propagated unchanged (`validateNonEmpty`)

**Public API Discipline**: Maintained
- Port signature `MigratePromptPort.promptStateFilePath()` unchanged (still returns `Promise<MigratePromptResult<string>>`)
- Test seam `MigratePromptClackHelpers` is explicitly marked as test-only in JSDoc (lines 19-28)
- No breaking changes to external consumers

### Design Decisions ✅

**Placeholder → initialValue Migration**: Sound
- `@clack/prompts` `path()` does not support `placeholder` option
- `initialValue` ("`.mantle-state.yml`") preserves user UX (pre-filled default, editable)
- User can press Enter to accept or edit/backspace to trigger completion suggestions
- Validated behavior matches intent per PR summary

**Abstraction Reuse**: Good
- New `fromPath()` helper (lines 188-198) mirrors existing `fromText()` pattern
- Reduces duplication and keeps mutation translation centralized
- Same cancel predicate, same Result structure

**Dependency**: No impact
- `@clack/prompts@1.2.0` already in runtime catalog
- No version bump, no new packages

### Testing Notes

Line 155 (`vi.mocked(path).mock.calls[0]?.[0]?.validate`) correctly extracts the validator from the first call's options object, allowing line 157-160 to exercise the validation function independently—good separation of concerns.

### Minor Observations

- `.gitignore` addition of `.env` is appropriate and unrelated to feature scope
- Test assertions at line 124-126 properly distinguish between placeholder (absent) and initialValue (present) to catch the implementation detail change
- Cancel handling test (line 195-204) correctly mirrors the `fromText` pattern for consistency

### Summary

This PR exhibits **exemplary compliance** with Bedrock's architecture, testing discipline, and code standards. The change is minimal, well-isolated, properly tested, and maintains backward compatibility at all public boundaries. The abstraction (new `fromPath` helper) mirrors existing patterns cleanly and avoids duplication. No concerns for approval from an architectural perspective.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->