### PR TITLE
feat(core): lift mantle display-name prefixes to environment labels

### DIFF
--- a/packages/bedrock/src/core/migrate/environment-label.spec.ts
+++ b/packages/bedrock/src/core/migrate/environment-label.spec.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+
+import { asRobloxAssetId, asSha256Hex } from "../../types/ids.ts";
+import { computeEnvironmentLabel } from "./environment-label.ts";
+import type { EnvironmentFoldResult } from "./fold-environment.ts";
+import type { PlaceFoldEntry } from "./fold-places.ts";
+
+const VALID_HASH = asSha256Hex("908498abb7f4fca2b7d2b050bfe7c48c009202fabd85f489b03bb19ac6e0b1d9");
+
+function placeFold(displayName: string | undefined): PlaceFoldEntry {
+	return {
+		entry:
+			displayName === undefined
+				? { filePath: "place.rbxl" }
+				: { displayName, filePath: "place.rbxl" },
+		fileHash: VALID_HASH,
+		outputs: { versionNumber: 53 },
+		placeId: "17613681043",
+	};
+}
+
+function universeWithDisplayName(
+	displayName: string | undefined,
+): EnvironmentFoldResult["universe"] {
+	return {
+		entry:
+			displayName === undefined
+				? { universeId: "1234567890" }
+				: { displayName, universeId: "1234567890" },
+		outputs: { rootPlaceId: asRobloxAssetId("17613681043") },
+	};
+}
+
+function fold(overrides: Partial<EnvironmentFoldResult> = {}): EnvironmentFoldResult {
+	return {
+		passes: [],
+		places: new Map(),
+		products: [],
+		universe: undefined,
+		warnings: [],
+		...overrides,
+	};
+}
+
+function withPlaces(
+	places: ReadonlyArray<readonly [key: string, displayName: string | undefined]>,
+): EnvironmentFoldResult {
+	return fold({
+		places: new Map(places.map(([key, displayName]) => [key, placeFold(displayName)])),
+	});
+}
+
+describe(computeEnvironmentLabel, () => {
+	it("should return the lowercased label when every place displayName shares the same bracketed prefix", () => {
+		expect.assertions(1);
+
+		const result = computeEnvironmentLabel(
+			withPlaces([
+				["start", "[DEVELOPMENT] Lobby"],
+				["game", "[DEVELOPMENT] Match"],
+			]),
+		);
+
+		expect(result).toBe("development");
+	});
+
+	it("should return undefined when every displayName lacks a bracketed prefix", () => {
+		expect.assertions(1);
+
+		const result = computeEnvironmentLabel(
+			withPlaces([
+				["start", "Lobby"],
+				["game", "Match"],
+			]),
+		);
+
+		expect(result).toBeUndefined();
+	});
+
+	it("should return undefined when display names mix prefixed and unprefixed entries", () => {
+		expect.assertions(1);
+
+		const result = computeEnvironmentLabel(
+			withPlaces([
+				["start", "Lobby"],
+				["game", "[DEVELOPMENT] Match"],
+			]),
+		);
+
+		expect(result).toBeUndefined();
+	});
+
+	it("should return undefined when display names carry differing bracketed prefixes", () => {
+		expect.assertions(1);
+
+		const result = computeEnvironmentLabel(
+			withPlaces([
+				["start", "[DEV] Lobby"],
+				["game", "[STAGING] Match"],
+			]),
+		);
+
+		expect(result).toBeUndefined();
+	});
+
+	it("should return undefined when the environment has no display names at all", () => {
+		expect.assertions(1);
+
+		const result = computeEnvironmentLabel(
+			withPlaces([
+				["start", undefined],
+				["game", undefined],
+			]),
+		);
+
+		expect(result).toBeUndefined();
+	});
+
+	it("should consider the universe displayName alongside place display names", () => {
+		expect.assertions(1);
+
+		const result = computeEnvironmentLabel(
+			fold({
+				places: new Map([["game", placeFold("[DEVELOPMENT] Match")]]),
+				universe: universeWithDisplayName("[DEVELOPMENT] My Game"),
+			}),
+		);
+
+		expect(result).toBe("development");
+	});
+
+	it("should return undefined when the universe and a place disagree on prefix", () => {
+		expect.assertions(1);
+
+		const result = computeEnvironmentLabel(
+			fold({
+				places: new Map([["game", placeFold("[DEV] Match")]]),
+				universe: universeWithDisplayName("[DEVELOPMENT] My Game"),
+			}),
+		);
+
+		expect(result).toBeUndefined();
+	});
+
+	it("should ignore places that have no displayName when computing consensus", () => {
+		expect.assertions(1);
+
+		const result = computeEnvironmentLabel(
+			withPlaces([
+				["start", undefined],
+				["game", "[DEVELOPMENT] Match"],
+			]),
+		);
+
+		expect(result).toBe("development");
+	});
+});

--- a/packages/bedrock/src/core/migrate/environment-label.ts
+++ b/packages/bedrock/src/core/migrate/environment-label.ts
@@ -16,19 +16,13 @@ import type { EnvironmentFoldResult } from "./fold-environment.ts";
  *   bracketed prefix; `undefined` otherwise.
  */
 export function computeEnvironmentLabel(fold: EnvironmentFoldResult): string | undefined {
-	const labels = new Set<string | undefined>();
-	const universeDisplayName = fold.universe?.entry.displayName;
-	if (universeDisplayName !== undefined) {
-		labels.add(extractDisplayNamePrefix(universeDisplayName).label);
-	}
-
-	for (const place of fold.places.values()) {
-		const placeDisplayName = place.entry.displayName;
-		if (placeDisplayName !== undefined) {
-			labels.add(extractDisplayNamePrefix(placeDisplayName).label);
-		}
-	}
-
+	const displayNames = [
+		fold.universe?.entry.displayName,
+		...[...fold.places.values()].map(({ entry }) => entry.displayName),
+	].filter((displayName): displayName is string => displayName !== undefined);
+	const labels = new Set(
+		displayNames.map((displayName) => extractDisplayNamePrefix(displayName).label),
+	);
 	if (labels.size !== 1) {
 		return undefined;
 	}

--- a/packages/bedrock/src/core/migrate/environment-label.ts
+++ b/packages/bedrock/src/core/migrate/environment-label.ts
@@ -1,0 +1,38 @@
+import { extractDisplayNamePrefix } from "./extract-display-name-prefix.ts";
+import type { EnvironmentFoldResult } from "./fold-environment.ts";
+
+/**
+ * Compute the environment-label candidate that round-trips a Mantle-style
+ * `[LABEL]` prefix through bedrock's deploy-time prefix system. Inspects
+ * every present `displayName` on the env's universe and place folds; if all
+ * extractions agree on the same captured label the function returns it
+ * lowercased. Any disagreement (mixed prefixes, prefixed alongside
+ * unprefixed, or all unprefixed) yields `undefined`, signalling that the
+ * caller should keep raw per-environment displayName overrides instead of
+ * promoting a label.
+ *
+ * @param fold - Per-environment fold result to inspect.
+ * @returns Lowercased label string when every displayName shares one
+ *   bracketed prefix; `undefined` otherwise.
+ */
+export function computeEnvironmentLabel(fold: EnvironmentFoldResult): string | undefined {
+	const labels = new Set<string | undefined>();
+	const universeDisplayName = fold.universe?.entry.displayName;
+	if (universeDisplayName !== undefined) {
+		labels.add(extractDisplayNamePrefix(universeDisplayName).label);
+	}
+
+	for (const place of fold.places.values()) {
+		const placeDisplayName = place.entry.displayName;
+		if (placeDisplayName !== undefined) {
+			labels.add(extractDisplayNamePrefix(placeDisplayName).label);
+		}
+	}
+
+	if (labels.size !== 1) {
+		return undefined;
+	}
+
+	const [label] = labels;
+	return label?.toLowerCase();
+}

--- a/packages/bedrock/src/core/migrate/extract-display-name-prefix.spec.ts
+++ b/packages/bedrock/src/core/migrate/extract-display-name-prefix.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { extractDisplayNamePrefix } from "./extract-display-name-prefix.ts";
+
+describe(extractDisplayNamePrefix, () => {
+	it("should capture the label and unprefixed body when input starts with a bracketed prefix", () => {
+		expect.assertions(1);
+
+		expect(extractDisplayNamePrefix("[DEV] My Game")).toStrictEqual({
+			body: "My Game",
+			label: "DEV",
+		});
+	});
+
+	it("should preserve trailing whitespace in the body verbatim", () => {
+		expect.assertions(1);
+
+		expect(extractDisplayNamePrefix("[DEV] My Game  ")).toStrictEqual({
+			body: "My Game  ",
+			label: "DEV",
+		});
+	});
+
+	it("should consume only the first bracket group when multiple brackets appear", () => {
+		expect.assertions(1);
+
+		expect(extractDisplayNamePrefix("[A] [B] X")).toStrictEqual({
+			body: "[B] X",
+			label: "A",
+		});
+	});
+
+	it.for<[label: string, value: string]>([
+		["plain string with no brackets", "My Game"],
+		["empty brackets", "[] My Game"],
+		["no whitespace after the closing bracket", "[DEV]X"],
+		["only the bracketed label with no body", "[DEV] "],
+		["leading content before the bracket", "prefix [DEV] X"],
+	])("should pass through input with %s", ([, value]) => {
+		expect.assertions(1);
+
+		expect(extractDisplayNamePrefix(value)).toStrictEqual({
+			body: value,
+			label: undefined,
+		});
+	});
+});

--- a/packages/bedrock/src/core/migrate/extract-display-name-prefix.ts
+++ b/packages/bedrock/src/core/migrate/extract-display-name-prefix.ts
@@ -3,7 +3,7 @@
  * `label` is `undefined` when the input does not match the bracketed-prefix
  * shape Mantle emits; in that case `body` echoes the input unchanged.
  */
-export interface ExtractedDisplayName {
+interface ExtractedDisplayName {
 	/** Display name with the bracketed prefix and trailing whitespace stripped, or the input verbatim when no prefix matched. */
 	readonly body: string;
 	/** Captured label from the bracketed prefix, or `undefined` when the input did not match. */

--- a/packages/bedrock/src/core/migrate/extract-display-name-prefix.ts
+++ b/packages/bedrock/src/core/migrate/extract-display-name-prefix.ts
@@ -1,0 +1,46 @@
+/**
+ * Result of inspecting a display name for a Mantle-style `[LABEL]` prefix.
+ * `label` is `undefined` when the input does not match the bracketed-prefix
+ * shape Mantle emits; in that case `body` echoes the input unchanged.
+ */
+export interface ExtractedDisplayName {
+	/** Display name with the bracketed prefix and trailing whitespace stripped, or the input verbatim when no prefix matched. */
+	readonly body: string;
+	/** Captured label from the bracketed prefix, or `undefined` when the input did not match. */
+	readonly label: string | undefined;
+}
+
+/**
+ * Lift the leading bracketed prefix off a display name produced by Mantle's
+ * environment-name stamping. A match requires `[LABEL] body` with a
+ * non-empty label, mandatory whitespace after the closing bracket, and a
+ * non-empty body. When the input does not match, `label` is `undefined` and
+ * `body` is the input verbatim, so callers can round-trip arbitrary
+ * display-name shapes without losing data.
+ *
+ * @param value - Raw display name to inspect.
+ * @returns The captured label (or `undefined`) and the unprefixed body.
+ */
+export function extractDisplayNamePrefix(value: string): ExtractedDisplayName {
+	const passthrough: ExtractedDisplayName = { body: value, label: undefined };
+	if (!value.startsWith("[")) {
+		return passthrough;
+	}
+
+	const closeIndex = value.indexOf("]");
+	if (closeIndex < 2) {
+		return passthrough;
+	}
+
+	const afterBracket = value.slice(closeIndex + 1);
+	const body = afterBracket.trimStart();
+	if (body === afterBracket) {
+		return passthrough;
+	}
+
+	if (body === "") {
+		return passthrough;
+	}
+
+	return { body, label: value.slice(1, closeIndex) };
+}

--- a/packages/bedrock/src/core/migrate/factorize-environments-warnings.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments-warnings.ts
@@ -6,7 +6,7 @@ const RESOURCE_MISSING_RULE = "factorize-environments/resource-missing-from-env"
 /**
  * Inputs to {@link collectMissingResourceWarnings}.
  */
-export interface MissingResourceInputs {
+interface MissingResourceInputs {
 	/** Per-environment fold results, keyed by environment name. */
 	readonly folds: ReadonlyMap<string, EnvironmentFoldResult>;
 	/** The chosen primary environment, used as the symmetry baseline. */

--- a/packages/bedrock/src/core/migrate/factorize-environments-warnings.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments-warnings.ts
@@ -1,0 +1,124 @@
+import type { EnvironmentFoldResult } from "./fold-environment.ts";
+import type { MigrationWarning } from "./migration-report.ts";
+
+const RESOURCE_MISSING_RULE = "factorize-environments/resource-missing-from-env";
+
+/**
+ * Inputs to {@link collectMissingResourceWarnings}.
+ */
+export interface MissingResourceInputs {
+	/** Per-environment fold results, keyed by environment name. */
+	readonly folds: ReadonlyMap<string, EnvironmentFoldResult>;
+	/** The chosen primary environment, used as the symmetry baseline. */
+	readonly primary: { readonly fold: EnvironmentFoldResult; readonly name: string };
+}
+
+interface AsymmetryContext {
+	readonly environmentName: string;
+	readonly fold: EnvironmentFoldResult;
+	readonly primary: EnvironmentFoldResult;
+}
+
+interface MissingResourcePaths {
+	readonly bedrockSegment: string;
+	readonly environmentName: string;
+	readonly mantleSegment: string;
+}
+
+interface KeyedAsymmetrySpec {
+	readonly bedrockPrefix: string;
+	readonly mantlePrefix: string;
+	readonly readKeys: (fold: EnvironmentFoldResult) => ReadonlyArray<string>;
+}
+
+const KEYED_ASYMMETRY_SPECS: ReadonlyArray<KeyedAsymmetrySpec> = [
+	{
+		bedrockPrefix: "places",
+		mantlePrefix: "place_",
+		readKeys: (fold) => [...fold.places.keys()],
+	},
+	{
+		bedrockPrefix: "passes",
+		mantlePrefix: "pass_",
+		readKeys: (fold) => fold.passes.map(({ key }) => key),
+	},
+	{
+		bedrockPrefix: "products",
+		mantlePrefix: "product_",
+		readKeys: (fold) => fold.products.map(({ key }) => key),
+	},
+];
+
+/**
+ * Walk every environment fold and emit one `interpretive` warning per
+ * resource the environment lacks relative to the chosen primary, and per
+ * resource the environment introduces that the primary lacks. The walk
+ * covers the universe singleton plus every keyed kind in
+ * {@link KEYED_ASYMMETRY_SPECS}.
+ *
+ * @param inputs - Per-environment folds and the resolved primary.
+ * @returns Flat list of resource-asymmetry warnings.
+ */
+export function collectMissingResourceWarnings(
+	inputs: MissingResourceInputs,
+): ReadonlyArray<MigrationWarning> {
+	const primaryFold = inputs.primary.fold;
+	return [...inputs.folds.entries()].flatMap(([name, fold]): ReadonlyArray<MigrationWarning> => {
+		const context: AsymmetryContext = { environmentName: name, fold, primary: primaryFold };
+		return [
+			...universeAsymmetryWarnings(context),
+			...KEYED_ASYMMETRY_SPECS.flatMap((spec) => keyedAsymmetryWarnings(context, spec)),
+		];
+	});
+}
+
+function asymmetricKeys(
+	environmentKeys: ReadonlyArray<string>,
+	primaryKeys: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+	const environmentSet = new Set(environmentKeys);
+	const primarySet = new Set(primaryKeys);
+	const onlyInEnvironment = environmentKeys.filter((key) => !primarySet.has(key));
+	const onlyInPrimary = primaryKeys.filter((key) => !environmentSet.has(key));
+	return [...onlyInEnvironment, ...onlyInPrimary];
+}
+
+function missingResourceWarning(paths: MissingResourcePaths): MigrationWarning {
+	return {
+		bedrockPath: `environments.${paths.environmentName}.${paths.bedrockSegment}`,
+		kind: "interpretive",
+		mantlePath: `${paths.environmentName}.${paths.mantleSegment}`,
+		rule: RESOURCE_MISSING_RULE,
+	};
+}
+
+function keyedAsymmetryWarnings(
+	context: AsymmetryContext,
+	spec: KeyedAsymmetrySpec,
+): ReadonlyArray<MigrationWarning> {
+	return asymmetricKeys(spec.readKeys(context.fold), spec.readKeys(context.primary)).map(
+		(key) => {
+			return missingResourceWarning({
+				bedrockSegment: `${spec.bedrockPrefix}.${key}`,
+				environmentName: context.environmentName,
+				mantleSegment: `${spec.mantlePrefix}${key}`,
+			});
+		},
+	);
+}
+
+function universeAsymmetryWarnings(context: AsymmetryContext): ReadonlyArray<MigrationWarning> {
+	const hasEnvironmentUniverse = context.fold.universe !== undefined;
+	const hasPrimaryUniverse = context.primary.universe !== undefined;
+	if (hasEnvironmentUniverse === hasPrimaryUniverse) {
+		return [];
+	}
+
+	return [
+		missingResourceWarning({
+			bedrockSegment: "universe",
+			environmentName: context.environmentName,
+			mantleSegment: "experience_singleton",
+		}),
+	];
+}

--- a/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
@@ -928,6 +928,50 @@ describe(factorizeEnvironments, () => {
 		});
 	});
 
+	it("should lift the shared body to root and label each environment when every env carries a different bracketed prefix on the same body", () => {
+		expect.assertions(4);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { displayName: "[DEV] Lobby", filePath: "place.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+			[
+				"staging",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { displayName: "[STAGING] Lobby", filePath: "place.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "staging" });
+
+		assert(result.success);
+
+		expect(result.data.config.places?.["start"]?.displayName).toBe("Lobby");
+		expect(result.data.config.environments["development"]?.label).toBe("dev");
+		expect(result.data.config.environments["staging"]?.label).toBe("staging");
+		expect(result.data.config.environments["development"]?.places).toStrictEqual({
+			start: { placeId: "17613681043" },
+		});
+	});
+
 	it("should put stripped per-environment overlays on each labeled environment when stripped bodies disagree across envs", () => {
 		expect.assertions(4);
 

--- a/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
@@ -974,6 +974,72 @@ describe(factorizeEnvironments, () => {
 		});
 	});
 
+	it("should preserve the universe displayName verbatim when the primary environment has no label", () => {
+		expect.assertions(2);
+
+		const folds = new Map([
+			[
+				"production",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({ entry: { displayName: "Lobby", filePath: "place.rbxl" } }),
+						],
+					]),
+					universe: {
+						entry: { displayName: "[BETA] My Game", universeId: "1234567890" },
+						outputs: { rootPlaceId: asRobloxAssetId("17613681043") },
+					},
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.universe?.displayName).toBe("[BETA] My Game");
+		expect(result.data.config.environments["production"]?.label).toBeUndefined();
+	});
+
+	it("should strip the primary environment's display-name prefix from the root universe entry when the env has a label", () => {
+		expect.assertions(2);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: {
+									displayName: "[DEVELOPMENT] Lobby",
+									filePath: "place.rbxl",
+								},
+							}),
+						],
+					]),
+					universe: {
+						entry: {
+							displayName: "[DEVELOPMENT] My Game",
+							universeId: "1111111111",
+						},
+						outputs: { rootPlaceId: asRobloxAssetId("2222222222") },
+					},
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "development" });
+
+		assert(result.success);
+
+		expect(result.data.config.universe?.displayName).toBe("My Game");
+		expect(result.data.config.environments["development"]?.label).toBe("development");
+	});
+
 	it("should land serverSize on root and omit the place overlay when both environments share the same serverSize", () => {
 		expect.assertions(2);
 

--- a/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
@@ -804,6 +804,176 @@ describe(factorizeEnvironments, () => {
 		});
 	});
 
+	it("should land displayName on root when only one environment has the place and that env's entry carries a displayName", () => {
+		expect.assertions(1);
+
+		const folds = new Map([
+			["development", fold()],
+			[
+				"production",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { displayName: "Solo Name", filePath: "place.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.places?.["start"]?.displayName).toBe("Solo Name");
+	});
+
+	it("should lift the unprefixed displayName to root and label the environment when every place in an env shares a bracketed prefix", () => {
+		expect.assertions(4);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: {
+									displayName: "[DEVELOPMENT] Anime Rush Match",
+									filePath: "game.rbxl",
+								},
+							}),
+						],
+					]),
+				}),
+			],
+			[
+				"production",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { displayName: "Anime Rush Match", filePath: "game.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.places?.["start"]?.displayName).toBe("Anime Rush Match");
+		expect(result.data.config.environments["development"]?.label).toBe("development");
+		expect(result.data.config.environments["production"]?.label).toBeUndefined();
+		expect(result.data.config.environments["development"]?.places).toStrictEqual({
+			start: { placeId: "17613681043" },
+		});
+	});
+
+	it("should keep the raw displayName on the env overlay when an environment mixes prefixed and unprefixed display names", () => {
+		expect.assertions(3);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					places: new Map([
+						[
+							"game",
+							placeFold({
+								entry: { displayName: "[DEV] Match", filePath: "place.rbxl" },
+							}),
+						],
+						[
+							"start",
+							placeFold({ entry: { displayName: "Lobby", filePath: "place.rbxl" } }),
+						],
+					]),
+				}),
+			],
+			[
+				"production",
+				fold({
+					places: new Map([
+						[
+							"game",
+							placeFold({ entry: { displayName: "Match", filePath: "place.rbxl" } }),
+						],
+						[
+							"start",
+							placeFold({ entry: { displayName: "Lobby", filePath: "place.rbxl" } }),
+						],
+					]),
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.environments["development"]?.label).toBeUndefined();
+		expect(result.data.config.places?.["game"]?.displayName).toBeUndefined();
+		expect(result.data.config.environments["development"]?.places).toStrictEqual({
+			game: { displayName: "[DEV] Match", placeId: "17613681043" },
+			start: { placeId: "17613681043" },
+		});
+	});
+
+	it("should put stripped per-environment overlays on each labeled environment when stripped bodies disagree across envs", () => {
+		expect.assertions(4);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { displayName: "[DEV] Lobby", filePath: "place.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+			[
+				"staging",
+				fold({
+					places: new Map([
+						[
+							"start",
+							placeFold({
+								entry: { displayName: "[STAGING] Foyer", filePath: "place.rbxl" },
+							}),
+						],
+					]),
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "staging" });
+
+		assert(result.success);
+
+		expect(result.data.config.places?.["start"]?.displayName).toBeUndefined();
+		expect(result.data.config.environments["development"]?.label).toBe("dev");
+		expect(result.data.config.environments["development"]?.places).toStrictEqual({
+			start: { displayName: "Lobby", placeId: "17613681043" },
+		});
+		expect(result.data.config.environments["staging"]?.places).toStrictEqual({
+			start: { displayName: "Foyer", placeId: "17613681043" },
+		});
+	});
+
 	it("should land serverSize on root and omit the place overlay when both environments share the same serverSize", () => {
 		expect.assertions(2);
 

--- a/packages/bedrock/src/core/migrate/factorize-environments.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.ts
@@ -7,6 +7,7 @@ import type {
 	GamePassEntry,
 	PlaceEntry,
 } from "../schema.ts";
+import { computeEnvironmentLabel } from "./environment-label.ts";
 import { buildPlacesOverlay, buildRootPlaces } from "./factorize-places.ts";
 import { buildProductsOverlay, buildRootProducts } from "./factorize-products.ts";
 import type { EnvironmentFoldResult } from "./fold-environment.ts";
@@ -32,9 +33,16 @@ interface ResolvedPrimary {
 }
 
 interface OverlayContext {
+	readonly labels: ReadonlyMap<string, string | undefined>;
 	readonly primary: EnvironmentFoldResult | undefined;
 	readonly rootPlaces: Record<string, PlaceEntry> | undefined;
 	readonly rootProducts: Record<string, DeveloperProductEntry> | undefined;
+}
+
+interface EnvironmentEntryInputs {
+	readonly context: OverlayContext;
+	readonly fold: EnvironmentFoldResult;
+	readonly label: string | undefined;
 }
 
 /**
@@ -164,33 +172,19 @@ function buildPassesOverlay(
 	return Object.keys(overlay).length === 0 ? undefined : overlay;
 }
 
-function buildEnvironmentEntry(
-	fold: EnvironmentFoldResult,
-	context: OverlayContext,
-): EnvironmentEntry {
+function buildEnvironmentEntry(inputs: EnvironmentEntryInputs): EnvironmentEntry {
+	const { context, fold, label } = inputs;
 	const passes = buildPassesOverlay(fold, context.primary);
-	const places = buildPlacesOverlay(fold, context.rootPlaces);
+	const places = buildPlacesOverlay({ fold, label, rootPlaces: context.rootPlaces });
 	const products = buildProductsOverlay(fold, context.rootProducts);
 	const universe = buildUniverseOverlay(fold, context.primary);
-
-	const entry: EnvironmentEntry = {};
-	if (passes !== undefined) {
-		entry.passes = passes;
-	}
-
-	if (places !== undefined) {
-		entry.places = places;
-	}
-
-	if (products !== undefined) {
-		entry.products = products;
-	}
-
-	if (universe !== undefined) {
-		entry.universe = universe;
-	}
-
-	return entry;
+	return {
+		...(label !== undefined && { label }),
+		...(passes !== undefined && { passes }),
+		...(places !== undefined && { places }),
+		...(products !== undefined && { products }),
+		...(universe !== undefined && { universe }),
+	};
 }
 
 function buildEnvironmentEntries(
@@ -199,19 +193,32 @@ function buildEnvironmentEntries(
 ): Record<string, EnvironmentEntry> {
 	const entries: Record<string, EnvironmentEntry> = {};
 	for (const [name, fold] of folds) {
-		entries[name] = buildEnvironmentEntry(fold, context);
+		entries[name] = buildEnvironmentEntry({ context, fold, label: context.labels.get(name) });
 	}
 
 	return entries;
+}
+
+function buildEnvironmentLabels(
+	folds: ReadonlyMap<string, EnvironmentFoldResult>,
+): ReadonlyMap<string, string | undefined> {
+	const labels = new Map<string, string | undefined>();
+	for (const [name, fold] of folds) {
+		labels.set(name, computeEnvironmentLabel(fold));
+	}
+
+	return labels;
 }
 
 function buildConfig(
 	folds: ReadonlyMap<string, EnvironmentFoldResult>,
 	primaryFold: EnvironmentFoldResult,
 ): Config {
-	const places = buildRootPlaces(folds, primaryFold);
+	const labels = buildEnvironmentLabels(folds);
+	const places = buildRootPlaces({ folds, labels, primaryFold });
 	const products = buildRootProducts(folds, primaryFold);
 	const environments = buildEnvironmentEntries(folds, {
+		labels,
 		primary: primaryFold,
 		rootPlaces: places,
 		rootProducts: products,

--- a/packages/bedrock/src/core/migrate/factorize-environments.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.ts
@@ -8,6 +8,8 @@ import type {
 	PlaceEntry,
 } from "../schema.ts";
 import { computeEnvironmentLabel } from "./environment-label.ts";
+import { extractDisplayNamePrefix } from "./extract-display-name-prefix.ts";
+import { collectMissingResourceWarnings } from "./factorize-environments-warnings.ts";
 import { buildPlacesOverlay, buildRootPlaces } from "./factorize-places.ts";
 import { buildProductsOverlay, buildRootProducts } from "./factorize-products.ts";
 import type { EnvironmentFoldResult } from "./fold-environment.ts";
@@ -45,6 +47,12 @@ interface EnvironmentEntryInputs {
 	readonly label: string | undefined;
 }
 
+interface BuildConfigInputs {
+	readonly folds: ReadonlyMap<string, EnvironmentFoldResult>;
+	readonly primaryFold: EnvironmentFoldResult;
+	readonly primaryName: string;
+}
+
 /**
  * Project per-environment fold results into a single bedrock `Config` by
  * factoring the chosen primary environment's resolved values up to the root
@@ -72,7 +80,11 @@ export function factorizeEnvironments(
 	const primary = primaryResult.data;
 	return {
 		data: {
-			config: buildConfig(inputs.folds, primary.fold),
+			config: buildConfig({
+				folds: inputs.folds,
+				primaryFold: primary.fold,
+				primaryName: primary.name,
+			}),
 			primaryEnvironment: primary.name,
 			warnings: collectMissingResourceWarnings({ folds: inputs.folds, primary }),
 		},
@@ -210,10 +222,20 @@ function buildEnvironmentLabels(
 	return labels;
 }
 
-function buildConfig(
-	folds: ReadonlyMap<string, EnvironmentFoldResult>,
+function resolveRootUniverse(
 	primaryFold: EnvironmentFoldResult,
-): Config {
+	label: string | undefined,
+): Config["universe"] {
+	const entry = primaryFold.universe?.entry;
+	if (entry === undefined || label === undefined || entry.displayName === undefined) {
+		return entry;
+	}
+
+	return { ...entry, displayName: extractDisplayNamePrefix(entry.displayName).body };
+}
+
+function buildConfig(inputs: BuildConfigInputs): Config {
+	const { folds, primaryFold, primaryName } = inputs;
 	const labels = buildEnvironmentLabels(folds);
 	const places = buildRootPlaces({ folds, labels, primaryFold });
 	const products = buildRootProducts(folds, primaryFold);
@@ -224,131 +246,12 @@ function buildConfig(
 		rootProducts: products,
 	});
 	const passes = buildRootPasses(primaryFold);
-	const universe = primaryFold.universe?.entry;
-
-	const config: Config = { environments };
-	if (passes !== undefined) {
-		config.passes = passes;
-	}
-
-	if (places !== undefined) {
-		config.places = places;
-	}
-
-	if (products !== undefined) {
-		config.products = products;
-	}
-
-	if (universe !== undefined) {
-		config.universe = universe;
-	}
-
-	return config;
-}
-
-const RESOURCE_MISSING_RULE = "factorize-environments/resource-missing-from-env";
-
-interface AsymmetryContext {
-	readonly environmentName: string;
-	readonly fold: EnvironmentFoldResult;
-	readonly primary: EnvironmentFoldResult;
-}
-
-interface MissingResourcePaths {
-	readonly bedrockSegment: string;
-	readonly environmentName: string;
-	readonly mantleSegment: string;
-}
-
-interface MissingResourceInputs {
-	readonly folds: ReadonlyMap<string, EnvironmentFoldResult>;
-	readonly primary: ResolvedPrimary;
-}
-
-interface KeyedAsymmetrySpec {
-	readonly bedrockPrefix: string;
-	readonly mantlePrefix: string;
-	readonly readKeys: (fold: EnvironmentFoldResult) => ReadonlyArray<string>;
-}
-
-function missingResourceWarning(paths: MissingResourcePaths): MigrationWarning {
+	const universe = resolveRootUniverse(primaryFold, labels.get(primaryName));
 	return {
-		bedrockPath: `environments.${paths.environmentName}.${paths.bedrockSegment}`,
-		kind: "interpretive",
-		mantlePath: `${paths.environmentName}.${paths.mantleSegment}`,
-		rule: RESOURCE_MISSING_RULE,
+		environments,
+		...(passes !== undefined && { passes }),
+		...(places !== undefined && { places }),
+		...(products !== undefined && { products }),
+		...(universe !== undefined && { universe }),
 	};
-}
-
-function universeAsymmetryWarnings(context: AsymmetryContext): ReadonlyArray<MigrationWarning> {
-	const hasEnvironmentUniverse = context.fold.universe !== undefined;
-	const hasPrimaryUniverse = context.primary.universe !== undefined;
-	if (hasEnvironmentUniverse === hasPrimaryUniverse) {
-		return [];
-	}
-
-	return [
-		missingResourceWarning({
-			bedrockSegment: "universe",
-			environmentName: context.environmentName,
-			mantleSegment: "experience_singleton",
-		}),
-	];
-}
-
-function asymmetricKeys(
-	environmentKeys: ReadonlyArray<string>,
-	primaryKeys: ReadonlyArray<string>,
-): ReadonlyArray<string> {
-	const environmentSet = new Set(environmentKeys);
-	const primarySet = new Set(primaryKeys);
-	const onlyInEnvironment = environmentKeys.filter((key) => !primarySet.has(key));
-	const onlyInPrimary = primaryKeys.filter((key) => !environmentSet.has(key));
-	return [...onlyInEnvironment, ...onlyInPrimary];
-}
-
-const KEYED_ASYMMETRY_SPECS: ReadonlyArray<KeyedAsymmetrySpec> = [
-	{
-		bedrockPrefix: "places",
-		mantlePrefix: "place_",
-		readKeys: (fold) => [...fold.places.keys()],
-	},
-	{
-		bedrockPrefix: "passes",
-		mantlePrefix: "pass_",
-		readKeys: (fold) => fold.passes.map(({ key }) => key),
-	},
-	{
-		bedrockPrefix: "products",
-		mantlePrefix: "product_",
-		readKeys: (fold) => fold.products.map(({ key }) => key),
-	},
-];
-
-function keyedAsymmetryWarnings(
-	context: AsymmetryContext,
-	spec: KeyedAsymmetrySpec,
-): ReadonlyArray<MigrationWarning> {
-	return asymmetricKeys(spec.readKeys(context.fold), spec.readKeys(context.primary)).map(
-		(key) => {
-			return missingResourceWarning({
-				bedrockSegment: `${spec.bedrockPrefix}.${key}`,
-				environmentName: context.environmentName,
-				mantleSegment: `${spec.mantlePrefix}${key}`,
-			});
-		},
-	);
-}
-
-function collectMissingResourceWarnings(
-	inputs: MissingResourceInputs,
-): ReadonlyArray<MigrationWarning> {
-	const primaryFold = inputs.primary.fold;
-	return [...inputs.folds.entries()].flatMap(([name, fold]): ReadonlyArray<MigrationWarning> => {
-		const context: AsymmetryContext = { environmentName: name, fold, primary: primaryFold };
-		return [
-			...universeAsymmetryWarnings(context),
-			...KEYED_ASYMMETRY_SPECS.flatMap((spec) => keyedAsymmetryWarnings(context, spec)),
-		];
-	});
 }

--- a/packages/bedrock/src/core/migrate/factorize-environments.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.ts
@@ -203,23 +203,18 @@ function buildEnvironmentEntries(
 	folds: ReadonlyMap<string, EnvironmentFoldResult>,
 	context: OverlayContext,
 ): Record<string, EnvironmentEntry> {
-	const entries: Record<string, EnvironmentEntry> = {};
-	for (const [name, fold] of folds) {
-		entries[name] = buildEnvironmentEntry({ context, fold, label: context.labels.get(name) });
-	}
-
-	return entries;
+	return Object.fromEntries(
+		[...folds].map(([name, fold]) => [
+			name,
+			buildEnvironmentEntry({ context, fold, label: context.labels.get(name) }),
+		]),
+	);
 }
 
 function buildEnvironmentLabels(
 	folds: ReadonlyMap<string, EnvironmentFoldResult>,
 ): ReadonlyMap<string, string | undefined> {
-	const labels = new Map<string, string | undefined>();
-	for (const [name, fold] of folds) {
-		labels.set(name, computeEnvironmentLabel(fold));
-	}
-
-	return labels;
+	return new Map([...folds].map(([name, fold]) => [name, computeEnvironmentLabel(fold)]));
 }
 
 function resolveRootUniverse(

--- a/packages/bedrock/src/core/migrate/factorize-places.ts
+++ b/packages/bedrock/src/core/migrate/factorize-places.ts
@@ -6,7 +6,7 @@ import type { PlaceFoldEntry } from "./fold-places.ts";
 /**
  * Inputs to {@link buildRootPlaces}.
  */
-export interface BuildRootPlacesInputs {
+interface BuildRootPlacesInputs {
 	/** Per-environment fold results, keyed by environment name. */
 	readonly folds: ReadonlyMap<string, EnvironmentFoldResult>;
 	/**
@@ -22,7 +22,7 @@ export interface BuildRootPlacesInputs {
 /**
  * Inputs to {@link buildPlacesOverlay}.
  */
-export interface BuildPlacesOverlayInputs {
+interface BuildPlacesOverlayInputs {
 	/** The per-environment fold whose places are being overlaid. */
 	readonly fold: EnvironmentFoldResult;
 	/** The environment's label (or `undefined`); enables prefix-stripping on the overlay's `displayName`. */

--- a/packages/bedrock/src/core/migrate/factorize-places.ts
+++ b/packages/bedrock/src/core/migrate/factorize-places.ts
@@ -1,39 +1,87 @@
 import type { EnvironmentEntry, PlaceEntry } from "../schema.ts";
+import { extractDisplayNamePrefix } from "./extract-display-name-prefix.ts";
 import type { EnvironmentFoldResult } from "./fold-environment.ts";
 import type { PlaceFoldEntry } from "./fold-places.ts";
 
+/**
+ * Inputs to {@link buildRootPlaces}.
+ */
+export interface BuildRootPlacesInputs {
+	/** Per-environment fold results, keyed by environment name. */
+	readonly folds: ReadonlyMap<string, EnvironmentFoldResult>;
+	/**
+	 * Per-environment label map. An environment whose label is `undefined`
+	 * contributes raw `displayName` values to consensus; otherwise the value
+	 * is stripped via {@link extractDisplayNamePrefix} before comparison.
+	 */
+	readonly labels: ReadonlyMap<string, string | undefined>;
+	/** The chosen primary environment's fold; supplies `filePath` for every place entry on root. */
+	readonly primaryFold: EnvironmentFoldResult;
+}
+
+/**
+ * Inputs to {@link buildPlacesOverlay}.
+ */
+export interface BuildPlacesOverlayInputs {
+	/** The per-environment fold whose places are being overlaid. */
+	readonly fold: EnvironmentFoldResult;
+	/** The environment's label (or `undefined`); enables prefix-stripping on the overlay's `displayName`. */
+	readonly label: string | undefined;
+	/** The already-built root `places` block; matching field values suppress overlay entries. */
+	readonly rootPlaces: Record<string, PlaceEntry> | undefined;
+}
+
 type PlaceOverlayEntry = NonNullable<EnvironmentEntry["places"]>[string];
 
-type OptionalPlaceField = "description" | "displayName" | "serverSize";
+type OptionalPlaceField = "description" | "serverSize";
+
+interface LabeledFold {
+	readonly fold: EnvironmentFoldResult;
+	readonly label: string | undefined;
+}
 
 interface ConsensusInputs<F extends OptionalPlaceField> {
 	readonly field: F;
-	readonly folds: ReadonlyArray<EnvironmentFoldResult>;
+	readonly folds: ReadonlyArray<LabeledFold>;
 	readonly placeKey: string;
+}
+
+interface DisplayNameConsensusInputs {
+	readonly folds: ReadonlyArray<LabeledFold>;
+	readonly placeKey: string;
+}
+
+interface BuildPlaceOverlayEntryInputs {
+	readonly fold: PlaceFoldEntry;
+	readonly label: string | undefined;
+	readonly rootEntry: PlaceEntry | undefined;
 }
 
 /**
  * Project the per-environment place folds into bedrock's root `places`
  * block, giving each optional metadata field (`description`, `displayName`,
  * `serverSize`) a value only when every environment that owns the place
- * key agrees. Divergent or partially-set fields are omitted from root and
- * surface on each environment's overlay via {@link buildPlacesOverlay}.
+ * key agrees. `displayName` consensus runs on the unprefixed body when an
+ * environment carries a label, so a Mantle-stamped `[ENV] Foo` in one
+ * environment matches a plain `Foo` in another. Divergent or partially-set
+ * fields are omitted from root and surface on each environment's overlay
+ * via {@link buildPlacesOverlay}.
  *
- * @param folds - Per-environment fold results, keyed by environment name.
- * @param primaryFold - The chosen primary environment's fold; supplies
- *   `filePath` (required) for every place entry on root.
+ * @param inputs - Per-environment folds, label map, and primary fold.
  * @returns The root `places` block, or `undefined` when the primary has
  *   no place folds.
  */
 export function buildRootPlaces(
-	folds: ReadonlyMap<string, EnvironmentFoldResult>,
-	primaryFold: EnvironmentFoldResult,
+	inputs: BuildRootPlacesInputs,
 ): Record<string, PlaceEntry> | undefined {
+	const { folds, labels, primaryFold } = inputs;
 	if (primaryFold.places.size === 0) {
 		return undefined;
 	}
 
-	const folded = [...folds.values()];
+	const folded: ReadonlyArray<LabeledFold> = [...folds.entries()].map(([name, fold]) => {
+		return { fold, label: labels.get(name) };
+	});
 	return Object.fromEntries(
 		[...primaryFold.places.entries()].map(([placeKey, primary]) => [
 			placeKey,
@@ -44,39 +92,66 @@ export function buildRootPlaces(
 
 /**
  * Build the per-environment overlay for `places`, carrying each field only
- * when the environment's value diverges from the resolved root entry. Fields
- * the environment omits are absent from the overlay so the consumer's
- * defu merge resolves them to the root's (also absent) value rather than
- * overwriting with `undefined`.
+ * when the environment's value diverges from the resolved root entry. When
+ * the environment has a label, the overlay stores the unprefixed
+ * `displayName` body so the deploy-time prefix system reapplies the bracket
+ * cleanly without double-prefixing. Fields the environment omits are absent
+ * from the overlay so the consumer's defu merge resolves them to the root's
+ * (also absent) value rather than overwriting with `undefined`.
  *
- * @param fold - The per-environment fold whose places are being overlaid.
- * @param rootPlaces - The already-built root `places` block; per-place
- *   field values from this map suppress overlay entries that match.
+ * @param inputs - Fold, label, and the already-built root `places` block.
  * @returns The overlay `places` block, or `undefined` when the fold has
  *   no place entries.
  */
 export function buildPlacesOverlay(
-	fold: EnvironmentFoldResult,
-	rootPlaces: Record<string, PlaceEntry> | undefined,
+	inputs: BuildPlacesOverlayInputs,
 ): Record<string, PlaceOverlayEntry> | undefined {
+	const { fold, label, rootPlaces } = inputs;
 	if (fold.places.size === 0) {
 		return undefined;
 	}
 
 	return Object.fromEntries(
-		[...fold.places.entries()].map(([placeKey, foldEntry]) => [
-			placeKey,
-			buildPlaceOverlayEntry(foldEntry, rootPlaces?.[placeKey]),
-		]),
+		[...fold.places.entries()].map(([placeKey, foldEntry]) => {
+			return [
+				placeKey,
+				buildPlaceOverlayEntry({
+					fold: foldEntry,
+					label,
+					rootEntry: rootPlaces?.[placeKey],
+				}),
+			];
+		}),
 	);
 }
 
 function placeFieldConsensus<F extends OptionalPlaceField>(
 	inputs: ConsensusInputs<F>,
 ): PlaceEntry[F] | undefined {
-	const values = inputs.folds.flatMap((fold) => {
+	const values = inputs.folds.flatMap(({ fold }) => {
 		const entry = fold.places.get(inputs.placeKey)?.entry;
 		return entry === undefined ? [] : [entry[inputs.field]];
+	});
+
+	const [first] = values;
+	return values.every((value) => Object.is(first, value)) ? first : undefined;
+}
+
+function resolveDisplayName(
+	displayName: string | undefined,
+	label: string | undefined,
+): string | undefined {
+	if (displayName === undefined || label === undefined) {
+		return displayName;
+	}
+
+	return extractDisplayNamePrefix(displayName).body;
+}
+
+function displayNameConsensus(inputs: DisplayNameConsensusInputs): string | undefined {
+	const values = inputs.folds.flatMap(({ fold, label }): ReadonlyArray<string | undefined> => {
+		const entry = fold.places.get(inputs.placeKey)?.entry;
+		return entry === undefined ? [] : [resolveDisplayName(entry.displayName, label)];
 	});
 
 	const [first] = values;
@@ -86,12 +161,12 @@ function placeFieldConsensus<F extends OptionalPlaceField>(
 function buildRootPlaceEntry(
 	primary: PlaceFoldEntry,
 	consensusBase: {
-		readonly folds: ReadonlyArray<EnvironmentFoldResult>;
+		readonly folds: ReadonlyArray<LabeledFold>;
 		readonly placeKey: string;
 	},
 ): PlaceEntry {
 	const description = placeFieldConsensus({ ...consensusBase, field: "description" });
-	const displayName = placeFieldConsensus({ ...consensusBase, field: "displayName" });
+	const displayName = displayNameConsensus(consensusBase);
 	const serverSize = placeFieldConsensus({ ...consensusBase, field: "serverSize" });
 	return {
 		filePath: primary.entry.filePath,
@@ -101,11 +176,10 @@ function buildRootPlaceEntry(
 	};
 }
 
-function buildPlaceOverlayEntry(
-	fold: PlaceFoldEntry,
-	rootEntry: PlaceEntry | undefined,
-): PlaceOverlayEntry {
-	const { description, displayName, filePath, serverSize } = fold.entry;
+function buildPlaceOverlayEntry(inputs: BuildPlaceOverlayEntryInputs): PlaceOverlayEntry {
+	const { fold, label, rootEntry } = inputs;
+	const { description, displayName: rawDisplayName, filePath, serverSize } = fold.entry;
+	const displayName = resolveDisplayName(rawDisplayName, label);
 	return {
 		placeId: fold.placeId,
 		...(filePath !== rootEntry?.filePath && { filePath }),

--- a/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
@@ -343,6 +343,31 @@ describe(migrateMantleState, () => {
 		expect(development.data.universe?.universeId).toBe("6031475575");
 	});
 
+	it("should set environment.label and round-trip mantle's bracketed display-name prefix through selectEnvironment", async () => {
+		expect.assertions(4);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			primaryEnvironment: "production",
+			stateFilePath: REAL_FIXTURE,
+		});
+
+		assert(result.success);
+
+		expect(result.data.config.environments["development"]?.label).toBe("development");
+		expect(result.data.config.environments["production"]?.label).toBeUndefined();
+
+		const production = selectEnvironment(result.data.config, "production");
+		const development = selectEnvironment(result.data.config, "development");
+		assert(production.success);
+		assert(development.success);
+
+		expect(production.data.universe?.displayName).toBe("roblox-ts Project Template");
+		expect(development.data.universe?.displayName).toBe(
+			"[DEVELOPMENT] roblox-ts Project Template",
+		);
+	});
+
 	it("should round-trip a per-environment universe overlay through loadConfig", async () => {
 		expect.assertions(2);
 

--- a/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
@@ -525,7 +525,7 @@ describe(migrateMantleState, () => {
 			consoleEnabled: true,
 			desktopEnabled: true,
 			discordSocialLink: { title: "Join our Discord", uri: "https://discord.gg/example" },
-			displayName: "[DEVELOPMENT] roblox-ts Project Template",
+			displayName: "roblox-ts Project Template",
 			icon: { "en-us": "assets/marketing/example-icon.png" },
 			mobileEnabled: true,
 			privateServerPriceRobux: 0,

--- a/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
@@ -343,8 +343,8 @@ describe(migrateMantleState, () => {
 		expect(development.data.universe?.universeId).toBe("6031475575");
 	});
 
-	it("should set environment.label and round-trip mantle's bracketed display-name prefix through selectEnvironment", async () => {
-		expect.assertions(4);
+	it("should set environment.label on environments mantle stamped with bracketed display-name prefixes", async () => {
+		expect.assertions(2);
 
 		const result = await migrateMantleState({
 			configFormat: "typescript",
@@ -356,6 +356,18 @@ describe(migrateMantleState, () => {
 
 		expect(result.data.config.environments["development"]?.label).toBe("development");
 		expect(result.data.config.environments["production"]?.label).toBeUndefined();
+	});
+
+	it("should reapply the environment-label prefix to displayName via selectEnvironment after migration", async () => {
+		expect.assertions(2);
+
+		const result = await migrateMantleState({
+			configFormat: "typescript",
+			primaryEnvironment: "production",
+			stateFilePath: REAL_FIXTURE,
+		});
+
+		assert(result.success);
 
 		const production = selectEnvironment(result.data.config, "production");
 		const development = selectEnvironment(result.data.config, "development");


### PR DESCRIPTION
## Summary

- Detect mantle's `[LABEL]` display-name stamping during `migrate-mantle-state` and store the captured label on `EnvironmentEntry.label`.
- Lift the unprefixed `displayName` body to `places.<key>` and `universe` on root, removing the duplicated per-env overrides today's migration emits.
- Bedrock's existing deploy-time prefix system (`displayNamePrefix.format` defaulting to `[{LABEL}] `) reapplies the bracket so each environment renders the same name mantle originally produced.

## Why

Today, migrating a multi-env mantle project produces per-environment `displayName` overlays for every place and universe whose name carries a bracketed prefix in source, even though every environment's *unprefixed* body is identical. The migrated config ends up duplicating the canonical name across every environment override and leaves `places.<key>.displayName` blank at root. This change lets the migrator notice the prefix pattern, set one label per environment, and lift the canonical body to root.

## Behavior

- **Default-on**, no flag. Conservative fallback: any per-env consistency check that fails leaves the environment with raw overrides exactly as before.
- **Strict per-env consistency**: an environment with mixed prefixed and unprefixed display names gets no label and keeps raw overlays.
- **Square-bracket pattern only** (`/^\[([^\]]+)\]\s+(.+)$/`). Mantle is the only producer; users with hand-edited bracket styles fall through to the existing per-env override path.
- **Captured label is lowercased**. With the default `[{LABEL}] ` template the deploy-time render reproduces mantle's all-caps prefix unchanged.

## Slices

Each commit is one TDD slice with RED + GREEN together:

1. `chore(core): add extract-display-name-prefix helper` — pure regex helper.
2. `chore(core): add environment-label consensus helper` — strict per-env aggregation across places + universe.
3. `feat(core): lift mantle display-name prefixes to environment labels` — wires the consensus into `factorize-places` and `factorize-environments`.
4. `feat(core): strip display-name prefix from primary universe on migration` — extends the same treatment to the primary universe entry; extracts the asymmetry-warning subsystem to a sibling module to satisfy the per-file size cap.
5. `test(core): cover environment-label round-trip through migrate` — end-to-end integration test through `migrateMantleState` and `selectEnvironment`.
6. `chore(core): keep migration helper types internal` — knip cleanup.

## Test plan

- [x] `pnpm --filter @bedrock/core test` — 1737 passed, 10 skipped.
- [x] `pnpm --filter @bedrock/core typecheck` — clean.
- [x] `pnpm lint` — clean.
- [x] `pnpm mutate:changed` — 100% mutation score across all five touched src files (77 mutants killed, 0 survived).
- [x] Round-trip integration test confirms `selectEnvironment` produces the original `[DEVELOPMENT] ...` rendering at deploy.
- [ ] Reviewer: spot-check the migration output on your own mantle state file if you have one with bracketed display names.

## Out of scope / follow-ups

- `buildUniverseOverlay` only emits `universeId` today; per-env universe-displayName divergence is still not propagated, with or without this change.
- Custom `displayNamePrefix.format` values are not consulted by migration — the helper writes labels suited to the default `[{LABEL}] ` template; users with non-default formats can adjust post-migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)