### PR TITLE
fix(core): incomplete url substring sanitization

### DIFF
--- a/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
@@ -208,7 +208,8 @@ describe(createGistStateAdapter, () => {
 			expect.assertions(2);
 
 			const { fetchFn } = fakeFetch((request) => {
-				if (request.url.startsWith("https://api.github.com")) {
+				const url = new URL(request.url);
+				if (url.protocol === "https:" && url.hostname === "api.github.com") {
 					return okJson({
 						files: {
 							"state.production.json": {
@@ -304,7 +305,8 @@ describe(createGistStateAdapter, () => {
 			expect.assertions(2);
 
 			const { fetchFn } = fakeFetch((request) => {
-				if (request.url.startsWith("https://api.github.com")) {
+				const url = new URL(request.url);
+				if (url.protocol === "https:" && url.hostname === "api.github.com") {
 					return okJson({
 						files: {
 							"state.production.json": {

--- a/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
@@ -379,7 +379,8 @@ describe(createGistStateAdapter, () => {
 			const state: BedrockState = { environment: "production", resources: [], version: 1 };
 			const content = serializeStateFile(state);
 			const { fetchFn } = fakeFetch((request) => {
-				if (request.url.startsWith("https://api.github.com")) {
+				const url = new URL(request.url);
+				if (url.protocol === "https:" && url.hostname === "api.github.com") {
 					return okJson({
 						files: {
 							"state.production.json": {
@@ -431,7 +432,8 @@ describe(createGistStateAdapter, () => {
 			const state: BedrockState = { environment: "production", resources: [], version: 1 };
 			const content = serializeStateFile(state);
 			const { fetchFn } = fakeFetch((request) => {
-				if (request.url.startsWith("https://api.github.com")) {
+				const url = new URL(request.url);
+				if (url.protocol === "https:" && url.hostname === "api.github.com") {
 					return okJson({
 						files: {
 							"state.production.json": {


### PR DESCRIPTION
Potential fix for [https://github.com/christopher-buss/bedrock/security/code-scanning/4](https://github.com/christopher-buss/bedrock/security/code-scanning/4)

Use URL parsing and exact host/protocol checks instead of `startsWith`.  
Best fix: in `packages/bedrock/src/adapters/gist-state-adapter.spec.ts`, replace both instances of:

- `if (request.url.startsWith("https://api.github.com")) {`

with logic that parses `request.url` via `new URL(request.url)` and verifies:

- `url.protocol === "https:"`
- `url.hostname === "api.github.com"`

This preserves current behavior (routing GitHub API requests to `okJson`, other URLs to raw content response) while removing incomplete substring sanitization.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
