### PR TITLE
feat(core): add local file option to migrate state backend prompt

### DIFF
--- a/packages/bedrock/src/cli/commands/migrate.spec.ts
+++ b/packages/bedrock/src/cli/commands/migrate.spec.ts
@@ -618,7 +618,7 @@ describe(migrateCommand, () => {
 		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
 
 		expect(writeFile).toHaveBeenCalledWith(
-			"/projects/example/bedrock-state/production.json",
+			"/projects/example/.bedrock/state/production.json",
 			expect.stringContaining('"environment": "production"'),
 		);
 		expect(writeFile).toHaveBeenCalledWith(
@@ -652,7 +652,7 @@ describe(migrateCommand, () => {
 
 		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
 
-		expect(mkdir).toHaveBeenCalledExactlyOnceWith("/projects/example/bedrock-state");
+		expect(mkdir).toHaveBeenCalledExactlyOnceWith("/projects/example/.bedrock/state");
 		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(0);
 	});
 
@@ -667,7 +667,7 @@ describe(migrateCommand, () => {
 		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
 
 		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
-			"local state directory create failed (/projects/example/bedrock-state): EACCES: permission denied",
+			"local state directory create failed (/projects/example/.bedrock/state): EACCES: permission denied",
 		);
 		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("migrate failed");
 		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
@@ -705,7 +705,9 @@ describe(migrateCommand, () => {
 			migratePromptPort: promptPort,
 		})(stateFilePath, { from: "mantle" });
 
-		expect(existsSync(join(temporaryDirectory, "missing-parent", "bedrock-state"))).toBeTrue();
+		expect(
+			existsSync(join(temporaryDirectory, "missing-parent", ".bedrock", "state")),
+		).toBeTrue();
 		expect(exit).toHaveBeenCalledExactlyOnceWith(0);
 	});
 
@@ -720,7 +722,7 @@ describe(migrateCommand, () => {
 		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
 
 		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
-			"local state write failed (/projects/example/bedrock-state/production.json): EROFS: read-only file system",
+			"local state write failed (/projects/example/.bedrock/state/production.json): EROFS: read-only file system",
 		);
 		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("migrate failed");
 		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);

--- a/packages/bedrock/src/cli/commands/migrate.spec.ts
+++ b/packages/bedrock/src/cli/commands/migrate.spec.ts
@@ -1,5 +1,8 @@
 import { fakeClackPort } from "#tests/helpers/clack";
 import { fakeMigratePromptPort } from "#tests/helpers/migrate-prompt-port";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import process from "node:process";
 import { describe, expect, it, onTestFinished, vi } from "vitest";
 
@@ -12,6 +15,7 @@ import { migrateCommand } from "./migrate.ts";
 
 type ExitFunc = NonNullable<ProgDeps["exit"]>;
 type WriteFileFunc = NonNullable<ProgDeps["writeFile"]>;
+type MkdirFunc = NonNullable<ProgDeps["mkdir"]>;
 type MigrateFunc = NonNullable<ProgDeps["migrateMantleState"]>;
 type BuildStatePortFunc = NonNullable<ProgDeps["buildStatePort"]>;
 
@@ -52,12 +56,15 @@ function makeDeps(overrides: Partial<ProgDeps> = {}): ProgDeps {
 	migrate.mockResolvedValue({ data: SAMPLE_REPORT, success: true });
 	const writeFile = vi.fn<WriteFileFunc>();
 	writeFile.mockResolvedValue();
+	const mkdir = vi.fn<MkdirFunc>();
+	mkdir.mockResolvedValue();
 	return {
 		buildStatePort: vi.fn<BuildStatePortFunc>(() => ({ data: happyPort(), success: true })),
 		clack: fakeClackPort(),
 		exit: vi.fn<ExitFunc>(),
 		migrateMantleState: migrate,
 		migratePromptPort: fakeMigratePromptPort(),
+		mkdir,
 		writeFile,
 		...overrides,
 	};
@@ -583,6 +590,151 @@ describe(migrateCommand, () => {
 			"/projects/example/bedrock.config.yaml",
 			expect.any(String),
 		);
+	});
+
+	function scriptLocalBackendPrompts(deps: ProgDeps, stateFilePath: string): void {
+		vi.mocked(deps.migratePromptPort!.promptStateFilePath).mockResolvedValueOnce({
+			data: stateFilePath,
+			success: true,
+		});
+		vi.mocked(deps.migratePromptPort!.promptConfigFormat).mockResolvedValueOnce({
+			data: "typescript",
+			success: true,
+		});
+		vi.mocked(deps.migratePromptPort!.promptStateBackend).mockResolvedValueOnce({
+			data: "local",
+			success: true,
+		});
+	}
+
+	it("should dump per-env state JSON beside bedrock.config when 'local' backend is picked", async () => {
+		expect.assertions(3);
+
+		const writeFile = vi.fn<WriteFileFunc>();
+		writeFile.mockResolvedValue();
+		const deps = makeDeps({ writeFile });
+		scriptLocalBackendPrompts(deps, "/projects/example/.mantle-state.yml");
+
+		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
+
+		expect(writeFile).toHaveBeenCalledWith(
+			"/projects/example/bedrock-state/production.json",
+			expect.stringContaining('"environment": "production"'),
+		);
+		expect(writeFile).toHaveBeenCalledWith(
+			"/projects/example/bedrock.config.ts",
+			expect.not.stringContaining('"state"'),
+		);
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(0);
+	});
+
+	it("should skip the gist-id prompt and buildStatePort when 'local' backend is picked", async () => {
+		expect.assertions(3);
+
+		const buildStatePort = vi.fn<BuildStatePortFunc>(() => happyPortResult());
+		const deps = makeDeps({ buildStatePort });
+		scriptLocalBackendPrompts(deps, "/projects/example/.mantle-state.yml");
+
+		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.migratePromptPort?.promptGistId).not.toHaveBeenCalled();
+		expect(buildStatePort).not.toHaveBeenCalled();
+		expect(deps.clack?.logSuccess).toHaveBeenCalledWith("production: 0 resources migrated");
+	});
+
+	it("should create the local-dump output directory before writing per-env state files", async () => {
+		expect.assertions(2);
+
+		const mkdir = vi.fn<MkdirFunc>();
+		mkdir.mockResolvedValue();
+		const deps = makeDeps({ mkdir });
+		scriptLocalBackendPrompts(deps, "/projects/example/.mantle-state.yml");
+
+		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
+
+		expect(mkdir).toHaveBeenCalledExactlyOnceWith("/projects/example/bedrock-state");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(0);
+	});
+
+	it("should render an error and exit 1 when the local-dump mkdir rejects", async () => {
+		expect.assertions(3);
+
+		const mkdir = vi.fn<MkdirFunc>();
+		mkdir.mockRejectedValueOnce(new Error("EACCES: permission denied"));
+		const deps = makeDeps({ mkdir });
+		scriptLocalBackendPrompts(deps, "/projects/example/.mantle-state.yml");
+
+		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
+			"local state directory create failed (/projects/example/bedrock-state): EACCES: permission denied",
+		);
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("migrate failed");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should default to recursive node mkdir when no mkdir slot is provided", async () => {
+		expect.assertions(2);
+
+		const temporaryDirectory = mkdtempSync(join(tmpdir(), "bedrock-migrate-local-"));
+		onTestFinished(() => {
+			rmSync(temporaryDirectory, { force: true, recursive: true });
+		});
+		const stateFilePath = join(temporaryDirectory, "missing-parent", ".mantle-state.yml");
+		const exit = vi.fn<ExitFunc>();
+		const migrate = vi.fn<MigrateFunc>();
+		migrate.mockResolvedValue({ data: SAMPLE_REPORT, success: true });
+		const promptPort = fakeMigratePromptPort();
+		vi.mocked(promptPort.promptStateFilePath).mockResolvedValueOnce({
+			data: stateFilePath,
+			success: true,
+		});
+		vi.mocked(promptPort.promptConfigFormat).mockResolvedValueOnce({
+			data: "typescript",
+			success: true,
+		});
+		vi.mocked(promptPort.promptStateBackend).mockResolvedValueOnce({
+			data: "local",
+			success: true,
+		});
+
+		await migrateCommand({
+			clack: fakeClackPort(),
+			exit,
+			migrateMantleState: migrate,
+			migratePromptPort: promptPort,
+		})(stateFilePath, { from: "mantle" });
+
+		expect(existsSync(join(temporaryDirectory, "missing-parent", "bedrock-state"))).toBeTrue();
+		expect(exit).toHaveBeenCalledExactlyOnceWith(0);
+	});
+
+	it("should render an error and exit 1 when the local-dump writeFile rejects", async () => {
+		expect.assertions(3);
+
+		const writeFile = vi.fn<WriteFileFunc>();
+		writeFile.mockRejectedValueOnce(new Error("EROFS: read-only file system"));
+		const deps = makeDeps({ writeFile });
+		vi.mocked(deps.migratePromptPort!.promptStateFilePath).mockResolvedValueOnce({
+			data: "/projects/example/.mantle-state.yml",
+			success: true,
+		});
+		vi.mocked(deps.migratePromptPort!.promptConfigFormat).mockResolvedValueOnce({
+			data: "typescript",
+			success: true,
+		});
+		vi.mocked(deps.migratePromptPort!.promptStateBackend).mockResolvedValueOnce({
+			data: "local",
+			success: true,
+		});
+
+		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
+			"local state write failed (/projects/example/bedrock-state/production.json): EROFS: read-only file system",
+		);
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("migrate failed");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
 	});
 
 	it("should default to process.exit when no exit slot is provided", async () => {

--- a/packages/bedrock/src/cli/commands/migrate.spec.ts
+++ b/packages/bedrock/src/cli/commands/migrate.spec.ts
@@ -715,18 +715,7 @@ describe(migrateCommand, () => {
 		const writeFile = vi.fn<WriteFileFunc>();
 		writeFile.mockRejectedValueOnce(new Error("EROFS: read-only file system"));
 		const deps = makeDeps({ writeFile });
-		vi.mocked(deps.migratePromptPort!.promptStateFilePath).mockResolvedValueOnce({
-			data: "/projects/example/.mantle-state.yml",
-			success: true,
-		});
-		vi.mocked(deps.migratePromptPort!.promptConfigFormat).mockResolvedValueOnce({
-			data: "typescript",
-			success: true,
-		});
-		vi.mocked(deps.migratePromptPort!.promptStateBackend).mockResolvedValueOnce({
-			data: "local",
-			success: true,
-		});
+		scriptLocalBackendPrompts(deps, "/projects/example/.mantle-state.yml");
 
 		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
 
@@ -735,6 +724,31 @@ describe(migrateCommand, () => {
 		);
 		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("migrate failed");
 		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should drop a pre-existing state field from the bedrock config when 'local' is picked", async () => {
+		expect.assertions(1);
+
+		const reportWithState: MigrationReport = {
+			...SAMPLE_REPORT,
+			config: {
+				...SAMPLE_CONFIG,
+				state: { backend: "gist", gistId: "leftover-from-source" },
+			},
+		};
+		const migrate = vi.fn<MigrateFunc>();
+		migrate.mockResolvedValue({ data: reportWithState, success: true });
+		const writeFile = vi.fn<WriteFileFunc>();
+		writeFile.mockResolvedValue();
+		const deps = makeDeps({ migrateMantleState: migrate, writeFile });
+		scriptLocalBackendPrompts(deps, "/projects/example/.mantle-state.yml");
+
+		await migrateCommand(deps)("/projects/example/.mantle-state.yml", { from: "mantle" });
+
+		expect(writeFile).toHaveBeenCalledWith(
+			"/projects/example/bedrock.config.ts",
+			expect.not.stringContaining("leftover-from-source"),
+		);
 	});
 
 	it("should default to process.exit when no exit slot is provided", async () => {

--- a/packages/bedrock/src/cli/commands/migrate.ts
+++ b/packages/bedrock/src/cli/commands/migrate.ts
@@ -268,7 +268,10 @@ async function promptForStateTarget(
 
 	if (backend.data === "local") {
 		return {
-			data: { backend: "local", outputDir: join(dirname(stateFilePath), "bedrock-state") },
+			data: {
+				backend: "local",
+				outputDir: join(dirname(stateFilePath), ".bedrock", "state"),
+			},
 			success: true,
 		};
 	}

--- a/packages/bedrock/src/cli/commands/migrate.ts
+++ b/packages/bedrock/src/cli/commands/migrate.ts
@@ -1,12 +1,12 @@
 import type { Result } from "@bedrock/ocale";
 
-import { writeFile as nodeWriteFile } from "node:fs/promises";
+import { mkdir as nodeMkdir, writeFile as nodeWriteFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import process from "node:process";
 
 import type { MigrateError, MigrationReport } from "../../core/migrate/migration-report.ts";
 import { serializeConfig } from "../../core/migrate/serialize-config.ts";
-import type { Config, GistStateConfig } from "../../core/schema.ts";
+import type { Config } from "../../core/schema.ts";
 import { buildStatePort as defaultBuildStatePort } from "../../shell/build-state-port.ts";
 import {
 	migrateMantleState as defaultMigrateMantleState,
@@ -20,13 +20,12 @@ import { type MigrationSource, parseMigrateOptions } from "../parse-migrate-opti
 import {
 	type ClackPort,
 	createClackPort,
-	renderBuildStatePortError,
 	renderMigrateError,
 	renderMigrateParseError,
 	renderMigrationSummary,
-	renderStateWriteError,
 } from "../render.ts";
 import { resolveMigrationSource, resolveStateFilePath } from "./resolve-migrate-inputs.ts";
+import { type ResolvedStateTarget, writeMigratedStates } from "./write-migrated-states.ts";
 
 const FAILED_OUTRO = "migrate failed";
 
@@ -46,6 +45,7 @@ interface ResolvedMigrate {
 	readonly clack: ClackPort;
 	readonly exit: (code: number) => void;
 	readonly migrateMantleState: typeof defaultMigrateMantleState;
+	readonly mkdir: (path: string) => Promise<void>;
 	readonly promptPort: MigratePromptPort;
 	readonly writeFile: (path: string, contents: string) => Promise<void>;
 }
@@ -61,7 +61,7 @@ interface FinalizeInputs {
 	readonly configFormat: MigrateConfigFormat;
 	readonly report: MigrationReport;
 	readonly resolved: ResolvedMigrate;
-	readonly stateConfig: GistStateConfig;
+	readonly target: ResolvedStateTarget;
 }
 
 interface RunMigratorInputs {
@@ -114,6 +114,7 @@ function resolveMigrate(deps: ProgDeps): ResolvedMigrate {
 		clack: deps.clack ?? createClackPort(),
 		exit: deps.exit ?? ((code) => process.exit(code)),
 		migrateMantleState: deps.migrateMantleState ?? defaultMigrateMantleState,
+		mkdir: deps.mkdir ?? (async (path) => void (await nodeMkdir(path, { recursive: true }))),
 		promptPort: deps.migratePromptPort ?? createDefaultMigratePromptPort(),
 		writeFile:
 			deps.writeFile ?? (async (path, contents) => nodeWriteFile(path, contents, "utf8")),
@@ -204,49 +205,12 @@ async function runMigratorWithPrompt(
 	return renderedFailure(second.err, inputs.resolved);
 }
 
-async function promptForStateConfig(
-	resolved: ResolvedMigrate,
-): Promise<Result<GistStateConfig, "cancelled">> {
-	const backend = await resolved.promptPort.promptStateBackend();
-	if (!backend.success) {
-		return { err: "cancelled", success: false };
-	}
-
-	const gistId = await resolved.promptPort.promptGistId();
-	if (!gistId.success) {
-		return { err: "cancelled", success: false };
-	}
-
-	return { data: { backend: backend.data, gistId: gistId.data }, success: true };
-}
-
-async function writeMigratedStates(inputs: FinalizeInputs): Promise<Result<void, void>> {
-	const { report, resolved, stateConfig } = inputs;
-	const portResult = resolved.buildStatePort({
-		getEnv: (name) => process.env[name],
-		stateConfig,
-	});
-	if (!portResult.success) {
-		renderBuildStatePortError(portResult.err, resolved.clack);
-		return { err: undefined, success: false };
-	}
-
-	for (const [environment, state] of Object.entries(report.statesByEnvironment)) {
-		const writeResult = await portResult.data.write(state);
-		if (!writeResult.success) {
-			renderStateWriteError({ environment, err: writeResult.err }, resolved.clack);
-			return { err: undefined, success: false };
-		}
-
-		resolved.clack.logSuccess(`${environment}: ${state.resources.length} resources migrated`);
-	}
-
-	return { data: undefined, success: true };
-}
-
 async function writeBedrockConfig(inputs: FinalizeInputs): Promise<Result<void, void>> {
-	const { configFilePath, configFormat, report, resolved, stateConfig } = inputs;
-	const enrichedConfig: Config = { ...report.config, state: stateConfig };
+	const { configFilePath, configFormat, report, resolved, target } = inputs;
+	const enrichedConfig: Config =
+		target.backend === "gist"
+			? { ...report.config, state: target.stateConfig }
+			: { ...report.config };
 	const enrichedBytes = serializeConfig({ config: enrichedConfig, configFormat });
 	try {
 		await resolved.writeFile(configFilePath, enrichedBytes);
@@ -262,8 +226,17 @@ async function writeBedrockConfig(inputs: FinalizeInputs): Promise<Result<void, 
 }
 
 async function finalize(inputs: FinalizeInputs): Promise<number> {
-	const { report, resolved } = inputs;
-	const stateWritten = await writeMigratedStates(inputs);
+	const { report, resolved, target } = inputs;
+	const stateWritten = await writeMigratedStates({
+		deps: {
+			buildStatePort: resolved.buildStatePort,
+			clack: resolved.clack,
+			mkdir: resolved.mkdir,
+			writeFile: resolved.writeFile,
+		},
+		report,
+		target,
+	});
 	if (!stateWritten.success) {
 		return failAfterRender(resolved);
 	}
@@ -281,6 +254,33 @@ async function finalize(inputs: FinalizeInputs): Promise<number> {
 function configFileFor(stateFilePath: string, format: MigrateConfigFormat): string {
 	const extension = format === "typescript" ? "ts" : "yaml";
 	return join(dirname(stateFilePath), `bedrock.config.${extension}`);
+}
+
+async function promptForStateTarget(
+	resolved: ResolvedMigrate,
+	stateFilePath: string,
+): Promise<Result<ResolvedStateTarget, "cancelled">> {
+	const backend = await resolved.promptPort.promptStateBackend();
+	if (!backend.success) {
+		return { err: "cancelled", success: false };
+	}
+
+	if (backend.data === "local") {
+		return {
+			data: { backend: "local", outputDir: join(dirname(stateFilePath), "bedrock-state") },
+			success: true,
+		};
+	}
+
+	const gistId = await resolved.promptPort.promptGistId();
+	if (!gistId.success) {
+		return { err: "cancelled", success: false };
+	}
+
+	return {
+		data: { backend: "gist", stateConfig: { backend: "gist", gistId: gistId.data } },
+		success: true,
+	};
 }
 
 async function runWithStateFilePath(
@@ -301,8 +301,8 @@ async function runWithStateFilePath(
 		return reportResult.err === "cancelled" ? cancel(resolved) : EXIT_ERROR;
 	}
 
-	const stateConfigResult = await promptForStateConfig(resolved);
-	if (!stateConfigResult.success) {
+	const targetResult = await promptForStateTarget(resolved, stateFilePath);
+	if (!targetResult.success) {
 		return cancel(resolved);
 	}
 
@@ -311,7 +311,7 @@ async function runWithStateFilePath(
 		configFormat: formatResult.data,
 		report: reportResult.data,
 		resolved,
-		stateConfig: stateConfigResult.data,
+		target: targetResult.data,
 	});
 }
 

--- a/packages/bedrock/src/cli/commands/migrate.ts
+++ b/packages/bedrock/src/cli/commands/migrate.ts
@@ -207,10 +207,11 @@ async function runMigratorWithPrompt(
 
 async function writeBedrockConfig(inputs: FinalizeInputs): Promise<Result<void, void>> {
 	const { configFilePath, configFormat, report, resolved, target } = inputs;
+	const { state: _ignoredState, ...configWithoutState } = report.config;
 	const enrichedConfig: Config =
 		target.backend === "gist"
-			? { ...report.config, state: target.stateConfig }
-			: { ...report.config };
+			? { ...configWithoutState, state: target.stateConfig }
+			: configWithoutState;
 	const enrichedBytes = serializeConfig({ config: enrichedConfig, configFormat });
 	try {
 		await resolved.writeFile(configFilePath, enrichedBytes);

--- a/packages/bedrock/src/cli/commands/write-migrated-states.ts
+++ b/packages/bedrock/src/cli/commands/write-migrated-states.ts
@@ -1,0 +1,113 @@
+import type { Result } from "@bedrock/ocale";
+
+import { join } from "node:path";
+import process from "node:process";
+
+import type { MigrationReport } from "../../core/migrate/migration-report.ts";
+import type { GistStateConfig } from "../../core/schema.ts";
+import { serializeStateFile } from "../../core/state-file.ts";
+import type { buildStatePort as defaultBuildStatePort } from "../../shell/build-state-port.ts";
+import type { ClackPort } from "../render.ts";
+import { renderBuildStatePortError, renderStateWriteError } from "../render.ts";
+
+/**
+ * Where the migrate command persists per-environment states. The `gist`
+ * arm carries the resolved {@link GistStateConfig} that gets written to
+ * the bedrock config; the `local` arm carries the on-disk directory used
+ * for the JSON-per-environment dump.
+ */
+export type ResolvedStateTarget =
+	| { readonly backend: "gist"; readonly stateConfig: GistStateConfig }
+	| { readonly backend: "local"; readonly outputDir: string };
+
+/** Subset of the migrate command's resolved deps the writers need. */
+interface WriterDeps {
+	readonly buildStatePort: typeof defaultBuildStatePort;
+	readonly clack: ClackPort;
+	readonly mkdir: (path: string) => Promise<void>;
+	readonly writeFile: (path: string, contents: string) => Promise<void>;
+}
+
+interface WriteInputs {
+	readonly deps: WriterDeps;
+	readonly report: MigrationReport;
+	readonly target: ResolvedStateTarget;
+}
+
+/**
+ * Persist every per-environment state in the migration report to the
+ * resolved target. Dispatches to the GitHub Gist `StatePort` adapter or
+ * to a local-file dump under `target.outputDir`. On failure the writer
+ * has already rendered the error to `deps.clack`; the caller only needs
+ * to translate the Err into an exit code.
+ *
+ * @param inputs - Resolved deps, the migration report, and the target
+ *   the writer should dispatch on.
+ * @returns `Ok(void)` once every environment has been written; `Err(void)`
+ *   on the first failure (already rendered to clack).
+ */
+export async function writeMigratedStates(inputs: WriteInputs): Promise<Result<void, void>> {
+	if (inputs.target.backend === "local") {
+		return writeStatesToLocal({ ...inputs, target: inputs.target });
+	}
+
+	return writeStatesToGist({ ...inputs, target: inputs.target });
+}
+
+async function writeStatesToGist(
+	inputs: WriteInputs & { readonly target: { readonly stateConfig: GistStateConfig } },
+): Promise<Result<void, void>> {
+	const { deps, report, target } = inputs;
+	const portResult = deps.buildStatePort({
+		getEnv: (name) => process.env[name],
+		stateConfig: target.stateConfig,
+	});
+	if (!portResult.success) {
+		renderBuildStatePortError(portResult.err, deps.clack);
+		return { err: undefined, success: false };
+	}
+
+	for (const [environment, state] of Object.entries(report.statesByEnvironment)) {
+		const writeResult = await portResult.data.write(state);
+		if (!writeResult.success) {
+			renderStateWriteError({ environment, err: writeResult.err }, deps.clack);
+			return { err: undefined, success: false };
+		}
+
+		deps.clack.logSuccess(`${environment}: ${state.resources.length} resources migrated`);
+	}
+
+	return { data: undefined, success: true };
+}
+
+function describeUnknown(value: unknown): string {
+	return value instanceof Error ? value.message : String(value);
+}
+
+async function writeStatesToLocal(
+	inputs: WriteInputs & { readonly target: { readonly outputDir: string } },
+): Promise<Result<void, void>> {
+	const { deps, report, target } = inputs;
+	try {
+		await deps.mkdir(target.outputDir);
+	} catch (err) {
+		deps.clack.logError(
+			`local state directory create failed (${target.outputDir}): ${describeUnknown(err)}`,
+		);
+		return { err: undefined, success: false };
+	}
+
+	for (const [environment, state] of Object.entries(report.statesByEnvironment)) {
+		const filePath = join(target.outputDir, `${environment}.json`);
+		try {
+			await deps.writeFile(filePath, serializeStateFile(state));
+		} catch (err) {
+			deps.clack.logError(`local state write failed (${filePath}): ${describeUnknown(err)}`);
+			return { err: undefined, success: false };
+		}
+
+		deps.clack.logSuccess(`${environment}: ${state.resources.length} resources migrated`);
+	}
+
+	return { data: undefined, success: true };
+}

--- a/packages/bedrock/src/cli/default-migrate-prompt-port.spec.ts
+++ b/packages/bedrock/src/cli/default-migrate-prompt-port.spec.ts
@@ -85,7 +85,7 @@ describe(createDefaultMigratePromptPort, () => {
 			options: [
 				{ label: "GitHub Gist", value: "gist" },
 				{
-					hint: "writes bedrock-state/<env>.json next to bedrock.config",
+					hint: "writes .bedrock/state/<env>.json next to bedrock.config",
 					label: "Local files",
 					value: "local",
 				},

--- a/packages/bedrock/src/cli/default-migrate-prompt-port.spec.ts
+++ b/packages/bedrock/src/cli/default-migrate-prompt-port.spec.ts
@@ -82,7 +82,14 @@ describe(createDefaultMigratePromptPort, () => {
 		expect(select).toHaveBeenCalledExactlyOnceWith({
 			initialValue: "gist",
 			message: "State backend?",
-			options: [{ label: "GitHub Gist", value: "gist" }],
+			options: [
+				{ label: "GitHub Gist", value: "gist" },
+				{
+					hint: "writes ./bedrock-state/<env>.json next to bedrock.config",
+					label: "Local files",
+					value: "local",
+				},
+			],
 		});
 	});
 

--- a/packages/bedrock/src/cli/default-migrate-prompt-port.spec.ts
+++ b/packages/bedrock/src/cli/default-migrate-prompt-port.spec.ts
@@ -85,7 +85,7 @@ describe(createDefaultMigratePromptPort, () => {
 			options: [
 				{ label: "GitHub Gist", value: "gist" },
 				{
-					hint: "writes ./bedrock-state/<env>.json next to bedrock.config",
+					hint: "writes bedrock-state/<env>.json next to bedrock.config",
 					label: "Local files",
 					value: "local",
 				},

--- a/packages/bedrock/src/cli/default-migrate-prompt-port.ts
+++ b/packages/bedrock/src/cli/default-migrate-prompt-port.ts
@@ -51,7 +51,7 @@ const BACKEND_OPTIONS: ReadonlyArray<{ hint?: string; label: string; value: Migr
 	[
 		{ label: "GitHub Gist", value: "gist" },
 		{
-			hint: "writes bedrock-state/<env>.json next to bedrock.config",
+			hint: "writes .bedrock/state/<env>.json next to bedrock.config",
 			label: "Local files",
 			value: "local",
 		},

--- a/packages/bedrock/src/cli/default-migrate-prompt-port.ts
+++ b/packages/bedrock/src/cli/default-migrate-prompt-port.ts
@@ -47,9 +47,15 @@ const FORMAT_OPTIONS: ReadonlyArray<{ hint?: string; label: string; value: Migra
 		{ label: "YAML", value: "yaml" },
 	];
 
-const BACKEND_OPTIONS: ReadonlyArray<{ label: string; value: MigrateStateBackend }> = [
-	{ label: "GitHub Gist", value: "gist" },
-];
+const BACKEND_OPTIONS: ReadonlyArray<{ hint?: string; label: string; value: MigrateStateBackend }> =
+	[
+		{ label: "GitHub Gist", value: "gist" },
+		{
+			hint: "writes ./bedrock-state/<env>.json next to bedrock.config",
+			label: "Local files",
+			value: "local",
+		},
+	];
 
 const SOURCE_LABELS: Record<MigrationSource, string> = {
 	mantle: "Mantle",

--- a/packages/bedrock/src/cli/default-migrate-prompt-port.ts
+++ b/packages/bedrock/src/cli/default-migrate-prompt-port.ts
@@ -51,7 +51,7 @@ const BACKEND_OPTIONS: ReadonlyArray<{ hint?: string; label: string; value: Migr
 	[
 		{ label: "GitHub Gist", value: "gist" },
 		{
-			hint: "writes ./bedrock-state/<env>.json next to bedrock.config",
+			hint: "writes bedrock-state/<env>.json next to bedrock.config",
 			label: "Local files",
 			value: "local",
 		},

--- a/packages/bedrock/src/cli/index.spec-d.ts
+++ b/packages/bedrock/src/cli/index.spec-d.ts
@@ -21,6 +21,7 @@ describe("ProgDeps shape", () => {
 			| "loadConfig"
 			| "migrateMantleState"
 			| "migratePromptPort"
+			| "mkdir"
 			| "previewDiff"
 			| "writeFile"
 		>();
@@ -67,6 +68,12 @@ describe("ProgDeps migrate slots", () => {
 	it("should accept a (path, contents) writeFile signature in the writeFile slot", () => {
 		expectTypeOf<NonNullable<ProgDeps["writeFile"]>>().toEqualTypeOf<
 			(path: string, contents: string) => Promise<void>
+		>();
+	});
+
+	it("should accept a (path) mkdir signature in the mkdir slot", () => {
+		expectTypeOf<NonNullable<ProgDeps["mkdir"]>>().toEqualTypeOf<
+			(path: string) => Promise<void>
 		>();
 	});
 });

--- a/packages/bedrock/src/cli/index.ts
+++ b/packages/bedrock/src/cli/index.ts
@@ -37,6 +37,8 @@ export interface ProgDeps {
 	readonly migrateMantleState?: typeof defaultMigrateMantleState;
 	/** Domain-specific prompt port for the migrate command; defaults to `createDefaultMigratePromptPort()`. */
 	readonly migratePromptPort?: MigratePromptPort;
+	/** Directory-create seam used by the migrate command for the local-dump backend; defaults to `node:fs/promises.mkdir` with `recursive: true`. */
+	readonly mkdir?: (path: string) => Promise<void>;
 	/** Read-only preview of operations; defaults to the internal `previewDiff` shell helper. */
 	readonly previewDiff?: typeof defaultPreviewDiff;
 	/** File-write seam used by the migrate command to emit the bedrock config file; defaults to `node:fs/promises.writeFile`. */

--- a/packages/bedrock/src/cli/migrate-prompt-port.ts
+++ b/packages/bedrock/src/cli/migrate-prompt-port.ts
@@ -11,10 +11,12 @@ export type MigrateConfigFormat = "typescript" | "yaml";
 
 /**
  * State backend kind the user picks via `MigratePromptPort.promptStateBackend`.
- * Single-option today; the union exists so adding a new backend kind widens
- * one tuple without reshaping the prompt port.
+ * `gist` writes through the GitHub Gist `StatePort` adapter; `local` is a
+ * migrate-only dump that writes each environment's state JSON to disk
+ * beside the generated `bedrock.config` and leaves the config's `state:`
+ * field unset for the user to fill in later.
  */
-export type MigrateStateBackend = "gist";
+export type MigrateStateBackend = "gist" | "local";
 
 /**
  * Result returned by every method on {@link MigratePromptPort}.


### PR DESCRIPTION
## Summary

- Adds a "Local files" choice next to "GitHub Gist" on the `bedrock migrate` state-backend prompt. Picking it dumps each environment's state JSON to `<configDir>/.bedrock/state/<env>.json` and emits a `bedrock.config.{ts,yaml}` with the `state:` field stripped, so a user can inspect a migration without provisioning a gist first.
- The local arm is a migrate-only on-disk dump. The `StateConfig` schema, `buildStatePort`, and `deploy` are untouched; this is not a real `StatePort` adapter and is not picked up by `deploy`.
- Extracts the gist/local writers into `commands/write-migrated-states.ts` so `migrate.ts` stays under the per-file line cap; introduces a `mkdir` seam on `ProgDeps` so tests can stub directory creation.
- The `local` arm explicitly destructures `state` out of the migration report's config so the contract "config has no state field after a local dump" holds independent of the migration source.

## Test plan

- [x] `pnpm test --filter @bedrock/core` (1530+ passing, 4 skipped, no type errors)
- [x] `pnpm typecheck` (clean)
- [x] `pnpm lint` (clean for this change set)
- [x] `pnpm mutate:changed` against touched files (100% mutation score; 0 surviving, 0 no-coverage)
- [x] Smoke: ran `bedrock migrate <path>/.mantle-state.yml`, picked `Local files`; confirmed `.bedrock/state/{development,production,staging}.json` written and `bedrock.config.ts` emitted without `state:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)