### PR TITLE
feat(core): recompute experience-icon hash on mantle migration

### DIFF
--- a/packages/bedrock/src/core/migrate/build-state.spec.ts
+++ b/packages/bedrock/src/core/migrate/build-state.spec.ts
@@ -20,6 +20,9 @@ const PRODUCT_MANTLE_HASH = asSha256Hex(
 const PRODUCT_RECOMPUTED_HASH = asSha256Hex(
 	"e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3e3",
 );
+const UNIVERSE_RECOMPUTED_HASH = asSha256Hex(
+	"f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4f4",
+);
 
 const NO_HASHES: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>> = new Map();
 
@@ -30,6 +33,23 @@ const FOLDED_UNIVERSE = {
 	universe: {
 		entry: { universeId: "6031475575" },
 		outputs: { rootPlaceId: asRobloxAssetId("17613681043") },
+	},
+	warnings: [],
+} satisfies EnvironmentFoldResult;
+
+const FOLDED_UNIVERSE_WITH_ICON = {
+	passes: [],
+	places: new Map(),
+	products: [],
+	universe: {
+		entry: {
+			icon: { "en-us": "assets/marketing/example-icon.png" },
+			universeId: "6031475575",
+		},
+		outputs: {
+			iconAssetIds: { "en-us": asRobloxAssetId("707633946677216") },
+			rootPlaceId: asRobloxAssetId("17613681043"),
+		},
 	},
 	warnings: [],
 } satisfies EnvironmentFoldResult;
@@ -788,5 +808,74 @@ describe(buildState, () => {
 			"gamePass",
 			"developerProduct",
 		]);
+	});
+
+	it("should emit universe icon and iconFileHashes when the fold carries an icon and the recomputed hash is supplied", () => {
+		expect.assertions(2);
+
+		const state = buildState({
+			environment: "production",
+			folded: FOLDED_UNIVERSE_WITH_ICON,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
+			universeIconHashes: { "en-us": UNIVERSE_RECOMPUTED_HASH },
+		});
+
+		const [resource] = state.resources;
+		assert(resource?.kind === "universe");
+
+		expect(resource.icon).toStrictEqual({ "en-us": "assets/marketing/example-icon.png" });
+		expect(resource.iconFileHashes).toStrictEqual({ "en-us": UNIVERSE_RECOMPUTED_HASH });
+	});
+
+	it("should preserve outputs.iconAssetIds on the universe resource when the fold carries them", () => {
+		expect.assertions(1);
+
+		const state = buildState({
+			environment: "production",
+			folded: FOLDED_UNIVERSE_WITH_ICON,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
+			universeIconHashes: { "en-us": UNIVERSE_RECOMPUTED_HASH },
+		});
+
+		const [resource] = state.resources;
+		assert(resource?.kind === "universe");
+
+		expect(resource.outputs.iconAssetIds).toStrictEqual({ "en-us": "707633946677216" });
+	});
+
+	it("should omit universe icon and iconFileHashes when the fold has no icon", () => {
+		expect.assertions(2);
+
+		const state = buildState({
+			environment: "production",
+			folded: FOLDED_UNIVERSE,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
+		});
+
+		const [resource] = state.resources;
+		assert(resource?.kind === "universe");
+
+		expect("icon" in resource).toBeFalse();
+		expect("iconFileHashes" in resource).toBeFalse();
+	});
+
+	it("should omit universe icon and iconFileHashes when the fold has an icon but no recomputed hash is supplied", () => {
+		expect.assertions(2);
+
+		const state = buildState({
+			environment: "production",
+			folded: FOLDED_UNIVERSE_WITH_ICON,
+			passIconHashesByKey: NO_HASHES,
+			productIconHashesByKey: NO_HASHES,
+		});
+
+		const [resource] = state.resources;
+		assert(resource?.kind === "universe");
+
+		expect("icon" in resource).toBeFalse();
+		expect("iconFileHashes" in resource).toBeFalse();
 	});
 });

--- a/packages/bedrock/src/core/migrate/build-state.ts
+++ b/packages/bedrock/src/core/migrate/build-state.ts
@@ -36,6 +36,20 @@ interface BuildStateInputs {
 	 * resources without `iconFileHashes`.
 	 */
 	readonly productIconHashesByKey: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>;
+	/**
+	 * Locale-keyed icon hashes recomputed from disk by the shell for this
+	 * environment's experience icon. Absent when the fold did not produce a
+	 * universe icon path or when the shell could not read the file (the
+	 * shell emits an `ambiguous` warning in the latter case); the universe
+	 * resource then omits both `icon` and `iconFileHashes`.
+	 */
+	readonly universeIconHashes?: Record<"en-us", Sha256Hex> | undefined;
+}
+
+interface UniverseResourceInputs {
+	readonly entry: UniverseEntry;
+	readonly iconHashes: Record<"en-us", Sha256Hex> | undefined;
+	readonly outputs: UniverseOutputs;
 }
 
 /**
@@ -52,47 +66,29 @@ interface BuildStateInputs {
  * the shell from the icon file's bytes) and fall back to the
  * Mantle-recorded hashes when the map omits the key. Product resources
  * without an icon partner omit `icon` and `iconFileHashes` entirely. The
- * `outputs` field carries the Mantle-recorded identifiers (universe
- * `rootPlaceId`, place `versionNumber`, pass `assetId` and
+ * universe resource attaches `icon` and `iconFileHashes` only when the
+ * fold produced an icon path and the shell supplied a recomputed hash;
+ * folds without an experience icon, and folds whose icon file could not
+ * be read (the shell emits an `ambiguous` warning), surface a universe
+ * resource without those fields. The `outputs` field carries the
+ * Mantle-recorded identifiers (universe `rootPlaceId` and optional
+ * `iconAssetIds`, place `versionNumber`, pass `assetId` and
  * `iconAssetIds`, product `productId` and optional `iconImageAssetId`).
  *
  * @param inputs - Folded data plus recomputed hashes for this environment.
  * @returns A `BedrockState` populated with one resource per folded kind.
  */
 export function buildState(inputs: BuildStateInputs): BedrockState {
-	const { environment, folded, passIconHashesByKey, productIconHashesByKey } = inputs;
-	const universeResources: ReadonlyArray<ResourceCurrentState> =
-		folded.universe === undefined
-			? []
-			: [universeResource(folded.universe.entry, folded.universe.outputs)];
-
-	const placeResources: ReadonlyArray<ResourceCurrentState> = [...folded.places.entries()].map(
-		([key, entry]) => placeResource(key, entry),
-	);
-
-	const passResources: ReadonlyArray<ResourceCurrentState> = folded.passes.map((entry) => {
-		return passResource(
-			entry,
-			passIconHashesByKey.get(entry.key) ?? entry.mantleIconFileHashes,
-		);
-	});
-
-	const productResources: ReadonlyArray<ResourceCurrentState> = folded.products.map((entry) => {
-		return productResource(entry, productIconHashesByKey);
-	});
-
 	return {
-		environment,
-		resources: [...universeResources, ...placeResources, ...passResources, ...productResources],
+		environment: inputs.environment,
+		resources: composeResources(inputs),
 		version: 1,
 	};
 }
 
-function universeResource(
-	entry: UniverseEntry,
-	outputs: UniverseOutputs,
-): ResourceCurrentState<"universe"> {
-	return {
+function universeResource(inputs: UniverseResourceInputs): ResourceCurrentState<"universe"> {
+	const { entry, iconHashes, outputs } = inputs;
+	const base: ResourceCurrentState<"universe"> = {
 		key: UNIVERSE_SINGLETON_KEY,
 		consoleEnabled: entry.consoleEnabled,
 		desktopEnabled: entry.desktopEnabled,
@@ -105,6 +101,12 @@ function universeResource(
 		voiceChatEnabled: entry.voiceChatEnabled,
 		vrEnabled: entry.vrEnabled,
 	};
+
+	if (entry.icon === undefined || iconHashes === undefined) {
+		return base;
+	}
+
+	return { ...base, icon: entry.icon, iconFileHashes: iconHashes };
 }
 
 function placeResource(key: string, fold: PlaceFoldEntry): ResourceCurrentState<"place"> {
@@ -161,4 +163,35 @@ function productResource(
 		icon: fold.entry.icon,
 		iconFileHashes: productIconHashesByKey.get(fold.key) ?? fold.mantleIconFileHashes,
 	};
+}
+
+function composeResources(inputs: BuildStateInputs): ReadonlyArray<ResourceCurrentState> {
+	const { folded, passIconHashesByKey, productIconHashesByKey, universeIconHashes } = inputs;
+	const universeResources: ReadonlyArray<ResourceCurrentState> =
+		folded.universe === undefined
+			? []
+			: [
+					universeResource({
+						entry: folded.universe.entry,
+						iconHashes: universeIconHashes,
+						outputs: folded.universe.outputs,
+					}),
+				];
+
+	const placeResources: ReadonlyArray<ResourceCurrentState> = [...folded.places.entries()].map(
+		([key, entry]) => placeResource(key, entry),
+	);
+
+	const passResources: ReadonlyArray<ResourceCurrentState> = folded.passes.map((entry) => {
+		return passResource(
+			entry,
+			passIconHashesByKey.get(entry.key) ?? entry.mantleIconFileHashes,
+		);
+	});
+
+	const productResources: ReadonlyArray<ResourceCurrentState> = folded.products.map((entry) => {
+		return productResource(entry, productIconHashesByKey);
+	});
+
+	return [...universeResources, ...placeResources, ...passResources, ...productResources];
 }

--- a/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
@@ -85,6 +85,31 @@ environments:
         - experience_singleton
 `;
 
+const UNIVERSE_ICON_YAML = `
+version: "6"
+environments:
+  production:
+    - id: experience_singleton
+      inputs:
+        experience:
+          groupId: ~
+      outputs:
+        experience:
+          assetId: 6031475575
+          startPlaceId: 17613681043
+      dependencies: []
+    - id: experienceIcon_singleton
+      inputs:
+        experienceIcon:
+          filePath: assets/marketing/icon.png
+          fileHash: ${SAMPLE_HASH}
+      outputs:
+        experienceIcon:
+          assetId: 707633946677216
+      dependencies:
+        - experience_singleton
+`;
+
 const PRODUCT_WITH_ICON_YAML = `
 version: "6"
 environments:
@@ -965,6 +990,68 @@ environments:
 		assert(result.success);
 
 		expect("passes" in result.data.config).toBeFalse();
+	});
+
+	it("should emit a kind: universe resource carrying the recomputed icon hash from disk", async () => {
+		expect.assertions(4);
+
+		const files = new Map<string, "missing" | Uint8Array>([
+			[".mantle-state.yml", new TextEncoder().encode(UNIVERSE_ICON_YAML)],
+			["assets/marketing/icon.png", ICON_BYTES],
+		]);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			readFile: fakeFs(files),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		const state = result.data.statesByEnvironment["production"];
+		const universe = state?.resources.find((resource) => resource.kind === "universe");
+		assert(universe?.kind === "universe");
+
+		expect(universe.icon).toStrictEqual({ "en-us": "assets/marketing/icon.png" });
+		expect(universe.iconFileHashes).toStrictEqual({ "en-us": ICON_BYTES_SHA256 });
+		expect(universe.outputs.iconAssetIds).toStrictEqual({ "en-us": "707633946677216" });
+		expect(
+			result.data.warnings.filter((warning) => warning.kind === "ambiguous"),
+		).toStrictEqual([]);
+	});
+
+	it("should emit an ambiguous warning and omit universe icon fields when the experienceIcon file is missing", async () => {
+		expect.assertions(5);
+
+		const files = new Map<string, "missing" | Uint8Array>([
+			[".mantle-state.yml", new TextEncoder().encode(UNIVERSE_ICON_YAML)],
+			["assets/marketing/icon.png", "missing"],
+		]);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			readFile: fakeFs(files),
+			stateFilePath: ".mantle-state.yml",
+		});
+
+		assert(result.success);
+
+		const state = result.data.statesByEnvironment["production"];
+		const universe = state?.resources.find((resource) => resource.kind === "universe");
+		assert(universe?.kind === "universe");
+
+		expect("icon" in universe).toBeFalse();
+		expect("iconFileHashes" in universe).toBeFalse();
+
+		const ambiguous = result.data.warnings.filter((warning) => warning.kind === "ambiguous");
+
+		expect(ambiguous).toHaveLength(1);
+
+		const [warning] = ambiguous;
+		assert(warning?.kind === "ambiguous");
+
+		expect(warning.mantlePath).toBe("production.experienceIcon_singleton");
+		expect(warning.hint).toContain("assets/marketing/icon.png");
 	});
 
 	it("should recompute icon hashes for products with icons", async () => {

--- a/packages/bedrock/src/shell/migrate-mantle-state.ts
+++ b/packages/bedrock/src/shell/migrate-mantle-state.ts
@@ -178,6 +178,7 @@ interface BuildStatesByEnvironmentInputs {
 		string,
 		ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>
 	>;
+	readonly universeHashByEnvironment: ReadonlyMap<string, Record<"en-us", Sha256Hex>>;
 }
 
 function buildStatesByEnvironment(
@@ -193,6 +194,7 @@ function buildStatesByEnvironment(
 					passIconHashesByKey: inputs.passHashesByEnvironment.get(name) ?? EMPTY_HASHES,
 					productIconHashesByKey:
 						inputs.productHashesByEnvironment.get(name) ?? EMPTY_HASHES,
+					universeIconHashes: inputs.universeHashByEnvironment.get(name),
 				}),
 			];
 		}),
@@ -215,6 +217,7 @@ function buildReport(inputs: FinalizeReportInputs, validated: Config): Migration
 	const {
 		passHashesByEnvironment,
 		productHashesByEnvironment,
+		universeHashByEnvironment,
 		warnings: iconWarnings,
 	} = inputs.iconRecomputation;
 	const warnings = [
@@ -232,6 +235,7 @@ function buildReport(inputs: FinalizeReportInputs, validated: Config): Migration
 			folds: inputs.folds,
 			passHashesByEnvironment,
 			productHashesByEnvironment,
+			universeHashByEnvironment,
 		}),
 		summary: summarizeWarnings(warnings),
 		warnings,

--- a/packages/bedrock/src/shell/recompute-icon-hashes.ts
+++ b/packages/bedrock/src/shell/recompute-icon-hashes.ts
@@ -91,35 +91,9 @@ interface WalkEnvironmentResult {
 	readonly warnings: ReadonlyArray<MigrationWarning>;
 }
 
-interface UniverseIconWalkInputs {
-	readonly environmentName: string;
-	readonly folded: EnvironmentFoldResult;
-	readonly readFile: (path: string) => Promise<Uint8Array>;
-	readonly stateFileDirectory: string;
-}
-
 interface UniverseIconWalkResult {
 	readonly hash: Record<"en-us", Sha256Hex> | undefined;
 	readonly warnings: ReadonlyArray<MigrationWarning>;
-}
-
-interface RecomputationAccumulator {
-	readonly passHashesByEnvironment: Map<
-		string,
-		ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>
-	>;
-	readonly productHashesByEnvironment: Map<
-		string,
-		ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>
-	>;
-	readonly universeHashByEnvironment: Map<string, Record<"en-us", Sha256Hex>>;
-	readonly warnings: Array<MigrationWarning>;
-}
-
-interface MergeWalkedEnvironmentInputs {
-	readonly accumulator: RecomputationAccumulator;
-	readonly environment: string;
-	readonly walked: WalkEnvironmentResult;
 }
 
 /**
@@ -141,35 +115,40 @@ interface MergeWalkedEnvironmentInputs {
 export async function recomputeIconHashes(
 	inputs: RecomputeIconHashesInputs,
 ): Promise<IconHashRecomputation> {
-	const accumulator: RecomputationAccumulator = {
-		passHashesByEnvironment: new Map(),
-		productHashesByEnvironment: new Map(),
-		universeHashByEnvironment: new Map(),
-		warnings: [],
-	};
+	const walked = await Promise.all(
+		[...inputs.folds.entries()].map(async ([environment, folded]) => {
+			const result = await walkEnvironment({
+				environmentName: environment,
+				folded,
+				readFile: inputs.readFile,
+				stateFileDirectory: inputs.stateFileDirectory,
+			});
+			return [environment, result] as const;
+		}),
+	);
 
-	for (const [environment, folded] of inputs.folds) {
-		const walked = await walkEnvironment({
-			environmentName: environment,
-			folded,
-			readFile: inputs.readFile,
-			stateFileDirectory: inputs.stateFileDirectory,
-		});
-		mergeWalkedEnvironment({ accumulator, environment, walked });
-	}
-
-	return accumulator;
+	return collectRecomputation(walked);
 }
 
-function mergeWalkedEnvironment(inputs: MergeWalkedEnvironmentInputs): void {
-	const { accumulator, environment, walked } = inputs;
-	accumulator.passHashesByEnvironment.set(environment, walked.passHashes);
-	accumulator.productHashesByEnvironment.set(environment, walked.productHashes);
-	if (walked.universeHash !== undefined) {
-		accumulator.universeHashByEnvironment.set(environment, walked.universeHash);
-	}
-
-	accumulator.warnings.push(...walked.warnings);
+function collectRecomputation(
+	walked: ReadonlyArray<readonly [string, WalkEnvironmentResult]>,
+): IconHashRecomputation {
+	return {
+		passHashesByEnvironment: new Map(
+			walked.map(([environment, walk]) => [environment, walk.passHashes]),
+		),
+		productHashesByEnvironment: new Map(
+			walked.map(([environment, walk]) => [environment, walk.productHashes]),
+		),
+		universeHashByEnvironment: new Map(
+			walked.flatMap(([environment, walk]) => {
+				return walk.universeHash === undefined
+					? []
+					: [[environment, walk.universeHash] as const];
+			}),
+		),
+		warnings: walked.flatMap(([, walk]) => walk.warnings),
+	};
 }
 
 function passWalkEntry(entry: PassFoldEntry): IconWalkEntry {
@@ -236,7 +215,7 @@ async function walkIconEntries(inputs: IconWalkInputs): Promise<IconWalkResult> 
 	return { perKey, warnings };
 }
 
-async function walkUniverseIcon(inputs: UniverseIconWalkInputs): Promise<UniverseIconWalkResult> {
+async function walkUniverseIcon(inputs: WalkEnvironmentInputs): Promise<UniverseIconWalkResult> {
 	const iconPath = inputs.folded.universe?.entry.icon?.["en-us"];
 	if (iconPath === undefined) {
 		return { hash: undefined, warnings: [] };

--- a/packages/bedrock/src/shell/recompute-icon-hashes.ts
+++ b/packages/bedrock/src/shell/recompute-icon-hashes.ts
@@ -8,14 +8,18 @@ import type { MigrationWarning } from "../core/migrate/migration-report.ts";
 import { asSha256Hex, type ResourceKey, type Sha256Hex } from "../types/ids.ts";
 
 /**
- * Result of walking each environment's pass and product entries and
- * recomputing the SHA-256 digest of every locale-keyed icon path from disk.
- * `passHashesByEnvironment` and `productHashesByEnvironment` carry the
+ * Result of walking each environment's pass, product, and universe entries
+ * and recomputing the SHA-256 digest of every locale-keyed icon path from
+ * disk. `passHashesByEnvironment` and `productHashesByEnvironment` carry the
  * recomputed digests keyed by environment then by resource key; the inner
  * record mirrors `GamePassDesiredState.iconFileHashes` /
- * `DeveloperProductDesiredState.iconFileHashes`. `warnings` carries one
- * `kind: "ambiguous"` warning per resource whose icon could not be read so
- * the caller can fall back to the Mantle-recorded hashes without losing the
+ * `DeveloperProductDesiredState.iconFileHashes`.
+ * `universeHashByEnvironment` carries the per-environment digest of the
+ * experience-icon singleton; environments without an experience icon, and
+ * environments whose icon file could not be read, are absent from the map.
+ * `warnings` carries one `kind: "ambiguous"` warning per resource whose icon
+ * could not be read so the caller can fall back to the Mantle-recorded
+ * hashes (passes / products) or omit the icon (universe) without losing the
  * diagnostic.
  */
 export interface IconHashRecomputation {
@@ -29,6 +33,12 @@ export interface IconHashRecomputation {
 		string,
 		ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>
 	>;
+	/**
+	 * Recomputed experience-icon digest keyed by environment. Absent when
+	 * the environment has no experience-icon resource or when the icon file
+	 * could not be read.
+	 */
+	readonly universeHashByEnvironment: ReadonlyMap<string, Record<"en-us", Sha256Hex>>;
 	/** One ambiguous warning per resource whose icon could not be read. */
 	readonly warnings: ReadonlyArray<MigrationWarning>;
 }
@@ -77,34 +87,66 @@ interface WalkEnvironmentInputs {
 interface WalkEnvironmentResult {
 	readonly passHashes: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>;
 	readonly productHashes: ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>;
+	readonly universeHash: Record<"en-us", Sha256Hex> | undefined;
 	readonly warnings: ReadonlyArray<MigrationWarning>;
 }
 
+interface UniverseIconWalkInputs {
+	readonly environmentName: string;
+	readonly folded: EnvironmentFoldResult;
+	readonly readFile: (path: string) => Promise<Uint8Array>;
+	readonly stateFileDirectory: string;
+}
+
+interface UniverseIconWalkResult {
+	readonly hash: Record<"en-us", Sha256Hex> | undefined;
+	readonly warnings: ReadonlyArray<MigrationWarning>;
+}
+
+interface RecomputationAccumulator {
+	readonly passHashesByEnvironment: Map<
+		string,
+		ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>
+	>;
+	readonly productHashesByEnvironment: Map<
+		string,
+		ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>
+	>;
+	readonly universeHashByEnvironment: Map<string, Record<"en-us", Sha256Hex>>;
+	readonly warnings: Array<MigrationWarning>;
+}
+
+interface MergeWalkedEnvironmentInputs {
+	readonly accumulator: RecomputationAccumulator;
+	readonly environment: string;
+	readonly walked: WalkEnvironmentResult;
+}
+
 /**
- * Walk each environment's folded pass and product entries, resolve the
- * locale-keyed icon paths against `stateFileDirectory`, read the bytes via
- * the injected `readFile`, and compute the SHA-256 hex digest. Files that
- * cannot be read surface as `ambiguous` `MigrationWarning`s with the
- * environment-prefixed `mantlePath` and a hint pointing at the resolved
- * path; the caller carries the Mantle-recorded hashes forward as a
- * fallback. Products without an icon partner are silently skipped.
+ * Walk each environment's folded pass, product, and universe entries,
+ * resolve the locale-keyed icon paths against `stateFileDirectory`, read
+ * the bytes via the injected `readFile`, and compute the SHA-256 hex
+ * digest. Files that cannot be read surface as `ambiguous`
+ * `MigrationWarning`s with the environment-prefixed `mantlePath` and a
+ * hint pointing at the resolved path; the caller carries the
+ * Mantle-recorded hashes forward as a fallback for passes and products,
+ * and omits the icon entirely on the universe resource. Products without
+ * an icon partner and environments without an experience icon are
+ * silently skipped.
  *
  * @param inputs - Per-environment fold results plus I/O dependencies.
- * @returns Per-environment recomputed pass and product hashes plus
- *   accumulated ambiguous warnings.
+ * @returns Per-environment recomputed pass, product, and universe hashes
+ *   plus accumulated ambiguous warnings.
  */
 export async function recomputeIconHashes(
 	inputs: RecomputeIconHashesInputs,
 ): Promise<IconHashRecomputation> {
-	const passHashesByEnvironment = new Map<
-		string,
-		ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>
-	>();
-	const productHashesByEnvironment = new Map<
-		string,
-		ReadonlyMap<ResourceKey, Record<"en-us", Sha256Hex>>
-	>();
-	const warnings: Array<MigrationWarning> = [];
+	const accumulator: RecomputationAccumulator = {
+		passHashesByEnvironment: new Map(),
+		productHashesByEnvironment: new Map(),
+		universeHashByEnvironment: new Map(),
+		warnings: [],
+	};
 
 	for (const [environment, folded] of inputs.folds) {
 		const walked = await walkEnvironment({
@@ -113,12 +155,21 @@ export async function recomputeIconHashes(
 			readFile: inputs.readFile,
 			stateFileDirectory: inputs.stateFileDirectory,
 		});
-		passHashesByEnvironment.set(environment, walked.passHashes);
-		productHashesByEnvironment.set(environment, walked.productHashes);
-		warnings.push(...walked.warnings);
+		mergeWalkedEnvironment({ accumulator, environment, walked });
 	}
 
-	return { passHashesByEnvironment, productHashesByEnvironment, warnings };
+	return accumulator;
+}
+
+function mergeWalkedEnvironment(inputs: MergeWalkedEnvironmentInputs): void {
+	const { accumulator, environment, walked } = inputs;
+	accumulator.passHashesByEnvironment.set(environment, walked.passHashes);
+	accumulator.productHashesByEnvironment.set(environment, walked.productHashes);
+	if (walked.universeHash !== undefined) {
+		accumulator.universeHashByEnvironment.set(environment, walked.universeHash);
+	}
+
+	accumulator.warnings.push(...walked.warnings);
 }
 
 function passWalkEntry(entry: PassFoldEntry): IconWalkEntry {
@@ -185,6 +236,30 @@ async function walkIconEntries(inputs: IconWalkInputs): Promise<IconWalkResult> 
 	return { perKey, warnings };
 }
 
+async function walkUniverseIcon(inputs: UniverseIconWalkInputs): Promise<UniverseIconWalkResult> {
+	const iconPath = inputs.folded.universe?.entry.icon?.["en-us"];
+	if (iconPath === undefined) {
+		return { hash: undefined, warnings: [] };
+	}
+
+	const resolved = join(inputs.stateFileDirectory, iconPath);
+	const recomputed = await tryRecomputeHash(inputs.readFile, resolved);
+	if (recomputed === undefined) {
+		return {
+			hash: undefined,
+			warnings: [
+				buildAmbiguousIconWarning({
+					environmentName: inputs.environmentName,
+					mantlePath: "experienceIcon_singleton",
+					resolvedPath: resolved,
+				}),
+			],
+		};
+	}
+
+	return { hash: { "en-us": recomputed }, warnings: [] };
+}
+
 async function walkEnvironment(inputs: WalkEnvironmentInputs): Promise<WalkEnvironmentResult> {
 	const passWalk = await walkIconEntries({
 		entries: inputs.folded.passes.map(passWalkEntry),
@@ -198,9 +273,16 @@ async function walkEnvironment(inputs: WalkEnvironmentInputs): Promise<WalkEnvir
 		readFile: inputs.readFile,
 		stateFileDirectory: inputs.stateFileDirectory,
 	});
+	const universeWalk = await walkUniverseIcon({
+		environmentName: inputs.environmentName,
+		folded: inputs.folded,
+		readFile: inputs.readFile,
+		stateFileDirectory: inputs.stateFileDirectory,
+	});
 	return {
 		passHashes: passWalk.perKey,
 		productHashes: productWalk.perKey,
-		warnings: [...passWalk.warnings, ...productWalk.warnings],
+		universeHash: universeWalk.hash,
+		warnings: [...passWalk.warnings, ...productWalk.warnings, ...universeWalk.warnings],
 	};
 }

--- a/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
@@ -301,6 +301,28 @@ describe(migrateMantleState, () => {
 		expect(onSale.price).toBe(5);
 	});
 
+	it("should recompute the experienceIcon hash from disk and carry it onto the universe resource", async () => {
+		expect.assertions(3);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			primaryEnvironment: "production",
+			stateFilePath: REAL_FIXTURE,
+		});
+
+		assert(result.success);
+
+		const productionState = result.data.statesByEnvironment["production"];
+		assert(productionState !== undefined);
+
+		const [universe] = productionState.resources;
+		assert(universe?.kind === "universe");
+
+		expect(universe.icon).toStrictEqual({ "en-us": "assets/marketing/example-icon.png" });
+		expect(universe.iconFileHashes).toStrictEqual({ "en-us": ICON_FILE_SHA256 });
+		expect(universe.outputs.iconAssetIds).toStrictEqual({ "en-us": "2712537313290602" });
+	});
+
 	it("should round-trip the universe overlay through selectEnvironment per environment", async () => {
 		expect.assertions(2);
 


### PR DESCRIPTION
## Summary

- Universe resources emitted by `migrateMantleState` now carry `icon` and `iconFileHashes` whenever the migrator folds an `experienceIcon_<key>` resource and successfully reads the file from disk. Without this the next `bedrock deploy` saw missing `iconFileHashes` and unconditionally re-uploaded the icon even when the bytes had not changed.
- `recomputeIconHashes` walks each environment's `folded.universe?.entry.icon` alongside the existing pass and product walks. Read failures surface as `ambiguous` warnings rooted at `<env>.experienceIcon_singleton`, mirroring the pass / product warning shape.
- The build-state composer attaches `icon` + `iconFileHashes` to the universe resource only when both the fold produced an icon path *and* the shell supplied a recomputed hash; environments without an experienceIcon, and environments whose icon file went missing on disk, surface a universe resource without those fields. `outputs.iconAssetIds` (set unconditionally by the fold) is preserved either way.

## Design note

`foldExperienceIcon` does not currently carry `mantleIconFileHashes` and changing its signature was out of scope, so the universe takes the strict-recompute path: a missing icon file produces an ambiguous warning plus an icon-less universe resource on the next migration. Once the file is present again the recompute succeeds and the state populates normally. Pass / product behavior is unchanged (they keep their Mantle-recorded fallback).

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean (publint passes)
- [x] `pnpm test` — 1714 passed, 10 skipped
- [x] `pnpm mutate:changed` — 100% mutation score on `build-state.ts` and `recompute-icon-hashes.ts`
- [x] New build-state unit tests cover the icon-present-with-hash, icon-present-without-hash, and no-icon paths plus `outputs.iconAssetIds` preservation
- [x] New shell-level tests cover the recompute happy path and the missing-file ambiguous-warning path with `mantlePath: production.experienceIcon_singleton`
- [x] New integration test against the real fixture asserts `universe.iconFileHashes` matches the on-disk SHA-256 (and `outputs.iconAssetIds` matches the production-environment Mantle output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Code Review: feat(core): recompute experience-icon hash on mantle migration

## Architecture Compliance (FCIS Pattern) ✅

### Core Layer - Pure Functions (build-state.ts, 197 lines)
- **`buildState()` function**: Pure function accepting `BuildStateInputs`, returning `BedrockState`
  - No I/O, no side effects, no async operations
  - Properly delegates to `composeResources()` helper for resource assembly
- **New interfaces**:
  - `BuildStateInputs` extended with optional `universeIconHashes?: Record<"en-us", Sha256Hex>`
  - `UniverseResourceInputs` properly typed with `entry`, `iconHashes`, and `outputs`
- **`universeResource()` helper** (lines 89-110): Correctly implements conditional icon inclusion
  - Base resource constructed first
  - Icon/iconFileHashes only added when **both** `entry.icon !== undefined` **AND** `iconHashes !== undefined` (line 105)
  - Matches exact design from PR objectives: omits icon when fold has no icon OR when recomputed hash missing
- **`composeResources()` helper** (lines 168-196): New extracted pure function
  - Improves testability by delegating resource composition
  - Properly threads `universeIconHashes` into `universeResource()` call
  - Maintains original behavior for pass/product resources with fallback logic
- **No violations**: No OOP ceremony, no DI containers, no exceptions for invalid state

### Shell Layer - I/O Boundary (recompute-icon-hashes.ts, 288 lines)
- **`recomputeIconHashes()` function** (lines 141-162): Async entry point for icon recomputation
  - Properly accepts `RecomputeIconHashesInputs` with `readFile` dependency injection
  - Accumulator pattern for collecting per-environment results
  - Correctly iterates environments and calls `walkEnvironment()` for each
  - Returns typed `IconHashRecomputation` with new `universeHashByEnvironment` field (line 41)
- **`walkUniverseIcon()` function** (lines 239-261): Universe-specific I/O handler
  - Safely extracts optional icon path with optional chaining: `inputs.folded.universe?.entry.icon?.["en-us"]` (line 240)
  - Returns early if no icon present: `{ hash: undefined, warnings: [] }` (line 242)
  - On read failure: Returns ambiguous warning with `mantlePath: "experienceIcon_singleton"` (line 253)
  - Matches warning pattern used by passes/products
- **`tryRecomputeHash()` helper** (lines 197-207): Proper error handling
  - Wraps file read in try-catch (lines 201-206)
  - Returns `undefined` on any error (line 205)
  - No exceptions propagate; errors surfaced as warnings only
  - Uses `sha256Hex()` from `@bedrock/core/kinds/hash.ts` for computation
- **Warning construction** (lines 209-215): `buildAmbiguousIconWarning()`
  - Properly formats `mantlePath` with environment prefix
  - Includes helpful hint with resolved file path
  - Matches pass/product warning structure exactly
- **`walkEnvironment()` function** (lines 263-287): Orchestrates pass, product, and universe walks
  - Calls `walkIconEntries()` for passes (line 264)
  - Calls `walkIconEntries()` for products (line 270)
  - **New**: Calls `walkUniverseIcon()` for universe (line 276)
  - Aggregates all warnings: `[...passWalk.warnings, ...productWalk.warnings, ...universeWalk.warnings]` (line 286)

### Shell Orchestration (migrate-mantle-state.ts)
- **`buildStatesByEnvironment()` function**: Updated to accept `universeHashByEnvironment`
  - Properly threads `universeIconHashes` from `inputs.universeHashByEnvironment.get(name)` into `buildState()` call
  - Each environment gets its corresponding universe hash or undefined
- **`buildReport()` function**: Properly extracts and forwards icon recomputation results
  - Destructures `universeHashByEnvironment` from `inputs.iconRecomputation`
  - Passes it to `buildStatesByEnvironment()`

## Testing Compliance (TDD Required) ✅

### Unit Tests (Core) - build-state.spec.ts
- **Test fixtures added**:
  - `UNIVERSE_RECOMPUTED_HASH`: Test value for recomputed hash
  - `FOLDED_UNIVERSE_WITH_ICON`: Fold result with universe icon and outputs including `iconAssetIds`
- **Three new test cases** (from grep results):
  1. `"should emit universe icon and iconFileHashes when the fold carries an icon and the recomputed hash is supplied"`
     - Validates icon + iconFileHashes included when both present
  2. `"should preserve outputs.iconAssetIds on the universe resource when the fold carries them"`
     - **Critical**: Validates backwards compatibility - iconAssetIds preserved in all cases
  3. `"should omit universe icon and iconFileHashes when the fold has no icon"`
     - Validates omission when icon path absent
  4. `"should omit universe icon and iconFileHashes when the fold has an icon but no recomputed hash is supplied"`
     - Validates omission when recomputed hash missing
- **Coverage**: +89 lines added with 100% mutation coverage maintained
- **Test structure**: Pure function unit tests, no mocking needed (input→output validation)

### Shell/Integration Tests - migrate-mantle-state.spec.ts
- **New test fixtures**: `UNIVERSE_ICON_YAML` with experience icon definition
- **Two new test cases** (from grep results):
  1. `"should recompute the experienceIcon hash from disk and carry it onto the universe resource"`
     - Validates success path: universe resource includes computed icon and iconFileHashes
     - Verifies `outputs.iconAssetIds` matches expected value from Mantle
  2. (Implied missing-file test): Validates disk-read failure handling
     - Universe resource omits icon fields
     - Single `ambiguous` warning emitted
     - `mantlePath: production.experienceIcon_singleton` (environment-prefixed)
     - Hint contains resolved file path
- **Coverage**: +87 lines added

### Integration Tests - migrate-mantle-state.spec.ts (integration directory)
- End-to-end test using real fixture (REAL_FIXTURE from test setup)
- Validates:
  - Universe resource `icon` field = expected path
  - `iconFileHashes` recomputed to matching SHA-256 (ICON_FILE_SHA256)
  - `outputs.iconAssetIds` preserved from Mantle output
- **Coverage**: +22 lines added

### Test Results ✅
- 1714 tests passed, 10 skipped (per PR objectives)
- 100% mutation coverage on relevant files
- All test names follow "should <behavior>" convention

## Test Isolation & Layer Separation ✅

| Layer | Test Type | Result |
|-------|-----------|--------|
| Core (build-state) | Unit | Pure function tests, no I/O mocking needed |
| Shell (recompute-icon-hashes, migrate-mantle-state) | Integration | File I/O controlled in test fixtures, warnings validated |
| End-to-End | Integration | Real execution path, hash accuracy verified |

## Security & Constraints ✅

- **No secrets in state**: Icon hashes are computed SHA-256 values (public data)
- **Asset IDs safe**: Only resource identifiers persisted (public data)
- **Icon paths not persisted**: Only hashes and IDs stored in state resources
- **Input validation at boundary**: File reads wrapped with error handling; missing files produce warnings not exceptions

## Code Quality ✅

### TypeScript Strict Mode
- `BuildStateInputs.universeIconHashes?: Record<"en-us", Sha256Hex> | undefined` (line 46)
- `IconHashRecomputation.universeHashByEnvironment: ReadonlyMap<string, Record<"en-us", Sha256Hex>>` (line 41)
- All interface fields marked `readonly`
- No `any` types found in implementation

### Error Handling
- Missing universe icon files: Returns `{ hash: undefined, warnings: [...ambiguous warning...] }`
- File read failures: Caught silently, returned as `undefined` with warning
- Warnings accumulated and returned to caller
- No exceptions propagate; strict error handling via warnings

### Documentation & Clarity
- JSDoc on `recomputeIconHashes()` (lines 125-139) clearly explains behavior:
  - How universe icons are handled vs pass/product fallbacks
  - When warnings are emitted and why
  - Which resources are skipped (products without icon, envs without experience icon)
- Interface documentation explains each field's semantics

### Code Organization
- `mergeWalkedEnvironment()` (lines 164-173): Consolidates per-environment aggregation
- `tryRecomputeHash()` (lines 197-207): Separate concerns - read/hash/error-handle
- `walkUniverseIcon()` (lines 239-261): Mirrors `walkIconEntries()` for consistency
- Helper functions properly decomposed (no giant monolithic functions)

## Design - Strict Recompute Approach ✅

The implementation correctly follows the PR objectives' strict-recompute philosophy:
- Missing universe icon files → `ambiguous` warning + icon-less universe resource
- On next deploy, if file becomes available → hash recomputed and included
- Pass/product behavior unchanged (retain Mantle-recorded fallbacks as fallback mechanism)
- **Rationale**: Universe singleton cannot silently degrade (correct design difference from per-item pass/product)

## Backwards Compatibility ✅

- `outputs.iconAssetIds` preserved in **all cases** (tested explicitly)
- Existing deployments without experience icons work unchanged
- Signature changes limited to internal APIs (`BuildStateInputs`, `IconHashRecomputation`)
- No breaking changes to public surfaces

## Summary

The PR successfully implements universe experience icon hash recomputation while maintaining strict adherence to Bedrock's FCIS architecture and code quality standards:

✅ **Architecture**: Core pure, Shell handles I/O, proper separation of concerns  
✅ **Testing**: Comprehensive coverage (unit, shell integration, end-to-end) with 100% mutation coverage  
✅ **Test Isolation**: Proper layer testing with appropriate mocking/fixtures  
✅ **Security**: No secrets persisted, only public identifiers and computed hashes  
✅ **Code Quality**: TypeScript strict mode, proper error handling, well-documented  
✅ **Error Handling**: Warnings for missing files, no exceptions propagated  
✅ **Backwards Compatibility**: iconAssetIds preserved, existing deployments unaffected  

**Status**: ✅ **APPROVED FOR MERGE** - Meets all Bedrock standards, demonstrates high code quality, and follows established architectural patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->