### PR TITLE
fix(core): preserve place metadata during mantle migration

### DIFF
--- a/packages/bedrock/src/core/migrate/build-state.spec.ts
+++ b/packages/bedrock/src/core/migrate/build-state.spec.ts
@@ -210,6 +210,64 @@ describe(buildState, () => {
 		expect(resource.fileHash).toBe(VALID_HASH);
 	});
 
+	it("should propagate folded description, displayName, and serverSize onto the place resource", () => {
+		expect.assertions(3);
+
+		const state = buildState({
+			environment: "production",
+			folded: {
+				passes: [],
+				places: new Map([
+					[
+						"start",
+						placeFold({
+							entry: {
+								description: "A welcoming start place",
+								displayName: "Atrium",
+								filePath: "place.rbxl",
+								serverSize: 32,
+							},
+						}),
+					],
+				]),
+				universe: undefined,
+				warnings: [],
+			},
+			iconHashesByKey: NO_HASHES,
+		});
+
+		const [resource] = state.resources;
+		assert(resource !== undefined);
+		assert(resource.kind === "place");
+
+		expect(resource.description).toBe("A welcoming start place");
+		expect(resource.displayName).toBe("Atrium");
+		expect(resource.serverSize).toBe(32);
+	});
+
+	it("should leave description, displayName, and serverSize undefined when the folded entry omits them", () => {
+		expect.assertions(3);
+
+		const state = buildState({
+			environment: "production",
+			folded: {
+				passes: [],
+				places: new Map([["start", placeFold()]]),
+				universe: undefined,
+				warnings: [],
+			},
+			iconHashesByKey: NO_HASHES,
+		});
+
+		const [resource] = state.resources;
+		assert(resource !== undefined);
+		assert(resource.kind === "place");
+
+		expect(resource.description).toBeNil();
+		expect(resource.displayName).toBeNil();
+		expect(resource.serverSize).toBeNil();
+	});
+
 	it("should emit place resources after the universe resource", () => {
 		expect.assertions(2);
 

--- a/packages/bedrock/src/core/migrate/build-state.spec.ts
+++ b/packages/bedrock/src/core/migrate/build-state.spec.ts
@@ -263,9 +263,9 @@ describe(buildState, () => {
 		assert(resource !== undefined);
 		assert(resource.kind === "place");
 
-		expect(resource.description).toBeNil();
-		expect(resource.displayName).toBeNil();
-		expect(resource.serverSize).toBeNil();
+		expect(resource.description).toBeUndefined();
+		expect(resource.displayName).toBeUndefined();
+		expect(resource.serverSize).toBeUndefined();
 	});
 
 	it("should emit place resources after the universe resource", () => {

--- a/packages/bedrock/src/core/migrate/build-state.ts
+++ b/packages/bedrock/src/core/migrate/build-state.ts
@@ -93,7 +93,7 @@ function placeResource(key: string, fold: PlaceFoldEntry): ResourceCurrentState<
 	return {
 		key: asResourceKey(key),
 		description: fold.entry.description,
-		displayName: undefined,
+		displayName: fold.entry.displayName,
 		fileHash: fold.fileHash,
 		filePath: fold.entry.filePath,
 		kind: "place",

--- a/packages/bedrock/src/core/migrate/build-state.ts
+++ b/packages/bedrock/src/core/migrate/build-state.ts
@@ -92,7 +92,7 @@ function universeResource(
 function placeResource(key: string, fold: PlaceFoldEntry): ResourceCurrentState<"place"> {
 	return {
 		key: asResourceKey(key),
-		description: undefined,
+		description: fold.entry.description,
 		displayName: undefined,
 		fileHash: fold.fileHash,
 		filePath: fold.entry.filePath,

--- a/packages/bedrock/src/core/migrate/build-state.ts
+++ b/packages/bedrock/src/core/migrate/build-state.ts
@@ -99,7 +99,7 @@ function placeResource(key: string, fold: PlaceFoldEntry): ResourceCurrentState<
 		kind: "place",
 		outputs: fold.outputs,
 		placeId: asRobloxAssetId(fold.placeId),
-		serverSize: undefined,
+		serverSize: fold.entry.serverSize,
 	};
 }
 

--- a/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
@@ -531,6 +531,335 @@ describe(factorizeEnvironments, () => {
 		});
 	});
 
+	it("should land description on root and omit the place overlay when both environments share the same description", () => {
+		expect.assertions(2);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { description: "Shared place.", filePath: "place.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+			[
+				"production",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { description: "Shared place.", filePath: "place.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.places?.["start"]?.description).toBe("Shared place.");
+		expect(result.data.config.environments["development"]?.places).toStrictEqual({
+			start: { placeId: "17613681043" },
+		});
+	});
+
+	it("should override description on a non-primary place overlay when it diverges from the primary", () => {
+		expect.assertions(2);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { description: "Dev place.", filePath: "place.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+			[
+				"production",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { description: "Prod place.", filePath: "place.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.places?.["start"]?.description).toBe("Prod place.");
+		expect(result.data.config.environments["development"]?.places).toStrictEqual({
+			start: { description: "Dev place.", placeId: "17613681043" },
+		});
+	});
+
+	it("should override description on a non-primary place overlay when the primary has it and the env omits it", () => {
+		expect.assertions(1);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					places: new Map([["start", placeFold({ entry: { filePath: "place.rbxl" } })]]),
+				}),
+			],
+			[
+				"production",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { description: "Prod place.", filePath: "place.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.environments["development"]?.places).toStrictEqual({
+			start: { description: undefined, placeId: "17613681043" },
+		});
+	});
+
+	it("should land displayName on root and omit the place overlay when both environments share the same displayName", () => {
+		expect.assertions(2);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { displayName: "Shared Name", filePath: "place.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+			[
+				"production",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { displayName: "Shared Name", filePath: "place.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.places?.["start"]?.displayName).toBe("Shared Name");
+		expect(result.data.config.environments["development"]?.places).toStrictEqual({
+			start: { placeId: "17613681043" },
+		});
+	});
+
+	it("should override displayName on a non-primary place overlay when it diverges from the primary", () => {
+		expect.assertions(2);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { displayName: "Dev Name", filePath: "place.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+			[
+				"production",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { displayName: "Prod Name", filePath: "place.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.places?.["start"]?.displayName).toBe("Prod Name");
+		expect(result.data.config.environments["development"]?.places).toStrictEqual({
+			start: { displayName: "Dev Name", placeId: "17613681043" },
+		});
+	});
+
+	it("should override displayName on a non-primary place overlay when the primary has it and the env omits it", () => {
+		expect.assertions(1);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					places: new Map([["start", placeFold({ entry: { filePath: "place.rbxl" } })]]),
+				}),
+			],
+			[
+				"production",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { displayName: "Prod Name", filePath: "place.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.environments["development"]?.places).toStrictEqual({
+			start: { displayName: undefined, placeId: "17613681043" },
+		});
+	});
+
+	it("should land serverSize on root and omit the place overlay when both environments share the same serverSize", () => {
+		expect.assertions(2);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					places: new Map([
+						["start", placeFold({ entry: { filePath: "place.rbxl", serverSize: 50 } })],
+					]),
+				}),
+			],
+			[
+				"production",
+				fold({
+					places: new Map([
+						["start", placeFold({ entry: { filePath: "place.rbxl", serverSize: 50 } })],
+					]),
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.places?.["start"]?.serverSize).toBe(50);
+		expect(result.data.config.environments["development"]?.places).toStrictEqual({
+			start: { placeId: "17613681043" },
+		});
+	});
+
+	it("should override serverSize on a non-primary place overlay when it diverges from the primary", () => {
+		expect.assertions(2);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					places: new Map([
+						["start", placeFold({ entry: { filePath: "place.rbxl", serverSize: 25 } })],
+					]),
+				}),
+			],
+			[
+				"production",
+				fold({
+					places: new Map([
+						["start", placeFold({ entry: { filePath: "place.rbxl", serverSize: 50 } })],
+					]),
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.places?.["start"]?.serverSize).toBe(50);
+		expect(result.data.config.environments["development"]?.places).toStrictEqual({
+			start: { placeId: "17613681043", serverSize: 25 },
+		});
+	});
+
+	it("should override serverSize on a non-primary place overlay when the primary has it and the env omits it", () => {
+		expect.assertions(1);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					places: new Map([["start", placeFold({ entry: { filePath: "place.rbxl" } })]]),
+				}),
+			],
+			[
+				"production",
+				fold({
+					places: new Map([
+						["start", placeFold({ entry: { filePath: "place.rbxl", serverSize: 50 } })],
+					]),
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.environments["development"]?.places).toStrictEqual({
+			start: { placeId: "17613681043", serverSize: undefined },
+		});
+	});
+
 	it("should emit a resource-missing-from-env interpretive warning when the primary has a universe the env lacks", () => {
 		expect.assertions(2);
 

--- a/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
@@ -573,8 +573,8 @@ describe(factorizeEnvironments, () => {
 		});
 	});
 
-	it("should override description on a non-primary place overlay when it diverges from the primary", () => {
-		expect.assertions(2);
+	it("should omit description from root and put each env's value on its overlay when description diverges across environments", () => {
+		expect.assertions(3);
 
 		const folds = new Map([
 			[
@@ -609,14 +609,17 @@ describe(factorizeEnvironments, () => {
 
 		assert(result.success);
 
-		expect(result.data.config.places?.["start"]?.description).toBe("Prod place.");
+		expect(result.data.config.places?.["start"]?.description).toBeUndefined();
 		expect(result.data.config.environments["development"]?.places).toStrictEqual({
 			start: { description: "Dev place.", placeId: "17613681043" },
 		});
+		expect(result.data.config.environments["production"]?.places).toStrictEqual({
+			start: { description: "Prod place.", placeId: "17613681043" },
+		});
 	});
 
-	it("should override description on a non-primary place overlay when the primary has it and the env omits it", () => {
-		expect.assertions(1);
+	it("should omit description from root and from the omitting env's overlay when the primary has it and another env lacks it", () => {
+		expect.assertions(3);
 
 		const folds = new Map([
 			[
@@ -644,8 +647,12 @@ describe(factorizeEnvironments, () => {
 
 		assert(result.success);
 
+		expect(result.data.config.places?.["start"]?.description).toBeUndefined();
 		expect(result.data.config.environments["development"]?.places).toStrictEqual({
-			start: { description: undefined, placeId: "17613681043" },
+			start: { placeId: "17613681043" },
+		});
+		expect(result.data.config.environments["production"]?.places).toStrictEqual({
+			start: { description: "Prod place.", placeId: "17613681043" },
 		});
 	});
 
@@ -691,8 +698,8 @@ describe(factorizeEnvironments, () => {
 		});
 	});
 
-	it("should override displayName on a non-primary place overlay when it diverges from the primary", () => {
-		expect.assertions(2);
+	it("should omit displayName from root and put each env's value on its overlay when displayName diverges across environments", () => {
+		expect.assertions(3);
 
 		const folds = new Map([
 			[
@@ -727,14 +734,17 @@ describe(factorizeEnvironments, () => {
 
 		assert(result.success);
 
-		expect(result.data.config.places?.["start"]?.displayName).toBe("Prod Name");
+		expect(result.data.config.places?.["start"]?.displayName).toBeUndefined();
 		expect(result.data.config.environments["development"]?.places).toStrictEqual({
 			start: { displayName: "Dev Name", placeId: "17613681043" },
 		});
+		expect(result.data.config.environments["production"]?.places).toStrictEqual({
+			start: { displayName: "Prod Name", placeId: "17613681043" },
+		});
 	});
 
-	it("should override displayName on a non-primary place overlay when the primary has it and the env omits it", () => {
-		expect.assertions(1);
+	it("should omit displayName from root and from the omitting env's overlay when the primary has it and another env lacks it", () => {
+		expect.assertions(3);
 
 		const folds = new Map([
 			[
@@ -762,8 +772,12 @@ describe(factorizeEnvironments, () => {
 
 		assert(result.success);
 
+		expect(result.data.config.places?.["start"]?.displayName).toBeUndefined();
 		expect(result.data.config.environments["development"]?.places).toStrictEqual({
-			start: { displayName: undefined, placeId: "17613681043" },
+			start: { placeId: "17613681043" },
+		});
+		expect(result.data.config.environments["production"]?.places).toStrictEqual({
+			start: { displayName: "Prod Name", placeId: "17613681043" },
 		});
 	});
 
@@ -799,8 +813,8 @@ describe(factorizeEnvironments, () => {
 		});
 	});
 
-	it("should override serverSize on a non-primary place overlay when it diverges from the primary", () => {
-		expect.assertions(2);
+	it("should omit serverSize from root and put each env's value on its overlay when serverSize diverges across environments", () => {
+		expect.assertions(3);
 
 		const folds = new Map([
 			[
@@ -825,14 +839,17 @@ describe(factorizeEnvironments, () => {
 
 		assert(result.success);
 
-		expect(result.data.config.places?.["start"]?.serverSize).toBe(50);
+		expect(result.data.config.places?.["start"]?.serverSize).toBeUndefined();
 		expect(result.data.config.environments["development"]?.places).toStrictEqual({
 			start: { placeId: "17613681043", serverSize: 25 },
 		});
+		expect(result.data.config.environments["production"]?.places).toStrictEqual({
+			start: { placeId: "17613681043", serverSize: 50 },
+		});
 	});
 
-	it("should override serverSize on a non-primary place overlay when the primary has it and the env omits it", () => {
-		expect.assertions(1);
+	it("should omit serverSize from root and from the omitting env's overlay when the primary has it and another env lacks it", () => {
+		expect.assertions(3);
 
 		const folds = new Map([
 			[
@@ -855,8 +872,12 @@ describe(factorizeEnvironments, () => {
 
 		assert(result.success);
 
+		expect(result.data.config.places?.["start"]?.serverSize).toBeUndefined();
 		expect(result.data.config.environments["development"]?.places).toStrictEqual({
-			start: { placeId: "17613681043", serverSize: undefined },
+			start: { placeId: "17613681043" },
+		});
+		expect(result.data.config.environments["production"]?.places).toStrictEqual({
+			start: { placeId: "17613681043", serverSize: 50 },
 		});
 	});
 

--- a/packages/bedrock/src/core/migrate/factorize-environments.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.ts
@@ -1,8 +1,8 @@
 import type { Result } from "@bedrock/ocale";
 
 import type { Config, EnvironmentEntry, GamePassEntry, PlaceEntry } from "../schema.ts";
+import { buildPlacesOverlay, buildRootPlaces } from "./factorize-places.ts";
 import type { EnvironmentFoldResult } from "./fold-environment.ts";
-import type { PlaceFoldEntry } from "./fold-places.ts";
 import type { MigrateError, MigrationWarning } from "./migration-report.ts";
 
 interface FactorizeInputs {
@@ -17,12 +17,16 @@ interface FactorizeResult {
 }
 
 type PassOverlayEntry = NonNullable<EnvironmentEntry["passes"]>[string];
-type PlaceOverlayEntry = NonNullable<EnvironmentEntry["places"]>[string];
 type UniverseOverlay = NonNullable<EnvironmentEntry["universe"]>;
 
 interface ResolvedPrimary {
 	readonly name: string;
 	readonly fold: EnvironmentFoldResult;
+}
+
+interface OverlayContext {
+	readonly primary: EnvironmentFoldResult | undefined;
+	readonly rootPlaces: Record<string, PlaceEntry> | undefined;
 }
 
 /**
@@ -81,18 +85,6 @@ function pickPrimary(
 	return { data: { name: requested, fold }, success: true };
 }
 
-function buildRootPlaces(
-	primaryFold: EnvironmentFoldResult,
-): Record<string, PlaceEntry> | undefined {
-	if (primaryFold.places.size === 0) {
-		return undefined;
-	}
-
-	return Object.fromEntries(
-		[...primaryFold.places.entries()].map(([key, fold]) => [key, fold.entry]),
-	);
-}
-
 function buildRootPasses(
 	primaryFold: EnvironmentFoldResult,
 ): Record<string, GamePassEntry> | undefined {
@@ -101,50 +93,6 @@ function buildRootPasses(
 	}
 
 	return Object.fromEntries(primaryFold.passes.map(({ key, entry }) => [key, entry]));
-}
-
-function buildPlaceOverlayEntry(
-	fold: PlaceFoldEntry,
-	primary: PlaceFoldEntry | undefined,
-): PlaceOverlayEntry {
-	const overlay: PlaceOverlayEntry = { placeId: fold.placeId };
-	if (primary === undefined) {
-		return overlay;
-	}
-
-	if (primary.entry.filePath !== fold.entry.filePath) {
-		overlay.filePath = fold.entry.filePath;
-	}
-
-	if (!Object.is(primary.entry.description, fold.entry.description)) {
-		overlay.description = fold.entry.description;
-	}
-
-	if (!Object.is(primary.entry.displayName, fold.entry.displayName)) {
-		overlay.displayName = fold.entry.displayName;
-	}
-
-	if (!Object.is(primary.entry.serverSize, fold.entry.serverSize)) {
-		overlay.serverSize = fold.entry.serverSize;
-	}
-
-	return overlay;
-}
-
-function buildPlacesOverlay(
-	fold: EnvironmentFoldResult,
-	primary: EnvironmentFoldResult | undefined,
-): Record<string, PlaceOverlayEntry> | undefined {
-	if (fold.places.size === 0) {
-		return undefined;
-	}
-
-	const overlay: Record<string, PlaceOverlayEntry> = {};
-	for (const [key, foldEntry] of fold.places) {
-		overlay[key] = buildPlaceOverlayEntry(foldEntry, primary?.places.get(key));
-	}
-
-	return overlay;
 }
 
 function buildUniverseOverlay(
@@ -210,11 +158,11 @@ function buildPassesOverlay(
 
 function buildEnvironmentEntry(
 	fold: EnvironmentFoldResult,
-	primary: EnvironmentFoldResult | undefined,
+	context: OverlayContext,
 ): EnvironmentEntry {
-	const passes = buildPassesOverlay(fold, primary);
-	const places = buildPlacesOverlay(fold, primary);
-	const universe = buildUniverseOverlay(fold, primary);
+	const passes = buildPassesOverlay(fold, context.primary);
+	const places = buildPlacesOverlay(fold, context.rootPlaces);
+	const universe = buildUniverseOverlay(fold, context.primary);
 
 	const entry: EnvironmentEntry = {};
 	if (passes !== undefined) {
@@ -234,11 +182,11 @@ function buildEnvironmentEntry(
 
 function buildEnvironmentEntries(
 	folds: ReadonlyMap<string, EnvironmentFoldResult>,
-	primaryFold: EnvironmentFoldResult,
+	context: OverlayContext,
 ): Record<string, EnvironmentEntry> {
 	const entries: Record<string, EnvironmentEntry> = {};
 	for (const [name, fold] of folds) {
-		entries[name] = buildEnvironmentEntry(fold, primaryFold);
+		entries[name] = buildEnvironmentEntry(fold, context);
 	}
 
 	return entries;
@@ -248,8 +196,11 @@ function buildConfig(
 	folds: ReadonlyMap<string, EnvironmentFoldResult>,
 	primaryFold: EnvironmentFoldResult,
 ): Config {
-	const environments = buildEnvironmentEntries(folds, primaryFold);
-	const places = buildRootPlaces(primaryFold);
+	const places = buildRootPlaces(folds, primaryFold);
+	const environments = buildEnvironmentEntries(folds, {
+		primary: primaryFold,
+		rootPlaces: places,
+	});
 	const passes = buildRootPasses(primaryFold);
 	const universe = primaryFold.universe?.entry;
 

--- a/packages/bedrock/src/core/migrate/factorize-environments.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.ts
@@ -107,11 +107,28 @@ function buildPlaceOverlayEntry(
 	fold: PlaceFoldEntry,
 	primary: PlaceFoldEntry | undefined,
 ): PlaceOverlayEntry {
-	if (primary === undefined || primary.entry.filePath === fold.entry.filePath) {
-		return { placeId: fold.placeId };
+	const overlay: PlaceOverlayEntry = { placeId: fold.placeId };
+	if (primary === undefined) {
+		return overlay;
 	}
 
-	return { filePath: fold.entry.filePath, placeId: fold.placeId };
+	if (primary.entry.filePath !== fold.entry.filePath) {
+		overlay.filePath = fold.entry.filePath;
+	}
+
+	if (!Object.is(primary.entry.description, fold.entry.description)) {
+		overlay.description = fold.entry.description;
+	}
+
+	if (!Object.is(primary.entry.displayName, fold.entry.displayName)) {
+		overlay.displayName = fold.entry.displayName;
+	}
+
+	if (!Object.is(primary.entry.serverSize, fold.entry.serverSize)) {
+		overlay.serverSize = fold.entry.serverSize;
+	}
+
+	return overlay;
 }
 
 function buildPlacesOverlay(

--- a/packages/bedrock/src/core/migrate/factorize-places.ts
+++ b/packages/bedrock/src/core/migrate/factorize-places.ts
@@ -1,0 +1,146 @@
+import type { EnvironmentEntry, PlaceEntry } from "../schema.ts";
+import type { EnvironmentFoldResult } from "./fold-environment.ts";
+import type { PlaceFoldEntry } from "./fold-places.ts";
+
+type PlaceOverlayEntry = NonNullable<EnvironmentEntry["places"]>[string];
+
+type OptionalPlaceField = "description" | "displayName" | "serverSize";
+
+interface ConsensusInputs<F extends OptionalPlaceField> {
+	readonly field: F;
+	readonly folds: ReadonlyArray<EnvironmentFoldResult>;
+	readonly placeKey: string;
+}
+
+/**
+ * Project the per-environment place folds into bedrock's root `places`
+ * block, giving each optional metadata field (`description`, `displayName`,
+ * `serverSize`) a value only when every environment that owns the place
+ * key agrees. Divergent or partially-set fields are omitted from root and
+ * surface on each environment's overlay via {@link buildPlacesOverlay}.
+ *
+ * @param folds - Per-environment fold results, keyed by environment name.
+ * @param primaryFold - The chosen primary environment's fold; supplies
+ *   `filePath` (required) for every place entry on root.
+ * @returns The root `places` block, or `undefined` when the primary has
+ *   no place folds.
+ */
+export function buildRootPlaces(
+	folds: ReadonlyMap<string, EnvironmentFoldResult>,
+	primaryFold: EnvironmentFoldResult,
+): Record<string, PlaceEntry> | undefined {
+	if (primaryFold.places.size === 0) {
+		return undefined;
+	}
+
+	const folded = [...folds.values()];
+	return Object.fromEntries(
+		[...primaryFold.places.entries()].map(([placeKey, primary]) => [
+			placeKey,
+			buildRootPlaceEntry(primary, { folds: folded, placeKey }),
+		]),
+	);
+}
+
+/**
+ * Build the per-environment overlay for `places`, carrying each field only
+ * when the environment's value diverges from the resolved root entry. Fields
+ * the environment omits are absent from the overlay so the consumer's
+ * defu merge resolves them to the root's (also absent) value rather than
+ * overwriting with `undefined`.
+ *
+ * @param fold - The per-environment fold whose places are being overlaid.
+ * @param rootPlaces - The already-built root `places` block; per-place
+ *   field values from this map suppress overlay entries that match.
+ * @returns The overlay `places` block, or `undefined` when the fold has
+ *   no place entries.
+ */
+export function buildPlacesOverlay(
+	fold: EnvironmentFoldResult,
+	rootPlaces: Record<string, PlaceEntry> | undefined,
+): Record<string, PlaceOverlayEntry> | undefined {
+	if (fold.places.size === 0) {
+		return undefined;
+	}
+
+	const overlay: Record<string, PlaceOverlayEntry> = {};
+	for (const [placeKey, foldEntry] of fold.places) {
+		overlay[placeKey] = buildPlaceOverlayEntry(foldEntry, rootPlaces?.[placeKey]);
+	}
+
+	return overlay;
+}
+
+function placeFieldConsensus<F extends OptionalPlaceField>(
+	inputs: ConsensusInputs<F>,
+): PlaceEntry[F] | undefined {
+	let agreed: PlaceEntry[F] | undefined;
+	let hasSeen = false;
+	for (const fold of inputs.folds) {
+		const entry = fold.places.get(inputs.placeKey)?.entry;
+		if (entry === undefined) {
+			continue;
+		}
+
+		const value = entry[inputs.field];
+		if (!hasSeen) {
+			agreed = value;
+			hasSeen = true;
+		} else if (!Object.is(agreed, value)) {
+			return undefined;
+		}
+	}
+
+	return agreed;
+}
+
+function buildRootPlaceEntry(
+	primary: PlaceFoldEntry,
+	consensusBase: {
+		readonly folds: ReadonlyArray<EnvironmentFoldResult>;
+		readonly placeKey: string;
+	},
+): PlaceEntry {
+	const entry: PlaceEntry = { filePath: primary.entry.filePath };
+	const description = placeFieldConsensus({ ...consensusBase, field: "description" });
+	if (description !== undefined) {
+		entry.description = description;
+	}
+
+	const displayName = placeFieldConsensus({ ...consensusBase, field: "displayName" });
+	if (displayName !== undefined) {
+		entry.displayName = displayName;
+	}
+
+	const serverSize = placeFieldConsensus({ ...consensusBase, field: "serverSize" });
+	if (serverSize !== undefined) {
+		entry.serverSize = serverSize;
+	}
+
+	return entry;
+}
+
+function buildPlaceOverlayEntry(
+	fold: PlaceFoldEntry,
+	rootEntry: PlaceEntry | undefined,
+): PlaceOverlayEntry {
+	const overlay: PlaceOverlayEntry = { placeId: fold.placeId };
+	if (fold.entry.filePath !== rootEntry?.filePath) {
+		overlay.filePath = fold.entry.filePath;
+	}
+
+	const { description, displayName, serverSize } = fold.entry;
+	if (!Object.is(rootEntry?.description, description)) {
+		overlay.description = description;
+	}
+
+	if (!Object.is(rootEntry?.displayName, displayName)) {
+		overlay.displayName = displayName;
+	}
+
+	if (!Object.is(rootEntry?.serverSize, serverSize)) {
+		overlay.serverSize = serverSize;
+	}
+
+	return overlay;
+}

--- a/packages/bedrock/src/core/migrate/factorize-places.ts
+++ b/packages/bedrock/src/core/migrate/factorize-places.ts
@@ -74,24 +74,13 @@ export function buildPlacesOverlay(
 function placeFieldConsensus<F extends OptionalPlaceField>(
 	inputs: ConsensusInputs<F>,
 ): PlaceEntry[F] | undefined {
-	let agreed: PlaceEntry[F] | undefined;
-	let hasSeen = false;
-	for (const fold of inputs.folds) {
+	const values = inputs.folds.flatMap((fold) => {
 		const entry = fold.places.get(inputs.placeKey)?.entry;
-		if (entry === undefined) {
-			continue;
-		}
+		return entry === undefined ? [] : [entry[inputs.field]];
+	});
 
-		const value = entry[inputs.field];
-		if (!hasSeen) {
-			agreed = value;
-			hasSeen = true;
-		} else if (!Object.is(agreed, value)) {
-			return undefined;
-		}
-	}
-
-	return agreed;
+	const [first] = values;
+	return values.every((value) => Object.is(first, value)) ? first : undefined;
 }
 
 function buildRootPlaceEntry(

--- a/packages/bedrock/src/core/migrate/factorize-places.ts
+++ b/packages/bedrock/src/core/migrate/factorize-places.ts
@@ -63,12 +63,12 @@ export function buildPlacesOverlay(
 		return undefined;
 	}
 
-	const overlay: Record<string, PlaceOverlayEntry> = {};
-	for (const [placeKey, foldEntry] of fold.places) {
-		overlay[placeKey] = buildPlaceOverlayEntry(foldEntry, rootPlaces?.[placeKey]);
-	}
-
-	return overlay;
+	return Object.fromEntries(
+		[...fold.places.entries()].map(([placeKey, foldEntry]) => [
+			placeKey,
+			buildPlaceOverlayEntry(foldEntry, rootPlaces?.[placeKey]),
+		]),
+	);
 }
 
 function placeFieldConsensus<F extends OptionalPlaceField>(
@@ -101,46 +101,27 @@ function buildRootPlaceEntry(
 		readonly placeKey: string;
 	},
 ): PlaceEntry {
-	const entry: PlaceEntry = { filePath: primary.entry.filePath };
 	const description = placeFieldConsensus({ ...consensusBase, field: "description" });
-	if (description !== undefined) {
-		entry.description = description;
-	}
-
 	const displayName = placeFieldConsensus({ ...consensusBase, field: "displayName" });
-	if (displayName !== undefined) {
-		entry.displayName = displayName;
-	}
-
 	const serverSize = placeFieldConsensus({ ...consensusBase, field: "serverSize" });
-	if (serverSize !== undefined) {
-		entry.serverSize = serverSize;
-	}
-
-	return entry;
+	return {
+		filePath: primary.entry.filePath,
+		...(description !== undefined && { description }),
+		...(displayName !== undefined && { displayName }),
+		...(serverSize !== undefined && { serverSize }),
+	};
 }
 
 function buildPlaceOverlayEntry(
 	fold: PlaceFoldEntry,
 	rootEntry: PlaceEntry | undefined,
 ): PlaceOverlayEntry {
-	const overlay: PlaceOverlayEntry = { placeId: fold.placeId };
-	if (fold.entry.filePath !== rootEntry?.filePath) {
-		overlay.filePath = fold.entry.filePath;
-	}
-
-	const { description, displayName, serverSize } = fold.entry;
-	if (!Object.is(rootEntry?.description, description)) {
-		overlay.description = description;
-	}
-
-	if (!Object.is(rootEntry?.displayName, displayName)) {
-		overlay.displayName = displayName;
-	}
-
-	if (!Object.is(rootEntry?.serverSize, serverSize)) {
-		overlay.serverSize = serverSize;
-	}
-
-	return overlay;
+	const { description, displayName, filePath, serverSize } = fold.entry;
+	return {
+		placeId: fold.placeId,
+		...(filePath !== rootEntry?.filePath && { filePath }),
+		...(!Object.is(rootEntry?.description, description) && { description }),
+		...(!Object.is(rootEntry?.displayName, displayName) && { displayName }),
+		...(!Object.is(rootEntry?.serverSize, serverSize) && { serverSize }),
+	};
 }

--- a/packages/bedrock/src/core/migrate/fold-blocked-place-fields.ts
+++ b/packages/bedrock/src/core/migrate/fold-blocked-place-fields.ts
@@ -6,14 +6,10 @@ const PLACE_CONFIGURATION_KIND = "placeConfiguration";
 
 /**
  * `placeConfiguration_<k>` fields with no Open Cloud writable endpoint.
- * `name` and `description` are intentionally omitted: `foldDisplayName`
- * and `foldPlaces` fold them into the bedrock config.
+ * `name`, `description`, and `maxPlayerCount` are intentionally omitted:
+ * `foldDisplayName` and `foldPlaces` fold them into the bedrock config.
  */
 const BLOCKED_FIELDS: ReadonlyArray<BlockedFieldRule> = [
-	{
-		field: "maxPlayerCount",
-		reason: "placeConfiguration.maxPlayerCount has no Open Cloud equivalent",
-	},
 	{
 		field: "allowCopying",
 		reason: "placeConfiguration.allowCopying has no Open Cloud equivalent",

--- a/packages/bedrock/src/core/migrate/fold-blocked-place-fields.ts
+++ b/packages/bedrock/src/core/migrate/fold-blocked-place-fields.ts
@@ -6,15 +6,10 @@ const PLACE_CONFIGURATION_KIND = "placeConfiguration";
 
 /**
  * `placeConfiguration_<k>` fields with no Open Cloud writable endpoint.
- * `name` is intentionally omitted: `foldDisplayName` already owns it
- * (start-place name folds into `universe.displayName`; non-start names
- * already emit a blocked warning).
+ * `name` and `description` are intentionally omitted: `foldDisplayName`
+ * and `foldPlaces` fold them into the bedrock config.
  */
 const BLOCKED_FIELDS: ReadonlyArray<BlockedFieldRule> = [
-	{
-		field: "description",
-		reason: "placeConfiguration.description has no Open Cloud equivalent",
-	},
 	{
 		field: "maxPlayerCount",
 		reason: "placeConfiguration.maxPlayerCount has no Open Cloud equivalent",

--- a/packages/bedrock/src/core/migrate/fold-display-name.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-display-name.spec.ts
@@ -1,0 +1,53 @@
+import { assert, describe, expect, it } from "vitest";
+
+import { foldDisplayName } from "./fold-display-name.ts";
+import type { MantleResource } from "./types.ts";
+
+function place(key: string, inputs: unknown): MantleResource {
+	return {
+		key,
+		dependencies: [],
+		inputs,
+		kind: "place",
+		outputs: { assetId: 17613681043 },
+	};
+}
+
+function placeConfiguration(key: string, inputs: unknown): MantleResource {
+	return {
+		key,
+		dependencies: [],
+		inputs,
+		kind: "placeConfiguration",
+		outputs: undefined,
+	};
+}
+
+describe(foldDisplayName, () => {
+	it("should resolve duplicate start-key placeConfiguration records via last-wins", () => {
+		expect.assertions(1);
+
+		const result = foldDisplayName([
+			place("start", { isStart: true }),
+			placeConfiguration("start", { name: "Earlier" }),
+			placeConfiguration("start", { name: "Later" }),
+		]);
+
+		assert(result.entryFragment.displayName === "Later");
+
+		expect(result.entryFragment.displayName).toBe("Later");
+	});
+
+	it("should ignore non-placeConfiguration resources and other-keyed placeConfigurations when picking the start name", () => {
+		expect.assertions(1);
+
+		const result = foldDisplayName([
+			placeConfiguration("start", { name: "Start" }),
+			place("start", { isStart: true }),
+			placeConfiguration("lobby", { name: "Lobby" }),
+			place("lobby", { isStart: false }),
+		]);
+
+		expect(result.entryFragment.displayName).toBe("Start");
+	});
+});

--- a/packages/bedrock/src/core/migrate/fold-display-name.ts
+++ b/packages/bedrock/src/core/migrate/fold-display-name.ts
@@ -79,7 +79,7 @@ export function foldDisplayName(resources: ReadonlyArray<MantleResource>): FoldF
 		return EMPTY_FRAGMENT;
 	}
 
-	const startConfigResource = resources.find((resource) => {
+	const startConfigResource = resources.findLast((resource) => {
 		return resource.kind === PLACE_CONFIGURATION_KIND && resource.key === startKey;
 	});
 	if (startConfigResource === undefined) {

--- a/packages/bedrock/src/core/migrate/fold-display-name.ts
+++ b/packages/bedrock/src/core/migrate/fold-display-name.ts
@@ -1,11 +1,9 @@
 import {
 	ambiguousWarning,
-	blockedWarning,
 	EMPTY_FRAGMENT,
 	type FoldFragment,
 	interpretiveWarning,
 	isObjectPayload,
-	mergeFragment,
 } from "./fold-universe-shared.ts";
 import type { MantleResource } from "./types.ts";
 
@@ -38,18 +36,6 @@ function startKeys(resources: ReadonlyArray<MantleResource>): ReadonlyArray<stri
 	return resources.filter(isStartPlace).map((resource) => resource.key);
 }
 
-function blockedFragment(key: string): FoldFragment {
-	return {
-		entryFragment: {},
-		warnings: [
-			blockedWarning(
-				`${PLACE_CONFIGURATION_KIND}_${key}.name`,
-				"non-start placeConfiguration.name has no Open Cloud equivalent",
-			),
-		],
-	};
-}
-
 function interpretiveFragment(named: NamedPlaceConfig): FoldFragment {
 	return {
 		entryFragment: { displayName: named.name },
@@ -75,50 +61,31 @@ const AMBIGUOUS_MULTIPLE_STARTS: FoldFragment = {
 
 /**
  * Fold the start place's `placeConfiguration_<k>.name` into
- * `universe.displayName`. Non-start places' names emit `blocked` warnings;
- * multiple `isStart: true` places emit one `ambiguous` warning and skip
- * the displayName mapping (every placeConfiguration name is blocked in
- * that case).
+ * `universe.displayName`. Non-start places' names are folded onto each
+ * place's `displayName` by `foldPlaces`; multiple `isStart: true` places
+ * emit one `ambiguous` warning and skip the displayName mapping.
  *
  * @param resources - Mantle resource list for one environment.
  * @returns The folded displayName plus per-rule diagnostics.
  */
 export function foldDisplayName(resources: ReadonlyArray<MantleResource>): FoldFragment {
-	const namedConfigs = resources
-		.filter((resource) => resource.kind === PLACE_CONFIGURATION_KIND)
-		.flatMap((resource) => {
-			const named = readPlaceConfigName(resource);
-			return named === undefined ? [] : [named];
-		});
-
 	const starts = startKeys(resources);
 	if (starts.length >= 2) {
-		return mergeFragment(AMBIGUOUS_MULTIPLE_STARTS, foldAllBlocked(namedConfigs));
+		return AMBIGUOUS_MULTIPLE_STARTS;
 	}
 
 	const [startKey] = starts;
 	if (startKey === undefined) {
-		return foldAllBlocked(namedConfigs);
+		return EMPTY_FRAGMENT;
 	}
 
-	return foldFromSingleStart(startKey, namedConfigs);
-}
+	const startConfigResource = resources.find((resource) => {
+		return resource.kind === PLACE_CONFIGURATION_KIND && resource.key === startKey;
+	});
+	if (startConfigResource === undefined) {
+		return EMPTY_FRAGMENT;
+	}
 
-function foldFromSingleStart(
-	startKey: string,
-	namedConfigs: ReadonlyArray<NamedPlaceConfig>,
-): FoldFragment {
-	return namedConfigs.reduce<FoldFragment>((accumulator, named) => {
-		return mergeFragment(
-			accumulator,
-			named.key === startKey ? interpretiveFragment(named) : blockedFragment(named.key),
-		);
-	}, EMPTY_FRAGMENT);
-}
-
-function foldAllBlocked(namedConfigs: ReadonlyArray<NamedPlaceConfig>): FoldFragment {
-	return namedConfigs.reduce<FoldFragment>(
-		(accumulator, named) => mergeFragment(accumulator, blockedFragment(named.key)),
-		EMPTY_FRAGMENT,
-	);
+	const named = readPlaceConfigName(startConfigResource);
+	return named === undefined ? EMPTY_FRAGMENT : interpretiveFragment(named);
 }

--- a/packages/bedrock/src/core/migrate/fold-display-name.ts
+++ b/packages/bedrock/src/core/migrate/fold-display-name.ts
@@ -75,10 +75,6 @@ export function foldDisplayName(resources: ReadonlyArray<MantleResource>): FoldF
 	}
 
 	const [startKey] = starts;
-	if (startKey === undefined) {
-		return EMPTY_FRAGMENT;
-	}
-
 	const startConfigResource = resources.findLast((resource) => {
 		return resource.kind === PLACE_CONFIGURATION_KIND && resource.key === startKey;
 	});

--- a/packages/bedrock/src/core/migrate/fold-places.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.spec.ts
@@ -406,6 +406,92 @@ describe(foldPlaces, () => {
 		});
 	});
 
+	describe("placeConfiguration.name fold for non-start places", () => {
+		it("should fold a non-start placeConfiguration name onto entry.displayName", () => {
+			expect.assertions(1);
+
+			const result = foldPlaces([
+				place({ key: "start", inputs: { isStart: true }, outputs: { assetId: 1 } }),
+				place({ key: "lobby", inputs: { isStart: false }, outputs: { assetId: 2 } }),
+				defaultPlaceFile("start"),
+				defaultPlaceFile("lobby"),
+				placeConfiguration("lobby", { name: "Lobby" }),
+			]);
+
+			const entry = result.entries.get("lobby");
+			assert(entry !== undefined);
+
+			expect(entry.entry.displayName).toBe("Lobby");
+		});
+
+		it("should emit one interpretive warning for the non-start name fold", () => {
+			expect.assertions(1);
+
+			const result = foldPlaces([
+				place({ key: "start", inputs: { isStart: true }, outputs: { assetId: 1 } }),
+				place({ key: "lobby", inputs: { isStart: false }, outputs: { assetId: 2 } }),
+				defaultPlaceFile("start"),
+				defaultPlaceFile("lobby"),
+				placeConfiguration("lobby", { name: "Lobby" }),
+			]);
+
+			expect(result.warnings).toIncludeAllPartialMembers([
+				{
+					bedrockPath: "places.lobby.displayName",
+					kind: "interpretive",
+					mantlePath: "placeConfiguration_lobby.name",
+					rule: "place-name-to-display-name",
+				},
+			]);
+		});
+
+		it("should leave the start place's displayName unset on entry.displayName", () => {
+			expect.assertions(1);
+
+			const result = foldPlaces([
+				place({ key: "start", inputs: { isStart: true }, outputs: { assetId: 1 } }),
+				defaultPlaceFile("start"),
+				placeConfiguration("start", { name: "Start" }),
+			]);
+
+			const entry = result.entries.get("start");
+			assert(entry !== undefined);
+
+			expect(entry.entry.displayName).toBeNil();
+		});
+
+		it("should silently skip a non-string name", () => {
+			expect.assertions(2);
+
+			const result = foldPlaces([
+				place({ key: "lobby", inputs: { isStart: false }, outputs: { assetId: 2 } }),
+				defaultPlaceFile("lobby"),
+				placeConfiguration("lobby", { name: 42 }),
+			]);
+
+			const entry = result.entries.get("lobby");
+			assert(entry !== undefined);
+
+			expect(entry.entry.displayName).toBeNil();
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should treat a place resource with non-object inputs as non-start", () => {
+			expect.assertions(1);
+
+			const result = foldPlaces([
+				place({ key: "lobby", inputs: "not-an-object", outputs: { assetId: 2 } }),
+				defaultPlaceFile("lobby"),
+				placeConfiguration("lobby", { name: "Lobby" }),
+			]);
+
+			const entry = result.entries.get("lobby");
+			assert(entry !== undefined);
+
+			expect(entry.entry.displayName).toBe("Lobby");
+		});
+	});
+
 	describe("blocked placeConfiguration fields", () => {
 		it.for<[label: string, field: string, value: unknown, reason: string]>([
 			[

--- a/packages/bedrock/src/core/migrate/fold-places.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.spec.ts
@@ -339,13 +339,49 @@ describe(foldPlaces, () => {
 			expect(result.warnings).toStrictEqual([]);
 		});
 
-		it("should not synthesize an entry for an unmatched placeConfiguration", () => {
-			expect.assertions(2);
+		it("should emit an ambiguous warning when a placeConfiguration has no matching place or placeFile", () => {
+			expect.assertions(4);
 
 			const result = foldPlaces([placeConfiguration("orphan", { description: "Stranded" })]);
 
 			expect(result.entries.size).toBe(0);
-			expect(result.warnings).toStrictEqual([]);
+			expect(result.warnings).toHaveLength(1);
+
+			const [warning] = result.warnings;
+			assert(warning?.kind === "ambiguous");
+
+			expect(warning.mantlePath).toBe("placeConfiguration_orphan");
+			expect(warning.hint).toMatch(/verify your mantle state/i);
+		});
+
+		it("should emit a placeConfiguration orphan warning alongside the place orphan warning when only the placeFile is missing", () => {
+			expect.assertions(2);
+
+			const result = foldPlaces([
+				place({ key: "lonely", outputs: { assetId: 17613681043 } }),
+				placeConfiguration("lonely", { description: "Stranded" }),
+			]);
+
+			expect(result.entries.size).toBe(0);
+			expect(result.warnings).toIncludeAllPartialMembers([
+				{ kind: "ambiguous", mantlePath: "place_lonely" },
+				{ kind: "ambiguous", mantlePath: "placeConfiguration_lonely" },
+			]);
+		});
+
+		it("should emit a placeConfiguration orphan warning alongside the placeFile orphan warning when only the place is missing", () => {
+			expect.assertions(2);
+
+			const result = foldPlaces([
+				defaultPlaceFile("lonely"),
+				placeConfiguration("lonely", { description: "Stranded" }),
+			]);
+
+			expect(result.entries.size).toBe(0);
+			expect(result.warnings).toIncludeAllPartialMembers([
+				{ kind: "ambiguous", mantlePath: "placeFile_lonely" },
+				{ kind: "ambiguous", mantlePath: "placeConfiguration_lonely" },
+			]);
 		});
 	});
 
@@ -515,7 +551,11 @@ describe(foldPlaces, () => {
 		])("should emit a blocked warning when %s is set", ([, field, value, reason]) => {
 			expect.assertions(1);
 
-			const result = foldPlaces([placeConfiguration("start", { [field]: value })]);
+			const result = foldPlaces([
+				place({ key: "start", outputs: { assetId: 17613681043 } }),
+				defaultPlaceFile("start"),
+				placeConfiguration("start", { [field]: value }),
+			]);
 
 			expect(result.warnings).toStrictEqual([
 				{
@@ -530,6 +570,8 @@ describe(foldPlaces, () => {
 			expect.assertions(1);
 
 			const result = foldPlaces([
+				place({ key: "start", outputs: { assetId: 17613681043 } }),
+				defaultPlaceFile("start"),
 				placeConfiguration("start", {
 					allowCopying: undefined,
 					description: undefined,
@@ -543,6 +585,10 @@ describe(foldPlaces, () => {
 			expect.assertions(1);
 
 			const result = foldPlaces([
+				place({ key: "start", outputs: { assetId: 17613681043 } }),
+				defaultPlaceFile("start"),
+				place({ key: "lobby", outputs: { assetId: 17613681044 } }),
+				defaultPlaceFile("lobby"),
 				placeConfiguration("start", {
 					allowCopying: true,
 					customSocialSlotsCount: 4,
@@ -571,7 +617,11 @@ describe(foldPlaces, () => {
 		it("should skip a placeConfiguration whose inputs is not an object", () => {
 			expect.assertions(1);
 
-			const result = foldPlaces([placeConfiguration("start", "not-an-object")]);
+			const result = foldPlaces([
+				place({ key: "start", outputs: { assetId: 17613681043 } }),
+				defaultPlaceFile("start"),
+				placeConfiguration("start", "not-an-object"),
+			]);
 
 			expect(result.warnings).toStrictEqual([]);
 		});
@@ -579,7 +629,11 @@ describe(foldPlaces, () => {
 		it("should not emit a blocked warning for the name field (foldDisplayName owns it)", () => {
 			expect.assertions(1);
 
-			const result = foldPlaces([placeConfiguration("start", { name: "My Place" })]);
+			const result = foldPlaces([
+				place({ key: "start", outputs: { assetId: 17613681043 } }),
+				defaultPlaceFile("start"),
+				placeConfiguration("start", { name: "My Place" }),
+			]);
 
 			expect(
 				result.warnings.filter((warning) => {

--- a/packages/bedrock/src/core/migrate/fold-places.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.spec.ts
@@ -349,6 +349,63 @@ describe(foldPlaces, () => {
 		});
 	});
 
+	describe("placeConfiguration.maxPlayerCount fold", () => {
+		it("should fold maxPlayerCount onto entry.serverSize", () => {
+			expect.assertions(1);
+
+			const result = foldPlaces([
+				place({ key: "start", outputs: { assetId: 17613681043 } }),
+				defaultPlaceFile("start"),
+				placeConfiguration("start", { maxPlayerCount: 700 }),
+			]);
+
+			const entry = result.entries.get("start");
+			assert(entry !== undefined);
+
+			expect(entry.entry.serverSize).toBe(700);
+		});
+
+		it("should emit one interpretive warning for the serverSize rename", () => {
+			expect.assertions(1);
+
+			const result = foldPlaces([
+				place({ key: "start", outputs: { assetId: 17613681043 } }),
+				defaultPlaceFile("start"),
+				placeConfiguration("start", { maxPlayerCount: 700 }),
+			]);
+
+			expect(result.warnings).toStrictEqual([
+				{
+					bedrockPath: "places.start.serverSize",
+					kind: "interpretive",
+					mantlePath: "placeConfiguration_start.maxPlayerCount",
+					rule: "max-player-count-to-server-size",
+				},
+			]);
+		});
+
+		it.for<[label: string, value: unknown]>([
+			["zero", 0],
+			["negative", -3],
+			["fractional", 1.5],
+			["string", "700"],
+		])("should silently skip a %s maxPlayerCount", ([, value]) => {
+			expect.assertions(2);
+
+			const result = foldPlaces([
+				place({ key: "start", outputs: { assetId: 17613681043 } }),
+				defaultPlaceFile("start"),
+				placeConfiguration("start", { maxPlayerCount: value }),
+			]);
+
+			const entry = result.entries.get("start");
+			assert(entry !== undefined);
+
+			expect(entry.entry.serverSize).toBeNil();
+			expect(result.warnings).toStrictEqual([]);
+		});
+	});
+
 	describe("blocked placeConfiguration fields", () => {
 		it.for<[label: string, field: string, value: unknown, reason: string]>([
 			[

--- a/packages/bedrock/src/core/migrate/fold-places.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.spec.ts
@@ -288,20 +288,69 @@ describe(foldPlaces, () => {
 		expect(lobby.entry).toStrictEqual({ filePath: "lobby.rbxl" });
 	});
 
+	describe("placeConfiguration.description fold", () => {
+		it("should fold description onto the matched entry", () => {
+			expect.assertions(1);
+
+			const result = foldPlaces([
+				place({ key: "start", outputs: { assetId: 17613681043 } }),
+				defaultPlaceFile("start"),
+				placeConfiguration("start", { description: "A project template" }),
+			]);
+
+			const entry = result.entries.get("start");
+			assert(entry !== undefined);
+
+			expect(entry.entry.description).toBe("A project template");
+		});
+
+		it("should emit one interpretive warning for the description fold", () => {
+			expect.assertions(1);
+
+			const result = foldPlaces([
+				place({ key: "start", outputs: { assetId: 17613681043 } }),
+				defaultPlaceFile("start"),
+				placeConfiguration("start", { description: "A project template" }),
+			]);
+
+			expect(result.warnings).toStrictEqual([
+				{
+					bedrockPath: "places.start.description",
+					kind: "interpretive",
+					mantlePath: "placeConfiguration_start.description",
+					rule: "place-description",
+				},
+			]);
+		});
+
+		it("should silently skip a non-string description", () => {
+			expect.assertions(2);
+
+			const result = foldPlaces([
+				place({ key: "start", outputs: { assetId: 17613681043 } }),
+				defaultPlaceFile("start"),
+				placeConfiguration("start", { description: 42 }),
+			]);
+
+			const entry = result.entries.get("start");
+			assert(entry !== undefined);
+
+			expect(entry.entry.description).toBeNil();
+			expect(result.warnings).toStrictEqual([]);
+		});
+
+		it("should not synthesize an entry for an unmatched placeConfiguration", () => {
+			expect.assertions(2);
+
+			const result = foldPlaces([placeConfiguration("orphan", { description: "Stranded" })]);
+
+			expect(result.entries.size).toBe(0);
+			expect(result.warnings).toStrictEqual([]);
+		});
+	});
+
 	describe("blocked placeConfiguration fields", () => {
 		it.for<[label: string, field: string, value: unknown, reason: string]>([
-			[
-				"description",
-				"description",
-				"A project template",
-				"placeConfiguration.description has no Open Cloud equivalent",
-			],
-			[
-				"maxPlayerCount",
-				"maxPlayerCount",
-				700,
-				"placeConfiguration.maxPlayerCount has no Open Cloud equivalent",
-			],
 			[
 				"allowCopying",
 				"allowCopying",
@@ -353,16 +402,14 @@ describe(foldPlaces, () => {
 			const result = foldPlaces([
 				placeConfiguration("start", {
 					allowCopying: true,
-					description: "Start place",
-					maxPlayerCount: 50,
+					customSocialSlotsCount: 4,
 				}),
 				placeConfiguration("lobby", { socialSlotType: "Empty" }),
 			]);
 
 			expect(result.warnings).toIncludeAllPartialMembers([
-				{ kind: "blocked", mantlePath: "placeConfiguration_start.description" },
-				{ kind: "blocked", mantlePath: "placeConfiguration_start.maxPlayerCount" },
 				{ kind: "blocked", mantlePath: "placeConfiguration_start.allowCopying" },
+				{ kind: "blocked", mantlePath: "placeConfiguration_start.customSocialSlotsCount" },
 				{ kind: "blocked", mantlePath: "placeConfiguration_lobby.socialSlotType" },
 			]);
 		});

--- a/packages/bedrock/src/core/migrate/fold-places.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.ts
@@ -2,11 +2,13 @@ import { isSha256Hex, type Sha256Hex } from "../../types/ids.ts";
 import type { PlaceOutputs } from "../resources.ts";
 import type { PlaceEntry } from "../schema.ts";
 import { foldBlockedPlaceFields } from "./fold-blocked-place-fields.ts";
+import { interpretiveWarning } from "./fold-universe-shared.ts";
 import type { MigrationWarning } from "./migration-report.ts";
 import type { MantleResource } from "./types.ts";
 
 const PLACE_KIND = "place";
 const PLACE_FILE_KIND = "placeFile";
+const PLACE_CONFIGURATION_KIND = "placeConfiguration";
 
 /**
  * Folded place data for one Mantle resource key.
@@ -59,6 +61,17 @@ interface PlaceFileOutputsRaw {
 	readonly version: number;
 }
 
+interface PlaceConfigFoldResult {
+	readonly entry: PlaceFoldEntry;
+	readonly warnings: ReadonlyArray<MigrationWarning>;
+}
+
+interface ApplyPlaceConfigFieldsInputs {
+	readonly key: string;
+	readonly configResource: MantleResource | undefined;
+	readonly folded: PlaceFoldEntry;
+}
+
 /**
  * Fold the place-related Mantle resources of one environment into a map of
  * `PlaceFoldEntry` plus accompanying warnings. Pairs each `place_<k>`
@@ -77,7 +90,7 @@ interface PlaceFileOutputsRaw {
  * @returns The folded entries plus orphan warnings.
  */
 export function foldPlaces(resources: ReadonlyArray<MantleResource>): PlaceFoldResult {
-	const { placeFiles, places } = bucketByKind(resources);
+	const { placeConfigurations, placeFiles, places } = bucketByKind(resources);
 	const entries = new Map<string, PlaceFoldEntry>();
 	const warnings: Array<MigrationWarning> = [];
 
@@ -89,9 +102,17 @@ export function foldPlaces(resources: ReadonlyArray<MantleResource>): PlaceFoldR
 		}
 
 		const folded = mergeMatchedPair(placeResource, fileResource);
-		if (folded !== undefined) {
-			entries.set(key, folded);
+		if (folded === undefined) {
+			continue;
 		}
+
+		const configFold = applyPlaceConfigFields({
+			key,
+			configResource: placeConfigurations.get(key),
+			folded,
+		});
+		entries.set(key, configFold.entry);
+		warnings.push(...configFold.warnings);
 	}
 
 	for (const [key] of placeFiles) {
@@ -104,20 +125,62 @@ export function foldPlaces(resources: ReadonlyArray<MantleResource>): PlaceFoldR
 }
 
 function bucketByKind(resources: ReadonlyArray<MantleResource>): {
+	readonly placeConfigurations: Map<string, MantleResource>;
 	readonly placeFiles: Map<string, MantleResource>;
 	readonly places: Map<string, MantleResource>;
 } {
 	const places = new Map<string, MantleResource>();
 	const placeFiles = new Map<string, MantleResource>();
+	const placeConfigurations = new Map<string, MantleResource>();
 	for (const resource of resources) {
-		if (resource.kind === PLACE_KIND) {
-			places.set(resource.key, resource);
-		} else if (resource.kind === PLACE_FILE_KIND) {
-			placeFiles.set(resource.key, resource);
+		switch (resource.kind) {
+			case PLACE_CONFIGURATION_KIND: {
+				placeConfigurations.set(resource.key, resource);
+
+				break;
+			}
+			case PLACE_FILE_KIND: {
+				placeFiles.set(resource.key, resource);
+
+				break;
+			}
+			case PLACE_KIND: {
+				places.set(resource.key, resource);
+
+				break;
+			}
+			// No default
 		}
 	}
 
-	return { placeFiles, places };
+	return { placeConfigurations, placeFiles, places };
+}
+
+function isObjectPayload(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function applyPlaceConfigFields(inputs: ApplyPlaceConfigFieldsInputs): PlaceConfigFoldResult {
+	const { key, configResource, folded } = inputs;
+	if (configResource === undefined || !isObjectPayload(configResource.inputs)) {
+		return { entry: folded, warnings: [] };
+	}
+
+	const { description } = configResource.inputs;
+	if (typeof description !== "string") {
+		return { entry: folded, warnings: [] };
+	}
+
+	return {
+		entry: { ...folded, entry: { ...folded.entry, description } },
+		warnings: [
+			interpretiveWarning({
+				bedrockPath: `places.${key}.description`,
+				mantlePath: `${PLACE_CONFIGURATION_KIND}_${key}.description`,
+				rule: "place-description",
+			}),
+		],
+	};
 }
 
 function coerceRobloxId(value: unknown): string | undefined {
@@ -130,10 +193,6 @@ function coerceRobloxId(value: unknown): string | undefined {
 	}
 
 	return undefined;
-}
-
-function isObjectPayload(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function readPlaceOutputs(resource: MantleResource): PlaceOutputsRaw | undefined {

--- a/packages/bedrock/src/core/migrate/fold-places.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.ts
@@ -2,7 +2,7 @@ import { isSha256Hex, type Sha256Hex } from "../../types/ids.ts";
 import type { PlaceOutputs } from "../resources.ts";
 import type { PlaceEntry } from "../schema.ts";
 import { foldBlockedPlaceFields } from "./fold-blocked-place-fields.ts";
-import { interpretiveWarning } from "./fold-universe-shared.ts";
+import { interpretiveWarning, isObjectPayload } from "./fold-universe-shared.ts";
 import type { MigrationWarning } from "./migration-report.ts";
 import type { MantleResource } from "./types.ts";
 
@@ -197,10 +197,6 @@ function bucketByKind(resources: ReadonlyArray<MantleResource>): PlaceBuckets {
 	}
 
 	return { placeConfigurations, placeFiles, places };
-}
-
-function isObjectPayload(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function readString(value: unknown): string | undefined {

--- a/packages/bedrock/src/core/migrate/fold-places.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.ts
@@ -72,6 +72,17 @@ interface ApplyPlaceConfigFieldsInputs {
 	readonly folded: PlaceFoldEntry;
 }
 
+interface PlaceConfigFragmentRule {
+	readonly bedrockField: string;
+	readonly mantleField: string;
+	readonly rule: string;
+}
+
+interface PlaceConfigFragment {
+	readonly entry: Partial<PlaceEntry>;
+	readonly warnings: ReadonlyArray<PlaceConfigFragmentRule>;
+}
+
 /**
  * Fold the place-related Mantle resources of one environment into a map of
  * `PlaceFoldEntry` plus accompanying warnings. Pairs each `place_<k>`
@@ -160,26 +171,86 @@ function isObjectPayload(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function readString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function readPositiveInteger(value: unknown): number | undefined {
+	if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+		return undefined;
+	}
+
+	return value;
+}
+
+const PLACE_CONFIG_RULES: ReadonlyArray<{
+	readonly bedrockField: keyof PlaceEntry;
+	readonly mantleField: string;
+	readonly read: (value: unknown) => number | string | undefined;
+	readonly rule: string;
+}> = [
+	{
+		bedrockField: "description",
+		mantleField: "description",
+		read: readString,
+		rule: "place-description",
+	},
+	{
+		bedrockField: "serverSize",
+		mantleField: "maxPlayerCount",
+		read: readPositiveInteger,
+		rule: "max-player-count-to-server-size",
+	},
+];
+
+function readPlaceConfigFragment(inputs: Record<string, unknown>): PlaceConfigFragment {
+	return PLACE_CONFIG_RULES.reduce<{
+		entry: Partial<PlaceEntry>;
+		warnings: Array<PlaceConfigFragmentRule>;
+	}>(
+		(accumulator, rule) => {
+			const value = rule.read(inputs[rule.mantleField]);
+			if (value === undefined) {
+				return accumulator;
+			}
+
+			return {
+				entry: { ...accumulator.entry, [rule.bedrockField]: value },
+				warnings: [
+					...accumulator.warnings,
+					{
+						bedrockField: rule.bedrockField,
+						mantleField: rule.mantleField,
+						rule: rule.rule,
+					},
+				],
+			};
+		},
+		{ entry: {}, warnings: [] },
+	);
+}
+
 function applyPlaceConfigFields(inputs: ApplyPlaceConfigFieldsInputs): PlaceConfigFoldResult {
 	const { key, configResource, folded } = inputs;
 	if (configResource === undefined || !isObjectPayload(configResource.inputs)) {
 		return { entry: folded, warnings: [] };
 	}
 
-	const { description } = configResource.inputs;
-	if (typeof description !== "string") {
-		return { entry: folded, warnings: [] };
-	}
+	const fragment = readPlaceConfigFragment(configResource.inputs);
+	const entry: PlaceFoldEntry = {
+		...folded,
+		entry: { ...folded.entry, ...fragment.entry },
+	};
 
 	return {
-		entry: { ...folded, entry: { ...folded.entry, description } },
-		warnings: [
-			interpretiveWarning({
-				bedrockPath: `places.${key}.description`,
-				mantlePath: `${PLACE_CONFIGURATION_KIND}_${key}.description`,
-				rule: "place-description",
-			}),
-		],
+		entry,
+		warnings: fragment.warnings.map((rule) => {
+			return interpretiveWarning({
+				bedrockPath: `places.${key}.${rule.bedrockField}`,
+				mantlePath: `${PLACE_CONFIGURATION_KIND}_${key}.${rule.mantleField}`,
+				rule: rule.rule,
+			});
+		}),
 	};
 }
 

--- a/packages/bedrock/src/core/migrate/fold-places.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.ts
@@ -70,6 +70,7 @@ interface ApplyPlaceConfigFieldsInputs {
 	readonly key: string;
 	readonly configResource: MantleResource | undefined;
 	readonly folded: PlaceFoldEntry;
+	readonly isStart: boolean;
 }
 
 interface PlaceConfigFragmentRule {
@@ -81,6 +82,13 @@ interface PlaceConfigFragmentRule {
 interface PlaceConfigFragment {
 	readonly entry: Partial<PlaceEntry>;
 	readonly warnings: ReadonlyArray<PlaceConfigFragmentRule>;
+}
+
+interface PlaceConfigRule {
+	readonly bedrockField: keyof PlaceEntry;
+	readonly mantleField: string;
+	readonly read: (value: unknown) => number | string | undefined;
+	readonly rule: string;
 }
 
 /**
@@ -121,6 +129,7 @@ export function foldPlaces(resources: ReadonlyArray<MantleResource>): PlaceFoldR
 			key,
 			configResource: placeConfigurations.get(key),
 			folded,
+			isStart: isStartPlace(placeResource),
 		});
 		entries.set(key, configFold.entry);
 		warnings.push(...configFold.warnings);
@@ -183,12 +192,7 @@ function readPositiveInteger(value: unknown): number | undefined {
 	return value;
 }
 
-const PLACE_CONFIG_RULES: ReadonlyArray<{
-	readonly bedrockField: keyof PlaceEntry;
-	readonly mantleField: string;
-	readonly read: (value: unknown) => number | string | undefined;
-	readonly rule: string;
-}> = [
+const ALWAYS_RULES: ReadonlyArray<PlaceConfigRule> = [
 	{
 		bedrockField: "description",
 		mantleField: "description",
@@ -203,8 +207,24 @@ const PLACE_CONFIG_RULES: ReadonlyArray<{
 	},
 ];
 
-function readPlaceConfigFragment(inputs: Record<string, unknown>): PlaceConfigFragment {
-	return PLACE_CONFIG_RULES.reduce<{
+const NON_START_RULES: ReadonlyArray<PlaceConfigRule> = [
+	{
+		bedrockField: "displayName",
+		mantleField: "name",
+		read: readString,
+		rule: "place-name-to-display-name",
+	},
+];
+
+function placeConfigRules(isStart: boolean): ReadonlyArray<PlaceConfigRule> {
+	return isStart ? ALWAYS_RULES : [...ALWAYS_RULES, ...NON_START_RULES];
+}
+
+function readPlaceConfigFragment(
+	inputs: Record<string, unknown>,
+	rules: ReadonlyArray<PlaceConfigRule>,
+): PlaceConfigFragment {
+	return rules.reduce<{
 		entry: Partial<PlaceEntry>;
 		warnings: Array<PlaceConfigFragmentRule>;
 	}>(
@@ -231,12 +251,12 @@ function readPlaceConfigFragment(inputs: Record<string, unknown>): PlaceConfigFr
 }
 
 function applyPlaceConfigFields(inputs: ApplyPlaceConfigFieldsInputs): PlaceConfigFoldResult {
-	const { key, configResource, folded } = inputs;
+	const { key, configResource, folded, isStart } = inputs;
 	if (configResource === undefined || !isObjectPayload(configResource.inputs)) {
 		return { entry: folded, warnings: [] };
 	}
 
-	const fragment = readPlaceConfigFragment(configResource.inputs);
+	const fragment = readPlaceConfigFragment(configResource.inputs, placeConfigRules(isStart));
 	const entry: PlaceFoldEntry = {
 		...folded,
 		entry: { ...folded.entry, ...fragment.entry },
@@ -252,6 +272,14 @@ function applyPlaceConfigFields(inputs: ApplyPlaceConfigFieldsInputs): PlaceConf
 			});
 		}),
 	};
+}
+
+function isStartPlace(resource: MantleResource): boolean {
+	if (!isObjectPayload(resource.inputs)) {
+		return false;
+	}
+
+	return resource.inputs["isStart"] === true;
 }
 
 function coerceRobloxId(value: unknown): string | undefined {

--- a/packages/bedrock/src/core/migrate/fold-places.ts
+++ b/packages/bedrock/src/core/migrate/fold-places.ts
@@ -91,6 +91,12 @@ interface PlaceConfigRule {
 	readonly rule: string;
 }
 
+interface PlaceBuckets {
+	readonly placeConfigurations: Map<string, MantleResource>;
+	readonly placeFiles: Map<string, MantleResource>;
+	readonly places: Map<string, MantleResource>;
+}
+
 /**
  * Fold the place-related Mantle resources of one environment into a map of
  * `PlaceFoldEntry` plus accompanying warnings. Pairs each `place_<k>`
@@ -109,10 +115,19 @@ interface PlaceConfigRule {
  * @returns The folded entries plus orphan warnings.
  */
 export function foldPlaces(resources: ReadonlyArray<MantleResource>): PlaceFoldResult {
-	const { placeConfigurations, placeFiles, places } = bucketByKind(resources);
+	const buckets = bucketByKind(resources);
+	const matched = collectMatchedFolds(buckets);
+	const orphans = collectOrphanWarnings(buckets);
+	return {
+		entries: matched.entries,
+		warnings: [...matched.warnings, ...orphans, ...foldBlockedPlaceFields(resources)],
+	};
+}
+
+function collectMatchedFolds(buckets: PlaceBuckets): PlaceFoldResult {
+	const { placeConfigurations, placeFiles, places } = buckets;
 	const entries = new Map<string, PlaceFoldEntry>();
 	const warnings: Array<MigrationWarning> = [];
-
 	for (const [key, placeResource] of places) {
 		const fileResource = placeFiles.get(key);
 		if (fileResource === undefined) {
@@ -135,20 +150,28 @@ export function foldPlaces(resources: ReadonlyArray<MantleResource>): PlaceFoldR
 		warnings.push(...configFold.warnings);
 	}
 
+	return { entries, warnings };
+}
+
+function collectOrphanWarnings(buckets: PlaceBuckets): ReadonlyArray<MigrationWarning> {
+	const { placeConfigurations, placeFiles, places } = buckets;
+	const warnings: Array<MigrationWarning> = [];
 	for (const [key] of placeFiles) {
 		if (!places.has(key)) {
 			warnings.push(orphanWarning(PLACE_FILE_KIND, key));
 		}
 	}
 
-	return { entries, warnings: [...warnings, ...foldBlockedPlaceFields(resources)] };
+	for (const [key] of placeConfigurations) {
+		if (!places.has(key) || !placeFiles.has(key)) {
+			warnings.push(placeConfigOrphanWarning(key));
+		}
+	}
+
+	return warnings;
 }
 
-function bucketByKind(resources: ReadonlyArray<MantleResource>): {
-	readonly placeConfigurations: Map<string, MantleResource>;
-	readonly placeFiles: Map<string, MantleResource>;
-	readonly places: Map<string, MantleResource>;
-} {
+function bucketByKind(resources: ReadonlyArray<MantleResource>): PlaceBuckets {
 	const places = new Map<string, MantleResource>();
 	const placeFiles = new Map<string, MantleResource>();
 	const placeConfigurations = new Map<string, MantleResource>();
@@ -360,5 +383,13 @@ function orphanWarning(kind: string, key: string): MigrationWarning {
 		hint: "Verify your Mantle state file: each place_<k> resource must be paired with a matching placeFile_<k>, and vice versa.",
 		kind: "ambiguous",
 		mantlePath: `${kind}_${key}`,
+	};
+}
+
+function placeConfigOrphanWarning(key: string): MigrationWarning {
+	return {
+		hint: "Verify your Mantle state file: each placeConfiguration_<k> requires a matching place_<k>+placeFile_<k> pair to fold its data into the bedrock config.",
+		kind: "ambiguous",
+		mantlePath: `${PLACE_CONFIGURATION_KIND}_${key}`,
 	};
 }

--- a/packages/bedrock/src/core/migrate/fold-universe.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.spec.ts
@@ -989,6 +989,21 @@ describe(foldUniverse, () => {
 			]);
 		});
 
+		it("should resolve duplicate start-key placeConfiguration records via last-wins", () => {
+			expect.assertions(1);
+
+			const result = foldUniverse([
+				experience(DEFAULT_EXPERIENCE_OUTPUTS),
+				place("start", { isStart: true }),
+				placeConfiguration("start", { name: "Earlier" }),
+				placeConfiguration("start", { name: "Later" }),
+			]);
+
+			assert(result !== undefined);
+
+			expect(result.entry.displayName).toBe("Later");
+		});
+
 		it("should leave displayName untouched when no placeConfiguration matches the start key", () => {
 			expect.assertions(2);
 

--- a/packages/bedrock/src/core/migrate/fold-universe.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.spec.ts
@@ -989,21 +989,6 @@ describe(foldUniverse, () => {
 			]);
 		});
 
-		it("should resolve duplicate start-key placeConfiguration records via last-wins", () => {
-			expect.assertions(1);
-
-			const result = foldUniverse([
-				experience(DEFAULT_EXPERIENCE_OUTPUTS),
-				place("start", { isStart: true }),
-				placeConfiguration("start", { name: "Earlier" }),
-				placeConfiguration("start", { name: "Later" }),
-			]);
-
-			assert(result !== undefined);
-
-			expect(result.entry.displayName).toBe("Later");
-		});
-
 		it("should leave displayName untouched when no placeConfiguration matches the start key", () => {
 			expect.assertions(2);
 

--- a/packages/bedrock/src/core/migrate/fold-universe.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.spec.ts
@@ -927,27 +927,28 @@ describe(foldUniverse, () => {
 			]);
 		});
 
-		it("should emit blocked for non-start placeConfiguration.name and not include it in displayName", () => {
+		it("should leave non-start placeConfiguration.name out of universe.displayName", () => {
 			expect.assertions(2);
 
 			const result = foldUniverse([
 				experience(DEFAULT_EXPERIENCE_OUTPUTS),
 				place("start", { isStart: true }),
 				place("lobby", { isStart: false }),
-				placeConfiguration("start", { name: "My Place" }),
 				placeConfiguration("lobby", { name: "Lobby" }),
+				placeConfiguration("start", { name: "My Place" }),
 			]);
 
 			assert(result !== undefined);
 
 			expect(result.entry.displayName).toBe("My Place");
-			expect(result.warnings).toIncludeAllPartialMembers([
-				{
-					kind: "blocked",
-					mantlePath: "placeConfiguration_lobby.name",
-					reason: "non-start placeConfiguration.name has no Open Cloud equivalent",
-				},
-			]);
+			expect(
+				result.warnings.filter((warning) => {
+					return (
+						warning.kind === "blocked" &&
+						warning.mantlePath === "placeConfiguration_lobby.name"
+					);
+				}),
+			).toStrictEqual([]);
 		});
 
 		it("should leave displayName untouched when no places have isStart true", () => {
@@ -962,13 +963,7 @@ describe(foldUniverse, () => {
 			assert(result !== undefined);
 
 			expect(result.entry.displayName).toBeNil();
-			expect(result.warnings).toStrictEqual([
-				{
-					kind: "blocked",
-					mantlePath: "placeConfiguration_start.name",
-					reason: "non-start placeConfiguration.name has no Open Cloud equivalent",
-				},
-			]);
+			expect(result.warnings).toStrictEqual([]);
 		});
 
 		it("should not treat isStart=true on a non-place resource as a start place", () => {
@@ -1009,7 +1004,7 @@ describe(foldUniverse, () => {
 		});
 
 		it("should omit displayName and emit ambiguous when multiple places have isStart true", () => {
-			expect.assertions(3);
+			expect.assertions(2);
 
 			const result = foldUniverse([
 				experience(DEFAULT_EXPERIENCE_OUTPUTS),
@@ -1028,7 +1023,6 @@ describe(foldUniverse, () => {
 					mantlePath: "place_*.isStart",
 				},
 			]);
-			expect(result.warnings.filter((warning) => warning.kind === "blocked")).toHaveLength(2);
 		});
 
 		it("should silently skip a placeConfiguration whose name is non-string", () => {
@@ -1073,12 +1067,14 @@ describe(foldUniverse, () => {
 			assert(result !== undefined);
 
 			expect(result.entry).toStrictEqual({ universeId: "1" });
-			expect(result.warnings).toIncludeAllPartialMembers([
-				{
-					kind: "blocked",
-					mantlePath: "placeConfiguration_start.name",
-				},
-			]);
+			expect(
+				result.warnings.filter((warning) => {
+					return (
+						warning.kind === "blocked" &&
+						warning.mantlePath === "placeConfiguration_start.name"
+					);
+				}),
+			).toStrictEqual([]);
 		});
 	});
 

--- a/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
@@ -496,12 +496,12 @@ describe(migrateMantleState, () => {
 
 		const blocked = result.data.warnings.filter((warning) => warning.kind === "blocked");
 
-		// 13 fields per environment × 2 environments + 1 isFriendsOnly only
+		// 12 fields per environment × 2 environments + 1 isFriendsOnly only
 		// in production (development uses the YAML null sentinel).
 		// Excluded: price and customSocialSlotsCount (null sentinel);
 		// experience.groupId (null in both environments).
-		expect(blocked).toHaveLength(27);
-		expect(result.data.summary.blockedCount).toBe(27);
+		expect(blocked).toHaveLength(25);
+		expect(result.data.summary.blockedCount).toBe(25);
 
 		const paths = blocked.map((warning) => warning.mantlePath);
 
@@ -509,7 +509,6 @@ describe(migrateMantleState, () => {
 			"development.experienceConfiguration_singleton.genre",
 			"production.experienceConfiguration_singleton.genre",
 			"production.experienceConfiguration_singleton.universeAvatarType",
-			"production.placeConfiguration_start.maxPlayerCount",
 			"production.placeConfiguration_start.allowCopying",
 		]);
 	});

--- a/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
@@ -496,12 +496,12 @@ describe(migrateMantleState, () => {
 
 		const blocked = result.data.warnings.filter((warning) => warning.kind === "blocked");
 
-		// 14 fields per environment × 2 environments + 1 isFriendsOnly only
+		// 13 fields per environment × 2 environments + 1 isFriendsOnly only
 		// in production (development uses the YAML null sentinel).
 		// Excluded: price and customSocialSlotsCount (null sentinel);
 		// experience.groupId (null in both environments).
-		expect(blocked).toHaveLength(29);
-		expect(result.data.summary.blockedCount).toBe(29);
+		expect(blocked).toHaveLength(27);
+		expect(result.data.summary.blockedCount).toBe(27);
 
 		const paths = blocked.map((warning) => warning.mantlePath);
 
@@ -509,7 +509,7 @@ describe(migrateMantleState, () => {
 			"development.experienceConfiguration_singleton.genre",
 			"production.experienceConfiguration_singleton.genre",
 			"production.experienceConfiguration_singleton.universeAvatarType",
-			"production.placeConfiguration_start.description",
+			"production.placeConfiguration_start.maxPlayerCount",
 			"production.placeConfiguration_start.allowCopying",
 		]);
 	});


### PR DESCRIPTION
## References

- Parent PRD: #103 (mantle state migration)
- Related: #208 — originally listed `placeConfiguration.{description, maxPlayerCount}` as blocked fields, but cloud-v2 `Cloud_UpdatePlace` exposes both as writable. This PR corrects that mapping.

## Summary

`bedrock migrate` was emitting `blocked` warnings for three `placeConfiguration` fields and dropping the values, but `Cloud_UpdatePlace` exposes all three as writable on the per-place schema (see [places-writable-keys.spec.ts](packages/open-cloud/tests/conformance/places-writable-keys.spec.ts)). The migrator now folds them into the matching `Config.places.<k>` entry as `interpretive` warnings instead.

| Mantle field | Bedrock target | Rule id |
|---|---|---|
| `placeConfiguration_<k>.description` | `Config.places.<k>.description` | `place-description` |
| `placeConfiguration_<k>.maxPlayerCount` | `Config.places.<k>.serverSize` | `max-player-count-to-server-size` |
| `placeConfiguration_<k>.name` (non-start) | `Config.places.<k>.displayName` | `place-name-to-display-name` |

The start place's `name` still folds into `universe.displayName` as before (`start-place-name-to-display-name`). Per-environment overlay diffing was extended to all three new fields, mirroring the `filePath` precedent at `factorize-environments.ts:106-115` — common values land on root, divergent values on the per-env overlay.

The remaining `BLOCKED_FIELDS` (`allowCopying`, `socialSlotType`, `customSocialSlotsCount`) stay blocked because the cloud-v2 Place schema does not expose them.

## Test Plan

- [x] `pnpm --filter @bedrock/core test` — 1636 passed, 0 failed
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `MUTATE_BASE_REF=main pnpm mutate:changed` — 100% (56 killed, 0 survived) across `fold-places.ts`, `fold-display-name.ts`, `factorize-environments.ts`
- [ ] End-to-end smoke: run `bedrock migrate` against a `.mantle-state.yml` with non-empty placeConfiguration fields and verify the rendered `bedrock.config.{ts,yaml}` and state files carry the new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Bedrock Code Review: PR #327 - Place Metadata Migration

## Architecture Assessment

### ✅ FCIS Pattern Compliance
**PASS** - All changes remain in the `core/migrate/` pure domain layer with no I/O operations detected. The new `factorize-places.ts` module and modifications to `fold-places.ts`, `fold-display-name.ts`, and `factorize-environments.ts` are pure functions operating on plain data structures. No violations of the core/shell/adapters/ports boundaries found.

- Core functions (`foldPlaces`, `buildRootPlaces`, `buildPlacesOverlay`) accept only data, return only data
- `factorize-environments.ts` properly delegates place logic to `factorize-places.ts` via imports rather than duplicating logic
- No Result types inappropriately returned from pure core functions (Result types correctly reserved for shell/adapter boundaries)

### ✅ TDD & 100% Coverage Compliance
**PASS** - Comprehensive test coverage demonstrates RED-GREEN-REFACTOR cycle:

| File | Change | Tests Added | Coverage |
|------|--------|------------|----------|
| `fold-display-name.spec.ts` | New | 53 lines | ✅ |
| `fold-places.spec.ts` | +263 | Expanded test cases for description/displayName/serverSize folding, placeConfiguration orphan warnings | ✅ |
| `factorize-environments.spec.ts` | +350 | Coverage for overlay/root placement consensus across 3 fields | ✅ |
| `build-state.spec.ts` | +58 | Tests verify field propagation and undefined handling | ✅ |
| Integration test | -1 blocked warning | Updated expected counts (29→25 blocked warnings) | ✅ |

- PR summary confirms: **1636 core tests passed**, **mutation tests show 100% coverage for changed files**, typecheck and lint clean
- Test naming follows specification: `it("should <behavior>")` format consistently applied
- No mocking detected (search returned no matches), validating real behavior testing in pure Core layer

### ✅ Test Isolation
**PASS** - Proper isolation strategy for Core layer:

- No mocking framework usage (`vi.mock`/`jest.mock` not found)
- Pure functions require no isolation helpers
- Tests verify real behavior: field consensus algorithms, orphan detection, config folding rules
- Build-state tests verify field propagation through resource emission (end-to-end within Core)

### ✅ Security & Input Validation
**PASS** - Proper validation at interpretation boundaries:

- `readString()`, `readPositiveInteger()` validation in `foldPlaces` confirms non-string/non-positive inputs are silently skipped (no exceptions leaked)
- `isObjectPayload()` guards prevent NPE on malformed inputs
- Orphan warnings (ambiguous kind) for missing placeConfiguration pairs catch incomplete Mantle state
- No secrets, no legacy Roblox APIs, only public Open Cloud resource IDs

### ✅ Code Quality
**PASS** - TypeScript strict mode compliance:

- Extends `@bedrock/typescript-config/tsconfig.base.json` with strict compiler options
- No `any` types detected in modified files
- Proper typed errors via `MigrationWarning` discriminated union (kind: "ambiguous" | "interpretive" | "blocked")
- Plain data structures (PlaceFoldEntry, PlaceEntry, PlaceOverlayEntry) with no methods
- Conditional field spreading (`...condition && { field }`) prevents undefined from overwriting root values in overlays

### ⚠️ Architecture Notes
**OBSERVATION** - Minor semantic refinement:

The refactoring correctly separates concerns:
- `fold-places.ts`: Pairs place/placeFile/placeConfiguration resources, reads inputs, emits warnings
- `factorize-places.ts`: Projects folds into root+overlay shape with consensus algorithm for optional fields
- `factorize-environments.ts`: Calls both modules and threads OverlayContext instead of passing raw folds

This delegation pattern prevents environment-specific overlay logic from leaking into the fold layer, maintaining proper layering.

### 🔍 Testing Rigor Highlights
- `factorize-environments.spec.ts` (+350 lines): Validates three consensus scenarios per field: (1) uniform across envs → root, (2) divergent → overlay, (3) partial → overlay
- `fold-places.spec.ts` (+263 lines): Tests placeConfiguration folding rules (description/displayName/serverSize) with isStart branching, plus orphan warnings for missing pairs
- `build-state.spec.ts` (+58 lines): Verifies field propagation from fold entries to emitted resources, including undefined handling
- All tests assert exact behavior without fixtures or shared setup coupling

## Summary
This PR exemplifies Bedrock's architecture standards: pure domain logic, comprehensive test coverage with proper isolation, TypeScript strict mode compliance, and clear separation of concerns. The migration from "blocked fields" to "interpretive warnings with folding" is properly implemented across all layers without violating architectural boundaries. Ready for merge pending e2e smoke run against real .mantle-state.yml (noted as outstanding in PR objectives).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->