### PR TITLE
feat(core): migrate developer products from mantle state

### DIFF
--- a/packages/bedrock/src/core/migrate/build-state.spec.ts
+++ b/packages/bedrock/src/core/migrate/build-state.spec.ts
@@ -7,11 +7,18 @@ import { buildState } from "./build-state.ts";
 import type { EnvironmentFoldResult } from "./fold-environment.ts";
 import type { PassFoldEntry } from "./fold-passes.ts";
 import type { PlaceFoldEntry } from "./fold-places.ts";
+import type { ProductFoldEntry } from "./fold-products.ts";
 
 const SAMPLE_HASH = asSha256Hex("86890ed405cabad0fcdabf52225d528981790fa551e915c070348761c28373c1");
 const VALID_HASH = asSha256Hex("908498abb7f4fca2b7d2b050bfe7c48c009202fabd85f489b03bb19ac6e0b1d9");
 const RECOMPUTED_HASH = asSha256Hex(
 	"a665a45920422f9d417e4867efdc4fb8a04a1f3fff1fa07e998e86f7f7a27ae3",
+);
+const PRODUCT_MANTLE_HASH = asSha256Hex(
+	"d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2d2",
+);
+const PRODUCT_RECOMPUTED_HASH = asSha256Hex(
+	"e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3",
 );
 
 const NO_HASHES: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>> = new Map();
@@ -55,6 +62,40 @@ function passEntry(key: string): PassFoldEntry {
 	};
 }
 
+function productEntryWithIcon(key: string): ProductFoldEntry {
+	return {
+		key: asResourceKey(key),
+		entry: {
+			name: "Gem Pack",
+			description: "Stocks the player up with 1,000 premium gems.",
+			icon: { "en-us": "assets/marketing/gem-pack.png" },
+			price: 100,
+		},
+		mantleIconFileHashes: { "en-us": PRODUCT_MANTLE_HASH },
+		mantlePath: `product_${key}`,
+		outputs: {
+			iconImageAssetId: asRobloxAssetId("99887766"),
+			productId: asRobloxAssetId("12345678"),
+		},
+	};
+}
+
+function productEntryWithoutIcon(key: string): ProductFoldEntry {
+	return {
+		key: asResourceKey(key),
+		entry: {
+			name: "Coin Pack",
+			description: "Adds 500 coins to the player's wallet.",
+			price: 50,
+		},
+		mantlePath: `product_${key}`,
+		outputs: {
+			iconImageAssetId: undefined,
+			productId: asRobloxAssetId("87654321"),
+		},
+	};
+}
+
 describe(buildState, () => {
 	it("should set the schema version literal to 1", () => {
 		expect.assertions(1);
@@ -62,7 +103,8 @@ describe(buildState, () => {
 		const state = buildState({
 			environment: "production",
 			folded: FOLDED_UNIVERSE,
-			iconHashesByKey: NO_HASHES,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		expect(state.version).toBe(1);
@@ -74,7 +116,8 @@ describe(buildState, () => {
 		const state = buildState({
 			environment: "staging",
 			folded: FOLDED_UNIVERSE,
-			iconHashesByKey: NO_HASHES,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		expect(state.environment).toBe("staging");
@@ -86,7 +129,8 @@ describe(buildState, () => {
 		const state = buildState({
 			environment: "production",
 			folded: FOLDED_UNIVERSE,
-			iconHashesByKey: NO_HASHES,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		expect(state.resources).toHaveLength(1);
@@ -106,7 +150,8 @@ describe(buildState, () => {
 		const state = buildState({
 			environment: "production",
 			folded: FOLDED_UNIVERSE,
-			iconHashesByKey: NO_HASHES,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		const [resource] = state.resources;
@@ -122,7 +167,8 @@ describe(buildState, () => {
 		const state = buildState({
 			environment: "production",
 			folded: FOLDED_UNIVERSE,
-			iconHashesByKey: NO_HASHES,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		const [resource] = state.resources;
@@ -142,7 +188,8 @@ describe(buildState, () => {
 		const state = buildState({
 			environment: "production",
 			folded: FOLDED_UNIVERSE,
-			iconHashesByKey: NO_HASHES,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		const [resource] = state.resources;
@@ -164,7 +211,8 @@ describe(buildState, () => {
 				universe: undefined,
 				warnings: [],
 			},
-			iconHashesByKey: NO_HASHES,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		expect(state.resources).toStrictEqual([]);
@@ -182,7 +230,8 @@ describe(buildState, () => {
 				universe: undefined,
 				warnings: [],
 			},
-			iconHashesByKey: NO_HASHES,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		expect(state.resources).toHaveLength(1);
@@ -209,7 +258,8 @@ describe(buildState, () => {
 				universe: undefined,
 				warnings: [],
 			},
-			iconHashesByKey: NO_HASHES,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		const [resource] = state.resources;
@@ -289,7 +339,8 @@ describe(buildState, () => {
 				universe: FOLDED_UNIVERSE.universe,
 				warnings: [],
 			},
-			iconHashesByKey: NO_HASHES,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		expect(state.resources).toHaveLength(2);
@@ -316,7 +367,8 @@ describe(buildState, () => {
 		const state = buildState({
 			environment: "production",
 			folded,
-			iconHashesByKey: hashes,
+			passIconHashesByKey: hashes,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		const [resource] = state.resources;
@@ -333,7 +385,7 @@ describe(buildState, () => {
 		expect(resource.price).toBe(5);
 	});
 
-	it("should fall back to the Mantle-recorded hash when iconHashesByKey omits a pass key", () => {
+	it("should fall back to the Mantle-recorded hash when passIconHashesByKey omits a pass key", () => {
 		expect.assertions(1);
 
 		const folded: EnvironmentFoldResult = {
@@ -347,7 +399,8 @@ describe(buildState, () => {
 		const state = buildState({
 			environment: "production",
 			folded,
-			iconHashesByKey: NO_HASHES,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		const [resource] = state.resources;
@@ -370,7 +423,8 @@ describe(buildState, () => {
 		const state = buildState({
 			environment: "production",
 			folded,
-			iconHashesByKey: NO_HASHES,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		expect(state.resources).toHaveLength(2);
@@ -401,12 +455,334 @@ describe(buildState, () => {
 		const state = buildState({
 			environment: "production",
 			folded,
-			iconHashesByKey: NO_HASHES,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		const [resource] = state.resources;
 		assert(resource?.kind === "gamePass");
 
 		expect(resource.price).toBeUndefined();
+	});
+
+	it("should emit one developerProduct resource per folded product entry", () => {
+		expect.assertions(2);
+
+		const folded: EnvironmentFoldResult = {
+			passes: [],
+			places: new Map(),
+			products: [productEntryWithIcon("gem-pack"), productEntryWithoutIcon("coin-pack")],
+			universe: undefined,
+			warnings: [],
+		};
+
+		const state = buildState({
+			environment: "production",
+			folded,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
+		});
+
+		expect(state.resources).toHaveLength(2);
+		expect(state.resources.map((resource) => resource.kind)).toStrictEqual([
+			"developerProduct",
+			"developerProduct",
+		]);
+	});
+
+	it("should preserve productId on the developer-product resource outputs", () => {
+		expect.assertions(1);
+
+		const folded: EnvironmentFoldResult = {
+			passes: [],
+			places: new Map(),
+			products: [productEntryWithIcon("gem-pack")],
+			universe: undefined,
+			warnings: [],
+		};
+
+		const state = buildState({
+			environment: "production",
+			folded,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
+		});
+
+		const [resource] = state.resources;
+		assert(resource?.kind === "developerProduct");
+
+		expect(resource.outputs.productId).toBe(asRobloxAssetId("12345678"));
+	});
+
+	it("should emit icon and iconFileHashes when the fold entry carries an icon", () => {
+		expect.assertions(2);
+
+		const folded: EnvironmentFoldResult = {
+			passes: [],
+			places: new Map(),
+			products: [productEntryWithIcon("gem-pack")],
+			universe: undefined,
+			warnings: [],
+		};
+
+		const state = buildState({
+			environment: "production",
+			folded,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
+		});
+
+		const [resource] = state.resources;
+		assert(resource?.kind === "developerProduct");
+
+		expect(resource.icon).toStrictEqual({ "en-us": "assets/marketing/gem-pack.png" });
+		expect(resource.iconFileHashes).toStrictEqual({ "en-us": PRODUCT_MANTLE_HASH });
+	});
+
+	it("should omit icon and iconFileHashes when the fold entry has no icon", () => {
+		expect.assertions(4);
+
+		const folded: EnvironmentFoldResult = {
+			passes: [],
+			places: new Map(),
+			products: [productEntryWithoutIcon("coin-pack")],
+			universe: undefined,
+			warnings: [],
+		};
+
+		const state = buildState({
+			environment: "production",
+			folded,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
+		});
+
+		const [resource] = state.resources;
+		assert(resource?.kind === "developerProduct");
+
+		expect(resource.icon).toBeUndefined();
+		expect(resource.iconFileHashes).toBeUndefined();
+		expect("icon" in resource).toBeFalse();
+		expect("iconFileHashes" in resource).toBeFalse();
+	});
+
+	it("should prefer recomputed icon hashes over the mantle-recorded fallback", () => {
+		expect.assertions(1);
+
+		const folded: EnvironmentFoldResult = {
+			passes: [],
+			places: new Map(),
+			products: [productEntryWithIcon("gem-pack")],
+			universe: undefined,
+			warnings: [],
+		};
+		const productHashes = new Map<ResourceKey, Record<"en-us", Sha256Hex>>([
+			[asResourceKey("gem-pack"), { "en-us": PRODUCT_RECOMPUTED_HASH }],
+		]);
+
+		const state = buildState({
+			environment: "production",
+			folded,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: productHashes,
+		});
+
+		const [resource] = state.resources;
+		assert(resource?.kind === "developerProduct");
+
+		expect(resource.iconFileHashes).toStrictEqual({ "en-us": PRODUCT_RECOMPUTED_HASH });
+	});
+
+	it("should fall back to mantleIconFileHashes when productIconHashesByKey omits the key", () => {
+		expect.assertions(1);
+
+		const folded: EnvironmentFoldResult = {
+			passes: [],
+			places: new Map(),
+			products: [productEntryWithIcon("gem-pack")],
+			universe: undefined,
+			warnings: [],
+		};
+
+		const state = buildState({
+			environment: "production",
+			folded,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
+		});
+
+		const [resource] = state.resources;
+		assert(resource?.kind === "developerProduct");
+
+		expect(resource.iconFileHashes).toStrictEqual({ "en-us": PRODUCT_MANTLE_HASH });
+	});
+
+	it("should set isRegionalPricingEnabled and storePageEnabled to undefined", () => {
+		expect.assertions(2);
+
+		const folded: EnvironmentFoldResult = {
+			passes: [],
+			places: new Map(),
+			products: [productEntryWithIcon("gem-pack")],
+			universe: undefined,
+			warnings: [],
+		};
+
+		const state = buildState({
+			environment: "production",
+			folded,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
+		});
+
+		const [resource] = state.resources;
+		assert(resource?.kind === "developerProduct");
+
+		expect(resource.isRegionalPricingEnabled).toBeUndefined();
+		expect(resource.storePageEnabled).toBeUndefined();
+	});
+
+	it("should preserve iconImageAssetId on outputs when the fold entry has an icon", () => {
+		expect.assertions(1);
+
+		const folded: EnvironmentFoldResult = {
+			passes: [],
+			places: new Map(),
+			products: [productEntryWithIcon("gem-pack")],
+			universe: undefined,
+			warnings: [],
+		};
+
+		const state = buildState({
+			environment: "production",
+			folded,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
+		});
+
+		const [resource] = state.resources;
+		assert(resource?.kind === "developerProduct");
+
+		expect(resource.outputs.iconImageAssetId).toBe(asRobloxAssetId("99887766"));
+	});
+
+	it("should leave iconImageAssetId undefined on outputs when the fold entry has no icon", () => {
+		expect.assertions(1);
+
+		const folded: EnvironmentFoldResult = {
+			passes: [],
+			places: new Map(),
+			products: [productEntryWithoutIcon("coin-pack")],
+			universe: undefined,
+			warnings: [],
+		};
+
+		const state = buildState({
+			environment: "production",
+			folded,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
+		});
+
+		const [resource] = state.resources;
+		assert(resource?.kind === "developerProduct");
+
+		expect(resource.outputs.iconImageAssetId).toBeUndefined();
+	});
+
+	it("should omit icon when the fold entry carries an icon path but no mantle hashes", () => {
+		expect.assertions(2);
+
+		const malformed = productEntryWithIcon("gem-pack");
+		const malformedEntry: ProductFoldEntry = {
+			key: malformed.key,
+			entry: malformed.entry,
+			mantlePath: malformed.mantlePath,
+			outputs: malformed.outputs,
+		};
+		const folded: EnvironmentFoldResult = {
+			passes: [],
+			places: new Map(),
+			products: [malformedEntry],
+			universe: undefined,
+			warnings: [],
+		};
+
+		const state = buildState({
+			environment: "production",
+			folded,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
+		});
+
+		const [resource] = state.resources;
+		assert(resource?.kind === "developerProduct");
+
+		expect("icon" in resource).toBeFalse();
+		expect("iconFileHashes" in resource).toBeFalse();
+	});
+
+	it("should omit icon when the fold entry has mantle hashes but no icon path", () => {
+		expect.assertions(2);
+
+		const folded: EnvironmentFoldResult = {
+			passes: [],
+			places: new Map(),
+			products: [
+				{
+					key: asResourceKey("coin-pack"),
+					entry: {
+						name: "Coin Pack",
+						description: "Adds 500 coins to the player's wallet.",
+						price: 50,
+					},
+					mantleIconFileHashes: { "en-us": PRODUCT_MANTLE_HASH },
+					mantlePath: "product_coin-pack",
+					outputs: {
+						iconImageAssetId: undefined,
+						productId: asRobloxAssetId("87654321"),
+					},
+				},
+			],
+			universe: undefined,
+			warnings: [],
+		};
+
+		const state = buildState({
+			environment: "production",
+			folded,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
+		});
+
+		const [resource] = state.resources;
+		assert(resource?.kind === "developerProduct");
+
+		expect("icon" in resource).toBeFalse();
+		expect("iconFileHashes" in resource).toBeFalse();
+	});
+
+	it("should emit developer-product resources after the pass resources", () => {
+		expect.assertions(1);
+
+		const folded: EnvironmentFoldResult = {
+			passes: [passEntry("1-example")],
+			places: new Map(),
+			products: [productEntryWithIcon("gem-pack")],
+			universe: undefined,
+			warnings: [],
+		};
+
+		const state = buildState({
+			environment: "production",
+			folded,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
+		});
+
+		expect(state.resources.map((resource) => resource.kind)).toStrictEqual([
+			"gamePass",
+			"developerProduct",
+		]);
 	});
 });

--- a/packages/bedrock/src/core/migrate/build-state.spec.ts
+++ b/packages/bedrock/src/core/migrate/build-state.spec.ts
@@ -19,6 +19,7 @@ const NO_HASHES: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>> = new Map(
 const FOLDED_UNIVERSE: EnvironmentFoldResult = {
 	passes: [],
 	places: new Map(),
+	products: [],
 	universe: {
 		entry: { universeId: "6031475575" },
 		outputs: { rootPlaceId: asRobloxAssetId("17613681043") },
@@ -156,7 +157,13 @@ describe(buildState, () => {
 
 		const state = buildState({
 			environment: "production",
-			folded: { passes: [], places: new Map(), universe: undefined, warnings: [] },
+			folded: {
+				passes: [],
+				places: new Map(),
+				products: [],
+				universe: undefined,
+				warnings: [],
+			},
 			iconHashesByKey: NO_HASHES,
 		});
 
@@ -171,6 +178,7 @@ describe(buildState, () => {
 			folded: {
 				passes: [],
 				places: new Map([["start", placeFold()]]),
+				products: [],
 				universe: undefined,
 				warnings: [],
 			},
@@ -197,6 +205,7 @@ describe(buildState, () => {
 			folded: {
 				passes: [],
 				places: new Map([["start", placeFold()]]),
+				products: [],
 				universe: undefined,
 				warnings: [],
 			},
@@ -276,6 +285,7 @@ describe(buildState, () => {
 			folded: {
 				passes: [],
 				places: new Map([["start", placeFold()]]),
+				products: [],
 				universe: FOLDED_UNIVERSE.universe,
 				warnings: [],
 			},
@@ -295,6 +305,7 @@ describe(buildState, () => {
 		const folded: EnvironmentFoldResult = {
 			passes: [passEntry("1-example")],
 			places: new Map(),
+			products: [],
 			universe: undefined,
 			warnings: [],
 		};
@@ -328,6 +339,7 @@ describe(buildState, () => {
 		const folded: EnvironmentFoldResult = {
 			passes: [passEntry("1-example")],
 			places: new Map(),
+			products: [],
 			universe: undefined,
 			warnings: [],
 		};
@@ -350,6 +362,7 @@ describe(buildState, () => {
 		const folded: EnvironmentFoldResult = {
 			passes: [passEntry("1-example")],
 			places: new Map(),
+			products: [],
 			universe: FOLDED_UNIVERSE.universe,
 			warnings: [],
 		};
@@ -380,6 +393,7 @@ describe(buildState, () => {
 		const folded: EnvironmentFoldResult = {
 			passes: [offSaleEntry],
 			places: new Map(),
+			products: [],
 			universe: undefined,
 			warnings: [],
 		};

--- a/packages/bedrock/src/core/migrate/build-state.spec.ts
+++ b/packages/bedrock/src/core/migrate/build-state.spec.ts
@@ -289,10 +289,12 @@ describe(buildState, () => {
 						}),
 					],
 				]),
+				products: [],
 				universe: undefined,
 				warnings: [],
 			},
-			iconHashesByKey: NO_HASHES,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		const [resource] = state.resources;
@@ -312,10 +314,12 @@ describe(buildState, () => {
 			folded: {
 				passes: [],
 				places: new Map([["start", placeFold()]]),
+				products: [],
 				universe: undefined,
 				warnings: [],
 			},
-			iconHashesByKey: NO_HASHES,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
 		});
 
 		const [resource] = state.resources;

--- a/packages/bedrock/src/core/migrate/build-state.spec.ts
+++ b/packages/bedrock/src/core/migrate/build-state.spec.ts
@@ -23,7 +23,7 @@ const PRODUCT_RECOMPUTED_HASH = asSha256Hex(
 
 const NO_HASHES: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>> = new Map();
 
-const FOLDED_UNIVERSE: EnvironmentFoldResult = {
+const FOLDED_UNIVERSE = {
 	passes: [],
 	places: new Map(),
 	products: [],
@@ -32,7 +32,7 @@ const FOLDED_UNIVERSE: EnvironmentFoldResult = {
 		outputs: { rootPlaceId: asRobloxAssetId("17613681043") },
 	},
 	warnings: [],
-};
+} satisfies EnvironmentFoldResult;
 
 function placeFold(overrides: Partial<PlaceFoldEntry> = {}): PlaceFoldEntry {
 	return {
@@ -357,13 +357,13 @@ describe(buildState, () => {
 	it("should emit a gamePass ResourceCurrentState per folded pass entry", () => {
 		expect.assertions(5);
 
-		const folded: EnvironmentFoldResult = {
+		const folded = {
 			passes: [passEntry("1-example")],
 			places: new Map(),
 			products: [],
 			universe: undefined,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 		const hashes = new Map<ResourceKey, Record<"en-us", Sha256Hex>>([
 			[asResourceKey("1-example"), { "en-us": RECOMPUTED_HASH }],
 		]);
@@ -392,13 +392,13 @@ describe(buildState, () => {
 	it("should fall back to the Mantle-recorded hash when passIconHashesByKey omits a pass key", () => {
 		expect.assertions(1);
 
-		const folded: EnvironmentFoldResult = {
+		const folded = {
 			passes: [passEntry("1-example")],
 			places: new Map(),
 			products: [],
 			universe: undefined,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 
 		const state = buildState({
 			environment: "production",
@@ -416,13 +416,13 @@ describe(buildState, () => {
 	it("should preserve the universe resource alongside emitted gamePass resources", () => {
 		expect.assertions(3);
 
-		const folded: EnvironmentFoldResult = {
+		const folded = {
 			passes: [passEntry("1-example")],
 			places: new Map(),
 			products: [],
 			universe: FOLDED_UNIVERSE.universe,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 
 		const state = buildState({
 			environment: "production",
@@ -440,21 +440,21 @@ describe(buildState, () => {
 		expect.assertions(1);
 
 		const offSale = passEntry("1-example");
-		const offSaleEntry: PassFoldEntry = {
+		const offSaleEntry = {
 			...offSale,
 			entry: {
 				name: offSale.entry.name,
 				description: offSale.entry.description,
 				icon: offSale.entry.icon,
 			},
-		};
-		const folded: EnvironmentFoldResult = {
+		} satisfies PassFoldEntry;
+		const folded = {
 			passes: [offSaleEntry],
 			places: new Map(),
 			products: [],
 			universe: undefined,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 
 		const state = buildState({
 			environment: "production",
@@ -472,13 +472,13 @@ describe(buildState, () => {
 	it("should emit one developerProduct resource per folded product entry", () => {
 		expect.assertions(2);
 
-		const folded: EnvironmentFoldResult = {
+		const folded = {
 			passes: [],
 			places: new Map(),
 			products: [productEntryWithIcon("gem-pack"), productEntryWithoutIcon("coin-pack")],
 			universe: undefined,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 
 		const state = buildState({
 			environment: "production",
@@ -497,13 +497,13 @@ describe(buildState, () => {
 	it("should preserve productId on the developer-product resource outputs", () => {
 		expect.assertions(1);
 
-		const folded: EnvironmentFoldResult = {
+		const folded = {
 			passes: [],
 			places: new Map(),
 			products: [productEntryWithIcon("gem-pack")],
 			universe: undefined,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 
 		const state = buildState({
 			environment: "production",
@@ -521,13 +521,13 @@ describe(buildState, () => {
 	it("should emit icon and iconFileHashes when the fold entry carries an icon", () => {
 		expect.assertions(2);
 
-		const folded: EnvironmentFoldResult = {
+		const folded = {
 			passes: [],
 			places: new Map(),
 			products: [productEntryWithIcon("gem-pack")],
 			universe: undefined,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 
 		const state = buildState({
 			environment: "production",
@@ -546,13 +546,13 @@ describe(buildState, () => {
 	it("should omit icon and iconFileHashes when the fold entry has no icon", () => {
 		expect.assertions(4);
 
-		const folded: EnvironmentFoldResult = {
+		const folded = {
 			passes: [],
 			places: new Map(),
 			products: [productEntryWithoutIcon("coin-pack")],
 			universe: undefined,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 
 		const state = buildState({
 			environment: "production",
@@ -573,13 +573,13 @@ describe(buildState, () => {
 	it("should prefer recomputed icon hashes over the mantle-recorded fallback", () => {
 		expect.assertions(1);
 
-		const folded: EnvironmentFoldResult = {
+		const folded = {
 			passes: [],
 			places: new Map(),
 			products: [productEntryWithIcon("gem-pack")],
 			universe: undefined,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 		const productHashes = new Map<ResourceKey, Record<"en-us", Sha256Hex>>([
 			[asResourceKey("gem-pack"), { "en-us": PRODUCT_RECOMPUTED_HASH }],
 		]);
@@ -600,13 +600,13 @@ describe(buildState, () => {
 	it("should fall back to mantleIconFileHashes when productIconHashesByKey omits the key", () => {
 		expect.assertions(1);
 
-		const folded: EnvironmentFoldResult = {
+		const folded = {
 			passes: [],
 			places: new Map(),
 			products: [productEntryWithIcon("gem-pack")],
 			universe: undefined,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 
 		const state = buildState({
 			environment: "production",
@@ -624,13 +624,13 @@ describe(buildState, () => {
 	it("should set isRegionalPricingEnabled and storePageEnabled to undefined", () => {
 		expect.assertions(2);
 
-		const folded: EnvironmentFoldResult = {
+		const folded = {
 			passes: [],
 			places: new Map(),
 			products: [productEntryWithIcon("gem-pack")],
 			universe: undefined,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 
 		const state = buildState({
 			environment: "production",
@@ -649,13 +649,13 @@ describe(buildState, () => {
 	it("should preserve iconImageAssetId on outputs when the fold entry has an icon", () => {
 		expect.assertions(1);
 
-		const folded: EnvironmentFoldResult = {
+		const folded = {
 			passes: [],
 			places: new Map(),
 			products: [productEntryWithIcon("gem-pack")],
 			universe: undefined,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 
 		const state = buildState({
 			environment: "production",
@@ -673,13 +673,13 @@ describe(buildState, () => {
 	it("should leave iconImageAssetId undefined on outputs when the fold entry has no icon", () => {
 		expect.assertions(1);
 
-		const folded: EnvironmentFoldResult = {
+		const folded = {
 			passes: [],
 			places: new Map(),
 			products: [productEntryWithoutIcon("coin-pack")],
 			universe: undefined,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 
 		const state = buildState({
 			environment: "production",
@@ -698,19 +698,19 @@ describe(buildState, () => {
 		expect.assertions(2);
 
 		const malformed = productEntryWithIcon("gem-pack");
-		const malformedEntry: ProductFoldEntry = {
+		const malformedEntry = {
 			key: malformed.key,
 			entry: malformed.entry,
 			mantlePath: malformed.mantlePath,
 			outputs: malformed.outputs,
-		};
-		const folded: EnvironmentFoldResult = {
+		} satisfies ProductFoldEntry;
+		const folded = {
 			passes: [],
 			places: new Map(),
 			products: [malformedEntry],
 			universe: undefined,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 
 		const state = buildState({
 			environment: "production",
@@ -729,7 +729,7 @@ describe(buildState, () => {
 	it("should omit icon when the fold entry has mantle hashes but no icon path", () => {
 		expect.assertions(2);
 
-		const folded: EnvironmentFoldResult = {
+		const folded = {
 			passes: [],
 			places: new Map(),
 			products: [
@@ -750,7 +750,7 @@ describe(buildState, () => {
 			],
 			universe: undefined,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 
 		const state = buildState({
 			environment: "production",
@@ -769,13 +769,13 @@ describe(buildState, () => {
 	it("should emit developer-product resources after the pass resources", () => {
 		expect.assertions(1);
 
-		const folded: EnvironmentFoldResult = {
+		const folded = {
 			passes: [passEntry("1-example")],
 			places: new Map(),
 			products: [productEntryWithIcon("gem-pack")],
 			universe: undefined,
 			warnings: [],
-		};
+		} satisfies EnvironmentFoldResult;
 
 		const state = buildState({
 			environment: "production",

--- a/packages/bedrock/src/core/migrate/build-state.ts
+++ b/packages/bedrock/src/core/migrate/build-state.ts
@@ -10,6 +10,7 @@ import type { BedrockState } from "../state.ts";
 import type { EnvironmentFoldResult } from "./fold-environment.ts";
 import type { PassFoldEntry } from "./fold-passes.ts";
 import type { PlaceFoldEntry } from "./fold-places.ts";
+import type { ProductFoldEntry } from "./fold-products.ts";
 
 /**
  * Inputs to {@link buildState}. Bundled into one object because the
@@ -27,7 +28,14 @@ interface BuildStateInputs {
 	 * shell. Keys absent from the map fall back to `mantleIconFileHashes`
 	 * from the matching fold entry.
 	 */
-	readonly iconHashesByKey: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>;
+	readonly passIconHashesByKey: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>;
+	/**
+	 * Per-product-key locale-keyed icon hashes recomputed from disk by the
+	 * shell. Keys absent from the map fall back to `mantleIconFileHashes`
+	 * from the matching fold entry; products without any icon partner emit
+	 * resources without `iconFileHashes`.
+	 */
+	readonly productIconHashesByKey: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>;
 }
 
 /**
@@ -37,19 +45,22 @@ interface BuildStateInputs {
  * The resulting state carries one `kind: "universe"` resource (when an
  * experience folded), followed by one `kind: "place"` resource per
  * matched place pair, then one `kind: "gamePass"` resource per folded
- * pass entry, in declaration order. Each resource's declared fields
- * mirror its fold output; pass resources receive their `iconFileHashes`
- * from `iconHashesByKey` (computed by the shell from the icon file's
- * bytes) and fall back to the Mantle-recorded hashes when the map omits
- * the key. The `outputs` field carries the Mantle-recorded identifiers
- * (universe `rootPlaceId`, place `versionNumber`, pass `assetId` and
- * `iconAssetIds`).
+ * pass entry, then one `kind: "developerProduct"` resource per folded
+ * product entry, in declaration order. Each resource's declared fields
+ * mirror its fold output; pass and product resources receive their
+ * `iconFileHashes` from the matching `*IconHashesByKey` map (computed by
+ * the shell from the icon file's bytes) and fall back to the
+ * Mantle-recorded hashes when the map omits the key. Product resources
+ * without an icon partner omit `icon` and `iconFileHashes` entirely. The
+ * `outputs` field carries the Mantle-recorded identifiers (universe
+ * `rootPlaceId`, place `versionNumber`, pass `assetId` and
+ * `iconAssetIds`, product `productId` and optional `iconImageAssetId`).
  *
  * @param inputs - Folded data plus recomputed hashes for this environment.
  * @returns A `BedrockState` populated with one resource per folded kind.
  */
 export function buildState(inputs: BuildStateInputs): BedrockState {
-	const { environment, folded, iconHashesByKey } = inputs;
+	const { environment, folded, passIconHashesByKey, productIconHashesByKey } = inputs;
 	const universeResources: ReadonlyArray<ResourceCurrentState> =
 		folded.universe === undefined
 			? []
@@ -60,12 +71,19 @@ export function buildState(inputs: BuildStateInputs): BedrockState {
 	);
 
 	const passResources: ReadonlyArray<ResourceCurrentState> = folded.passes.map((entry) => {
-		return passResource(entry, iconHashesByKey.get(entry.key) ?? entry.mantleIconFileHashes);
+		return passResource(
+			entry,
+			passIconHashesByKey.get(entry.key) ?? entry.mantleIconFileHashes,
+		);
+	});
+
+	const productResources: ReadonlyArray<ResourceCurrentState> = folded.products.map((entry) => {
+		return productResource(entry, productIconHashesByKey);
 	});
 
 	return {
 		environment,
-		resources: [...universeResources, ...placeResources, ...passResources],
+		resources: [...universeResources, ...placeResources, ...passResources, ...productResources],
 		version: 1,
 	};
 }
@@ -116,5 +134,31 @@ function passResource(
 		kind: "gamePass",
 		outputs: fold.outputs,
 		price: fold.entry.price,
+	};
+}
+
+function productResource(
+	fold: ProductFoldEntry,
+	productIconHashesByKey: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>,
+): ResourceCurrentState<"developerProduct"> {
+	const base: ResourceCurrentState<"developerProduct"> = {
+		key: fold.key,
+		name: fold.entry.name,
+		description: fold.entry.description,
+		isRegionalPricingEnabled: undefined,
+		kind: "developerProduct",
+		outputs: fold.outputs,
+		price: fold.entry.price,
+		storePageEnabled: undefined,
+	};
+
+	if (fold.entry.icon === undefined || fold.mantleIconFileHashes === undefined) {
+		return base;
+	}
+
+	return {
+		...base,
+		icon: fold.entry.icon,
+		iconFileHashes: productIconHashesByKey.get(fold.key) ?? fold.mantleIconFileHashes,
 	};
 }

--- a/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
@@ -5,6 +5,7 @@ import { factorizeEnvironments } from "./factorize-environments.ts";
 import type { EnvironmentFoldResult } from "./fold-environment.ts";
 import type { PassFoldEntry } from "./fold-passes.ts";
 import type { PlaceFoldEntry } from "./fold-places.ts";
+import type { ProductFoldEntry } from "./fold-products.ts";
 
 const SAMPLE_HASH = asSha256Hex("86890ed405cabad0fcdabf52225d528981790fa551e915c070348761c28373c1");
 const VALID_HASH = asSha256Hex("908498abb7f4fca2b7d2b050bfe7c48c009202fabd85f489b03bb19ac6e0b1d9");
@@ -40,6 +41,27 @@ function passFold(key: string, overrides: Partial<PassFoldEntry> = {}): PassFold
 
 function passWithEntry(key: string, entry: PassFoldEntry["entry"]): PassFoldEntry {
 	return passFold(key, { entry });
+}
+
+function productFold(key: string, overrides: Partial<ProductFoldEntry> = {}): ProductFoldEntry {
+	return {
+		key: asResourceKey(key),
+		entry: {
+			name: "Example Product",
+			description: "This is an example product.",
+			price: 100,
+		},
+		mantlePath: `product_${key}`,
+		outputs: {
+			iconImageAssetId: undefined,
+			productId: asRobloxAssetId("987654321"),
+		},
+		...overrides,
+	};
+}
+
+function productWithEntry(key: string, entry: ProductFoldEntry["entry"]): ProductFoldEntry {
+	return productFold(key, { entry });
 }
 
 function fold(overrides: Partial<EnvironmentFoldResult> = {}): EnvironmentFoldResult {
@@ -1043,5 +1065,337 @@ describe(factorizeEnvironments, () => {
 		assert(result.success);
 
 		expect(result.data.warnings).toStrictEqual([]);
+	});
+
+	it("should expose folded products on the root config when only one environment exists", () => {
+		expect.assertions(2);
+
+		const folds = new Map([["production", fold({ products: [productFold("starter-pack")] })]]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: undefined });
+
+		assert(result.success);
+
+		expect(result.data.config.products).toBeDefined();
+		expect(result.data.config.products?.["starter-pack"]?.name).toBe("Example Product");
+	});
+
+	it("should hoist a product identical across all environments to the root only", () => {
+		expect.assertions(2);
+
+		const primaryEntry = {
+			name: "Example Product",
+			description: "This is an example product.",
+			price: 100,
+		};
+		const folds = new Map([
+			["development", fold({ products: [productWithEntry("starter-pack", primaryEntry)] })],
+			["production", fold({ products: [productWithEntry("starter-pack", primaryEntry)] })],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.products?.["starter-pack"]).toStrictEqual(primaryEntry);
+		expect(result.data.config.environments["development"]?.products).toBeUndefined();
+	});
+
+	it("should emit a per-environment overlay carrying only the diverging fields", () => {
+		expect.assertions(1);
+
+		const primaryEntry = {
+			name: "Example Product",
+			description: "This is an example product.",
+			price: 100,
+		};
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					products: [productWithEntry("starter-pack", { ...primaryEntry, price: 50 })],
+				}),
+			],
+			["production", fold({ products: [productWithEntry("starter-pack", primaryEntry)] })],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.environments["development"]?.products).toStrictEqual({
+			"starter-pack": { price: 50 },
+		});
+	});
+
+	it("should diff icon paths via icon[en-us] when the primary product has an icon", () => {
+		expect.assertions(1);
+
+		const primaryEntry = {
+			name: "Example Product",
+			description: "This is an example product.",
+			icon: { "en-us": "assets/marketing/product-icon.png" },
+			price: 100,
+		};
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					products: [
+						productWithEntry("starter-pack", {
+							...primaryEntry,
+							icon: { "en-us": "assets/dev-product-icon.png" },
+						}),
+					],
+				}),
+			],
+			["production", fold({ products: [productWithEntry("starter-pack", primaryEntry)] })],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.environments["development"]?.products).toStrictEqual({
+			"starter-pack": { icon: { "en-us": "assets/dev-product-icon.png" } },
+		});
+	});
+
+	it("should treat a primary without an icon and an overlay with an icon as a divergence", () => {
+		expect.assertions(1);
+
+		const primaryEntry = {
+			name: "Example Product",
+			description: "This is an example product.",
+			price: 100,
+		};
+		const overlayEntry = {
+			...primaryEntry,
+			icon: { "en-us": "assets/dev-product-icon.png" },
+		};
+		const folds = new Map([
+			["development", fold({ products: [productWithEntry("starter-pack", overlayEntry)] })],
+			["production", fold({ products: [productWithEntry("starter-pack", primaryEntry)] })],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.environments["development"]?.products).toStrictEqual({
+			"starter-pack": { icon: { "en-us": "assets/dev-product-icon.png" } },
+		});
+	});
+
+	it("should emit a `factorize-environments/resource-missing-from-env` warning when a product is missing in a non-primary environment", () => {
+		expect.assertions(1);
+
+		const folds = new Map([
+			["development", fold()],
+			["production", fold({ products: [productFold("starter-pack")] })],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.warnings).toContainEqual({
+			bedrockPath: "environments.development.products.starter-pack",
+			kind: "interpretive",
+			mantlePath: "development.product_starter-pack",
+			rule: "factorize-environments/resource-missing-from-env",
+		});
+	});
+
+	it("should emit the same warning when a product is present only in a non-primary environment", () => {
+		expect.assertions(1);
+
+		const folds = new Map([
+			["development", fold({ products: [productFold("dev-only")] })],
+			["production", fold()],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.warnings).toContainEqual({
+			bedrockPath: "environments.development.products.dev-only",
+			kind: "interpretive",
+			mantlePath: "development.product_dev-only",
+			rule: "factorize-environments/resource-missing-from-env",
+		});
+	});
+
+	it("should pass through unchanged products without emitting an empty overlay", () => {
+		expect.assertions(1);
+
+		const primaryEntry = {
+			name: "Example Product",
+			description: "This is an example product.",
+			price: 100,
+		};
+		const folds = new Map([
+			["development", fold({ products: [productWithEntry("starter-pack", primaryEntry)] })],
+			["production", fold({ products: [productWithEntry("starter-pack", primaryEntry)] })],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.environments["development"]?.products).toBeUndefined();
+	});
+
+	it("should override only the divergent product name on a non-primary overlay", () => {
+		expect.assertions(1);
+
+		const primaryEntry = {
+			name: "Example Product",
+			description: "This is an example product.",
+			price: 100,
+		};
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					products: [
+						productWithEntry("starter-pack", { ...primaryEntry, name: "Dev Pack" }),
+					],
+				}),
+			],
+			["production", fold({ products: [productWithEntry("starter-pack", primaryEntry)] })],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.environments["development"]?.products).toStrictEqual({
+			"starter-pack": { name: "Dev Pack" },
+		});
+	});
+
+	it("should override only the divergent product description on a non-primary overlay", () => {
+		expect.assertions(1);
+
+		const primaryEntry = {
+			name: "Example Product",
+			description: "This is an example product.",
+			price: 100,
+		};
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					products: [
+						productWithEntry("starter-pack", {
+							...primaryEntry,
+							description: "Dev only.",
+						}),
+					],
+				}),
+			],
+			["production", fold({ products: [productWithEntry("starter-pack", primaryEntry)] })],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.environments["development"]?.products).toStrictEqual({
+			"starter-pack": { description: "Dev only." },
+		});
+	});
+
+	it("should override only the divergent isRegionalPricingEnabled on a non-primary overlay", () => {
+		expect.assertions(1);
+
+		const primaryEntry = {
+			name: "Example Product",
+			description: "This is an example product.",
+			isRegionalPricingEnabled: false,
+			price: 100,
+		};
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					products: [
+						productWithEntry("starter-pack", {
+							...primaryEntry,
+							isRegionalPricingEnabled: true,
+						}),
+					],
+				}),
+			],
+			["production", fold({ products: [productWithEntry("starter-pack", primaryEntry)] })],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.environments["development"]?.products).toStrictEqual({
+			"starter-pack": { isRegionalPricingEnabled: true },
+		});
+	});
+
+	it("should override only the divergent storePageEnabled on a non-primary overlay", () => {
+		expect.assertions(1);
+
+		const primaryEntry = {
+			name: "Example Product",
+			description: "This is an example product.",
+			price: 100,
+			storePageEnabled: false,
+		};
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					products: [
+						productWithEntry("starter-pack", {
+							...primaryEntry,
+							storePageEnabled: true,
+						}),
+					],
+				}),
+			],
+			["production", fold({ products: [productWithEntry("starter-pack", primaryEntry)] })],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.environments["development"]?.products).toStrictEqual({
+			"starter-pack": { storePageEnabled: true },
+		});
+	});
+
+	it("should carry the full product entry on a non-primary overlay when the primary lacks the key", () => {
+		expect.assertions(1);
+
+		const developmentOnlyEntry = {
+			name: "Dev Only Product",
+			description: "Only available in development.",
+			price: 25,
+		};
+		const folds = new Map([
+			[
+				"development",
+				fold({ products: [productWithEntry("dev-only", developmentOnlyEntry)] }),
+			],
+			["production", fold({ products: [] })],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.environments["development"]?.products).toStrictEqual({
+			"dev-only": developmentOnlyEntry,
+		});
 	});
 });

--- a/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
@@ -46,6 +46,7 @@ function fold(overrides: Partial<EnvironmentFoldResult> = {}): EnvironmentFoldRe
 	return {
 		passes: [],
 		places: new Map(),
+		products: [],
 		universe: undefined,
 		warnings: [],
 		...overrides,

--- a/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
@@ -1398,4 +1398,203 @@ describe(factorizeEnvironments, () => {
 			"dev-only": developmentOnlyEntry,
 		});
 	});
+
+	it("should keep a divergent optional field off root so non-primary envs that omit it stay omitted after merge", () => {
+		expect.assertions(2);
+
+		const primaryEntry = {
+			name: "Example Product",
+			description: "This is an example product.",
+			price: 100,
+		};
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					products: [
+						productWithEntry("starter-pack", {
+							name: "Example Product",
+							description: "This is an example product.",
+						}),
+					],
+				}),
+			],
+			["production", fold({ products: [productWithEntry("starter-pack", primaryEntry)] })],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.products?.["starter-pack"]).toStrictEqual({
+			name: "Example Product",
+			description: "This is an example product.",
+		});
+		expect(result.data.config.environments["production"]?.products).toStrictEqual({
+			"starter-pack": { price: 100 },
+		});
+	});
+
+	it("should hoist a product icon to root when every environment shares the same icon path", () => {
+		expect.assertions(2);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					products: [
+						productWithEntry("starter-pack", {
+							name: "Example Product",
+							description: "This is an example product.",
+							icon: { "en-us": "assets/marketing/product-icon.png" },
+							price: 100,
+						}),
+					],
+				}),
+			],
+			[
+				"production",
+				fold({
+					products: [
+						productWithEntry("starter-pack", {
+							name: "Example Product",
+							description: "This is an example product.",
+							icon: { "en-us": "assets/marketing/product-icon.png" },
+							price: 100,
+						}),
+					],
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.products?.["starter-pack"]?.icon).toStrictEqual({
+			"en-us": "assets/marketing/product-icon.png",
+		});
+		expect(result.data.config.environments["development"]?.products).toBeUndefined();
+	});
+
+	it("should hoist a shared isRegionalPricingEnabled flag to root when every environment agrees", () => {
+		expect.assertions(2);
+
+		const sharedEntry = {
+			name: "Example Product",
+			description: "This is an example product.",
+			isRegionalPricingEnabled: true,
+			price: 100,
+		};
+		const folds = new Map([
+			["development", fold({ products: [productWithEntry("starter-pack", sharedEntry)] })],
+			["production", fold({ products: [productWithEntry("starter-pack", sharedEntry)] })],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.products?.["starter-pack"]?.isRegionalPricingEnabled).toBeTrue();
+		expect(result.data.config.environments["development"]?.products).toBeUndefined();
+	});
+
+	it("should hoist a shared storePageEnabled flag to root when every environment agrees", () => {
+		expect.assertions(2);
+
+		const sharedEntry = {
+			name: "Example Product",
+			description: "This is an example product.",
+			price: 100,
+			storePageEnabled: false,
+		};
+		const folds = new Map([
+			["development", fold({ products: [productWithEntry("starter-pack", sharedEntry)] })],
+			["production", fold({ products: [productWithEntry("starter-pack", sharedEntry)] })],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.products?.["starter-pack"]?.storePageEnabled).toBeFalse();
+		expect(result.data.config.environments["development"]?.products).toBeUndefined();
+	});
+
+	it("should compute consensus per product key when an environment has multiple products", () => {
+		expect.assertions(2);
+
+		const alphaEntry = {
+			name: "Alpha Pack",
+			description: "Alpha description.",
+			price: 10,
+		};
+		const betaEntry = {
+			name: "Beta Pack",
+			description: "Beta description.",
+			price: 200,
+		};
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					products: [
+						productWithEntry("alpha", alphaEntry),
+						productWithEntry("beta", betaEntry),
+					],
+				}),
+			],
+			[
+				"production",
+				fold({
+					products: [
+						productWithEntry("alpha", alphaEntry),
+						productWithEntry("beta", betaEntry),
+					],
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.products?.["alpha"]?.price).toBe(10);
+		expect(result.data.config.products?.["beta"]?.price).toBe(200);
+	});
+
+	it("should keep a divergent icon off root so a non-primary env without one does not inherit it", () => {
+		expect.assertions(2);
+
+		const primaryEntry = {
+			name: "Example Product",
+			description: "This is an example product.",
+			icon: { "en-us": "assets/marketing/product-icon.png" },
+			price: 100,
+		};
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					products: [
+						productWithEntry("starter-pack", {
+							name: "Example Product",
+							description: "This is an example product.",
+							price: 100,
+						}),
+					],
+				}),
+			],
+			["production", fold({ products: [productWithEntry("starter-pack", primaryEntry)] })],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.products?.["starter-pack"]?.icon).toBeUndefined();
+		expect(result.data.config.environments["production"]?.products).toStrictEqual({
+			"starter-pack": { icon: { "en-us": "assets/marketing/product-icon.png" } },
+		});
+	});
 });

--- a/packages/bedrock/src/core/migrate/factorize-environments.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.ts
@@ -2,6 +2,7 @@ import type { Result } from "@bedrock/ocale";
 
 import type { Config, EnvironmentEntry, GamePassEntry, PlaceEntry } from "../schema.ts";
 import { buildPlacesOverlay, buildRootPlaces } from "./factorize-places.ts";
+import { buildProductsOverlay, buildRootProducts } from "./factorize-products.ts";
 import type { EnvironmentFoldResult } from "./fold-environment.ts";
 import type { MigrateError, MigrationWarning } from "./migration-report.ts";
 
@@ -162,6 +163,7 @@ function buildEnvironmentEntry(
 ): EnvironmentEntry {
 	const passes = buildPassesOverlay(fold, context.primary);
 	const places = buildPlacesOverlay(fold, context.rootPlaces);
+	const products = buildProductsOverlay(fold, context.primary);
 	const universe = buildUniverseOverlay(fold, context.primary);
 
 	const entry: EnvironmentEntry = {};
@@ -171,6 +173,10 @@ function buildEnvironmentEntry(
 
 	if (places !== undefined) {
 		entry.places = places;
+	}
+
+	if (products !== undefined) {
+		entry.products = products;
 	}
 
 	if (universe !== undefined) {
@@ -202,6 +208,7 @@ function buildConfig(
 		rootPlaces: places,
 	});
 	const passes = buildRootPasses(primaryFold);
+	const products = buildRootProducts(primaryFold);
 	const universe = primaryFold.universe?.entry;
 
 	const config: Config = { environments };
@@ -211,6 +218,10 @@ function buildConfig(
 
 	if (places !== undefined) {
 		config.places = places;
+	}
+
+	if (products !== undefined) {
+		config.products = products;
 	}
 
 	if (universe !== undefined) {
@@ -237,6 +248,12 @@ interface MissingResourcePaths {
 interface MissingResourceInputs {
 	readonly folds: ReadonlyMap<string, EnvironmentFoldResult>;
 	readonly primary: ResolvedPrimary;
+}
+
+interface KeyedAsymmetrySpec {
+	readonly bedrockPrefix: string;
+	readonly mantlePrefix: string;
+	readonly readKeys: (fold: EnvironmentFoldResult) => ReadonlyArray<string>;
 }
 
 function missingResourceWarning(paths: MissingResourcePaths): MigrationWarning {
@@ -275,29 +292,37 @@ function asymmetricKeys(
 	return [...onlyInEnvironment, ...onlyInPrimary];
 }
 
-function placeAsymmetryWarnings(context: AsymmetryContext): ReadonlyArray<MigrationWarning> {
-	return asymmetricKeys([...context.fold.places.keys()], [...context.primary.places.keys()]).map(
+const KEYED_ASYMMETRY_SPECS: ReadonlyArray<KeyedAsymmetrySpec> = [
+	{
+		bedrockPrefix: "places",
+		mantlePrefix: "place_",
+		readKeys: (fold) => [...fold.places.keys()],
+	},
+	{
+		bedrockPrefix: "passes",
+		mantlePrefix: "pass_",
+		readKeys: (fold) => fold.passes.map(({ key }) => key),
+	},
+	{
+		bedrockPrefix: "products",
+		mantlePrefix: "product_",
+		readKeys: (fold) => fold.products.map(({ key }) => key),
+	},
+];
+
+function keyedAsymmetryWarnings(
+	context: AsymmetryContext,
+	spec: KeyedAsymmetrySpec,
+): ReadonlyArray<MigrationWarning> {
+	return asymmetricKeys(spec.readKeys(context.fold), spec.readKeys(context.primary)).map(
 		(key) => {
 			return missingResourceWarning({
-				bedrockSegment: `places.${key}`,
+				bedrockSegment: `${spec.bedrockPrefix}.${key}`,
 				environmentName: context.environmentName,
-				mantleSegment: `place_${key}`,
+				mantleSegment: `${spec.mantlePrefix}${key}`,
 			});
 		},
 	);
-}
-
-function passAsymmetryWarnings(context: AsymmetryContext): ReadonlyArray<MigrationWarning> {
-	return asymmetricKeys(
-		context.fold.passes.map(({ key }) => key),
-		context.primary.passes.map(({ key }) => key),
-	).map((key) => {
-		return missingResourceWarning({
-			bedrockSegment: `passes.${key}`,
-			environmentName: context.environmentName,
-			mantleSegment: `pass_${key}`,
-		});
-	});
 }
 
 function collectMissingResourceWarnings(
@@ -308,8 +333,7 @@ function collectMissingResourceWarnings(
 		const context: AsymmetryContext = { environmentName: name, fold, primary: primaryFold };
 		return [
 			...universeAsymmetryWarnings(context),
-			...placeAsymmetryWarnings(context),
-			...passAsymmetryWarnings(context),
+			...KEYED_ASYMMETRY_SPECS.flatMap((spec) => keyedAsymmetryWarnings(context, spec)),
 		];
 	});
 }

--- a/packages/bedrock/src/core/migrate/factorize-environments.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.ts
@@ -1,6 +1,12 @@
 import type { Result } from "@bedrock/ocale";
 
-import type { Config, EnvironmentEntry, GamePassEntry, PlaceEntry } from "../schema.ts";
+import type {
+	Config,
+	DeveloperProductEntry,
+	EnvironmentEntry,
+	GamePassEntry,
+	PlaceEntry,
+} from "../schema.ts";
 import { buildPlacesOverlay, buildRootPlaces } from "./factorize-places.ts";
 import { buildProductsOverlay, buildRootProducts } from "./factorize-products.ts";
 import type { EnvironmentFoldResult } from "./fold-environment.ts";
@@ -28,6 +34,7 @@ interface ResolvedPrimary {
 interface OverlayContext {
 	readonly primary: EnvironmentFoldResult | undefined;
 	readonly rootPlaces: Record<string, PlaceEntry> | undefined;
+	readonly rootProducts: Record<string, DeveloperProductEntry> | undefined;
 }
 
 /**
@@ -163,7 +170,7 @@ function buildEnvironmentEntry(
 ): EnvironmentEntry {
 	const passes = buildPassesOverlay(fold, context.primary);
 	const places = buildPlacesOverlay(fold, context.rootPlaces);
-	const products = buildProductsOverlay(fold, context.primary);
+	const products = buildProductsOverlay(fold, context.rootProducts);
 	const universe = buildUniverseOverlay(fold, context.primary);
 
 	const entry: EnvironmentEntry = {};
@@ -203,12 +210,13 @@ function buildConfig(
 	primaryFold: EnvironmentFoldResult,
 ): Config {
 	const places = buildRootPlaces(folds, primaryFold);
+	const products = buildRootProducts(folds, primaryFold);
 	const environments = buildEnvironmentEntries(folds, {
 		primary: primaryFold,
 		rootPlaces: places,
+		rootProducts: products,
 	});
 	const passes = buildRootPasses(primaryFold);
-	const products = buildRootProducts(primaryFold);
 	const universe = primaryFold.universe?.entry;
 
 	const config: Config = { environments };

--- a/packages/bedrock/src/core/migrate/factorize-products.ts
+++ b/packages/bedrock/src/core/migrate/factorize-products.ts
@@ -1,55 +1,77 @@
 import type { DeveloperProductEntry, EnvironmentEntry } from "../schema.ts";
 import type { EnvironmentFoldResult } from "./fold-environment.ts";
+import type { ProductFoldEntry } from "./fold-products.ts";
 
 type ProductOverlayEntry = NonNullable<EnvironmentEntry["products"]>[string];
 
+type OptionalProductField = "icon" | "isRegionalPricingEnabled" | "price" | "storePageEnabled";
+
+interface ConsensusInputs<F extends OptionalProductField> {
+	readonly field: F;
+	readonly folds: ReadonlyArray<EnvironmentFoldResult>;
+	readonly productKey: string;
+}
+
+interface FieldEqualInputs {
+	readonly field: OptionalProductField;
+	readonly left: DeveloperProductEntry[OptionalProductField];
+	readonly right: DeveloperProductEntry[OptionalProductField];
+}
+
 /**
- * Project the primary environment's folded products onto the bedrock root
- * `Config.products` block. Returns `undefined` when the primary has no
- * products so the caller omits the field entirely.
+ * Project the per-environment product folds into bedrock's root `products`
+ * block, giving each optional field (`icon`, `price`, `isRegionalPricingEnabled`,
+ * `storePageEnabled`) a value only when every environment that owns the
+ * product key agrees. Required fields (`name`, `description`) fall back to
+ * the primary's values; divergence on those surfaces in each environment's
+ * overlay. Optional fields that diverge stay off root so an environment that
+ * omits an optional field does not silently inherit the primary's value
+ * through defu's "undefined treated as empty" merge.
  *
- * @param primaryFold - The chosen primary environment's fold result.
- * @returns A keyed record of root product entries, or `undefined` when none
- *   are present.
+ * @param folds - Per-environment fold results, keyed by environment name.
+ * @param primaryFold - The chosen primary environment's fold; supplies the
+ *   product key list and the `name` / `description` fallbacks.
+ * @returns The root `products` block, or `undefined` when the primary has
+ *   no product folds.
  */
 export function buildRootProducts(
+	folds: ReadonlyMap<string, EnvironmentFoldResult>,
 	primaryFold: EnvironmentFoldResult,
 ): Record<string, DeveloperProductEntry> | undefined {
 	if (primaryFold.products.length === 0) {
 		return undefined;
 	}
 
-	return Object.fromEntries(primaryFold.products.map(({ key, entry }) => [key, entry]));
+	const folded = [...folds.values()];
+	return Object.fromEntries(
+		primaryFold.products.map(({ key, entry }) => [
+			key,
+			buildRootProductEntry(entry, { folds: folded, productKey: key }),
+		]),
+	);
 }
 
 /**
- * Build the per-environment products overlay for one environment by diffing
- * each product against the matching primary product. Returns `undefined` when
- * no product diverges, so the caller omits the overlay.
+ * Build the per-environment overlay for `products`, carrying each field only
+ * when the environment's value diverges from the resolved root entry. Fields
+ * the environment omits are absent from the overlay so the consumer's defu
+ * merge resolves them to the root's (also absent) value rather than
+ * inheriting a primary value the environment never had.
  *
- * Products absent from the primary carry the full entry on the overlay.
- *
- * @param fold - The non-primary environment's fold result.
- * @param primary - The primary environment's fold result, or `undefined` when
- *   the caller is rendering the primary itself.
- * @returns A keyed record of divergent product fields, or `undefined` when no
- *   product diverges from the primary.
+ * @param fold - The per-environment fold whose products are being overlaid.
+ * @param rootProducts - The already-built root `products` block; per-product
+ *   field values from this map suppress overlay entries that match.
+ * @returns The overlay `products` block, or `undefined` when no product
+ *   diverges from the root.
  */
 export function buildProductsOverlay(
 	fold: EnvironmentFoldResult,
-	primary: EnvironmentFoldResult | undefined,
+	rootProducts: Record<string, DeveloperProductEntry> | undefined,
 ): Record<string, ProductOverlayEntry> | undefined {
-	const primaryByKey = new Map<string, DeveloperProductEntry>(
-		primary?.products.map(({ key, entry }) => [key, entry]),
-	);
 	const overlay: Record<string, ProductOverlayEntry> = {};
 	for (const { key, entry } of fold.products) {
-		const primaryEntry = primaryByKey.get(key);
-		const productOverlay =
-			primaryEntry === undefined
-				? { ...entry }
-				: buildProductOverlayEntry(entry, primaryEntry);
-		if (productOverlay !== undefined) {
+		const productOverlay = buildProductOverlayEntry(entry, rootProducts?.[key]);
+		if (Object.keys(productOverlay).length > 0) {
 			overlay[key] = productOverlay;
 		}
 	}
@@ -57,34 +79,85 @@ export function buildProductsOverlay(
 	return Object.keys(overlay).length === 0 ? undefined : overlay;
 }
 
+function entryForKey(
+	fold: EnvironmentFoldResult,
+	productKey: string,
+): DeveloperProductEntry | undefined {
+	return fold.products.find(({ key }) => key === productKey)?.entry;
+}
+
+function asIcon(
+	value: DeveloperProductEntry[OptionalProductField],
+): Record<"en-us", string> | undefined {
+	return typeof value === "object" ? value : undefined;
+}
+
+function optionalFieldEqual(inputs: FieldEqualInputs): boolean {
+	if (inputs.field === "icon") {
+		return Object.is(asIcon(inputs.left)?.["en-us"], asIcon(inputs.right)?.["en-us"]);
+	}
+
+	return Object.is(inputs.left, inputs.right);
+}
+
+function productOptionalFieldConsensus<F extends OptionalProductField>(
+	inputs: ConsensusInputs<F>,
+): DeveloperProductEntry[F] | undefined {
+	const values = inputs.folds.flatMap((fold): ReadonlyArray<DeveloperProductEntry[F]> => {
+		const entry = entryForKey(fold, inputs.productKey);
+		return entry === undefined ? [] : [entry[inputs.field]];
+	});
+
+	const [first] = values;
+	return values.every((value) => {
+		return optionalFieldEqual({ field: inputs.field, left: first, right: value });
+	})
+		? first
+		: undefined;
+}
+
+function buildRootProductEntry(
+	primaryEntry: ProductFoldEntry["entry"],
+	consensusBase: {
+		readonly folds: ReadonlyArray<EnvironmentFoldResult>;
+		readonly productKey: string;
+	},
+): DeveloperProductEntry {
+	const icon = productOptionalFieldConsensus({ ...consensusBase, field: "icon" });
+	const isRegionalPricingEnabled = productOptionalFieldConsensus({
+		...consensusBase,
+		field: "isRegionalPricingEnabled",
+	});
+	const price = productOptionalFieldConsensus({ ...consensusBase, field: "price" });
+	const isStorePageEnabled = productOptionalFieldConsensus({
+		...consensusBase,
+		field: "storePageEnabled",
+	});
+
+	return {
+		name: primaryEntry.name,
+		description: primaryEntry.description,
+		...(icon !== undefined && { icon }),
+		...(isRegionalPricingEnabled !== undefined && { isRegionalPricingEnabled }),
+		...(price !== undefined && { price }),
+		...(isStorePageEnabled !== undefined && { storePageEnabled: isStorePageEnabled }),
+	};
+}
+
 function buildProductOverlayEntry(
-	entry: DeveloperProductEntry,
-	primary: DeveloperProductEntry,
-): ProductOverlayEntry | undefined {
-	const overlay: ProductOverlayEntry = {};
-	if (!Object.is(primary.name, entry.name)) {
-		overlay.name = entry.name;
-	}
-
-	if (!Object.is(primary.description, entry.description)) {
-		overlay.description = entry.description;
-	}
-
-	if (!Object.is(primary.icon?.["en-us"], entry.icon?.["en-us"]) && entry.icon !== undefined) {
-		overlay.icon = entry.icon;
-	}
-
-	if (!Object.is(primary.price, entry.price)) {
-		overlay.price = entry.price;
-	}
-
-	if (!Object.is(primary.isRegionalPricingEnabled, entry.isRegionalPricingEnabled)) {
-		overlay.isRegionalPricingEnabled = entry.isRegionalPricingEnabled;
-	}
-
-	if (!Object.is(primary.storePageEnabled, entry.storePageEnabled)) {
-		overlay.storePageEnabled = entry.storePageEnabled;
-	}
-
-	return Object.keys(overlay).length === 0 ? undefined : overlay;
+	entry: ProductFoldEntry["entry"],
+	rootEntry: DeveloperProductEntry | undefined,
+): ProductOverlayEntry {
+	return {
+		...(entry.name !== rootEntry?.name && { name: entry.name }),
+		...(entry.description !== rootEntry?.description && { description: entry.description }),
+		...(!Object.is(rootEntry?.icon?.["en-us"], entry.icon?.["en-us"]) && { icon: entry.icon }),
+		...(!Object.is(rootEntry?.price, entry.price) && { price: entry.price }),
+		...(!Object.is(rootEntry?.isRegionalPricingEnabled, entry.isRegionalPricingEnabled) && {
+			isRegionalPricingEnabled: entry.isRegionalPricingEnabled,
+		}),
+		...(!Object.is(rootEntry?.storePageEnabled, entry.storePageEnabled) && {
+			storePageEnabled: entry.storePageEnabled,
+		}),
+	};
 }

--- a/packages/bedrock/src/core/migrate/factorize-products.ts
+++ b/packages/bedrock/src/core/migrate/factorize-products.ts
@@ -1,0 +1,90 @@
+import type { DeveloperProductEntry, EnvironmentEntry } from "../schema.ts";
+import type { EnvironmentFoldResult } from "./fold-environment.ts";
+
+type ProductOverlayEntry = NonNullable<EnvironmentEntry["products"]>[string];
+
+/**
+ * Project the primary environment's folded products onto the bedrock root
+ * `Config.products` block. Returns `undefined` when the primary has no
+ * products so the caller omits the field entirely.
+ *
+ * @param primaryFold - The chosen primary environment's fold result.
+ * @returns A keyed record of root product entries, or `undefined` when none
+ *   are present.
+ */
+export function buildRootProducts(
+	primaryFold: EnvironmentFoldResult,
+): Record<string, DeveloperProductEntry> | undefined {
+	if (primaryFold.products.length === 0) {
+		return undefined;
+	}
+
+	return Object.fromEntries(primaryFold.products.map(({ key, entry }) => [key, entry]));
+}
+
+/**
+ * Build the per-environment products overlay for one environment by diffing
+ * each product against the matching primary product. Returns `undefined` when
+ * no product diverges, so the caller omits the overlay.
+ *
+ * Products absent from the primary carry the full entry on the overlay.
+ *
+ * @param fold - The non-primary environment's fold result.
+ * @param primary - The primary environment's fold result, or `undefined` when
+ *   the caller is rendering the primary itself.
+ * @returns A keyed record of divergent product fields, or `undefined` when no
+ *   product diverges from the primary.
+ */
+export function buildProductsOverlay(
+	fold: EnvironmentFoldResult,
+	primary: EnvironmentFoldResult | undefined,
+): Record<string, ProductOverlayEntry> | undefined {
+	const primaryByKey = new Map<string, DeveloperProductEntry>(
+		primary?.products.map(({ key, entry }) => [key, entry]),
+	);
+	const overlay: Record<string, ProductOverlayEntry> = {};
+	for (const { key, entry } of fold.products) {
+		const primaryEntry = primaryByKey.get(key);
+		const productOverlay =
+			primaryEntry === undefined
+				? { ...entry }
+				: buildProductOverlayEntry(entry, primaryEntry);
+		if (productOverlay !== undefined) {
+			overlay[key] = productOverlay;
+		}
+	}
+
+	return Object.keys(overlay).length === 0 ? undefined : overlay;
+}
+
+function buildProductOverlayEntry(
+	entry: DeveloperProductEntry,
+	primary: DeveloperProductEntry,
+): ProductOverlayEntry | undefined {
+	const overlay: ProductOverlayEntry = {};
+	if (!Object.is(primary.name, entry.name)) {
+		overlay.name = entry.name;
+	}
+
+	if (!Object.is(primary.description, entry.description)) {
+		overlay.description = entry.description;
+	}
+
+	if (!Object.is(primary.icon?.["en-us"], entry.icon?.["en-us"]) && entry.icon !== undefined) {
+		overlay.icon = entry.icon;
+	}
+
+	if (!Object.is(primary.price, entry.price)) {
+		overlay.price = entry.price;
+	}
+
+	if (!Object.is(primary.isRegionalPricingEnabled, entry.isRegionalPricingEnabled)) {
+		overlay.isRegionalPricingEnabled = entry.isRegionalPricingEnabled;
+	}
+
+	if (!Object.is(primary.storePageEnabled, entry.storePageEnabled)) {
+		overlay.storePageEnabled = entry.storePageEnabled;
+	}
+
+	return Object.keys(overlay).length === 0 ? undefined : overlay;
+}

--- a/packages/bedrock/src/core/migrate/fold-environment.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-environment.spec.ts
@@ -54,6 +54,20 @@ function pass(key: string): MantleResource {
 	};
 }
 
+function product(key: string): MantleResource {
+	return {
+		key,
+		dependencies: [],
+		inputs: {
+			name: "Example Product",
+			description: "This is an example product.",
+			price: 5,
+		},
+		kind: "product",
+		outputs: { assetId: 1835296153, productId: 58109926 },
+	};
+}
+
 describe(foldEnvironment, () => {
 	it("should expose the folded universe entry when an experience is present", () => {
 		expect.assertions(1);
@@ -154,7 +168,7 @@ describe(foldEnvironment, () => {
 		const result = foldEnvironment([
 			experience(),
 			mantleResource("badge", "first-win"),
-			mantleResource("product", "starter"),
+			mantleResource("audioAsset", "theme"),
 		]);
 
 		expect(result.warnings).toHaveLength(2);
@@ -162,6 +176,37 @@ describe(foldEnvironment, () => {
 			"deferred",
 			"deferred",
 		]);
+	});
+
+	it("should expose folded products when product resources are present", () => {
+		expect.assertions(2);
+
+		const result = foldEnvironment([experience(), product("1-example")]);
+
+		expect(result.products.map((entry) => entry.key)).toStrictEqual([
+			asResourceKey("1-example"),
+		]);
+		expect(result.products[0]?.entry).toStrictEqual({
+			name: "Example Product",
+			description: "This is an example product.",
+			price: 5,
+		});
+	});
+
+	it("should expose an empty products array when no product resources are present", () => {
+		expect.assertions(1);
+
+		const result = foldEnvironment([experience()]);
+
+		expect(result.products).toStrictEqual([]);
+	});
+
+	it("should not emit a deferred warning for a product resource", () => {
+		expect.assertions(1);
+
+		const result = foldEnvironment([experience(), product("1-example")]);
+
+		expect(result.warnings).toStrictEqual([]);
 	});
 
 	it("should emit deferred warnings with resource-rooted mantlePath", () => {

--- a/packages/bedrock/src/core/migrate/fold-environment.ts
+++ b/packages/bedrock/src/core/migrate/fold-environment.ts
@@ -2,6 +2,7 @@ import type { UniverseOutputs } from "../resources.ts";
 import type { UniverseEntry } from "../schema.ts";
 import { foldPasses, type PassFoldEntry } from "./fold-passes.ts";
 import { foldPlaces, type PlaceFoldEntry } from "./fold-places.ts";
+import { foldProducts, type ProductFoldEntry } from "./fold-products.ts";
 import { foldUniverse } from "./fold-universe.ts";
 import { foldUnsupported } from "./fold-unsupported.ts";
 import type { MigrationWarning } from "./migration-report.ts";
@@ -11,18 +12,20 @@ import type { MantleResource } from "./types.ts";
  * Result of folding one Mantle environment's resource list into bedrock
  * shapes. A Mantle environment without an experience resource yields
  * `universe: undefined`, signalling that the bedrock `Config` for this
- * environment carries no `universe` block. `places` and `passes` are
- * always present (potentially empty) so the orchestrator does not have
- * to special-case "no <kind>" against "<kind> not yet wired"; orphan
- * place resources surface as `ambiguous` warnings, and resources of
- * kinds bedrock plans to support but does not yet model surface as
- * `deferred` warnings.
+ * environment carries no `universe` block. `places`, `passes`, and
+ * `products` are always present (potentially empty) so the orchestrator
+ * does not have to special-case "no <kind>" against "<kind> not yet
+ * wired"; orphan place resources surface as `ambiguous` warnings, and
+ * resources of kinds bedrock plans to support but does not yet model
+ * surface as `deferred` warnings.
  */
 export interface EnvironmentFoldResult {
 	/** Folded pass entries for this environment, in declaration order. */
 	readonly passes: ReadonlyArray<PassFoldEntry>;
 	/** Folded place entries for this environment, keyed by Mantle's place key. */
 	readonly places: ReadonlyMap<string, PlaceFoldEntry>;
+	/** Folded developer-product entries for this environment, in declaration order. */
+	readonly products: ReadonlyArray<ProductFoldEntry>;
 	/** Folded universe data for this environment, or `undefined` when no experience is present. */
 	readonly universe:
 		| undefined
@@ -37,8 +40,8 @@ export interface EnvironmentFoldResult {
 /**
  * Orchestrate the per-kind folds for one Mantle environment, gathering
  * the results and warnings into a single `EnvironmentFoldResult`. Pure;
- * delegates to `foldUniverse`, `foldPlaces`, `foldPasses`, and
- * `foldUnsupported`. Emitted warning paths are resource-rooted.
+ * delegates to `foldUniverse`, `foldPlaces`, `foldPasses`, `foldProducts`,
+ * and `foldUnsupported`. Emitted warning paths are resource-rooted.
  *
  * @param resources - Mantle resource list for one environment.
  * @returns The folded per-kind data plus aggregated warnings.
@@ -52,17 +55,20 @@ export function foldEnvironment(resources: ReadonlyArray<MantleResource>): Envir
 
 	const placesResult = foldPlaces(resources);
 	const passesResult = foldPasses(resources);
+	const productsResult = foldProducts(resources);
 
 	const warnings = [
 		...(universeResult?.warnings ?? []),
 		...placesResult.warnings,
 		...passesResult.warnings,
+		...productsResult.warnings,
 		...foldUnsupported(resources),
 	];
 
 	return {
 		passes: passesResult.passes,
 		places: placesResult.entries,
+		products: productsResult.products,
 		universe,
 		warnings,
 	};

--- a/packages/bedrock/src/core/migrate/fold-products.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-products.spec.ts
@@ -1,8 +1,10 @@
 import { assert, describe, expect, it } from "vitest";
 
-import { asResourceKey } from "../../types/ids.ts";
+import { asResourceKey, asSha256Hex } from "../../types/ids.ts";
 import { foldProducts } from "./fold-products.ts";
 import type { MantleResource } from "./types.ts";
+
+const SAMPLE_HASH = "86890ed405cabad0fcdabf52225d528981790fa551e915c070348761c28373c1";
 
 interface ProductFixture {
 	readonly inputs: unknown;
@@ -19,6 +21,16 @@ function product(key: string, payload: ProductFixture): MantleResource {
 	};
 }
 
+function productIcon(key: string, payload: ProductFixture): MantleResource {
+	return {
+		key,
+		dependencies: [],
+		inputs: payload.inputs,
+		kind: "productIcon",
+		outputs: payload.outputs,
+	};
+}
+
 function onSaleInputs(): Record<string, unknown> {
 	return {
 		name: "Example Product",
@@ -31,10 +43,28 @@ function productOutputs(): Record<string, unknown> {
 	return { assetId: 1835296153, productId: 58109926 };
 }
 
+function productIconInputs(): Record<string, unknown> {
+	return {
+		fileHash: SAMPLE_HASH,
+		filePath: "assets/marketing/example-icon.png",
+	};
+}
+
+function productIconOutputs(): Record<string, unknown> {
+	return { assetId: 18280868488 };
+}
+
 function fixture(inputs?: unknown, outputs?: unknown): ProductFixture {
 	return {
 		inputs: inputs === undefined ? onSaleInputs() : inputs,
 		outputs: outputs === undefined ? productOutputs() : outputs,
+	};
+}
+
+function iconFixture(inputs?: unknown, outputs?: unknown): ProductFixture {
+	return {
+		inputs: inputs === undefined ? productIconInputs() : inputs,
+		outputs: outputs === undefined ? productIconOutputs() : outputs,
 	};
 }
 
@@ -53,7 +83,10 @@ describe(foldProducts, () => {
 			description: "This is an example product.",
 			price: 5,
 		});
-		expect(entry.outputs).toStrictEqual({ productId: "58109926" });
+		expect(entry.outputs).toStrictEqual({
+			iconImageAssetId: undefined,
+			productId: "58109926",
+		});
 	});
 
 	it("should preserve price when set to a positive integer", () => {
@@ -174,5 +207,80 @@ describe(foldProducts, () => {
 		assert(entry !== undefined);
 
 		expect(entry.outputs.productId).toBe("58109926");
+	});
+
+	it("should pair a productIcon resource with its product by key", () => {
+		expect.assertions(3);
+
+		const result = foldProducts([
+			product("1-example", fixture()),
+			productIcon("1-example", iconFixture()),
+		]);
+		const [entry] = result.products;
+		assert(entry !== undefined);
+
+		expect(entry.entry.icon).toStrictEqual({
+			"en-us": "assets/marketing/example-icon.png",
+		});
+		expect(entry.outputs.iconImageAssetId).toBe("18280868488");
+		expect(result.warnings).toStrictEqual([]);
+	});
+
+	it("should preserve the mantle-recorded icon file hash on the fold entry", () => {
+		expect.assertions(1);
+
+		const result = foldProducts([
+			product("1-example", fixture()),
+			productIcon("1-example", iconFixture()),
+		]);
+		const [entry] = result.products;
+		assert(entry !== undefined);
+
+		expect(entry.mantleIconFileHashes).toStrictEqual({ "en-us": asSha256Hex(SAMPLE_HASH) });
+	});
+
+	it("should fold a product without a productIcon as an entry without icon fields", () => {
+		expect.assertions(3);
+
+		const result = foldProducts([product("1-example", fixture())]);
+		const [entry] = result.products;
+		assert(entry !== undefined);
+
+		expect(entry.entry.icon).toBeNil();
+		expect(entry.outputs.iconImageAssetId).toBeNil();
+		expect(entry.mantleIconFileHashes).toBeNil();
+	});
+
+	it("should emit an ambiguous warning for an orphan productIcon resource", () => {
+		expect.assertions(2);
+
+		const result = foldProducts([productIcon("1-example", iconFixture())]);
+
+		expect(result.products).toStrictEqual([]);
+		expect(result.warnings).toStrictEqual([
+			{
+				hint: "Verify your Mantle state file: each productIcon_<k> resource must be paired with a matching product_<k>.",
+				kind: "ambiguous",
+				mantlePath: "productIcon_1-example",
+			},
+		]);
+	});
+
+	it("should drop a productIcon resource with a malformed file hash", () => {
+		expect.assertions(3);
+
+		const malformedInputs = productIconInputs();
+		malformedInputs["fileHash"] = "not-a-real-hash";
+
+		const result = foldProducts([
+			product("1-example", fixture()),
+			productIcon("1-example", iconFixture(malformedInputs)),
+		]);
+		const [entry] = result.products;
+		assert(entry !== undefined);
+
+		expect(entry.entry.icon).toBeNil();
+		expect(entry.outputs.iconImageAssetId).toBeNil();
+		expect(entry.mantleIconFileHashes).toBeNil();
 	});
 });

--- a/packages/bedrock/src/core/migrate/fold-products.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-products.spec.ts
@@ -1,0 +1,178 @@
+import { assert, describe, expect, it } from "vitest";
+
+import { asResourceKey } from "../../types/ids.ts";
+import { foldProducts } from "./fold-products.ts";
+import type { MantleResource } from "./types.ts";
+
+interface ProductFixture {
+	readonly inputs: unknown;
+	readonly outputs: unknown;
+}
+
+function product(key: string, payload: ProductFixture): MantleResource {
+	return {
+		key,
+		dependencies: [],
+		inputs: payload.inputs,
+		kind: "product",
+		outputs: payload.outputs,
+	};
+}
+
+function onSaleInputs(): Record<string, unknown> {
+	return {
+		name: "Example Product",
+		description: "This is an example product.",
+		price: 5,
+	};
+}
+
+function productOutputs(): Record<string, unknown> {
+	return { assetId: 1835296153, productId: 58109926 };
+}
+
+function fixture(inputs?: unknown, outputs?: unknown): ProductFixture {
+	return {
+		inputs: inputs === undefined ? onSaleInputs() : inputs,
+		outputs: outputs === undefined ? productOutputs() : outputs,
+	};
+}
+
+describe(foldProducts, () => {
+	it("should fold a well-formed product resource into one entry", () => {
+		expect.assertions(4);
+
+		const result = foldProducts([product("1-example", fixture())]);
+		const [entry] = result.products;
+		assert(entry !== undefined);
+
+		expect(entry.key).toBe(asResourceKey("1-example"));
+		expect(entry.mantlePath).toBe("product_1-example");
+		expect(entry.entry).toStrictEqual({
+			name: "Example Product",
+			description: "This is an example product.",
+			price: 5,
+		});
+		expect(entry.outputs).toStrictEqual({ productId: "58109926" });
+	});
+
+	it("should preserve price when set to a positive integer", () => {
+		expect.assertions(1);
+
+		const inputs = onSaleInputs();
+		inputs["price"] = 250;
+
+		const result = foldProducts([product("1-example", fixture(inputs))]);
+		const [entry] = result.products;
+		assert(entry !== undefined);
+
+		expect(entry.entry.price).toBe(250);
+	});
+
+	it("should treat null price as off-sale (undefined)", () => {
+		expect.assertions(1);
+
+		const inputs = onSaleInputs();
+		inputs["price"] = undefined;
+
+		const result = foldProducts([product("1-example", fixture(inputs))]);
+		const [entry] = result.products;
+		assert(entry !== undefined);
+
+		expect(entry.entry).toStrictEqual({
+			name: "Example Product",
+			description: "This is an example product.",
+		});
+	});
+
+	it("should treat missing price as off-sale (undefined)", () => {
+		expect.assertions(1);
+
+		const inputs = onSaleInputs();
+		delete inputs["price"];
+
+		const result = foldProducts([product("1-example", fixture(inputs))]);
+		const [entry] = result.products;
+		assert(entry !== undefined);
+
+		expect(entry.entry).toStrictEqual({
+			name: "Example Product",
+			description: "This is an example product.",
+		});
+	});
+
+	it("should ignore non-product resource kinds", () => {
+		expect.assertions(1);
+
+		const result = foldProducts([
+			{
+				key: "1-spurious",
+				dependencies: [],
+				inputs: onSaleInputs(),
+				kind: "pass",
+				outputs: productOutputs(),
+			},
+		]);
+
+		expect(result.products).toStrictEqual([]);
+	});
+
+	it("should drop a product resource missing required string fields", () => {
+		expect.assertions(2);
+
+		const noName = onSaleInputs();
+		delete noName["name"];
+		const noDescription = onSaleInputs();
+		delete noDescription["description"];
+
+		expect(foldProducts([product("1-example", fixture(noName))]).products).toStrictEqual([]);
+		expect(foldProducts([product("1-example", fixture(noDescription))]).products).toStrictEqual(
+			[],
+		);
+	});
+
+	it("should drop a product resource without outputs.productId", () => {
+		expect.assertions(1);
+
+		const result = foldProducts([
+			product("1-example", fixture(undefined, { assetId: 1835296153 })),
+		]);
+
+		expect(result.products).toStrictEqual([]);
+	});
+
+	it("should drop a product whose inputs payload is not an object", () => {
+		expect.assertions(3);
+
+		// eslint-disable-next-line unicorn/no-null -- exercising the null branch of the defensive guard
+		expect(foldProducts([product("1-example", fixture(null))]).products).toStrictEqual([]);
+		expect(foldProducts([product("1-example", fixture([]))]).products).toStrictEqual([]);
+		expect(
+			foldProducts([product("1-example", fixture("not-an-object"))]).products,
+		).toStrictEqual([]);
+	});
+
+	it("should drop a product whose outputs payload is not an object", () => {
+		expect.assertions(1);
+
+		// eslint-disable-next-line unicorn/no-null -- exercising the null branch of the defensive guard
+		const result = foldProducts([product("1-example", fixture(undefined, null))]);
+
+		expect(result.products).toStrictEqual([]);
+	});
+
+	it("should accept a string-formatted productId in the outputs", () => {
+		expect.assertions(1);
+
+		const result = foldProducts([
+			product(
+				"1-example",
+				fixture(undefined, { assetId: "1835296153", productId: "58109926" }),
+			),
+		]);
+		const [entry] = result.products;
+		assert(entry !== undefined);
+
+		expect(entry.outputs.productId).toBe("58109926");
+	});
+});

--- a/packages/bedrock/src/core/migrate/fold-products.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-products.spec.ts
@@ -106,7 +106,10 @@ describe(foldProducts, () => {
 		expect.assertions(1);
 
 		const inputs = onSaleInputs();
-		inputs["price"] = undefined;
+		// Mantle YAML emits `price: ~` for off-sale products, which the parser
+		// surfaces as a literal `null` in the wire payload before this fold runs.
+		// eslint-disable-next-line unicorn/no-null -- exercise the wire-data null path
+		inputs["price"] = null;
 
 		const result = foldProducts([product("1-example", fixture(inputs))]);
 		const [entry] = result.products;

--- a/packages/bedrock/src/core/migrate/fold-products.ts
+++ b/packages/bedrock/src/core/migrate/fold-products.ts
@@ -1,25 +1,31 @@
-import { asResourceKey, asRobloxAssetId } from "../../types/ids.ts";
-import type { ResourceKey } from "../../types/ids.ts";
+import { asResourceKey, asRobloxAssetId, asSha256Hex, isSha256Hex } from "../../types/ids.ts";
+import type { ResourceKey, Sha256Hex } from "../../types/ids.ts";
 import type { DeveloperProductOutputs } from "../resources.ts";
 import type { DeveloperProductEntry } from "../schema.ts";
 import type { MigrationWarning } from "./migration-report.ts";
 import type { MantleResource } from "./types.ts";
 
 const PRODUCT_KIND = "product";
+const PRODUCT_ICON_KIND = "productIcon";
 
 /**
  * Folded representation of one Mantle `product_<k>` resource.
  *
- * `entry` carries the bedrock `Config.products[<k>]` shape (without an icon
- * in this slice; pairing with `productIcon_<k>` lands in a later slice).
- * `outputs` carries the Roblox-assigned identifier for the developer product.
- * `mantlePath` roots warnings at the resource so the report is searchable.
+ * `entry` carries the bedrock `Config.products[<k>]` shape; when a matching
+ * `productIcon_<k>` resource is present it also carries the locale-keyed icon
+ * path. `outputs` carries the Roblox-assigned identifiers for the product and
+ * its optional icon. `mantleIconFileHashes` preserves the hash recorded by
+ * Mantle so the shell can fall back to it when the icon file is missing on
+ * disk; absent when no icon partner is found. `mantlePath` roots warnings at
+ * the resource so the report is searchable.
  */
 export interface ProductFoldEntry {
 	/** User-supplied Mantle key, branded as a bedrock `ResourceKey`. */
 	readonly key: ResourceKey;
 	/** Bedrock `Config.products[<k>]` block populated from the product resource. */
 	readonly entry: DeveloperProductEntry;
+	/** Locale-keyed Mantle-recorded icon hashes; absent when no productIcon partner is paired. */
+	readonly mantleIconFileHashes?: Record<"en-us", Sha256Hex>;
 	/** Resource-rooted Mantle path (`product_<k>`) used to anchor warnings. */
 	readonly mantlePath: string;
 	/** Roblox-assigned identifiers carried into `BedrockState.resources[*].outputs`. */
@@ -27,17 +33,17 @@ export interface ProductFoldEntry {
 }
 
 /**
- * Output of folding the `product_<k>` Mantle resources of one environment
- * into bedrock-shaped developer-product entries.
+ * Output of folding the `product_<k>` and `productIcon_<k>` Mantle resources
+ * of one environment into bedrock-shaped developer-product entries.
  *
  * `products` carries one record per well-formed `product_<k>` resource;
- * malformed resources are dropped silently in this slice. `warnings`
- * accumulates per-rule diagnostics.
+ * malformed resources are dropped silently. `warnings` carries one
+ * `ambiguous` warning per orphan `productIcon_<k>` (no matching product).
  */
 interface ProductsFoldResult {
 	/** One folded entry per well-formed Mantle `product_<k>` resource. */
 	readonly products: ReadonlyArray<ProductFoldEntry>;
-	/** Per-rule diagnostics; empty in this slice. */
+	/** Per-rule diagnostics: orphan productIcon resources surface as `ambiguous` warnings. */
 	readonly warnings: ReadonlyArray<MigrationWarning>;
 }
 
@@ -51,40 +57,80 @@ interface ProductOutputsRaw {
 	readonly productId: string;
 }
 
-/**
- * Fold the `product_<k>` Mantle resources of one environment into a list
- * of bedrock developer-product entries plus matching outputs.
- *
- * Each well-formed `product_<k>.inputs.{name, description, price}` becomes
- * the corresponding `Config.products[<k>]` entry; the matching
- * `product_<k>.outputs.productId` becomes the `BedrockState` resource's
- * `outputs.productId`. Resources whose payload is malformed (non-object,
- * missing required string field, missing `productId`) are dropped silently
- * in this slice.
- *
- * @param resources - Resource list for one Mantle environment.
- * @returns The folded product entries plus an aggregated warnings list.
- */
-export function foldProducts(resources: ReadonlyArray<MantleResource>): ProductsFoldResult {
-	const products = resources.flatMap((resource): ReadonlyArray<ProductFoldEntry> => {
-		if (resource.kind !== PRODUCT_KIND) {
-			return [];
-		}
-
-		const folded = foldOneProduct(resource);
-		return folded === undefined ? [] : [folded];
-	});
-
-	return { products, warnings: [] };
+interface ProductIconInputs {
+	readonly fileHash: Sha256Hex;
+	readonly filePath: string;
 }
 
-function buildEntry(inputs: ProductInputs): DeveloperProductEntry {
+interface ProductIconOutputsRaw {
+	readonly assetId: string;
+}
+
+interface ProductIconParts {
+	readonly icon: Record<"en-us", string>;
+	readonly iconImageAssetId: string;
+	readonly mantleIconFileHashes: Record<"en-us", Sha256Hex>;
+}
+
+/**
+ * Fold the `product_<k>` (and matching `productIcon_<k>`) Mantle resources
+ * of one environment into a list of bedrock developer-product entries plus
+ * matching outputs. Pairs each `product_<k>` with the optional
+ * `productIcon_<k>` resource sharing the same key; when the icon partner is
+ * present and well-formed, the locale-keyed icon path lands on the entry
+ * and the Roblox-assigned `iconImageAssetId` lands on the outputs.
+ *
+ * Resources whose payload is malformed (non-object, missing required string
+ * field, missing `productId`, malformed `fileHash`) are dropped silently.
+ * Orphan `productIcon_<k>` resources (no matching product) emit one
+ * `ambiguous` warning each.
+ *
+ * @param resources - Resource list for one Mantle environment.
+ * @returns The folded product entries plus per-rule diagnostics.
+ */
+export function foldProducts(resources: ReadonlyArray<MantleResource>): ProductsFoldResult {
+	const { productIcons, products } = bucketByKind(resources);
+	const folded = products.flatMap((resource): ReadonlyArray<ProductFoldEntry> => {
+		const iconResource = productIcons.get(resource.key);
+		const entry = foldOneProduct(resource, iconResource);
+		return entry === undefined ? [] : [entry];
+	});
+
+	const productKeys = new Set(products.map((resource) => resource.key));
+	const warnings = [...productIcons.keys()]
+		.filter((key) => !productKeys.has(key))
+		.map((key) => orphanIconWarning(key));
+
+	return { products: folded, warnings };
+}
+
+function bucketByKind(resources: ReadonlyArray<MantleResource>): {
+	readonly productIcons: Map<string, MantleResource>;
+	readonly products: ReadonlyArray<MantleResource>;
+} {
+	const products: Array<MantleResource> = [];
+	const productIcons = new Map<string, MantleResource>();
+	for (const resource of resources) {
+		if (resource.kind === PRODUCT_KIND) {
+			products.push(resource);
+		} else if (resource.kind === PRODUCT_ICON_KIND) {
+			productIcons.set(resource.key, resource);
+		}
+	}
+
+	return { productIcons, products };
+}
+
+function buildEntry(
+	inputs: ProductInputs,
+	icon: Record<"en-us", string> | undefined,
+): DeveloperProductEntry {
 	const base: DeveloperProductEntry = {
 		name: inputs.name,
 		description: inputs.description,
 	};
-
-	return inputs.price === undefined ? base : { ...base, price: inputs.price };
+	const withPrice = inputs.price === undefined ? base : { ...base, price: inputs.price };
+	return icon === undefined ? withPrice : { ...withPrice, icon };
 }
 
 function isObjectPayload(value: unknown): value is Record<string, unknown> {
@@ -139,7 +185,51 @@ function readProductOutputs(raw: unknown): ProductOutputsRaw | undefined {
 	return { productId };
 }
 
-function foldOneProduct(resource: MantleResource): ProductFoldEntry | undefined {
+function readProductIconInputs(raw: unknown): ProductIconInputs | undefined {
+	if (!isObjectPayload(raw)) {
+		return undefined;
+	}
+
+	const filePath = readString(raw["filePath"]);
+	const fileHash = readString(raw["fileHash"]);
+	if (filePath === undefined || fileHash === undefined || !isSha256Hex(fileHash)) {
+		return undefined;
+	}
+
+	return { fileHash: asSha256Hex(fileHash), filePath };
+}
+
+function readProductIconOutputs(raw: unknown): ProductIconOutputsRaw | undefined {
+	if (!isObjectPayload(raw)) {
+		return undefined;
+	}
+
+	const assetId = coerceRobloxId(raw["assetId"]);
+	if (assetId === undefined) {
+		return undefined;
+	}
+
+	return { assetId };
+}
+
+function readProductIconParts(resource: MantleResource): ProductIconParts | undefined {
+	const inputs = readProductIconInputs(resource.inputs);
+	const outputs = readProductIconOutputs(resource.outputs);
+	if (inputs === undefined || outputs === undefined) {
+		return undefined;
+	}
+
+	return {
+		icon: { "en-us": inputs.filePath },
+		iconImageAssetId: outputs.assetId,
+		mantleIconFileHashes: { "en-us": inputs.fileHash },
+	};
+}
+
+function foldOneProduct(
+	resource: MantleResource,
+	iconResource: MantleResource | undefined,
+): ProductFoldEntry | undefined {
 	const inputs = readProductInputs(resource.inputs);
 	if (inputs === undefined) {
 		return undefined;
@@ -150,10 +240,31 @@ function foldOneProduct(resource: MantleResource): ProductFoldEntry | undefined 
 		return undefined;
 	}
 
-	return {
+	const iconParts = iconResource === undefined ? undefined : readProductIconParts(iconResource);
+	const productOutputs: DeveloperProductOutputs =
+		iconParts === undefined
+			? { iconImageAssetId: undefined, productId: asRobloxAssetId(outputs.productId) }
+			: {
+					iconImageAssetId: asRobloxAssetId(iconParts.iconImageAssetId),
+					productId: asRobloxAssetId(outputs.productId),
+				};
+
+	const base: ProductFoldEntry = {
 		key: asResourceKey(resource.key),
-		entry: buildEntry(inputs),
+		entry: buildEntry(inputs, iconParts?.icon),
 		mantlePath: `${PRODUCT_KIND}_${resource.key}`,
-		outputs: { productId: asRobloxAssetId(outputs.productId) },
+		outputs: productOutputs,
+	};
+
+	return iconParts === undefined
+		? base
+		: { ...base, mantleIconFileHashes: iconParts.mantleIconFileHashes };
+}
+
+function orphanIconWarning(key: string): MigrationWarning {
+	return {
+		hint: "Verify your Mantle state file: each productIcon_<k> resource must be paired with a matching product_<k>.",
+		kind: "ambiguous",
+		mantlePath: `${PRODUCT_ICON_KIND}_${key}`,
 	};
 }

--- a/packages/bedrock/src/core/migrate/fold-products.ts
+++ b/packages/bedrock/src/core/migrate/fold-products.ts
@@ -2,6 +2,7 @@ import { asResourceKey, asRobloxAssetId, asSha256Hex, isSha256Hex } from "../../
 import type { ResourceKey, Sha256Hex } from "../../types/ids.ts";
 import type { DeveloperProductOutputs } from "../resources.ts";
 import type { DeveloperProductEntry } from "../schema.ts";
+import { coerceRobloxId, isObjectPayload } from "./fold-universe-shared.ts";
 import type { MigrationWarning } from "./migration-report.ts";
 import type { MantleResource } from "./types.ts";
 
@@ -133,10 +134,6 @@ function buildEntry(
 	return icon === undefined ? withPrice : { ...withPrice, icon };
 }
 
-function isObjectPayload(value: unknown): value is Record<string, unknown> {
-	return Object.prototype.toString.call(value) === "[object Object]";
-}
-
 function readString(value: unknown): string | undefined {
 	return typeof value === "string" ? value : undefined;
 }
@@ -158,18 +155,6 @@ function readProductInputs(raw: unknown): ProductInputs | undefined {
 	}
 
 	return { name, description, price: readPrice(raw) };
-}
-
-function coerceRobloxId(value: unknown): string | undefined {
-	if (typeof value === "string") {
-		return value;
-	}
-
-	if (Number.isInteger(value)) {
-		return String(value);
-	}
-
-	return undefined;
 }
 
 function readProductOutputs(raw: unknown): ProductOutputsRaw | undefined {

--- a/packages/bedrock/src/core/migrate/fold-products.ts
+++ b/packages/bedrock/src/core/migrate/fold-products.ts
@@ -1,0 +1,159 @@
+import { asResourceKey, asRobloxAssetId } from "../../types/ids.ts";
+import type { ResourceKey } from "../../types/ids.ts";
+import type { DeveloperProductOutputs } from "../resources.ts";
+import type { DeveloperProductEntry } from "../schema.ts";
+import type { MigrationWarning } from "./migration-report.ts";
+import type { MantleResource } from "./types.ts";
+
+const PRODUCT_KIND = "product";
+
+/**
+ * Folded representation of one Mantle `product_<k>` resource.
+ *
+ * `entry` carries the bedrock `Config.products[<k>]` shape (without an icon
+ * in this slice; pairing with `productIcon_<k>` lands in a later slice).
+ * `outputs` carries the Roblox-assigned identifier for the developer product.
+ * `mantlePath` roots warnings at the resource so the report is searchable.
+ */
+export interface ProductFoldEntry {
+	/** User-supplied Mantle key, branded as a bedrock `ResourceKey`. */
+	readonly key: ResourceKey;
+	/** Bedrock `Config.products[<k>]` block populated from the product resource. */
+	readonly entry: DeveloperProductEntry;
+	/** Resource-rooted Mantle path (`product_<k>`) used to anchor warnings. */
+	readonly mantlePath: string;
+	/** Roblox-assigned identifiers carried into `BedrockState.resources[*].outputs`. */
+	readonly outputs: DeveloperProductOutputs;
+}
+
+/**
+ * Output of folding the `product_<k>` Mantle resources of one environment
+ * into bedrock-shaped developer-product entries.
+ *
+ * `products` carries one record per well-formed `product_<k>` resource;
+ * malformed resources are dropped silently in this slice. `warnings`
+ * accumulates per-rule diagnostics.
+ */
+interface ProductsFoldResult {
+	/** One folded entry per well-formed Mantle `product_<k>` resource. */
+	readonly products: ReadonlyArray<ProductFoldEntry>;
+	/** Per-rule diagnostics; empty in this slice. */
+	readonly warnings: ReadonlyArray<MigrationWarning>;
+}
+
+interface ProductInputs {
+	readonly name: string;
+	readonly description: string;
+	readonly price: number | undefined;
+}
+
+interface ProductOutputsRaw {
+	readonly productId: string;
+}
+
+/**
+ * Fold the `product_<k>` Mantle resources of one environment into a list
+ * of bedrock developer-product entries plus matching outputs.
+ *
+ * Each well-formed `product_<k>.inputs.{name, description, price}` becomes
+ * the corresponding `Config.products[<k>]` entry; the matching
+ * `product_<k>.outputs.productId` becomes the `BedrockState` resource's
+ * `outputs.productId`. Resources whose payload is malformed (non-object,
+ * missing required string field, missing `productId`) are dropped silently
+ * in this slice.
+ *
+ * @param resources - Resource list for one Mantle environment.
+ * @returns The folded product entries plus an aggregated warnings list.
+ */
+export function foldProducts(resources: ReadonlyArray<MantleResource>): ProductsFoldResult {
+	const products = resources.flatMap((resource): ReadonlyArray<ProductFoldEntry> => {
+		if (resource.kind !== PRODUCT_KIND) {
+			return [];
+		}
+
+		const folded = foldOneProduct(resource);
+		return folded === undefined ? [] : [folded];
+	});
+
+	return { products, warnings: [] };
+}
+
+function buildEntry(inputs: ProductInputs): DeveloperProductEntry {
+	const base: DeveloperProductEntry = {
+		name: inputs.name,
+		description: inputs.description,
+	};
+
+	return inputs.price === undefined ? base : { ...base, price: inputs.price };
+}
+
+function isObjectPayload(value: unknown): value is Record<string, unknown> {
+	return Object.prototype.toString.call(value) === "[object Object]";
+}
+
+function readString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function readPrice(raw: Record<string, unknown>): number | undefined {
+	const candidate = raw["price"];
+	return typeof candidate === "number" ? candidate : undefined;
+}
+
+function readProductInputs(raw: unknown): ProductInputs | undefined {
+	if (!isObjectPayload(raw)) {
+		return undefined;
+	}
+
+	const name = readString(raw["name"]);
+	const description = readString(raw["description"]);
+	if (name === undefined || description === undefined) {
+		return undefined;
+	}
+
+	return { name, description, price: readPrice(raw) };
+}
+
+function coerceRobloxId(value: unknown): string | undefined {
+	if (typeof value === "string") {
+		return value;
+	}
+
+	if (Number.isInteger(value)) {
+		return String(value);
+	}
+
+	return undefined;
+}
+
+function readProductOutputs(raw: unknown): ProductOutputsRaw | undefined {
+	if (!isObjectPayload(raw)) {
+		return undefined;
+	}
+
+	const productId = coerceRobloxId(raw["productId"]);
+	if (productId === undefined) {
+		return undefined;
+	}
+
+	return { productId };
+}
+
+function foldOneProduct(resource: MantleResource): ProductFoldEntry | undefined {
+	const inputs = readProductInputs(resource.inputs);
+	if (inputs === undefined) {
+		return undefined;
+	}
+
+	const outputs = readProductOutputs(resource.outputs);
+	if (outputs === undefined) {
+		return undefined;
+	}
+
+	return {
+		key: asResourceKey(resource.key),
+		entry: buildEntry(inputs),
+		mantlePath: `${PRODUCT_KIND}_${resource.key}`,
+		outputs: { productId: asRobloxAssetId(outputs.productId) },
+	};
+}

--- a/packages/bedrock/src/core/migrate/fold-universe-shared.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe-shared.ts
@@ -62,6 +62,26 @@ export function isObjectPayload(value: unknown): value is Record<string, unknown
 }
 
 /**
+ * Coerce a Mantle-recorded Roblox identifier to a string. YAML can carry
+ * IDs as either a quoted string or a bare integer; both are accepted.
+ * Anything else (null, float, object) returns `undefined`.
+ *
+ * @param value - Raw value pulled from a Mantle resource's outputs.
+ * @returns The stringified ID, or `undefined` when the value is not a valid wire shape.
+ */
+export function coerceRobloxId(value: unknown): string | undefined {
+	if (typeof value === "string") {
+		return value;
+	}
+
+	if (Number.isInteger(value)) {
+		return String(value);
+	}
+
+	return undefined;
+}
+
+/**
  * Combine two fragments, with the right-hand side overriding overlapping
  * `entryFragment` keys and its `warnings` appended after the left's.
  * Does not merge `outputsFragment`; outputs composition is handled by

--- a/packages/bedrock/src/core/migrate/fold-unsupported.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-unsupported.spec.ts
@@ -17,7 +17,6 @@ const DEFERRED_CASES: ReadonlyArray<DeferredCase> = [
 	{ humanName: "experience thumbnail ordering", kind: "experienceThumbnailOrder" },
 	{ humanName: "image assets", kind: "imageAsset" },
 	{ humanName: "experience notifications", kind: "notification" },
-	{ humanName: "developer-product icons", kind: "productIcon" },
 ];
 
 describe(foldUnsupported, () => {

--- a/packages/bedrock/src/core/migrate/fold-unsupported.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-unsupported.spec.ts
@@ -17,7 +17,6 @@ const DEFERRED_CASES: ReadonlyArray<DeferredCase> = [
 	{ humanName: "experience thumbnail ordering", kind: "experienceThumbnailOrder" },
 	{ humanName: "image assets", kind: "imageAsset" },
 	{ humanName: "experience notifications", kind: "notification" },
-	{ humanName: "developer products", kind: "product" },
 	{ humanName: "developer-product icons", kind: "productIcon" },
 ];
 
@@ -74,7 +73,7 @@ describe(foldUnsupported, () => {
 
 		const warnings = foldUnsupported([
 			mantleResource("badge", "first-win"),
-			mantleResource("product", "starter-pack"),
+			mantleResource("audioAsset", "theme"),
 			mantleResource("experienceThumbnail", "singleton"),
 		]);
 

--- a/packages/bedrock/src/core/migrate/fold-unsupported.ts
+++ b/packages/bedrock/src/core/migrate/fold-unsupported.ts
@@ -16,7 +16,6 @@ const DEFERRED_KIND_REASONS: Readonly<Record<string, string>> = {
 	experienceThumbnailOrder: "experience thumbnail ordering",
 	imageAsset: "image assets",
 	notification: "experience notifications",
-	product: "developer products",
 	productIcon: "developer-product icons",
 };
 

--- a/packages/bedrock/src/core/migrate/fold-unsupported.ts
+++ b/packages/bedrock/src/core/migrate/fold-unsupported.ts
@@ -16,7 +16,6 @@ const DEFERRED_KIND_REASONS: Readonly<Record<string, string>> = {
 	experienceThumbnailOrder: "experience thumbnail ordering",
 	imageAsset: "image assets",
 	notification: "experience notifications",
-	productIcon: "developer-product icons",
 };
 
 /**

--- a/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
@@ -264,10 +264,6 @@ environments:
           assetId: 6031475575
           startPlaceId: 17613681043
       dependencies: []
-    - id: productIcon_starter
-      inputs:
-        productIcon: {}
-      dependencies: []
     - id: badge_first-win
       inputs:
         badge: {}
@@ -987,7 +983,7 @@ environments:
 
 		assert(result.success);
 
-		expect(result.data.warnings).toHaveLength(10);
+		expect(result.data.warnings).toHaveLength(9);
 		expect(new Set(result.data.warnings.map((warning) => warning.kind))).toStrictEqual(
 			new Set(["deferred"]),
 		);
@@ -1007,7 +1003,7 @@ environments:
 		expect(result.data.summary).toStrictEqual({
 			ambiguousCount: 0,
 			blockedCount: 0,
-			deferredCount: 10,
+			deferredCount: 9,
 			interpretiveCount: 0,
 		});
 	});
@@ -1024,7 +1020,6 @@ environments:
 		assert(result.success);
 
 		expect(result.data.warnings.map((warning) => warning.mantlePath)).toStrictEqual([
-			"production.productIcon_starter",
 			"production.badge_first-win",
 			"production.badgeIcon_first-win",
 			"production.imageAsset_logo",

--- a/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
@@ -264,10 +264,6 @@ environments:
           assetId: 6031475575
           startPlaceId: 17613681043
       dependencies: []
-    - id: product_starter
-      inputs:
-        product: {}
-      dependencies: []
     - id: productIcon_starter
       inputs:
         productIcon: {}
@@ -1028,7 +1024,6 @@ environments:
 		assert(result.success);
 
 		expect(result.data.warnings.map((warning) => warning.mantlePath)).toStrictEqual([
-			"production.product_starter",
 			"production.productIcon_starter",
 			"production.badge_first-win",
 			"production.badgeIcon_first-win",

--- a/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
@@ -149,6 +149,117 @@ environments:
         - experience_singleton
 `;
 
+const ORPHAN_PRODUCT_ICON_YAML = `
+version: "6"
+environments:
+  production:
+    - id: experience_singleton
+      inputs:
+        experience:
+          groupId: ~
+      outputs:
+        experience:
+          assetId: 6031475575
+          startPlaceId: 17613681043
+      dependencies: []
+    - id: productIcon_1-orphan
+      inputs:
+        productIcon:
+          filePath: assets/marketing/orphan.png
+          fileHash: ${SAMPLE_HASH}
+      outputs:
+        productIcon:
+          assetId: 18280868488
+      dependencies:
+        - experience_singleton
+`;
+
+const TWO_ENV_PRODUCT_PRICE_YAML = `
+version: "6"
+environments:
+  development:
+    - id: experience_singleton
+      inputs:
+        experience:
+          groupId: ~
+      outputs:
+        experience:
+          assetId: 1111111111
+          startPlaceId: 2222222222
+      dependencies: []
+    - id: product_1-gem-pack
+      inputs:
+        product:
+          name: Gem Pack
+          description: Stocks the player up with 1,000 premium gems.
+          price: 50
+      outputs:
+        product:
+          assetId: 1835296153
+          productId: 58109901
+      dependencies:
+        - experience_singleton
+  production:
+    - id: experience_singleton
+      inputs:
+        experience:
+          groupId: ~
+      outputs:
+        experience:
+          assetId: 6031475575
+          startPlaceId: 17613681043
+      dependencies: []
+    - id: product_1-gem-pack
+      inputs:
+        product:
+          name: Gem Pack
+          description: Stocks the player up with 1,000 premium gems.
+          price: 100
+      outputs:
+        product:
+          assetId: 1835296153
+          productId: 58109926
+      dependencies:
+        - experience_singleton
+`;
+
+const TWO_ENV_PRODUCT_MISSING_YAML = `
+version: "6"
+environments:
+  development:
+    - id: experience_singleton
+      inputs:
+        experience:
+          groupId: ~
+      outputs:
+        experience:
+          assetId: 1111111111
+          startPlaceId: 2222222222
+      dependencies: []
+  production:
+    - id: experience_singleton
+      inputs:
+        experience:
+          groupId: ~
+      outputs:
+        experience:
+          assetId: 6031475575
+          startPlaceId: 17613681043
+      dependencies: []
+    - id: product_1-gem-pack
+      inputs:
+        product:
+          name: Gem Pack
+          description: Stocks the player up with 1,000 premium gems.
+          price: 100
+      outputs:
+        product:
+          assetId: 1835296153
+          productId: 58109926
+      dependencies:
+        - experience_singleton
+`;
+
 const TWO_ENV_PLACE_YAML = `
 version: "6"
 environments:
@@ -946,6 +1057,180 @@ environments:
 
 		expect(warning.mantlePath).toBe("production.product_1-gem-pack");
 		expect(warning.hint).toContain("assets/marketing/gem-pack.png");
+	});
+
+	it("should expose a product with an icon on the resolved Config.products record", async () => {
+		expect.assertions(2);
+
+		const files = new Map<string, "missing" | Uint8Array>([
+			[".mantle-state.yml", new TextEncoder().encode(PRODUCT_WITH_ICON_YAML)],
+			["assets/marketing/gem-pack.png", ICON_BYTES],
+		]);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			readFile: fakeFs(files),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		expect(result.data.config.products).toStrictEqual({
+			"1-gem-pack": {
+				name: "Gem Pack",
+				description: "Stocks the player up with 1,000 premium gems.",
+				icon: { "en-us": "assets/marketing/gem-pack.png" },
+				price: 100,
+			},
+		});
+
+		expect(result.data.warnings).toStrictEqual([]);
+	});
+
+	it("should emit a developerProduct resource with recomputed icon hash and Mantle outputs", async () => {
+		expect.assertions(5);
+
+		const files = new Map<string, "missing" | Uint8Array>([
+			[".mantle-state.yml", new TextEncoder().encode(PRODUCT_WITH_ICON_YAML)],
+			["assets/marketing/gem-pack.png", ICON_BYTES],
+		]);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			readFile: fakeFs(files),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		const state = result.data.statesByEnvironment["production"];
+		const product = state?.resources.find((resource) => resource.kind === "developerProduct");
+		assert(product?.kind === "developerProduct");
+
+		expect(product.key).toBe("1-gem-pack");
+		expect(product.outputs.productId).toBe("58109926");
+		expect(product.outputs.iconImageAssetId).toBe("18280868488");
+		expect(product.iconFileHashes).toStrictEqual({ "en-us": ICON_BYTES_SHA256 });
+		expect(product.iconFileHashes?.["en-us"]).not.toBe(SAMPLE_HASH);
+	});
+
+	it("should migrate a product without an icon end-to-end", async () => {
+		expect.assertions(4);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			readFile: fakeReadFile(PRODUCT_WITHOUT_ICON_YAML),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		expect(result.data.config.products).toStrictEqual({
+			"1-coin-pack": {
+				name: "Coin Pack",
+				description: "Adds 500 coins to the player's wallet.",
+				price: 50,
+			},
+		});
+
+		const state = result.data.statesByEnvironment["production"];
+		const product = state?.resources.find((resource) => resource.kind === "developerProduct");
+		assert(product?.kind === "developerProduct");
+
+		expect(product.icon).toBeUndefined();
+		expect(product.iconFileHashes).toBeUndefined();
+		expect(product.outputs.iconImageAssetId).toBeUndefined();
+	});
+
+	it("should emit an ambiguous warning for an orphan productIcon resource", async () => {
+		expect.assertions(3);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			readFile: fakeReadFile(ORPHAN_PRODUCT_ICON_YAML),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		const ambiguous = result.data.warnings.filter((warning) => warning.kind === "ambiguous");
+
+		expect(ambiguous).toHaveLength(1);
+
+		const [warning] = ambiguous;
+		assert(warning?.kind === "ambiguous");
+
+		expect(warning.mantlePath).toBe("production.productIcon_1-orphan");
+		expect(result.data.summary.ambiguousCount).toBe(1);
+	});
+
+	it("should not emit deferred warnings for product or productIcon resources", async () => {
+		expect.assertions(1);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			readFile: fakeReadFile(PRODUCT_WITH_ICON_YAML),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		const productKindDeferred = result.data.warnings.filter((warning) => {
+			if (warning.kind !== "deferred") {
+				return false;
+			}
+
+			const segments = warning.mantlePath.split(".");
+			const last = segments[segments.length - 1] ?? "";
+			return last.startsWith("product_") || last.startsWith("productIcon_");
+		});
+
+		expect(productKindDeferred).toStrictEqual([]);
+	});
+
+	it("should factorize products across multi-environment migrations", async () => {
+		expect.assertions(2);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			primaryEnvironment: "production",
+			readFile: fakeReadFile(TWO_ENV_PRODUCT_PRICE_YAML),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		expect(result.data.config.products).toStrictEqual({
+			"1-gem-pack": {
+				name: "Gem Pack",
+				description: "Stocks the player up with 1,000 premium gems.",
+				price: 100,
+			},
+		});
+
+		expect(result.data.config.environments["development"]?.products).toStrictEqual({
+			"1-gem-pack": { price: 50 },
+		});
+	});
+
+	it("should emit a missing-resource warning when a product is absent in a non-primary environment", async () => {
+		expect.assertions(1);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			primaryEnvironment: "production",
+			readFile: fakeReadFile(TWO_ENV_PRODUCT_MISSING_YAML),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		expect(result.data.warnings).toContainEqual({
+			bedrockPath: "environments.development.products.1-gem-pack",
+			kind: "interpretive",
+			mantlePath: "development.product_1-gem-pack",
+			rule: "factorize-environments/resource-missing-from-env",
+		});
 	});
 
 	it("should re-throw a readFile rejection whose code is not a string", async () => {

--- a/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
@@ -1189,7 +1189,7 @@ environments:
 	});
 
 	it("should factorize products across multi-environment migrations", async () => {
-		expect.assertions(2);
+		expect.assertions(3);
 
 		const result = await migrateMantleState({
 			configFormat: "typescript",
@@ -1204,12 +1204,15 @@ environments:
 			"1-gem-pack": {
 				name: "Gem Pack",
 				description: "Stocks the player up with 1,000 premium gems.",
-				price: 100,
 			},
 		});
 
 		expect(result.data.config.environments["development"]?.products).toStrictEqual({
 			"1-gem-pack": { price: 50 },
+		});
+
+		expect(result.data.config.environments["production"]?.products).toStrictEqual({
+			"1-gem-pack": { price: 100 },
 		});
 	});
 

--- a/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
@@ -1424,7 +1424,7 @@ environments:
 
 		assert(result.success);
 
-		expect(result.data.warnings).toHaveLength(9);
+		expect(result.data.warnings).toHaveLength(8);
 		expect(new Set(result.data.warnings.map((warning) => warning.kind))).toStrictEqual(
 			new Set(["deferred"]),
 		);
@@ -1444,7 +1444,7 @@ environments:
 		expect(result.data.summary).toStrictEqual({
 			ambiguousCount: 0,
 			blockedCount: 0,
-			deferredCount: 9,
+			deferredCount: 8,
 			interpretiveCount: 0,
 		});
 	});

--- a/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
@@ -85,6 +85,70 @@ environments:
         - experience_singleton
 `;
 
+const PRODUCT_WITH_ICON_YAML = `
+version: "6"
+environments:
+  production:
+    - id: experience_singleton
+      inputs:
+        experience:
+          groupId: ~
+      outputs:
+        experience:
+          assetId: 6031475575
+          startPlaceId: 17613681043
+      dependencies: []
+    - id: product_1-gem-pack
+      inputs:
+        product:
+          name: Gem Pack
+          description: Stocks the player up with 1,000 premium gems.
+          price: 100
+      outputs:
+        product:
+          assetId: 1835296153
+          productId: 58109926
+      dependencies:
+        - experience_singleton
+    - id: productIcon_1-gem-pack
+      inputs:
+        productIcon:
+          filePath: assets/marketing/gem-pack.png
+          fileHash: ${SAMPLE_HASH}
+      outputs:
+        productIcon:
+          assetId: 18280868488
+      dependencies:
+        - product_1-gem-pack
+`;
+
+const PRODUCT_WITHOUT_ICON_YAML = `
+version: "6"
+environments:
+  production:
+    - id: experience_singleton
+      inputs:
+        experience:
+          groupId: ~
+      outputs:
+        experience:
+          assetId: 6031475575
+          startPlaceId: 17613681043
+      dependencies: []
+    - id: product_1-coin-pack
+      inputs:
+        product:
+          name: Coin Pack
+          description: Adds 500 coins to the player's wallet.
+          price: 50
+      outputs:
+        product:
+          assetId: 1835296153
+          productId: 58109926
+      dependencies:
+        - experience_singleton
+`;
+
 const TWO_ENV_PLACE_YAML = `
 version: "6"
 environments:
@@ -790,6 +854,98 @@ environments:
 		assert(result.success);
 
 		expect("passes" in result.data.config).toBeFalse();
+	});
+
+	it("should recompute icon hashes for products with icons", async () => {
+		expect.assertions(2);
+
+		const files = new Map<string, "missing" | Uint8Array>([
+			[".mantle-state.yml", new TextEncoder().encode(PRODUCT_WITH_ICON_YAML)],
+			["assets/marketing/gem-pack.png", ICON_BYTES],
+		]);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			readFile: fakeFs(files),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		const state = result.data.statesByEnvironment["production"];
+		const product = state?.resources.find((resource) => resource.kind === "developerProduct");
+		assert(product?.kind === "developerProduct");
+
+		expect(product.iconFileHashes).toStrictEqual({ "en-us": ICON_BYTES_SHA256 });
+		expect(result.data.warnings).toStrictEqual([]);
+	});
+
+	it("should omit products without icons from the recomputed product map", async () => {
+		expect.assertions(3);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			readFile: fakeReadFile(PRODUCT_WITHOUT_ICON_YAML),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		const state = result.data.statesByEnvironment["production"];
+		const product = state?.resources.find((resource) => resource.kind === "developerProduct");
+		assert(product?.kind === "developerProduct");
+
+		expect(product.iconFileHashes).toBeUndefined();
+		expect(product.icon).toBeUndefined();
+		expect(result.data.warnings).toStrictEqual([]);
+	});
+
+	it("should fall back to the mantle-recorded hash when a product icon file is missing", async () => {
+		expect.assertions(1);
+
+		const files = new Map<string, "missing" | Uint8Array>([
+			[".mantle-state.yml", new TextEncoder().encode(PRODUCT_WITH_ICON_YAML)],
+			["assets/marketing/gem-pack.png", "missing"],
+		]);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			readFile: fakeFs(files),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		const state = result.data.statesByEnvironment["production"];
+		const product = state?.resources.find((resource) => resource.kind === "developerProduct");
+		assert(product?.kind === "developerProduct");
+
+		expect(product.iconFileHashes).toStrictEqual({ "en-us": SAMPLE_HASH });
+	});
+
+	it("should emit an ambiguous warning for a missing product icon file", async () => {
+		expect.assertions(3);
+
+		const files = new Map<string, "missing" | Uint8Array>([
+			[".mantle-state.yml", new TextEncoder().encode(PRODUCT_WITH_ICON_YAML)],
+			["assets/marketing/gem-pack.png", "missing"],
+		]);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			readFile: fakeFs(files),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		expect(result.data.warnings).toHaveLength(1);
+
+		const [warning] = result.data.warnings;
+		assert(warning?.kind === "ambiguous");
+
+		expect(warning.mantlePath).toBe("production.product_1-gem-pack");
+		expect(warning.hint).toContain("assets/marketing/gem-pack.png");
 	});
 
 	it("should re-throw a readFile rejection whose code is not a string", async () => {

--- a/packages/bedrock/src/shell/migrate-mantle-state.ts
+++ b/packages/bedrock/src/shell/migrate-mantle-state.ts
@@ -166,6 +166,8 @@ export async function migrateMantleState(
 	});
 }
 
+const EMPTY_HASHES: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>> = new Map();
+
 function buildStatesByEnvironment(
 	folds: ReadonlyMap<string, EnvironmentFoldResult>,
 	hashesByEnvironment: ReadonlyMap<string, ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>>,
@@ -177,7 +179,8 @@ function buildStatesByEnvironment(
 				buildState({
 					environment: name,
 					folded,
-					iconHashesByKey: hashesByEnvironment.get(name) ?? new Map(),
+					passIconHashesByKey: hashesByEnvironment.get(name) ?? EMPTY_HASHES,
+					productIconHashesByKey: EMPTY_HASHES,
 				}),
 			];
 		}),

--- a/packages/bedrock/src/shell/migrate-mantle-state.ts
+++ b/packages/bedrock/src/shell/migrate-mantle-state.ts
@@ -168,19 +168,31 @@ export async function migrateMantleState(
 
 const EMPTY_HASHES: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>> = new Map();
 
+interface BuildStatesByEnvironmentInputs {
+	readonly folds: ReadonlyMap<string, EnvironmentFoldResult>;
+	readonly passHashesByEnvironment: ReadonlyMap<
+		string,
+		ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>
+	>;
+	readonly productHashesByEnvironment: ReadonlyMap<
+		string,
+		ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>
+	>;
+}
+
 function buildStatesByEnvironment(
-	folds: ReadonlyMap<string, EnvironmentFoldResult>,
-	hashesByEnvironment: ReadonlyMap<string, ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>>,
+	inputs: BuildStatesByEnvironmentInputs,
 ): Readonly<Record<string, BedrockState>> {
 	return Object.fromEntries(
-		[...folds.entries()].map(([name, folded]): [string, BedrockState] => {
+		[...inputs.folds.entries()].map(([name, folded]): [string, BedrockState] => {
 			return [
 				name,
 				buildState({
 					environment: name,
 					folded,
-					passIconHashesByKey: hashesByEnvironment.get(name) ?? EMPTY_HASHES,
-					productIconHashesByKey: EMPTY_HASHES,
+					passIconHashesByKey: inputs.passHashesByEnvironment.get(name) ?? EMPTY_HASHES,
+					productIconHashesByKey:
+						inputs.productHashesByEnvironment.get(name) ?? EMPTY_HASHES,
 				}),
 			];
 		}),
@@ -200,7 +212,11 @@ function collectFoldWarnings(
 }
 
 function buildReport(inputs: FinalizeReportInputs, validated: Config): MigrationReport {
-	const { hashesByEnvironment, warnings: iconWarnings } = inputs.iconRecomputation;
+	const {
+		passHashesByEnvironment,
+		productHashesByEnvironment,
+		warnings: iconWarnings,
+	} = inputs.iconRecomputation;
 	const warnings = [
 		...collectFoldWarnings(inputs.folds),
 		...inputs.factorizeWarnings,
@@ -212,7 +228,11 @@ function buildReport(inputs: FinalizeReportInputs, validated: Config): Migration
 			config: validated,
 			configFormat: inputs.configFormat,
 		}),
-		statesByEnvironment: buildStatesByEnvironment(inputs.folds, hashesByEnvironment),
+		statesByEnvironment: buildStatesByEnvironment({
+			folds: inputs.folds,
+			passHashesByEnvironment,
+			productHashesByEnvironment,
+		}),
 		summary: summarizeWarnings(warnings),
 		warnings,
 	};

--- a/packages/bedrock/src/shell/recompute-icon-hashes.ts
+++ b/packages/bedrock/src/shell/recompute-icon-hashes.ts
@@ -3,31 +3,39 @@ import { join } from "node:path";
 import { sha256Hex } from "../core/kinds/hash.ts";
 import type { EnvironmentFoldResult } from "../core/migrate/fold-environment.ts";
 import type { PassFoldEntry } from "../core/migrate/fold-passes.ts";
+import type { ProductFoldEntry } from "../core/migrate/fold-products.ts";
 import type { MigrationWarning } from "../core/migrate/migration-report.ts";
 import { asSha256Hex, type ResourceKey, type Sha256Hex } from "../types/ids.ts";
 
 /**
- * Result of walking each environment's pass entries and recomputing the
- * SHA-256 digest of every locale-keyed icon path from disk.
- * `hashesByEnvironment` carries the recomputed digests keyed by environment
- * then by pass key; the inner record mirrors `GamePassDesiredState.iconFileHashes`.
- * `warnings` carries one `kind: "ambiguous"` warning per pass whose icon
- * could not be read so the caller can fall back to the Mantle-recorded
- * hashes without losing the diagnostic.
+ * Result of walking each environment's pass and product entries and
+ * recomputing the SHA-256 digest of every locale-keyed icon path from disk.
+ * `passHashesByEnvironment` and `productHashesByEnvironment` carry the
+ * recomputed digests keyed by environment then by resource key; the inner
+ * record mirrors `GamePassDesiredState.iconFileHashes` /
+ * `DeveloperProductDesiredState.iconFileHashes`. `warnings` carries one
+ * `kind: "ambiguous"` warning per resource whose icon could not be read so
+ * the caller can fall back to the Mantle-recorded hashes without losing the
+ * diagnostic.
  */
 export interface IconHashRecomputation {
-	/** Recomputed digests keyed by environment then by pass key. */
-	readonly hashesByEnvironment: ReadonlyMap<
+	/** Recomputed pass-icon digests keyed by environment then by pass key. */
+	readonly passHashesByEnvironment: ReadonlyMap<
 		string,
 		ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>
 	>;
-	/** One ambiguous warning per pass whose icon could not be read. */
+	/** Recomputed product-icon digests keyed by environment then by product key. */
+	readonly productHashesByEnvironment: ReadonlyMap<
+		string,
+		ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>
+	>;
+	/** One ambiguous warning per resource whose icon could not be read. */
 	readonly warnings: ReadonlyArray<MigrationWarning>;
 }
 
 /** Inputs for {@link recomputeIconHashes}. */
 interface RecomputeIconHashesInputs {
-	/** Per-environment fold results carrying pass entries to walk. */
+	/** Per-environment fold results carrying pass and product entries to walk. */
 	readonly folds: ReadonlyMap<string, EnvironmentFoldResult>;
 	/** Reads file bytes; same shape as `MigrateMantleStateDeps.readFile`. */
 	readonly readFile: (path: string) => Promise<Uint8Array>;
@@ -35,56 +43,104 @@ interface RecomputeIconHashesInputs {
 	readonly stateFileDirectory: string;
 }
 
-interface AmbiguousIconWarningInputs {
-	readonly entry: PassFoldEntry;
+interface IconWalkEntry {
+	readonly key: ResourceKey;
+	readonly iconPath: string;
+	readonly mantlePath: string;
+}
+
+interface IconWalkInputs {
+	readonly entries: ReadonlyArray<IconWalkEntry>;
 	readonly environmentName: string;
+	readonly readFile: (path: string) => Promise<Uint8Array>;
+	readonly stateFileDirectory: string;
+}
+
+interface IconWalkResult {
+	readonly perKey: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>;
+	readonly warnings: ReadonlyArray<MigrationWarning>;
+}
+
+interface AmbiguousIconWarningInputs {
+	readonly environmentName: string;
+	readonly mantlePath: string;
 	readonly resolvedPath: string;
 }
 
+interface WalkEnvironmentInputs {
+	readonly environmentName: string;
+	readonly folded: EnvironmentFoldResult;
+	readonly readFile: (path: string) => Promise<Uint8Array>;
+	readonly stateFileDirectory: string;
+}
+
+interface WalkEnvironmentResult {
+	readonly passHashes: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>;
+	readonly productHashes: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>;
+	readonly warnings: ReadonlyArray<MigrationWarning>;
+}
+
 /**
- * Walk each environment's folded pass entries, resolve the locale-keyed
- * `entry.icon` paths against `stateFileDirectory`, read the bytes via the
- * injected `readFile`, and compute the SHA-256 hex digest. Files that
+ * Walk each environment's folded pass and product entries, resolve the
+ * locale-keyed icon paths against `stateFileDirectory`, read the bytes via
+ * the injected `readFile`, and compute the SHA-256 hex digest. Files that
  * cannot be read surface as `ambiguous` `MigrationWarning`s with the
  * environment-prefixed `mantlePath` and a hint pointing at the resolved
  * path; the caller carries the Mantle-recorded hashes forward as a
- * fallback.
+ * fallback. Products without an icon partner are silently skipped.
  *
  * @param inputs - Per-environment fold results plus I/O dependencies.
- * @returns Per-environment recomputed hashes plus accumulated ambiguous
- *   warnings.
+ * @returns Per-environment recomputed pass and product hashes plus
+ *   accumulated ambiguous warnings.
  */
 export async function recomputeIconHashes(
 	inputs: RecomputeIconHashesInputs,
 ): Promise<IconHashRecomputation> {
-	const warnings: Array<MigrationWarning> = [];
-	const hashesByEnvironment = new Map<
+	const passHashesByEnvironment = new Map<
 		string,
 		ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>
 	>();
+	const productHashesByEnvironment = new Map<
+		string,
+		ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>
+	>();
+	const warnings: Array<MigrationWarning> = [];
 
 	for (const [environment, folded] of inputs.folds) {
-		const perKey = new Map<ResourceKey, Record<"en-us", Sha256Hex>>();
-		for (const passEntry of folded.passes) {
-			const resolved = join(inputs.stateFileDirectory, passEntry.entry.icon["en-us"]);
-			const recomputed = await tryRecomputeHash(inputs.readFile, resolved);
-			if (recomputed === undefined) {
-				warnings.push(
-					buildAmbiguousIconWarning({
-						entry: passEntry,
-						environmentName: environment,
-						resolvedPath: resolved,
-					}),
-				);
-			} else {
-				perKey.set(passEntry.key, { "en-us": recomputed });
-			}
-		}
-
-		hashesByEnvironment.set(environment, perKey);
+		const walked = await walkEnvironment({
+			environmentName: environment,
+			folded,
+			readFile: inputs.readFile,
+			stateFileDirectory: inputs.stateFileDirectory,
+		});
+		passHashesByEnvironment.set(environment, walked.passHashes);
+		productHashesByEnvironment.set(environment, walked.productHashes);
+		warnings.push(...walked.warnings);
 	}
 
-	return { hashesByEnvironment, warnings };
+	return { passHashesByEnvironment, productHashesByEnvironment, warnings };
+}
+
+function passWalkEntry(entry: PassFoldEntry): IconWalkEntry {
+	return {
+		key: entry.key,
+		iconPath: entry.entry.icon["en-us"],
+		mantlePath: entry.mantlePath,
+	};
+}
+
+function productWalkEntries(entry: ProductFoldEntry): ReadonlyArray<IconWalkEntry> {
+	if (entry.entry.icon === undefined) {
+		return [];
+	}
+
+	return [
+		{
+			key: entry.key,
+			iconPath: entry.entry.icon["en-us"],
+			mantlePath: entry.mantlePath,
+		},
+	];
 }
 
 async function tryRecomputeHash(
@@ -103,6 +159,48 @@ function buildAmbiguousIconWarning(inputs: AmbiguousIconWarningInputs): Migratio
 	return {
 		hint: `Could not read icon file at ${inputs.resolvedPath}; verify the file's location relative to the state file or correct the icon entry before re-running.`,
 		kind: "ambiguous",
-		mantlePath: `${inputs.environmentName}.${inputs.entry.mantlePath}`,
+		mantlePath: `${inputs.environmentName}.${inputs.mantlePath}`,
+	};
+}
+
+async function walkIconEntries(inputs: IconWalkInputs): Promise<IconWalkResult> {
+	const perKey = new Map<ResourceKey, Record<"en-us", Sha256Hex>>();
+	const warnings: Array<MigrationWarning> = [];
+	for (const entry of inputs.entries) {
+		const resolved = join(inputs.stateFileDirectory, entry.iconPath);
+		const recomputed = await tryRecomputeHash(inputs.readFile, resolved);
+		if (recomputed === undefined) {
+			warnings.push(
+				buildAmbiguousIconWarning({
+					environmentName: inputs.environmentName,
+					mantlePath: entry.mantlePath,
+					resolvedPath: resolved,
+				}),
+			);
+		} else {
+			perKey.set(entry.key, { "en-us": recomputed });
+		}
+	}
+
+	return { perKey, warnings };
+}
+
+async function walkEnvironment(inputs: WalkEnvironmentInputs): Promise<WalkEnvironmentResult> {
+	const passWalk = await walkIconEntries({
+		entries: inputs.folded.passes.map(passWalkEntry),
+		environmentName: inputs.environmentName,
+		readFile: inputs.readFile,
+		stateFileDirectory: inputs.stateFileDirectory,
+	});
+	const productWalk = await walkIconEntries({
+		entries: inputs.folded.products.flatMap(productWalkEntries),
+		environmentName: inputs.environmentName,
+		readFile: inputs.readFile,
+		stateFileDirectory: inputs.stateFileDirectory,
+	});
+	return {
+		passHashes: passWalk.perKey,
+		productHashes: productWalk.perKey,
+		warnings: [...passWalk.warnings, ...productWalk.warnings],
 	};
 }

--- a/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
@@ -19,6 +19,56 @@ const REAL_FIXTURE = join(FIXTURES_ROOT, "roblox-ts-example.mantle-state.yml");
 const ICON_FILE_SHA256 = "c2d4b446a44ce54fab8e01150e24dd24f3d850c7c14dcfe31f6321341dd86874";
 const MANTLE_RECORDED_HASH = "86890ed405cabad0fcdabf52225d528981790fa551e915c070348761c28373c1";
 
+const TWO_ENV_DIVERGENT_PRODUCT_YAML = [
+	'version: "6"',
+	"environments:",
+	"  development:",
+	"    - id: experience_singleton",
+	"      inputs:",
+	"        experience:",
+	"          groupId: ~",
+	"      outputs:",
+	"        experience:",
+	"          assetId: 1111111111",
+	"          startPlaceId: 2222222222",
+	"      dependencies: []",
+	"    - id: product_gem-pack",
+	"      inputs:",
+	"        product:",
+	"          name: Gem Pack",
+	"          description: Stocks the player up with 1,000 premium gems.",
+	"          price: ~",
+	"      outputs:",
+	"        product:",
+	"          assetId: 1000",
+	"          productId: 2000",
+	"      dependencies:",
+	"        - experience_singleton",
+	"  production:",
+	"    - id: experience_singleton",
+	"      inputs:",
+	"        experience:",
+	"          groupId: ~",
+	"      outputs:",
+	"        experience:",
+	"          assetId: 6031475575",
+	"          startPlaceId: 17613681043",
+	"      dependencies: []",
+	"    - id: product_gem-pack",
+	"      inputs:",
+	"        product:",
+	"          name: Gem Pack",
+	"          description: Stocks the player up with 1,000 premium gems.",
+	"          price: 100",
+	"      outputs:",
+	"        product:",
+	"          assetId: 3000",
+	"          productId: 4000",
+	"      dependencies:",
+	"        - experience_singleton",
+	"",
+].join("\n");
+
 const TWO_ENV_DIVERGENT_PASS_YAML = [
 	'version: "6"',
 	"environments:",
@@ -345,6 +395,35 @@ describe(migrateMantleState, () => {
 			});
 			expect(production.data.passes?.["vip"]?.price).toBe(500);
 			expect(development.data.passes?.["vip"]?.price).toBe(99);
+		});
+	});
+
+	it("should round-trip a per-environment product price overlay through loadConfig and selectEnvironment", async () => {
+		expect.assertions(3);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			primaryEnvironment: "production",
+			readFile: async () => new TextEncoder().encode(TWO_ENV_DIVERGENT_PRODUCT_YAML),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		await withTemporaryDirectory(async (directory) => {
+			writeFileSync(join(directory, "bedrock.config.ts"), result.data.configFileContent);
+			const loaded = await loadConfig({ cwd: directory });
+
+			assert(loaded.success);
+
+			const production = selectEnvironment(loaded.data, "production");
+			const development = selectEnvironment(loaded.data, "development");
+			assert(production.success);
+			assert(development.success);
+
+			expect(production.data.products?.["gem-pack"]?.price).toBe(100);
+			expect(development.data.products?.["gem-pack"]?.price).toBeUndefined();
+			expect(loaded.data.products?.["gem-pack"]?.price).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
## Summary

Lands developer-product migration support so a Mantle user with `product_<k>` (and optional `productIcon_<k>`) resources lands them on `Config.products` and `developerProduct` state resources after running `bedrock migrate`. Fills the deferred-product slice from PRD #103 now that #113's bedrock-side schema is shipped (#323, #324).

- New `foldProducts` helper pairs each `product_<k>` with an optional `productIcon_<k>` by key, mirroring the pass/place fold pattern. Orphan `productIcon_<k>` resources surface as `ambiguous` warnings.
- `Config.products` and per-environment `developerProduct` state resources are emitted with `productId` and `iconImageAssetId` outputs preserved, so the first deploy against the migrated universe is a no-op.
- Icon SHA-256 hashes are recomputed from disk through the same shell pipeline used for pass icons; missing files fall back to the Mantle-recorded hash and emit an `ambiguous` warning.
- Multi-environment factorization hoists identical product fields to the root config and emits per-environment overlays carrying only divergent fields, mirroring the pass overlay logic.
- `product` and `productIcon` removed from `DEFERRED_KIND_REASONS`; states with developer products no longer surface as deferred warnings.
- `isRegionalPricingEnabled` and `storePageEnabled` stay `undefined` (unmanaged) on migration since Mantle does not record them. The kind module's tri-state semantics already treat undefined as unmanaged.

## Implementation notes

- `BuildStateInputs` gains a second hash map (`productIconHashesByKey`) alongside the renamed `passIconHashesByKey`. The shared shell helper `recomputeIconHashes` walks both pass and product fold entries in one traversal.
- `factorize-products.ts` is split out as a sibling to `factorize-environments.ts` to keep that file under the 300-line lint cap. The three per-kind asymmetry helpers (`placeAsymmetryWarnings`, `passAsymmetryWarnings`, `productAsymmetryWarnings`) collapse into a single spec-driven `keyedAsymmetryWarnings` helper. Emission order is unchanged.

## Test plan

- [x] `pnpm gen:example-tests`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (1664 passed)
- [x] `pnpm build`
- [x] `pnpm mutate:changed` (100% mutation score on touched files in every slice)
- [x] Per-slice unit tests cover the fold, state emission, factorization, and icon recomputation contracts
- [x] End-to-end integration tests in `migrate-mantle-state.spec.ts` exercise: product with icon, product without icon, missing-icon-file fallback, orphan productIcon, multi-env factorization, missing-resource-from-env warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)