### PR TITLE
fix(core): block is-active instead of deriving universe visibility

### DIFF
--- a/packages/bedrock/src/core/migrate/fold-blocked-experience-fields.ts
+++ b/packages/bedrock/src/core/migrate/fold-blocked-experience-fields.ts
@@ -15,10 +15,7 @@ const GROUP_ID_REASON = "Open Cloud does not support transferring experience own
 
 /**
  * `experienceConfiguration_singleton` fields with no Open Cloud writable
- * endpoint. `isFriendsOnly` is intentionally omitted: `foldVisibility`
- * already owns it, and listing it here would double-emit when
- * `experienceActivation_singleton.isActive` is `true` and the cross-fold
- * blocks the public-friends combo.
+ * endpoint.
  */
 const BLOCKED_FIELDS: ReadonlyArray<BlockedFieldRule> = [
 	{ field: "genre", reason: "Roblox does not expose `genre` via Open Cloud" },
@@ -33,6 +30,7 @@ const BLOCKED_FIELDS: ReadonlyArray<BlockedFieldRule> = [
 		reason: "experienceConfiguration.permissions has no Open Cloud equivalent",
 	},
 	{ field: "isArchived", reason: "isArchived has no Open Cloud equivalent" },
+	{ field: "isFriendsOnly", reason: "isFriendsOnly has no Open Cloud equivalent" },
 ];
 
 /**

--- a/packages/bedrock/src/core/migrate/fold-universe.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.spec.ts
@@ -605,92 +605,16 @@ describe(foldUniverse, () => {
 		});
 	});
 
-	describe("visibility cross-fold", () => {
-		it.for<[label: string, isFriendsOnly: boolean | undefined]>([
-			["isFriendsOnly false", false],
-			["isFriendsOnly undefined", undefined],
-		])("should set visibility to public when isActive is true and %s", ([, isFriendsOnly]) => {
-			expect.assertions(1);
-
-			const result = foldUniverse([
-				experience(DEFAULT_EXPERIENCE_OUTPUTS),
-				experienceActivation({ isActive: true }),
-				experienceConfiguration({ isFriendsOnly }),
-			]);
-
-			assert(result !== undefined);
-
-			expect(result.entry).toStrictEqual({
-				universeId: "1",
-				visibility: "public",
-			});
-		});
-
-		it("should emit one interpretive warning for the active-public combo", () => {
-			expect.assertions(1);
-
-			const result = foldUniverse([
-				experience(DEFAULT_EXPERIENCE_OUTPUTS),
-				experienceActivation({ isActive: true }),
-				experienceConfiguration({ isFriendsOnly: false }),
-			]);
-
-			assert(result !== undefined);
-
-			expect(result.warnings).toStrictEqual([
-				{
-					bedrockPath: "universe.visibility",
-					kind: "interpretive",
-					mantlePath: "experienceActivation_singleton.isActive",
-					rule: "active-public-combo",
-				},
-			]);
-		});
-
-		it("should set visibility to public when experienceConfiguration is absent and isActive is true", () => {
-			expect.assertions(1);
-
-			const result = foldUniverse([
-				experience(DEFAULT_EXPERIENCE_OUTPUTS),
-				experienceActivation({ isActive: true }),
-			]);
-
-			assert(result !== undefined);
-
-			expect(result.entry).toStrictEqual({
-				universeId: "1",
-				visibility: "public",
-			});
-		});
-
-		it("should omit visibility and emit ambiguous when isActive is false", () => {
-			expect.assertions(4);
-
-			const result = foldUniverse([
-				experience(DEFAULT_EXPERIENCE_OUTPUTS),
-				experienceActivation({ isActive: false }),
-				experienceConfiguration({ isFriendsOnly: false }),
-			]);
-
-			assert(result !== undefined);
-
-			expect(result.entry).toStrictEqual({ universeId: "1" });
-			expect(result.warnings).toHaveLength(1);
-
-			const [warning] = result.warnings;
-			assert(warning?.kind === "ambiguous");
-
-			expect(warning.mantlePath).toBe("experienceActivation_singleton.isActive");
-			expect(warning.hint).toMatch(/dashboard/i);
-		});
-
-		it("should omit visibility and emit blocked when isFriendsOnly is true", () => {
+	describe("experienceActivation fold", () => {
+		it.for<[label: string, isActive: boolean]>([
+			["isActive true", true],
+			["isActive false", false],
+		])("should emit a blocked warning when %s", ([, isActive]) => {
 			expect.assertions(2);
 
 			const result = foldUniverse([
 				experience(DEFAULT_EXPERIENCE_OUTPUTS),
-				experienceActivation({ isActive: true }),
-				experienceConfiguration({ isFriendsOnly: true }),
+				experienceActivation({ isActive }),
 			]);
 
 			assert(result !== undefined);
@@ -699,10 +623,24 @@ describe(foldUniverse, () => {
 			expect(result.warnings).toStrictEqual([
 				{
 					kind: "blocked",
-					mantlePath: "experienceConfiguration_singleton.isFriendsOnly",
-					reason: "isFriendsOnly has no Open Cloud equivalent",
+					mantlePath: "experienceActivation_singleton.isActive",
+					reason: "isActive has no Open Cloud equivalent",
 				},
 			]);
+		});
+
+		it("should never set universe.visibility from isActive", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				experienceActivation({ isActive: true }),
+				experienceConfiguration({ isFriendsOnly: false }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry).not.toContainKey("visibility");
 		});
 
 		it("should leave the entry untouched when experienceActivation is absent", () => {
@@ -716,7 +654,11 @@ describe(foldUniverse, () => {
 			assert(result !== undefined);
 
 			expect(result.entry).toStrictEqual({ universeId: "1" });
-			expect(result.warnings).toStrictEqual([]);
+			expect(
+				result.warnings.filter(
+					(warning) => warning.mantlePath === "experienceActivation_singleton.isActive",
+				),
+			).toStrictEqual([]);
 		});
 
 		it("should leave the entry untouched when experienceActivation.isActive is non-boolean", () => {
@@ -1158,6 +1100,7 @@ describe(foldUniverse, () => {
 				"experienceConfiguration.permissions has no Open Cloud equivalent",
 			],
 			["isArchived", "isArchived", false, "isArchived has no Open Cloud equivalent"],
+			["isFriendsOnly", "isFriendsOnly", true, "isFriendsOnly has no Open Cloud equivalent"],
 		])("should emit a blocked warning when %s is set", ([, field, value, reason]) => {
 			expect.assertions(1);
 
@@ -1235,27 +1178,6 @@ describe(foldUniverse, () => {
 
 			expect(result.entry).toStrictEqual({ universeId: "1" });
 			expect(result.warnings).toStrictEqual([]);
-		});
-
-		it("should not double-emit a blocked for isFriendsOnly when foldVisibility owns it", () => {
-			expect.assertions(1);
-
-			const result = foldUniverse([
-				experience(DEFAULT_EXPERIENCE_OUTPUTS),
-				experienceActivation({ isActive: true }),
-				experienceConfiguration({ isFriendsOnly: true }),
-			]);
-
-			assert(result !== undefined);
-
-			const friendsOnlyBlocked = result.warnings.filter((warning) => {
-				return (
-					warning.kind === "blocked" &&
-					warning.mantlePath === "experienceConfiguration_singleton.isFriendsOnly"
-				);
-			});
-
-			expect(friendsOnlyBlocked).toHaveLength(1);
 		});
 
 		it.for<[label: string, key: string]>([

--- a/packages/bedrock/src/core/migrate/fold-universe.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.ts
@@ -5,7 +5,6 @@ import { foldBlockedExperienceFields } from "./fold-blocked-experience-fields.ts
 import { foldDisplayName } from "./fold-display-name.ts";
 import { foldSocialLinks } from "./fold-social-links.ts";
 import {
-	ambiguousWarning,
 	blockedWarning,
 	EMPTY_FRAGMENT,
 	type FoldFragment,
@@ -101,7 +100,7 @@ function collectUniverseFragments(
 		foldPlayableDevices(resources),
 		foldPrivateServers(resources),
 		foldVoiceChat(resources),
-		foldVisibility(resources),
+		foldExperienceActivation(resources),
 		foldSocialLinks(resources),
 		foldDisplayName(resources),
 		foldBlockedExperienceFields(resources),
@@ -204,33 +203,12 @@ function pricedPrivateServersFragment(price: number): FoldFragment {
 	};
 }
 
-const VISIBILITY_PUBLIC_FRAGMENT: FoldFragment = {
-	entryFragment: { visibility: "public" },
-	warnings: [
-		interpretiveWarning({
-			bedrockPath: "universe.visibility",
-			mantlePath: "experienceActivation_singleton.isActive",
-			rule: "active-public-combo",
-		}),
-	],
-};
-
-const VISIBILITY_AMBIGUOUS: FoldFragment = {
-	entryFragment: {},
-	warnings: [
-		ambiguousWarning(
-			"experienceActivation_singleton.isActive",
-			"Set visibility manually or deactivate the universe in the Roblox dashboard; auto-mapping isActive=false to visibility=private would kick live players.",
-		),
-	],
-};
-
-const VISIBILITY_FRIENDS_BLOCKED: FoldFragment = {
+const EXPERIENCE_ACTIVATION_BLOCKED: FoldFragment = {
 	entryFragment: {},
 	warnings: [
 		blockedWarning(
-			"experienceConfiguration_singleton.isFriendsOnly",
-			"isFriendsOnly has no Open Cloud equivalent",
+			"experienceActivation_singleton.isActive",
+			"isActive has no Open Cloud equivalent",
 		),
 	],
 };
@@ -245,32 +223,12 @@ function readIsActive(resources: ReadonlyArray<MantleResource>): boolean | undef
 	return typeof isActive === "boolean" ? isActive : undefined;
 }
 
-function readIsFriendsOnly(resources: ReadonlyArray<MantleResource>): boolean | undefined {
-	const config = resources.find((resource) => resource.kind === EXPERIENCE_CONFIGURATION_KIND);
-	if (config === undefined || !isObjectPayload(config.inputs)) {
-		return undefined;
-	}
-
-	const { isFriendsOnly } = config.inputs;
-	return typeof isFriendsOnly === "boolean" ? isFriendsOnly : undefined;
-}
-
-function foldVisibility(resources: ReadonlyArray<MantleResource>): FoldFragment {
-	const isActive = readIsActive(resources);
-	if (isActive === undefined) {
+function foldExperienceActivation(resources: ReadonlyArray<MantleResource>): FoldFragment {
+	if (readIsActive(resources) === undefined) {
 		return EMPTY_FRAGMENT;
 	}
 
-	if (!isActive) {
-		return VISIBILITY_AMBIGUOUS;
-	}
-
-	const isFriendsOnly = readIsFriendsOnly(resources);
-	if (isFriendsOnly === true) {
-		return VISIBILITY_FRIENDS_BLOCKED;
-	}
-
-	return VISIBILITY_PUBLIC_FRAGMENT;
+	return EXPERIENCE_ACTIVATION_BLOCKED;
 }
 
 function foldVoiceChat(resources: ReadonlyArray<MantleResource>): FoldFragment {

--- a/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
@@ -404,12 +404,11 @@ describe(migrateMantleState, () => {
 				uri: "https://twitter.com/example",
 			},
 			universeId: "6110424408",
-			visibility: "public",
 			voiceChatEnabled: true,
 		});
 	});
 
-	it("should fold the development primary into a separate universe shape with visibility omitted", async () => {
+	it("should fold the development primary into a separate universe shape", async () => {
 		expect.assertions(1);
 
 		const result = await migrateMantleState({
@@ -433,7 +432,7 @@ describe(migrateMantleState, () => {
 		});
 	});
 
-	it("should emit an ambiguous warning rooted at development.experienceActivation_singleton.isActive", async () => {
+	it("should emit a blocked warning rooted at every environment's experienceActivation_singleton.isActive", async () => {
 		expect.assertions(2);
 
 		const result = await migrateMantleState({
@@ -444,16 +443,18 @@ describe(migrateMantleState, () => {
 
 		assert(result.success);
 
-		const ambiguous = result.data.warnings.find((warning) => {
+		const isActiveBlocked = result.data.warnings.filter((warning) => {
 			return (
-				warning.kind === "ambiguous" &&
-				warning.mantlePath === "development.experienceActivation_singleton.isActive"
+				warning.kind === "blocked" &&
+				warning.mantlePath.endsWith(".experienceActivation_singleton.isActive")
 			);
 		});
-		assert(ambiguous?.kind === "ambiguous");
 
-		expect(ambiguous.hint).toMatch(/dashboard/i);
-		expect(result.data.summary.ambiguousCount).toBeGreaterThanOrEqual(1);
+		expect(isActiveBlocked.map((warning) => warning.mantlePath)).toIncludeAllMembers([
+			"development.experienceActivation_singleton.isActive",
+			"production.experienceActivation_singleton.isActive",
+		]);
+		expect(result.data.summary.blockedCount).toBeGreaterThanOrEqual(2);
 	});
 
 	it("should report interpretive warnings for every universe fold rule applied", async () => {
@@ -472,7 +473,6 @@ describe(migrateMantleState, () => {
 			.map((warning) => warning.rule);
 
 		expect(interpretiveRules).toIncludeAllMembers([
-			"active-public-combo",
 			"domain-to-field",
 			"list-to-flag",
 			"private-servers-priced",
@@ -496,11 +496,12 @@ describe(migrateMantleState, () => {
 
 		const blocked = result.data.warnings.filter((warning) => warning.kind === "blocked");
 
-		// 13 fields per environment × 2 environments. Excluded: price and
-		// customSocialSlotsCount (null sentinel); isFriendsOnly (foldVisibility
-		// owns it); experience.groupId (null in both environments).
-		expect(blocked).toHaveLength(26);
-		expect(result.data.summary.blockedCount).toBe(26);
+		// 14 fields per environment × 2 environments + 1 isFriendsOnly only
+		// in production (development uses the YAML null sentinel).
+		// Excluded: price and customSocialSlotsCount (null sentinel);
+		// experience.groupId (null in both environments).
+		expect(blocked).toHaveLength(29);
+		expect(result.data.summary.blockedCount).toBe(29);
 
 		const paths = blocked.map((warning) => warning.mantlePath);
 
@@ -535,8 +536,8 @@ describe(migrateMantleState, () => {
 		expect(paths.length).toBeGreaterThan(0);
 	});
 
-	it("should suppress blocked emission for fields owned by interpretive folds or set to the null sentinel", async () => {
-		expect.assertions(3);
+	it("should suppress blocked emission for fields set to the YAML null sentinel", async () => {
+		expect.assertions(2);
 
 		const result = await migrateMantleState({
 			configFormat: "typescript",
@@ -549,10 +550,6 @@ describe(migrateMantleState, () => {
 		const paths = result.data.warnings
 			.filter((warning) => warning.kind === "blocked")
 			.map((warning) => warning.mantlePath);
-
-		// isFriendsOnly: foldVisibility owns it (production sets isFriendsOnly:
-		// false + isActive: true → public visibility, no blocked).
-		expect(paths.filter((path) => path.endsWith(".isFriendsOnly"))).toStrictEqual([]);
 
 		// customSocialSlotsCount and price use the YAML null sentinel (~) so
 		// parseState strips them to undefined before the fold runs.


### PR DESCRIPTION
## Summary

The migrator was deriving `universe.visibility` from `experienceActivation_singleton.isActive` (the `active-public-combo` interpretive rule) and emitting an `ambiguous` warning when `isActive` was false. Both directions are wrong:

- `Universe.visibility` is `readOnly` on `Cloud_UpdateUniverse`, so any bedrock config emitted with a `visibility` value cannot be applied.
- The Open Cloud `/legacy-develop/v1/universes/{id}/activate` and `/deactivate` endpoints exist in the schema but reject API-key and OAuth requests in practice, so `isActive` has no working write path.

This PR reclassifies `experienceActivation_singleton.isActive` as `blocked` regardless of value, drops the visibility derivation entirely, and moves `isFriendsOnly` into the static `BLOCKED_FIELDS` table now that no cross-fold owns it.

## Test plan

- [x] `pnpm test` from `packages/bedrock` (1540 tests pass)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm build`
- [x] `pnpm mutate:changed` on touched `src/**` files: 100% kill rate, 0 survivors
- [x] Integration test asserts a `blocked` warning at every environment's `experienceActivation_singleton.isActive`
- [x] Integration test confirms `universe.visibility` is no longer derived from `isActive`

🤖 Generated with [Claude Code](https://claude.com/claude-code)