### PR TITLE
ci: label release deploys with production github environment

### DIFF
--- a/.github/workflows/website-release.yaml
+++ b/.github/workflows/website-release.yaml
@@ -23,6 +23,9 @@ jobs:
   deploy:
     name: Deploy production docs
     runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://bedrock-livid.vercel.app
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## Summary

Adds an `environment: production` block to the deploy job in [website-release.yaml](.github/workflows/website-release.yaml) so tagged release deploys land as a clearly named "production" entry on github.com/christopher-buss/bedrock/deployments.

## Why

Issue [#317](https://github.com/christopher-buss/bedrock/issues/317) reported "production docs generated on PR to main." The actual production project (`bedrock-livid`) was already disconnected from Git after PR [#286](https://github.com/christopher-buss/bedrock/pull/286), so PRs were not touching production docs at all. The confusion came from GitHub Deployments: Vercel's git integration on the `bedrock-next` preview project auto-stamps every main-branch deploy as "Production" (its own internal terminology), which surfaces in the GitHub Deployments UI alongside, and indistinguishable from, the real release deploys.

By giving `website-release.yaml` an explicit `environment: production` with the canonical URL, the tagged release now owns the "production" label in GitHub. Combined with disabling the `deployment_status` webhook on `bedrock-next` from the Vercel dashboard (manual companion step), the GitHub Deployments page reads as expected: only release tags create production entries.

## Test plan

- [ ] Wait for the next `@bedrock/core@*` tag (or trigger `website-release.yaml` via `workflow_dispatch`) and confirm a `production` entry appears at https://github.com/christopher-buss/bedrock/deployments pointing at https://bedrock-livid.vercel.app.
- [ ] After flipping the `deployment_status Events` toggle off on the `bedrock-next` Vercel project, push a commit to main and confirm no new "Production" entry appears for `bedrock-next` on the deployments page.

Closes #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds GitHub Actions environment metadata to the website release deployment workflow. The change adds an `environment` block to the deploy job in `.github/workflows/website-release.yaml`, declaring the deployment as `production` with the URL `https://bedrock-livid.vercel.app`. This enables the tagged release deploys to appear explicitly as "production" entries in GitHub Deployments, addressing issue #317.

## Context

Issue #317 reported that production documentation appeared to be generated on PRs to main. The root cause was that Vercel's bedrock-next preview project was auto-creating misleading "Production" entries in GitHub Deployments for every push to main, while the actual production releases (on bedrock-livid) had no environment label. This change resolves the confusion by explicitly labeling tagged releases as production.

## Changes

- **`.github/workflows/website-release.yaml`**: Added `environment` block with `name: production` and `url: https://bedrock-livid.vercel.app` to the deploy job (+3 lines)
- No changes to deployment commands or build logic
- Intended to be paired with a manual configuration change: disabling the `deployment_status` webhook on the bedrock-next Vercel project

## Notes

This is a CI/CD configuration change outside the scope of Bedrock's application architecture standards (FCIS pattern, TDD, test coverage). The change is minimal, correctly scoped, and directly addresses the reported issue. Verification depends on monitoring the next `@bedrock/core@*` release tag to confirm a production deployment entry appears in GitHub Deployments pointing to the correct URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->