### PR TITLE
chore: update hooks package

### DIFF
--- a/.claude/sentinel.local.md
+++ b/.claude/sentinel.local.md
@@ -1,7 +1,9 @@
 ---
 eslint: true
+lint-cadence: tiered
 lint: true
 maxLintAttempts: 1
 oxlint: false
+typecheck: false
 typecheck-args: --build --emitDeclarationOnly --pretty false
 ---

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,10 +24,6 @@
 		"deny": [],
 		"defaultMode": "plan"
 	},
-	"enabledPlugins": {
-		"sentinel@isentinel": true,
-		"worktrunk@worktrunk": true
-	},
 	"hooks": {
 		"SessionStart": [
 			{
@@ -53,12 +49,18 @@
 			}
 		]
 	},
+	"enabledPlugins": {
+		"sentinel@isentinel": true,
+		"typescript-lsp@claude-plugins-official": true,
+		"worktrunk@worktrunk": true
+	},
 	"extraKnownMarketplaces": {
 		"isentinel": {
 			"source": {
 				"source": "github",
 				"repo": "christopher-buss/skills"
-			}
+			},
+			"autoUpdate": true
 		},
 		"worktrunk": {
 			"source": {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -6,6 +6,7 @@ export default isentinel(
 		flawless: true,
 		ignores: [
 			"!.claude",
+			"!.claude/settings.json",
 			"!.claude/hooks/**",
 			"**/*.example.spec.ts",
 			"**/vendor/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,8 +76,8 @@ catalogs:
       specifier: 5.0.0-beta.11
       version: 5.0.0-beta.11
     '@isentinel/hooks':
-      specifier: 1.3.0
-      version: 1.3.0
+      specifier: 1.4.0
+      version: 1.4.0
     '@vitest/eslint-plugin':
       specifier: 1.6.16
       version: 1.6.16
@@ -241,7 +241,7 @@ importers:
         version: 5.0.0-beta.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/estree@1.0.8)(@typescript-eslint/utils@8.58.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(@voidzero-dev/vite-plus-test@0.1.19)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-eslint-plugin@7.0.0(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-jest-extended@3.0.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-n@17.24.0(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-react-naming-convention@2.3.9(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       '@isentinel/hooks':
         specifier: catalog:lint
-        version: 1.3.0(@typescript/native-preview@7.0.0-dev.20260428.1)(@typescript/typescript6@6.0.1)(jiti@2.6.1)
+        version: 1.4.0(@typescript/native-preview@7.0.0-dev.20260428.1)(@typescript/typescript6@6.0.1)(jiti@2.6.1)
       '@isentinel/tsconfig':
         specifier: catalog:tsc
         version: 1.2.0(@typescript/typescript6@6.0.1)
@@ -1949,8 +1949,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@isentinel/hooks@1.3.0':
-    resolution: {integrity: sha512-Y6Le/NCu5ABzKFH858ENuMSuW+sKTzQLYD0CU5e+qcHcWrdqlHQ+h4kGL8Vj/0YYTxqJkHh+eB2r3FR0Q8sALw==}
+  '@isentinel/hooks@1.4.0':
+    resolution: {integrity: sha512-DKB5OHSFmIwr+rxtJKkv5FqSBiYN/4kRRNsyafRE4ME0PedBCy4MQUShaOLa0QfMqm1hI1VvSV0ssDVvveboeQ==}
     engines: {node: '>=24.11.0'}
     peerDependencies:
       '@typescript/native-preview': '>=7'
@@ -8231,7 +8231,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@isentinel/hooks@1.3.0(@typescript/native-preview@7.0.0-dev.20260428.1)(@typescript/typescript6@6.0.1)(jiti@2.6.1)':
+  '@isentinel/hooks@1.4.0(@typescript/native-preview@7.0.0-dev.20260428.1)(@typescript/typescript6@6.0.1)(jiti@2.6.1)':
     dependencies:
       eslint_d: 15.0.2(jiti@2.6.1)
       file-entry-cache: 11.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,7 +59,7 @@ catalogs:
     "@commitlint/types": 20.5.0
     "@eslint/config-inspector": 1.5.0
     "@isentinel/eslint-config": 5.0.0-beta.11
-    "@isentinel/hooks": 1.3.0
+    "@isentinel/hooks": 1.4.0
     "@vitest/eslint-plugin": 1.6.16
     eslint: 9.39.2
     eslint-plugin-erasable-syntax-only: 0.4.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR Summary: chore: update hooks package

This PR updates the development tooling configuration and bumps the `@isentinel/hooks` dependency from version 1.3.0 to 1.4.0.

### Changes Overview

**Configuration Updates:**
- **`.claude/sentinel.local.md`**: Added `eslint` enablement and introduced `lint-cadence: tiered` configuration, explicitly disabling `typecheck` while maintaining existing lint settings
- **`.claude/settings.json`**: Expanded `enabledPlugins` to include `typescript-lsp@claude-plugins-official` alongside existing plugins; adjusted marketplace configuration for isentinel with `autoUpdate: true`
- **`eslint.config.ts`**: Added ignore pattern for `.claude/settings.json` to ensure configuration files are linted appropriately
- **`pnpm-workspace.yaml`**: Updated `@isentinel/hooks` version in catalogs from 1.3.0 to 1.4.0

### Architecture Compliance Assessment

✅ **No Architecture Violations**: This PR contains no functional code changes and therefore does not impact the FCIS pattern architecture (Core, Shell, Ports, Adapters).

⚠️ **Configuration-Only Changes**: All modifications are configuration and dependency management updates. No business logic, I/O operations, or side effects are introduced.

✅ **Testing Impact**: No changes require new tests as this is a tooling/dependency update rather than feature implementation.

### Observations

1. **Dependency Update**: The hooks package version bump to 1.4.0 suggests possible breaking or feature changes - recommend verifying compatibility with the broader codebase
2. **Linting Configuration**: The addition of ESLint configuration and TypeScript LSP plugin indicates enhanced developer tooling for code quality
3. **Configuration Organization**: Changes align with supporting AI-assisted development through Sentinel and Claude plugins

### Recommendation

✅ **Approve** - This PR contains safe configuration and dependency updates with no architectural concerns. Ensure that the `@isentinel/hooks` 1.4.0 version bump is compatible with all consuming packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->