### PR TITLE
fix(core): clarify group-id migration warning reason

### DIFF
--- a/packages/bedrock/src/core/migrate/fold-blocked-experience-fields.ts
+++ b/packages/bedrock/src/core/migrate/fold-blocked-experience-fields.ts
@@ -11,7 +11,8 @@ const EXPERIENCE_KIND = "experience";
 const EXPERIENCE_CONFIGURATION_KIND = "experienceConfiguration";
 const UNIVERSE_AVATAR_PREFIX = "universeAvatar";
 const UNIVERSE_AVATAR_REASON = "avatar configuration has no Open Cloud equivalent";
-const GROUP_ID_REASON = "Open Cloud does not support transferring experience ownership";
+const GROUP_ID_REASON =
+	"Mantle used `groupId` to set the owning group when creating the experience. Bedrock requires pre-existing universe and place IDs and does not use this field.";
 
 /**
  * `experienceConfiguration_singleton` fields with no Open Cloud writable

--- a/packages/bedrock/src/core/migrate/fold-universe.spec.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.spec.ts
@@ -1416,7 +1416,7 @@ describe(foldUniverse, () => {
 				{
 					kind: "blocked",
 					mantlePath: "experience_singleton.groupId",
-					reason: "Open Cloud does not support transferring experience ownership",
+					reason: "Mantle used `groupId` to set the owning group when creating the experience. Bedrock requires pre-existing universe and place IDs and does not use this field.",
 				},
 			]);
 		});
@@ -1459,7 +1459,7 @@ describe(foldUniverse, () => {
 			assert(groupIdBlocked[0]?.kind === "blocked");
 
 			expect(groupIdBlocked[0].reason).toBe(
-				"Open Cloud does not support transferring experience ownership",
+				"Mantle used `groupId` to set the owning group when creating the experience. Bedrock requires pre-existing universe and place IDs and does not use this field.",
 			);
 		});
 	});


### PR DESCRIPTION
## Summary

The `groupId` migration warning previously read `Open Cloud does not support transferring experience ownership`. That sentence is wrong on both halves: Mantle did not use `groupId` to transfer ownership (it set the owning group when *creating* the experience), and bedrock is not blocked by an Open Cloud capability gap (bedrock does not create universes or places, so the field has no role).

This PR rewords `GROUP_ID_REASON` in `fold-blocked-experience-fields.ts` to describe what Mantle actually did with the field and why bedrock has no equivalent. Two `fold-universe.spec.ts` assertions are updated to the new string.

The warning kind stays `blocked`; only the human-readable `reason` text changes. A future PR could revisit whether `blocked` is still the right classification for fields that bedrock omits by design rather than by Open Cloud limitation, but that is out of scope here.

## Test plan

- [x] `pnpm --filter @bedrock/core test fold-universe.spec.ts fold-blocked-experience-fields` passes
- [x] `pnpm lint` clean
- [x] `hk` pre-commit hooks (lint, typecheck, test, build) pass on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Architecture Compliance ✓

**FCIS Pattern**: Change is confined to `Core` layer (`packages/bedrock/src/core/migrate/`). The `foldBlockedExperienceFields()` function remains a pure function with no I/O, no side effects, and no state mutation. The constant string update preserves the functional contract.

**Driven Port Isolation**: No changes to `src/ports/`, `src/adapters/`, or `src/shell/`. Migration logic boundaries remain intact.

## Testing ✓

**TDD Compliance**: Unit tests in `fold-universe.spec.ts` are colocated and properly updated:
- Line 1419: First assertion updated to match new `GROUP_ID_REASON`
- Line 1462: Second assertion (in "should read groupId...when other resources precede it" test) updated identically

Test structure is sound:
- Assertion count is correct (`expect.assertions(1)` and `expect.assertions(2)`)
- Tests verify the warning emission and message content via `toStrictEqual()`
- Test naming follows project convention: `it("should emit a blocked warning when...")`
- No mock behavior testing — assertions check the actual warning object shape and reason field

**Coverage**: Change adds no new code paths; it only updates a constant and its corresponding assertion values. Existing coverage is maintained.

## Code Quality ✓

**TypeScript Strict Mode**: String constant is properly typed. No type widening or `any` types.

**Clarity**: The new message is more precise than the prior wording:
- Explicitly states Mantle's use of `groupId` for group ownership at creation time
- Clarifies Bedrock's architectural requirement: pre-existing universe and place IDs
- Explains why the field is not used in Bedrock (different design model)

**Minimal Scope**: Only two files touched; change is surgical and focused on user-facing message text.

## Observations

- Warning kind remains `blocked` (PR author acknowledges potential future reconsideration of whether `blocked` is appropriate for design-omitted fields, correctly noted as out of scope)
- No functional logic changes — this is a documentation/UX improvement
- Pre-commit hooks (lint, typecheck, test, build) all reported as passing locally

## Verdict

**Approved**. Low-risk clarification change with proper test updates and no architectural violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->