### PR TITLE
feat(core): require universe-id either at root or per environment

### DIFF
--- a/docs/adr/020-project-config-definition.md
+++ b/docs/adr/020-project-config-definition.md
@@ -222,6 +222,41 @@ so freezing our return would risk incompatibility with c12 utilities.
 - The `bedrock migrate` command (tracked in #104) performs the Mantle
   transform described above.
 
+## Amendments
+
+### 2026-05-05 — universeId XOR between root and per-environment
+
+The root `universe` block and each `environments[name].universe` overlay
+both carry a `universeId` slot. When both are populated for the same
+deploy, the two values disagree on which Roblox universe an environment
+targets. The runtime path resolved this ambiguity by letting the
+per-environment overlay win, but the resolution was implicit and
+hand-written configs frequently set both fields to the same value
+defensively, which a future change to the resolution rule would silently
+break.
+
+The schema now enforces XOR between the two slots: `universeId` must
+appear at the root *or* on every environment overlay that declares a
+`universe` block, never both. The arktype validator's runtime narrow
+rejects coexistence, rejects a per-environment overlay that omits
+`universeId` when the root block does not provide one, and rejects a
+root `universe` block that lacks `universeId` when no environment
+supplies one. Each rejection attributes the failure to the offending
+field path so authors see the conflict at validation time rather than
+during deploy.
+
+The migrator (`bedrock migrate`) honours the same rule: when the source
+state declares a single distinct `universeId` across environments it
+lands at the root unchanged, but when environments diverge the migrator
+omits `universeId` from the root universe block and writes it on every
+environment overlay. Other root universe fields (device flags, social
+links, display name, icon) continue to cascade root → per-env in both
+cases.
+
+This is a wire-contract change for hand-written configs that previously
+set both fields. Pre-1.0 and unpublished, so the schema breaks the
+combination outright with no compatibility shim; no codemod ships.
+
 ## Related Decisions
 
 - ADR-017 — Product Framing: establishes the programmatic-primary,

--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -332,6 +332,14 @@ describe(renderDeployError, () => {
 			},
 			expected: "place 'main-place' is missing 'placeId' under environment 'production'",
 		},
+		{
+			err: {
+				environment: "production",
+				kind: "incompleteUniverseEntry",
+				missingField: "universeId",
+			},
+			expected: "universe is missing 'universeId' under environment 'production'",
+		},
 	])("should render $err.kind via logError with a kind-specific message", ({ err, expected }) => {
 		expect.assertions(1);
 

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -257,6 +257,9 @@ function deployErrorMessage(err: DeployError): string {
 		case "incompletePlaceEntry": {
 			return `place '${err.key}' is missing '${err.missingField}' under environment '${err.environment}'`;
 		}
+		case "incompleteUniverseEntry": {
+			return `universe is missing '${err.missingField}' under environment '${err.environment}'`;
+		}
 		case "missingCredential": {
 			return `missing credential: environment variable ${err.variable} is not set`;
 		}

--- a/packages/bedrock/src/config.ts
+++ b/packages/bedrock/src/config.ts
@@ -9,6 +9,8 @@
 
 export type {
 	Config,
+	ConfigEnvironmentUniverseId,
+	ConfigRootUniverseId,
 	DeveloperProductEntry,
 	EnvironmentEntry,
 	GamePassEntry,
@@ -18,6 +20,8 @@ export type {
 	ResourceEntryByKind,
 	StateConfig,
 	UniverseEntry,
+	UniverseOverlayWithId,
+	UniverseOverlayWithoutId,
 } from "./core/schema.ts";
 export { defineConfig, type ConfigContext, type ConfigInput } from "./shell/define-config.ts";
 export type { SocialLink } from "@bedrock/ocale/universes";

--- a/packages/bedrock/src/core/migrate/build-state.ts
+++ b/packages/bedrock/src/core/migrate/build-state.ts
@@ -5,7 +5,7 @@ import {
 	UNIVERSE_SINGLETON_KEY,
 	type UniverseOutputs,
 } from "../resources.ts";
-import type { UniverseEntry } from "../schema.ts";
+import type { ResolvedUniverseEntry } from "../schema.ts";
 import type { BedrockState } from "../state.ts";
 import type { EnvironmentFoldResult } from "./fold-environment.ts";
 import type { PassFoldEntry } from "./fold-passes.ts";
@@ -47,7 +47,7 @@ interface BuildStateInputs {
 }
 
 interface UniverseResourceInputs {
-	readonly entry: UniverseEntry;
+	readonly entry: ResolvedUniverseEntry;
 	readonly iconHashes: Record<"en-us", Sha256Hex> | undefined;
 	readonly outputs: UniverseOutputs;
 }

--- a/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.spec.ts
@@ -168,7 +168,39 @@ describe(factorizeEnvironments, () => {
 		expect(result.data.primaryEnvironment).toBe("development");
 	});
 
-	it("should seed the root config from the chosen primary's universe entry", () => {
+	it("should seed the root universeId from the chosen primary when every environment shares the same universe", () => {
+		expect.assertions(2);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					universe: {
+						entry: { universeId: "6031475575" },
+						outputs: { rootPlaceId: asRobloxAssetId("17613681043") },
+					},
+				}),
+			],
+			[
+				"production",
+				fold({
+					universe: {
+						entry: { universeId: "6031475575" },
+						outputs: { rootPlaceId: asRobloxAssetId("17613681043") },
+					},
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.universe?.universeId).toBe("6031475575");
+		expect(result.data.config.environments["development"]?.universe).toBeUndefined();
+	});
+
+	it("should omit universeId from the root universe block when universes diverge across environments", () => {
 		expect.assertions(1);
 
 		const folds = new Map([
@@ -196,11 +228,11 @@ describe(factorizeEnvironments, () => {
 
 		assert(result.success);
 
-		expect(result.data.config.universe?.universeId).toBe("6031475575");
+		expect(result.data.config.universe).toBeUndefined();
 	});
 
-	it("should override universeId on a non-primary overlay when it diverges from the primary", () => {
-		expect.assertions(1);
+	it("should write a per-environment universeId overlay for every environment when universes diverge", () => {
+		expect.assertions(2);
 
 		const folds = new Map([
 			[
@@ -230,9 +262,68 @@ describe(factorizeEnvironments, () => {
 		expect(result.data.config.environments["development"]?.universe).toStrictEqual({
 			universeId: "1111111111",
 		});
+		expect(result.data.config.environments["production"]?.universe).toStrictEqual({
+			universeId: "6031475575",
+		});
 	});
 
-	it("should omit the universe overlay when the env's universe matches the primary's", () => {
+	it("should keep universeId on the root when one env has the universe and another env has no universe at all", () => {
+		expect.assertions(2);
+
+		const folds = new Map([
+			["development", fold()],
+			[
+				"production",
+				fold({
+					universe: {
+						entry: { universeId: "6031475575" },
+						outputs: { rootPlaceId: asRobloxAssetId("17613681043") },
+					},
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.universe?.universeId).toBe("6031475575");
+		expect(result.data.config.environments["production"]?.universe).toBeUndefined();
+	});
+
+	it("should preserve shared root universe fields while omitting universeId when universes diverge", () => {
+		expect.assertions(2);
+
+		const folds = new Map([
+			[
+				"development",
+				fold({
+					universe: {
+						entry: { displayName: "Shared Name", universeId: "1111111111" },
+						outputs: { rootPlaceId: asRobloxAssetId("2222222222") },
+					},
+				}),
+			],
+			[
+				"production",
+				fold({
+					universe: {
+						entry: { displayName: "Shared Name", universeId: "6031475575" },
+						outputs: { rootPlaceId: asRobloxAssetId("17613681043") },
+					},
+				}),
+			],
+		]);
+
+		const result = factorizeEnvironments({ folds, primaryEnvironment: "production" });
+
+		assert(result.success);
+
+		expect(result.data.config.universe?.displayName).toBe("Shared Name");
+		expect(result.data.config.universe?.universeId).toBeUndefined();
+	});
+
+	it("should omit the universe overlay when the env's universe matches the primary's and every env shares the same universe", () => {
 		expect.assertions(1);
 
 		const folds = new Map([

--- a/packages/bedrock/src/core/migrate/factorize-environments.ts
+++ b/packages/bedrock/src/core/migrate/factorize-environments.ts
@@ -6,12 +6,18 @@ import type {
 	EnvironmentEntry,
 	GamePassEntry,
 	PlaceEntry,
+	UniverseEntry,
 } from "../schema.ts";
 import { computeEnvironmentLabel } from "./environment-label.ts";
 import { extractDisplayNamePrefix } from "./extract-display-name-prefix.ts";
 import { collectMissingResourceWarnings } from "./factorize-environments-warnings.ts";
 import { buildPlacesOverlay, buildRootPlaces } from "./factorize-places.ts";
 import { buildProductsOverlay, buildRootProducts } from "./factorize-products.ts";
+import {
+	buildRootUniverse,
+	buildUniverseOverlay,
+	hasDivergentUniverseIds,
+} from "./factorize-universe.ts";
 import type { EnvironmentFoldResult } from "./fold-environment.ts";
 import type { MigrateError, MigrationWarning } from "./migration-report.ts";
 
@@ -27,7 +33,6 @@ interface FactorizeResult {
 }
 
 type PassOverlayEntry = NonNullable<EnvironmentEntry["passes"]>[string];
-type UniverseOverlay = NonNullable<EnvironmentEntry["universe"]>;
 
 interface ResolvedPrimary {
 	readonly name: string;
@@ -35,6 +40,7 @@ interface ResolvedPrimary {
 }
 
 interface OverlayContext {
+	readonly hasDivergentUniverseIds: boolean;
 	readonly labels: ReadonlyMap<string, string | undefined>;
 	readonly primary: EnvironmentFoldResult | undefined;
 	readonly rootPlaces: Record<string, PlaceEntry> | undefined;
@@ -51,6 +57,14 @@ interface BuildConfigInputs {
 	readonly folds: ReadonlyMap<string, EnvironmentFoldResult>;
 	readonly primaryFold: EnvironmentFoldResult;
 	readonly primaryName: string;
+}
+
+interface LooseConfigForBuild {
+	environments: Record<string, EnvironmentEntry>;
+	passes?: Record<string, GamePassEntry>;
+	places?: Record<string, PlaceEntry>;
+	products?: Record<string, DeveloperProductEntry>;
+	universe?: UniverseEntry;
 }
 
 /**
@@ -123,23 +137,6 @@ function buildRootPasses(
 	return Object.fromEntries(primaryFold.passes.map(({ key, entry }) => [key, entry]));
 }
 
-function buildUniverseOverlay(
-	fold: EnvironmentFoldResult,
-	primary: EnvironmentFoldResult | undefined,
-): undefined | UniverseOverlay {
-	const foldUniverse = fold.universe;
-	if (foldUniverse === undefined) {
-		return undefined;
-	}
-
-	const primaryUniverseId = primary?.universe?.entry.universeId;
-	if (primaryUniverseId === foldUniverse.entry.universeId) {
-		return undefined;
-	}
-
-	return { universeId: foldUniverse.entry.universeId };
-}
-
 function buildPassOverlayEntry(
 	entry: GamePassEntry,
 	primary: GamePassEntry,
@@ -189,7 +186,10 @@ function buildEnvironmentEntry(inputs: EnvironmentEntryInputs): EnvironmentEntry
 	const passes = buildPassesOverlay(fold, context.primary);
 	const places = buildPlacesOverlay({ fold, label, rootPlaces: context.rootPlaces });
 	const products = buildProductsOverlay(fold, context.rootProducts);
-	const universe = buildUniverseOverlay(fold, context.primary);
+	const universe = buildUniverseOverlay({
+		fold,
+		hasDivergentUniverseIds: context.hasDivergentUniverseIds,
+	});
 	return {
 		...(label !== undefined && { label }),
 		...(passes !== undefined && { passes }),
@@ -217,16 +217,15 @@ function buildEnvironmentLabels(
 	return new Map([...folds].map(([name, fold]) => [name, computeEnvironmentLabel(fold)]));
 }
 
-function resolveRootUniverse(
-	primaryFold: EnvironmentFoldResult,
+function stripDisplayNamePrefix(
+	universe: undefined | UniverseEntry,
 	label: string | undefined,
-): Config["universe"] {
-	const entry = primaryFold.universe?.entry;
-	if (entry === undefined || label === undefined || entry.displayName === undefined) {
-		return entry;
+): undefined | UniverseEntry {
+	if (universe === undefined || label === undefined || universe.displayName === undefined) {
+		return universe;
 	}
 
-	return { ...entry, displayName: extractDisplayNamePrefix(entry.displayName).body };
+	return { ...universe, displayName: extractDisplayNamePrefix(universe.displayName).body };
 }
 
 function buildConfig(inputs: BuildConfigInputs): Config {
@@ -234,19 +233,31 @@ function buildConfig(inputs: BuildConfigInputs): Config {
 	const labels = buildEnvironmentLabels(folds);
 	const places = buildRootPlaces({ folds, labels, primaryFold });
 	const products = buildRootProducts(folds, primaryFold);
+	const shouldOmitRootUniverseId = hasDivergentUniverseIds(folds);
 	const environments = buildEnvironmentEntries(folds, {
+		hasDivergentUniverseIds: shouldOmitRootUniverseId,
 		labels,
 		primary: primaryFold,
 		rootPlaces: places,
 		rootProducts: products,
 	});
 	const passes = buildRootPasses(primaryFold);
-	const universe = resolveRootUniverse(primaryFold, labels.get(primaryName));
-	return {
+	const universe = stripDisplayNamePrefix(
+		buildRootUniverse(primaryFold, shouldOmitRootUniverseId),
+		labels.get(primaryName),
+	);
+	const config: LooseConfigForBuild = {
 		environments,
 		...(passes !== undefined && { passes }),
 		...(places !== undefined && { places }),
 		...(products !== undefined && { products }),
 		...(universe !== undefined && { universe }),
 	};
+	// Precondition for the cast: `hasDivergentUniverseIds` decides
+	// `shouldOmitRootUniverseId` and `buildRootUniverse` and
+	// `buildUniverseOverlay` honour it, so the constructed config always
+	// lands in one arm of the discriminated `Config` union (root has
+	// `universeId` and no env carries one, or every env carries one and
+	// root omits it).
+	return config as unknown as Config;
 }

--- a/packages/bedrock/src/core/migrate/factorize-universe.ts
+++ b/packages/bedrock/src/core/migrate/factorize-universe.ts
@@ -1,0 +1,86 @@
+import type { EnvironmentEntry, UniverseEntry } from "../schema.ts";
+import type { EnvironmentFoldResult } from "./fold-environment.ts";
+
+type UniverseOverlay = NonNullable<EnvironmentEntry["universe"]>;
+
+interface UniverseOverlayContext {
+	readonly fold: EnvironmentFoldResult;
+	readonly hasDivergentUniverseIds: boolean;
+}
+
+/**
+ * Decide whether a fold map carries more than one distinct universeId,
+ * which forces the migrator to omit `universeId` from the root universe
+ * block and write it on every environment overlay (the schema-level XOR
+ * rule rejects the same `universeId` appearing in both places).
+ *
+ * @param folds - Per-environment fold results.
+ * @returns `true` when at least two folds carry different universeIds.
+ */
+export function hasDivergentUniverseIds(
+	folds: ReadonlyMap<string, EnvironmentFoldResult>,
+): boolean {
+	const distinctIds = new Set(
+		[...folds.values()].flatMap((fold) => {
+			return fold.universe === undefined ? [] : [fold.universe.entry.universeId];
+		}),
+	);
+	return distinctIds.size > 1;
+}
+
+/**
+ * Project the chosen primary environment's universe entry onto bedrock's
+ * root `universe` block. Strips `universeId` when universes diverge across
+ * environments so the schema-level XOR rule stays satisfied; the per-env
+ * overlay carries the id in that case (see {@link buildUniverseOverlay}).
+ *
+ * @param primaryFold - The chosen primary environment's fold; supplies
+ *   the universe entry whose shared fields land on root.
+ * @param shouldOmitUniverseId - `true` when universes diverge across the
+ *   input fold map (typically the output of {@link hasDivergentUniverseIds}).
+ * @returns The root `universe` block, or `undefined` when the primary has
+ *   no universe fold or when divergent universes leave nothing to land
+ *   at root.
+ */
+export function buildRootUniverse(
+	primaryFold: EnvironmentFoldResult,
+	shouldOmitUniverseId: boolean,
+): undefined | UniverseEntry {
+	const primaryUniverse = primaryFold.universe?.entry;
+	if (primaryUniverse === undefined) {
+		return undefined;
+	}
+
+	if (!shouldOmitUniverseId) {
+		return primaryUniverse;
+	}
+
+	const { universeId: _omittedUniverseId, ...sharedFields } = primaryUniverse;
+	if (Object.keys(sharedFields).length === 0) {
+		return undefined;
+	}
+
+	return sharedFields;
+}
+
+/**
+ * Build the per-environment overlay for `universe`. Returns the env's
+ * `universeId` when universes diverge across environments (schema-level
+ * XOR demands one universeId source per env); otherwise returns
+ * `undefined` so the env inherits the root universe block.
+ *
+ * @param context - The fold to overlay onto and the divergence flag.
+ * @returns The overlay, or `undefined` when no per-env overlay is needed.
+ */
+export function buildUniverseOverlay(context: UniverseOverlayContext): undefined | UniverseOverlay {
+	const foldUniverse = context.fold.universe;
+	if (foldUniverse === undefined) {
+		return undefined;
+	}
+
+	if (context.hasDivergentUniverseIds) {
+		return { universeId: foldUniverse.entry.universeId };
+	}
+
+	return undefined;
+}

--- a/packages/bedrock/src/core/migrate/fold-environment.ts
+++ b/packages/bedrock/src/core/migrate/fold-environment.ts
@@ -1,5 +1,5 @@
 import type { UniverseOutputs } from "../resources.ts";
-import type { UniverseEntry } from "../schema.ts";
+import type { ResolvedUniverseEntry } from "../schema.ts";
 import { foldPasses, type PassFoldEntry } from "./fold-passes.ts";
 import { foldPlaces, type PlaceFoldEntry } from "./fold-places.ts";
 import { foldProducts, type ProductFoldEntry } from "./fold-products.ts";
@@ -30,7 +30,7 @@ export interface EnvironmentFoldResult {
 	readonly universe:
 		| undefined
 		| {
-				readonly entry: UniverseEntry;
+				readonly entry: ResolvedUniverseEntry;
 				readonly outputs: UniverseOutputs;
 		  };
 	/** Per-rule diagnostics aggregated across all per-kind folds. */

--- a/packages/bedrock/src/core/migrate/fold-universe-shared.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe-shared.ts
@@ -14,13 +14,27 @@ import type { MigrationWarning } from "./migration-report.ts";
  * `warnings` because no rule that uses it currently produces outputs.
  */
 export interface FoldFragment {
-	/** Subset of universe fields this rule populated (empty when the rule did not fire). */
-	readonly entryFragment: Partial<UniverseEntry>;
+	/**
+	 * Subset of universe fields this rule populated (empty when the rule
+	 * did not fire). `universeId` is excluded because the orchestrator
+	 * seeds it from the experience resource's outputs; no fold rule
+	 * contributes to it.
+	 */
+	readonly entryFragment: UniverseEntryFragment;
 	/** Subset of universe outputs this rule populated; absent when the rule contributes no Roblox-assigned identifiers. */
 	readonly outputsFragment?: Partial<UniverseOutputs>;
 	/** Diagnostics this rule emitted. */
 	readonly warnings: ReadonlyArray<MigrationWarning>;
 }
+
+/**
+ * Subset of {@link UniverseEntry} that any individual fold rule may
+ * populate. `universeId` is excluded because the orchestrator seeds it
+ * from the experience resource's outputs; no fold rule contributes to it.
+ */
+type UniverseEntryFragment = {
+	readonly [Key in Exclude<keyof UniverseEntry, "universeId">]?: UniverseEntry[Key];
+};
 
 /** Sentinel value for fold rules that produced neither output nor warnings. */
 export const EMPTY_FRAGMENT: FoldFragment = { entryFragment: {}, warnings: [] };

--- a/packages/bedrock/src/core/migrate/fold-universe.ts
+++ b/packages/bedrock/src/core/migrate/fold-universe.ts
@@ -1,6 +1,6 @@
 import { asRobloxAssetId } from "../../types/ids.ts";
 import type { UniverseOutputs } from "../resources.ts";
-import type { UniverseEntry } from "../schema.ts";
+import type { ResolvedUniverseEntry } from "../schema.ts";
 import { foldBlockedExperienceFields } from "./fold-blocked-experience-fields.ts";
 import { foldDisplayName } from "./fold-display-name.ts";
 import { foldExperienceIcon } from "./fold-experience-icon.ts";
@@ -40,8 +40,13 @@ const PLAYABLE_DEVICE_TO_FLAG: Readonly<
  * presents to the user.
  */
 interface UniverseFoldResult {
-	/** Bedrock `Config.universe` block populated from the experience resource. */
-	readonly entry: UniverseEntry;
+	/**
+	 * Bedrock universe entry populated from the experience resource. Carries
+	 * `universeId` because the Mantle state always knows which universe the
+	 * environment targets; downstream consumers rely on the post-merge
+	 * invariant that `universeId` is present.
+	 */
+	readonly entry: ResolvedUniverseEntry;
 	/** Roblox-assigned identifiers carried into `BedrockState.resources[*].outputs`. */
 	readonly outputs: UniverseOutputs;
 	/** Per-rule diagnostics emitted while folding this environment's resources. */
@@ -80,7 +85,7 @@ export function foldUniverse(
 
 	const fragments = collectUniverseFragments(resources);
 
-	const entry: UniverseEntry = fragments.reduce<UniverseEntry>(
+	const entry: ResolvedUniverseEntry = fragments.reduce<ResolvedUniverseEntry>(
 		(accumulator, fragment) => ({ ...accumulator, ...fragment.entryFragment }),
 		{ universeId: outputs.assetId },
 	);

--- a/packages/bedrock/src/core/resolve-state-config.ts
+++ b/packages/bedrock/src/core/resolve-state-config.ts
@@ -1,6 +1,6 @@
 import type { Result } from "@bedrock/ocale";
 
-import type { Config, StateConfig } from "./schema.ts";
+import type { StateConfig } from "./schema.ts";
 
 /**
  * Failure surfaced when no `StateConfig` is configured for the requested
@@ -13,6 +13,17 @@ export interface StateNotConfiguredError {
 	readonly environment: string;
 	/** Literal discriminator for narrowing. */
 	readonly kind: "stateNotConfigured";
+}
+
+/**
+ * Minimal structural input the state resolver needs. Both `Config`
+ * (pre-merge, discriminated XOR union) and `ResolvedConfig` (post-merge)
+ * satisfy this shape, so callers can route either in without coupling
+ * the resolver to the discriminated-union arms.
+ */
+interface StateResolutionInputs {
+	readonly environments: Record<string, undefined | { readonly state?: StateConfig }>;
+	readonly state?: StateConfig;
 }
 
 /**
@@ -47,7 +58,7 @@ export interface StateNotConfiguredError {
  * ```
  */
 export function resolveStateConfig(
-	config: Config,
+	config: StateResolutionInputs,
 	environment: string,
 ): Result<StateConfig, StateNotConfiguredError> {
 	const override = config.environments[environment]?.state;

--- a/packages/bedrock/src/core/schema.spec-d.ts
+++ b/packages/bedrock/src/core/schema.spec-d.ts
@@ -6,6 +6,7 @@ import type {
 	GamePassEntry,
 	PlaceEntry,
 	ResolvedPlaceEntry,
+	ResolvedUniverseEntry,
 	StateConfig,
 	UniverseEntry,
 } from "./schema.ts";
@@ -62,14 +63,18 @@ describe("EnvironmentEntry overlay shapes", () => {
 		expectTypeOf(overlay).toExtend<PlaceOverlayEntry>();
 	});
 
-	it("should require universeId on a universe overlay while making other fields optional", () => {
+	it("should accept a universe overlay declaring only universeId", () => {
 		const overlay = { universeId: "9999999999" } as const satisfies UniverseOverlayEntry;
 		expectTypeOf(overlay).toExtend<UniverseOverlayEntry>();
 	});
 
-	it("should reject a universe overlay that omits universeId", () => {
-		// @ts-expect-error universeId is required on a universe overlay.
-		const overlay: UniverseOverlayEntry = { voiceChatEnabled: true };
+	it("should accept a universe overlay that omits universeId in favour of root authority", () => {
+		const overlay = { voiceChatEnabled: true } as const satisfies UniverseOverlayEntry;
+		expectTypeOf(overlay).toExtend<UniverseOverlayEntry>();
+	});
+
+	it("should keep every universe overlay field optional so the runtime XOR rule decides whether universeId must appear", () => {
+		const overlay = {} as const satisfies UniverseOverlayEntry;
 		expectTypeOf(overlay).toExtend<UniverseOverlayEntry>();
 	});
 
@@ -90,6 +95,91 @@ describe("EnvironmentEntry overlay derivation", () => {
 
 	it("should match the keys of UniverseEntry on a universe overlay", () => {
 		expectTypeOf<keyof UniverseOverlayEntry>().toEqualTypeOf<keyof UniverseEntry>();
+	});
+});
+
+describe("Config XOR — accepted root shapes", () => {
+	it("should accept a config that declares universeId on the root universe block only", () => {
+		const config = {
+			environments: { production: {} },
+			universe: { universeId: "111" },
+		} as const satisfies Config;
+		expectTypeOf(config).toExtend<Config>();
+	});
+
+	it("should accept a config that omits the universe block at the root and on every environment", () => {
+		const config = {
+			environments: { production: {} },
+		} as const satisfies Config;
+		expectTypeOf(config).toExtend<Config>();
+	});
+});
+
+describe("Config XOR — accepted env shapes", () => {
+	it("should accept a config that declares universeId on every environment overlay only", () => {
+		const config = {
+			environments: {
+				production: { universe: { universeId: "111" } },
+				staging: { universe: { universeId: "222" } },
+			},
+		} as const satisfies Config;
+		expectTypeOf(config).toExtend<Config>();
+	});
+
+	it("should accept a root universe block carrying shared fields without universeId when every env supplies one", () => {
+		const config = {
+			environments: {
+				production: { universe: { universeId: "111" } },
+			},
+			universe: { desktopEnabled: true, voiceChatEnabled: true },
+		} as const satisfies Config;
+		expectTypeOf(config).toExtend<Config>();
+	});
+});
+
+describe("Config XOR — rejected shapes", () => {
+	it("should reject a config that declares universeId on both the root and an environment overlay", () => {
+		// @ts-expect-error universeId on root and per-env overlay must not
+		// coexist.
+		const config: Config = {
+			environments: { production: { universe: { universeId: "999" } } },
+			universe: { universeId: "111" },
+		};
+		expectTypeOf(config).toExtend<Config>();
+	});
+
+	it("should reject root universeId paired with an env overlay that also declares one in any other environment slot", () => {
+		// @ts-expect-error universeId on root and per-env overlay must not
+		// coexist.
+		const config: Config = {
+			environments: {
+				staging: { universe: { universeId: "222" } },
+			},
+			universe: { universeId: "111" },
+		};
+		expectTypeOf(config).toExtend<Config>();
+	});
+});
+
+describe("UniverseEntry / ResolvedUniverseEntry split", () => {
+	it("should expose universeId as optional on the authored UniverseEntry so authors can supply it per-environment", () => {
+		expectTypeOf<UniverseEntry["universeId"]>().toEqualTypeOf<string | undefined>();
+	});
+
+	it("should require universeId on the post-merge ResolvedUniverseEntry as the resolution-boundary invariant", () => {
+		expectTypeOf<ResolvedUniverseEntry["universeId"]>().toEqualTypeOf<string>();
+	});
+
+	it("should make ResolvedUniverseEntry assignable to UniverseEntry but not the reverse", () => {
+		expectTypeOf<ResolvedUniverseEntry>().toExtend<UniverseEntry>();
+		expectTypeOf<UniverseEntry>().not.toExtend<ResolvedUniverseEntry>();
+	});
+
+	it("should leave every non-identity universe field optional on both sides of the split", () => {
+		expectTypeOf<UniverseEntry["voiceChatEnabled"]>().toEqualTypeOf<boolean | undefined>();
+		expectTypeOf<ResolvedUniverseEntry["voiceChatEnabled"]>().toEqualTypeOf<
+			boolean | undefined
+		>();
 	});
 });
 

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -1177,7 +1177,7 @@ describe(validateConfig, () => {
 		expect(result.err.issues[0]!.path).toStrictEqual(["environments", tooLong]);
 	});
 
-	it("should accept a per-environment universe overlay declaring only universeId", () => {
+	it("should accept a per-environment universe overlay declaring universeId when no root universe block exists", () => {
 		expect.assertions(1);
 
 		const result = validateConfig(
@@ -1186,7 +1186,6 @@ describe(validateConfig, () => {
 					production: { universe: { universeId: "9999999999" } },
 				},
 				state: { backend: "gist", gistId: "root-gist" },
-				universe: { universeId: "1111111111" },
 			},
 			SOURCE,
 		);
@@ -1196,7 +1195,28 @@ describe(validateConfig, () => {
 		expect(result.data.environments["production"]?.universe?.universeId).toBe("9999999999");
 	});
 
-	it("should reject a per-environment universe overlay missing universeId", () => {
+	it("should accept a per-environment universe overlay declaring universeId when the root universe block carries shared fields without universeId", () => {
+		expect.assertions(2);
+
+		const result = validateConfig(
+			{
+				environments: {
+					production: { universe: { universeId: "9999999999" } },
+					staging: { universe: { universeId: "5555555555" } },
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+				universe: { desktopEnabled: true, voiceChatEnabled: true },
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.universe?.desktopEnabled).toBeTrue();
+		expect(result.data.environments["production"]?.universe?.universeId).toBe("9999999999");
+	});
+
+	it("should reject a per-environment universe overlay missing universeId when no root universeId is declared", () => {
 		expect.assertions(1);
 
 		const result = validateConfig(
@@ -1218,6 +1238,186 @@ describe(validateConfig, () => {
 			"universe",
 			"universeId",
 		]);
+	});
+
+	it("should reject a config that declares universeId at the root and on a per-environment overlay", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: {
+					production: { universe: { universeId: "9999999999" } },
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+				universe: { universeId: "1111111111" },
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual([
+			"environments",
+			"production",
+			"universe",
+			"universeId",
+		]);
+	});
+
+	it("should reject a root universe block missing universeId when no environment supplies one", () => {
+		expect.assertions(2);
+
+		const result = validateConfig(
+			{
+				environments: { production: {} },
+				state: { backend: "gist", gistId: "root-gist" },
+				universe: { desktopEnabled: true },
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual(["universe", "universeId"]);
+		expect(result.err.issues[0]!.message).toContain(
+			"universeId must be declared on the root universe block",
+		);
+	});
+
+	it("should accept a config where root has universeId and an env declares a universe overlay carrying only shared fields", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: {
+					production: { universe: { voiceChatEnabled: false } },
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+				universe: { universeId: "1234567890", voiceChatEnabled: true },
+			},
+			SOURCE,
+		);
+
+		expect(result.success).toBeTrue();
+	});
+
+	it("should accept a config where root has universeId and one env supplies its own while another only carries shared fields", () => {
+		expect.assertions(2);
+
+		const result = validateConfig(
+			{
+				environments: {
+					production: { universe: { voiceChatEnabled: false } },
+					staging: {},
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+				universe: { universeId: "1234567890" },
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.universe?.universeId).toBe("1234567890");
+		expect(result.data.environments["production"]?.universe?.voiceChatEnabled).toBeFalse();
+	});
+
+	it("should attribute the both-set rejection to the offending env's universeId path with a descriptive message", () => {
+		expect.assertions(2);
+
+		const result = validateConfig(
+			{
+				environments: { production: { universe: { universeId: "9999999999" } } },
+				state: { backend: "gist", gistId: "root-gist" },
+				universe: { universeId: "1111111111" },
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual([
+			"environments",
+			"production",
+			"universe",
+			"universeId",
+		]);
+		expect(result.err.issues[0]!.message).toContain(
+			"universeId is declared at the root universe block",
+		);
+	});
+
+	it("should attribute the missing-env-universeId rejection with a descriptive message naming the root-must-supply requirement", () => {
+		expect.assertions(2);
+
+		const result = validateConfig(
+			{
+				environments: { production: { universe: { voiceChatEnabled: true } } },
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual([
+			"environments",
+			"production",
+			"universe",
+			"universeId",
+		]);
+		expect(result.err.issues[0]!.message).toContain("root universe block does not provide one");
+	});
+
+	it("should accept a config where the root carries shared universe fields without universeId, one env supplies its own, and another env omits the universe overlay entirely", () => {
+		expect.assertions(2);
+
+		const result = validateConfig(
+			{
+				environments: {
+					production: { universe: { universeId: "9999999999" } },
+					staging: {},
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+				universe: { desktopEnabled: true },
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.universe?.desktopEnabled).toBeTrue();
+		expect(result.data.environments["production"]?.universe?.universeId).toBe("9999999999");
+	});
+
+	it("should reject a config where one env supplies universeId and another env declares a universe overlay without one", () => {
+		expect.assertions(2);
+
+		const result = validateConfig(
+			{
+				environments: {
+					production: { universe: { universeId: "9999999999" } },
+					staging: { universe: { voiceChatEnabled: true } },
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual([
+			"environments",
+			"staging",
+			"universe",
+			"universeId",
+		]);
+		expect(result.err.issues[0]!.message).toContain("root universe block does not provide one");
 	});
 
 	it("should accept a per-environment places overlay that declares placeId without filePath", () => {

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -2,12 +2,13 @@ import type { Result } from "@bedrock/ocale";
 import type { SocialLink } from "@bedrock/ocale/universes";
 
 import { ArkErrors, type, type Type } from "arktype";
-import type { Except, SetRequired } from "type-fest";
+import type { SetRequired } from "type-fest";
 
 import { RESOURCE_KEY_PATTERN_SOURCE } from "../types/ids.ts";
 import type { ConfigError } from "./config-error.ts";
 import { ENV_NAME_PATTERN_SOURCE } from "./environment.ts";
 import { iconMap } from "./icons.ts";
+import { collectUniverseIdIssues } from "./validate-universe-xor.ts";
 
 /**
  * Body of a single entry in the `passes` collection. Keys in the parent
@@ -115,7 +116,11 @@ export interface ResolvedPlaceEntry {
  *
  * `universeId` is user-supplied because Open Cloud cannot mint universes;
  * the universe must already exist in Roblox before bedrock can reconcile
- * its configuration.
+ * its configuration. Declare `universeId` either here at the root (which
+ * applies to every environment) or under each `environments[name].universe`
+ * overlay, but never both: the schema rejects a config that sets it in
+ * both places, and rejects a `universe` block without a resolvable
+ * `universeId`.
  */
 export interface UniverseEntry {
 	/** Whether console players can join; omit or set `undefined` to leave unmanaged. */
@@ -175,8 +180,13 @@ export interface UniverseEntry {
 	 * `undefined` to clear it, or set to a `SocialLink` to update it.
 	 */
 	twitterSocialLink?: SocialLink | undefined;
-	/** Existing Roblox universe ID. */
-	universeId: string;
+	/**
+	 * Existing Roblox universe ID. Optional in this entry shape because
+	 * authors may declare it here (root-authoritative, single universe) or
+	 * on each `environments[name].universe` overlay (per-environment
+	 * universes), but never both.
+	 */
+	universeId?: string | undefined;
 	/** Whether voice chat is enabled; omit or set `undefined` to leave unmanaged. */
 	voiceChatEnabled?: boolean | undefined;
 	/** Whether VR players can join; omit or set `undefined` to leave unmanaged. */
@@ -216,10 +226,12 @@ export type StateConfig = GistStateConfig | { readonly backend: string & {} };
  * derive their field shapes from the matching root entry types so adding
  * a field to a base entry surfaces on the overlay automatically.
  *
- * `placeId` and `universeId` stay required when the matching overlay is
- * present because each environment targets its own Roblox object: an
- * overlay that mentions a place or universe must re-assert which Roblox
- * resource it points at.
+ * `placeId` stays required when the matching `places` overlay is present
+ * because each environment targets its own Roblox place. `universeId` is
+ * optional on the `universe` overlay because authors may declare it
+ * either at the root (root-authoritative) or per environment, but never
+ * both: the schema enforces this XOR at validation time, attributing the
+ * failure to the offending field's path.
  */
 export interface EnvironmentEntry {
 	/**
@@ -257,11 +269,12 @@ export interface EnvironmentEntry {
 	/** Per-environment state override; takes precedence over root `state`. */
 	state?: StateConfig;
 	/**
-	 * Per-environment universe overlay. `universeId` is required when the
-	 * overlay is present; other fields fall through to the root `universe`
-	 * block when omitted.
+	 * Per-environment universe overlay. Every field is optional, including
+	 * `universeId`: the schema-level XOR rule requires `universeId` here if
+	 * and only if the root `universe` block does not declare one. Other
+	 * fields fall through to the root `universe` block when omitted.
 	 */
-	universe?: Overlay<UniverseEntry, "universeId">;
+	universe?: Partial<UniverseEntry>;
 }
 
 /**
@@ -325,15 +338,90 @@ export interface DisplayNamePrefixConfig {
 }
 
 /**
+ * Per-environment universe overlay shape that forbids `universeId`.
+ * Used by {@link ConfigRootUniverseId}: when the root universe block
+ * declares `universeId`, no per-env overlay may redeclare it.
+ */
+export type UniverseOverlayWithoutId = Partial<WithoutKey<UniverseEntry, "universeId">> & {
+	universeId?: never;
+};
+
+/**
+ * Per-environment universe overlay shape that requires `universeId`.
+ * Used by {@link ConfigEnvironmentUniverseId}: when the root universe
+ * block does not declare `universeId`, every env that declares a
+ * `universe` overlay must supply one of its own.
+ */
+export type UniverseOverlayWithId = Partial<WithoutKey<UniverseEntry, "universeId">> & {
+	universeId: string;
+};
+
+/**
+ * Variant of `Config` where the root `universe` block declares
+ * `universeId`. Per-environment universe overlays may carry shared
+ * fields (device flags, social links, display name, icon) but cannot
+ * redeclare `universeId`; the schema rejects any env overlay that
+ * does. The runtime `selectEnvironment` merges shared-field overlays
+ * onto the root and inherits `universeId` from the root unchanged.
+ */
+export type ConfigRootUniverseId = ConfigBase & {
+	/**
+	 * Per-environment overrides keyed by environment name. Required and
+	 * non-empty; environment names match `[A-Za-z0-9_-]{1,64}`. Each env
+	 * entry's `universe` overlay forbids `universeId` because the root
+	 * declares it.
+	 */
+	environments: Record<
+		string,
+		WithoutKey<EnvironmentEntry, "universe"> & { universe?: UniverseOverlayWithoutId }
+	>;
+	/**
+	 * Singleton universe block declaring the Roblox universe bedrock
+	 * manages. `universeId` is required in this variant because no
+	 * per-environment overlay may supply one.
+	 */
+	universe?: UniverseEntry & { universeId: string };
+};
+
+/**
+ * Variant of `Config` where the root `universe` block omits
+ * `universeId`. Every env that declares a `universe` overlay must
+ * supply its own `universeId`; envs that omit the overlay deploy no
+ * universe at all. The root may still carry shared fields (device
+ * flags, social links, display name, icon) which `selectEnvironment`
+ * merges onto each env's overlay at resolution time.
+ */
+export type ConfigEnvironmentUniverseId = ConfigBase & {
+	/**
+	 * Per-environment overrides keyed by environment name. Required and
+	 * non-empty; environment names match `[A-Za-z0-9_-]{1,64}`. Every
+	 * env that declares a `universe` overlay must include `universeId`
+	 * because the root universe block does not provide one.
+	 */
+	environments: Record<
+		string,
+		WithoutKey<EnvironmentEntry, "universe"> & { universe?: UniverseOverlayWithId }
+	>;
+	/**
+	 * Singleton universe block declaring the Roblox universe bedrock
+	 * manages. `universeId` is forbidden in this variant because every
+	 * environment supplies its own.
+	 */
+	universe?: UniverseEntry & { universeId?: never };
+};
+
+/**
  * Validated project config as accepted by `loadConfig`. Plain mutable so
  * users can adjust fields in a long-running script before deploying.
  *
- * Shape matches the runtime schema declared below. `rootSchema` is typed
- * against this interface via `Type<Config>`, so any drift between the two
- * is a compile error at build time. State must be configured at the
- * root or under every entry of `environments`; `resolveStateConfig`
- * surfaces the missing case at the deploy boundary as
- * `stateNotConfigured`.
+ * Discriminated union over the location of `universeId`: it lives at the
+ * root universe block ({@link ConfigRootUniverseId}) or on every
+ * environment universe overlay ({@link ConfigEnvironmentUniverseId}), but never
+ * both. The TypeScript types reject the both-set case at compile time,
+ * and the arktype runtime narrow rejects every offending field path at
+ * `validateConfig` time. State must be configured at the root or under
+ * every entry of `environments`; `resolveStateConfig` surfaces the
+ * missing case at the deploy boundary as `stateNotConfigured`.
  *
  * @example
  *
@@ -356,33 +444,23 @@ export interface DisplayNamePrefixConfig {
  * expect(config.passes!["vip-pass"]!.name).toBe("VIP Pass");
  * ```
  */
-export interface Config {
-	/**
-	 * Project-level prefixing of universe and place display names with the
-	 * environment label. Default behaviour (when omitted) is enabled with a
-	 * `"[{LABEL}] "` template; set `enabled: false` to opt out, or set
-	 * `format` to a custom template.
-	 */
-	displayNamePrefix?: DisplayNamePrefixConfig;
-	/**
-	 * Per-environment overrides keyed by environment name. Required and
-	 * non-empty: every project declares at least one environment, and
-	 * `deploy()` rejects any environment name that is not a key of this
-	 * record. Environment names match `[A-Za-z0-9_-]{1,64}`.
-	 */
-	environments: Record<string, EnvironmentEntry>;
-	/** Reserved at the root for c12's config layering / overlay work. */
-	extends?: unknown;
-	/** Keyed-map collection of game-pass entries by user-supplied ResourceKey. */
-	passes?: Record<string, GamePassEntry>;
-	/** Keyed-map collection of place entries by user-supplied ResourceKey. */
-	places?: Record<string, PlaceEntry>;
-	/** Keyed-map collection of developer-product entries by user-supplied ResourceKey. */
-	products?: Record<string, DeveloperProductEntry>;
-	/** Where Bedrock persists state for this project; required at deploy time. */
-	state?: StateConfig;
-	/** Singleton universe block declaring the Roblox universe bedrock manages. */
-	universe?: UniverseEntry;
+export type Config = ConfigEnvironmentUniverseId | ConfigRootUniverseId;
+
+/**
+ * Body of the singleton `universe` block after `selectEnvironment` has
+ * merged a per-environment overlay onto the root. Identical to
+ * {@link UniverseEntry} except `universeId` is required: the schema-level
+ * XOR rule ensures every projected universe carries a resolved
+ * `universeId`. Resource drivers consume this shape rather than
+ * `UniverseEntry` so the post-merge invariant is visible in the type
+ * system.
+ */
+export interface ResolvedUniverseEntry extends Pick<
+	UniverseEntry,
+	Exclude<keyof UniverseEntry, "universeId">
+> {
+	/** Existing Roblox universe ID, resolved from the root or per-environment overlay. */
+	universeId: string;
 }
 
 /**
@@ -417,9 +495,22 @@ export interface Config {
  * }
  * ```
  */
-export interface ResolvedConfig extends Except<Config, "places"> {
+export interface ResolvedConfig extends Pick<ConfigBase, Exclude<keyof ConfigBase, "places">> {
+	/**
+	 * Per-environment overrides preserved from the source `Config`.
+	 * Carried for downstream context; `selectEnvironment` does not read
+	 * other environments after resolving the requested one.
+	 */
+	environments: Record<string, EnvironmentEntry>;
 	/** Keyed-map collection of resolved place entries; both `filePath` and `placeId` are present. */
 	places?: Record<string, ResolvedPlaceEntry>;
+	/**
+	 * Singleton universe block after `selectEnvironment` has resolved the
+	 * XOR between root and per-environment `universeId`. The schema narrow
+	 * rejects any config that would leave `universeId` unresolved, so the
+	 * post-merge invariant promotes `universeId` from optional to required.
+	 */
+	universe?: ResolvedUniverseEntry;
 }
 
 /**
@@ -433,6 +524,42 @@ export interface ResolvedConfig extends Except<Config, "places"> {
  * still declare (for example `"placeId"` or `"universeId"`).
  */
 type Overlay<T, RequiredKey extends keyof T> = SetRequired<Partial<T>, RequiredKey>;
+
+/**
+ * Helper that produces a shallow `Omit<T, K>` without using TypeScript's
+ * built-in `Omit` (deprecated under the project's lint rules because of
+ * its lossy interaction with mapped types).
+ *
+ * @template T - Source type to project keys away from.
+ * @template Key - Key (or union of keys) on `T` to remove.
+ */
+type WithoutKey<T, Key extends keyof T> = Pick<T, Exclude<keyof T, Key>>;
+
+/**
+ * Fields shared by every {@link Config} variant. The discriminated
+ * `Config` union narrows `universe` and `environments` to enforce the
+ * `universeId` XOR rule between the root and per-environment overlays;
+ * everything else lives here.
+ */
+interface ConfigBase {
+	/**
+	 * Project-level prefixing of universe and place display names with the
+	 * environment label. Default behaviour (when omitted) is enabled with a
+	 * `"[{LABEL}] "` template; set `enabled: false` to opt out, or set
+	 * `format` to a custom template.
+	 */
+	displayNamePrefix?: DisplayNamePrefixConfig;
+	/** Reserved at the root for c12's config layering / overlay work. */
+	extends?: unknown;
+	/** Keyed-map collection of game-pass entries by user-supplied ResourceKey. */
+	passes?: Record<string, GamePassEntry>;
+	/** Keyed-map collection of place entries by user-supplied ResourceKey. */
+	places?: Record<string, PlaceEntry>;
+	/** Keyed-map collection of developer-product entries by user-supplied ResourceKey. */
+	products?: Record<string, DeveloperProductEntry>;
+	/** Where Bedrock persists state for this project; required at deploy time. */
+	state?: StateConfig;
+}
 
 /**
  * Narrow a `StateConfig` to the `GistStateConfig` arm. The `(string & {})`
@@ -547,7 +674,7 @@ const universeEntry = type({
 	"tabletEnabled?": OPTIONAL_BOOLEAN,
 	"twitchSocialLink?": socialLinkOrUndefined,
 	"twitterSocialLink?": socialLinkOrUndefined,
-	"universeId": ROBLOX_ID_DIGITS,
+	"universeId?": ROBLOX_ID_DIGITS,
 	"voiceChatEnabled?": OPTIONAL_BOOLEAN,
 	"vrEnabled?": OPTIONAL_BOOLEAN,
 	"youtubeSocialLink?": socialLinkOrUndefined,
@@ -598,10 +725,12 @@ const placesOverlayCollection = type({
 	[`[/${RESOURCE_KEY_PATTERN_SOURCE}/]`]: placeOverlay,
 }).onUndeclaredKey("reject");
 
-// `Overlay<UniverseEntry, "universeId">` is structurally equal to
-// `UniverseEntry` itself: the base type already has every field except
-// `universeId` declared as optional. Reusing `universeEntry` here keeps
-// the field set in lockstep and avoids a parallel declaration to drift.
+// `Partial<UniverseEntry>` is structurally equal to `UniverseEntry`
+// itself because every field on `UniverseEntry` is optional. Reusing
+// `universeEntry` here keeps the field set in lockstep and avoids a
+// parallel declaration to drift. The XOR rule that ties root and
+// per-environment `universeId` together lives on `rootSchema` below,
+// where both sides of the relationship are in scope.
 const universeOverlay = universeEntry;
 
 const environmentEntry: Type<EnvironmentEntry> = type({
@@ -630,7 +759,16 @@ const environmentsCollection = type({
 		return true;
 	});
 
-const rootSchema: Type<Config> = type({
+// `rootSchema` is intentionally not annotated `Type<Config>` because
+// `Config` is a discriminated union enforcing the universeId XOR rule
+// at the type level. The arktype schema describes the loose
+// authored-shape that's structurally a supertype of every union arm;
+// the runtime narrow rejects any value that doesn't satisfy one arm so
+// `validateConfig` can cast the result to `Config` safely. Splitting
+// the schema into two `.or()` variants would mirror the type union but
+// duplicate every field declaration without buying additional runtime
+// coverage on top of the narrow.
+const rootSchema = type({
 	"displayNamePrefix?": displayNamePrefix,
 	"environments": environmentsCollection,
 	"extends?": "unknown",
@@ -639,7 +777,16 @@ const rootSchema: Type<Config> = type({
 	"products?": productsCollection,
 	"state?": stateConfig,
 	"universe?": universeEntry,
-}).onUndeclaredKey("reject");
+})
+	.onUndeclaredKey("reject")
+	.narrow((value, ctx) => {
+		// `ctx.reject` returns `false` for every issue and `reduce` walks the
+		// whole list so every offending field gets attributed; the seeded
+		// `true` flips to `false` on the first issue.
+		return collectUniverseIdIssues(value).reduce<boolean>((_accumulator, issue) => {
+			return ctx.reject({ message: issue.message, path: [...issue.path] });
+		}, true);
+	});
 
 /**
  * Validate a parsed config value against the runtime schema. Returns the
@@ -700,5 +847,11 @@ export function validateConfig(input: unknown, sourceFile: string): Result<Confi
 		};
 	}
 
-	return { data: validated, success: true };
+	// Precondition for the cast: the runtime narrow rejects every value
+	// that violates the universeId XOR rule, so a successful validation
+	// always lands in one arm of the discriminated `Config` union. The
+	// schema's inferred type is the structurally loose authored-shape
+	// (universeId optional in both root and per-env overlays); the cast
+	// collapses it to the strict union without loss of safety.
+	return { data: validated as unknown as Config, success: true };
 }

--- a/packages/bedrock/src/core/select-environment.example.spec.ts
+++ b/packages/bedrock/src/core/select-environment.example.spec.ts
@@ -9,12 +9,13 @@ it('Example 1', () => {
       production: { universe: { universeId: '999' } },
     },
     state: { backend: 'gist', gistId: 'abc123' },
-    universe: { universeId: '111' },
+    universe: { voiceChatEnabled: true },
   }
   const result = selectEnvironment(config, 'production')
   expect(result.success).toBeTrue()
   if (result.success) {
     expect(result.data.universe?.universeId).toBe('999')
+    expect(result.data.universe?.voiceChatEnabled).toBeTrue()
     expect(result.data.state?.backend).toBe('gist')
   }
 })

--- a/packages/bedrock/src/core/select-environment.spec-d.ts
+++ b/packages/bedrock/src/core/select-environment.spec-d.ts
@@ -21,9 +21,9 @@ describe("selectEnvironment signature", () => {
 		>();
 	});
 
-	it("should discriminate SelectEnvironmentError across the unknownEnvironment and incompletePlaceEntry kinds", () => {
+	it("should discriminate SelectEnvironmentError across the unknownEnvironment, incompletePlaceEntry, and incompleteUniverseEntry kinds", () => {
 		expectTypeOf<SelectEnvironmentError["kind"]>().toEqualTypeOf<
-			"incompletePlaceEntry" | "unknownEnvironment"
+			"incompletePlaceEntry" | "incompleteUniverseEntry" | "unknownEnvironment"
 		>();
 	});
 });

--- a/packages/bedrock/src/core/select-environment.spec.ts
+++ b/packages/bedrock/src/core/select-environment.spec.ts
@@ -95,18 +95,22 @@ describe(selectEnvironment, () => {
 
 		const config: Config = {
 			environments: {
-				production: { universe: { universeId: "9999999999" } },
+				production: { universe: { voiceChatEnabled: false } },
 			},
 			state: ROOT_STATE,
-			universe: { universeId: "1111111111", voiceChatEnabled: true },
+			universe: {
+				desktopEnabled: true,
+				universeId: "1111111111",
+				voiceChatEnabled: true,
+			},
 		};
 
 		const result = selectEnvironment(config, "production");
 
 		assert(result.success);
 
-		expect(result.data.universe?.universeId).toBe("9999999999");
-		expect(result.data.universe?.voiceChatEnabled).toBeTrue();
+		expect(result.data.universe?.voiceChatEnabled).toBeFalse();
+		expect(result.data.universe?.desktopEnabled).toBeTrue();
 	});
 
 	it("should let an environment universe overlay override the en-us icon path while inheriting unrelated root fields", () => {
@@ -117,7 +121,6 @@ describe(selectEnvironment, () => {
 				staging: {
 					universe: {
 						icon: { "en-us": "assets/staging-icon.png" },
-						universeId: "1111111111",
 					},
 				},
 			},
@@ -405,6 +408,24 @@ describe(selectEnvironment, () => {
 
 		expect(result.data.places?.["start-place"]?.placeId).toBe("1111");
 		expect(result.data.places?.["start-place"]?.filePath).toBe("places/start.rbxl");
+	});
+
+	it("should return Err(incompleteUniverseEntry) when neither root nor env overlay supplies universeId", () => {
+		expect.assertions(3);
+
+		const config: Config = {
+			environments: { production: { universe: { voiceChatEnabled: true } } },
+			state: ROOT_STATE,
+		};
+
+		const result = selectEnvironment(config, "production");
+
+		assert(!result.success);
+		assert(result.err.kind === "incompleteUniverseEntry");
+
+		expect(result.err.kind).toBe("incompleteUniverseEntry");
+		expect(result.err.missingField).toBe("universeId");
+		expect(result.err.environment).toBe("production");
 	});
 
 	it("should prefix universe.displayName with the default template when an environment declares a label", () => {

--- a/packages/bedrock/src/core/select-environment.ts
+++ b/packages/bedrock/src/core/select-environment.ts
@@ -1,7 +1,6 @@
 import type { Result } from "@bedrock/ocale";
 
 import { defu } from "defu";
-import type { SetRequired } from "type-fest";
 
 import { renderDisplayNamePrefix } from "./display-name-prefix.ts";
 import type {
@@ -11,6 +10,7 @@ import type {
 	GamePassEntry,
 	ResolvedConfig,
 	ResolvedPlaceEntry,
+	ResolvedUniverseEntry,
 	UniverseEntry,
 } from "./schema.ts";
 
@@ -49,8 +49,27 @@ export interface IncompletePlaceEntryError {
 	readonly missingField: "filePath" | "placeId";
 }
 
+/**
+ * Failure surfaced when a merged `universe` block lacks `universeId`.
+ * The schema-level XOR rule normally prevents this by requiring
+ * `universeId` either at the root or on every per-environment overlay;
+ * this error remains as a typed safety net for callers that bypass
+ * `validateConfig` and hand a `Config` to `selectEnvironment` directly.
+ */
+export interface IncompleteUniverseEntryError {
+	/** Environment whose overlay was projected onto the config. */
+	readonly environment: string;
+	/** Literal discriminator for narrowing. */
+	readonly kind: "incompleteUniverseEntry";
+	/** Field that the merged entry lacks. V1 only surfaces `"universeId"`. */
+	readonly missingField: "universeId";
+}
+
 /** Failure modes returned by {@link selectEnvironment}. */
-export type SelectEnvironmentError = IncompletePlaceEntryError | UnknownEnvironmentError;
+export type SelectEnvironmentError =
+	| IncompletePlaceEntryError
+	| IncompleteUniverseEntryError
+	| UnknownEnvironmentError;
 
 interface ProjectInputs {
 	readonly config: Config;
@@ -113,7 +132,7 @@ interface ProjectInputs {
  *         production: { universe: { universeId: "999" } },
  *     },
  *     state: { backend: "gist", gistId: "abc123" },
- *     universe: { universeId: "111" },
+ *     universe: { voiceChatEnabled: true },
  * };
  *
  * const result = selectEnvironment(config, "production");
@@ -121,6 +140,7 @@ interface ProjectInputs {
  * expect(result.success).toBeTrue();
  * if (result.success) {
  *     expect(result.data.universe?.universeId).toBe("999");
+ *     expect(result.data.universe?.voiceChatEnabled).toBeTrue();
  *     expect(result.data.state?.backend).toBe("gist");
  * }
  * ```
@@ -143,12 +163,38 @@ export function selectEnvironment(
 	}
 
 	const projected = projectConfig({ config, entry });
-	const incomplete = findIncompletePlace(projected, environment);
-	if (incomplete !== undefined) {
-		return { err: incomplete, success: false };
+	const incompletePlace = findIncompletePlace(projected, environment);
+	if (incompletePlace !== undefined) {
+		return { err: incompletePlace, success: false };
+	}
+
+	const incompleteUniverse = findIncompleteUniverse(projected, environment);
+	if (incompleteUniverse !== undefined) {
+		return { err: incompleteUniverse, success: false };
 	}
 
 	return { data: projected, success: true };
+}
+
+function findIncompleteUniverse(
+	projected: ResolvedConfig,
+	environment: string,
+): IncompleteUniverseEntryError | undefined {
+	const { universe } = projected;
+	if (universe === undefined) {
+		return undefined;
+	}
+
+	// `universe` is typed as `ResolvedUniverseEntry` (universeId required)
+	// because the merge boundary already promised completeness; this routine
+	// exists to honour that promise at runtime, so it widens the view back to
+	// `Partial<ResolvedUniverseEntry>` for the duration of the check.
+	const candidate: Partial<ResolvedUniverseEntry> = universe;
+	if (candidate.universeId === undefined) {
+		return { environment, kind: "incompleteUniverseEntry", missingField: "universeId" };
+	}
+
+	return undefined;
 }
 
 function findIncompletePlace(
@@ -229,14 +275,20 @@ function mergeKeyedRecord<Resolved extends object>(
 }
 
 function mergeUniverse(
-	overlay: SetRequired<Partial<UniverseEntry>, "universeId"> | undefined,
+	overlay: Partial<UniverseEntry> | undefined,
 	base: undefined | UniverseEntry,
-): undefined | UniverseEntry {
-	if (overlay === undefined) {
-		return base;
+): ResolvedUniverseEntry | undefined {
+	if (overlay === undefined && base === undefined) {
+		return undefined;
 	}
 
-	return mergeEntry(overlay, base);
+	// Precondition for the cast: see `mergeEntry`. The schema-level XOR rule
+	// guarantees a present `universeId` post-merge whenever the result is
+	// non-empty, and `findIncompleteUniverse` re-verifies the invariant on
+	// the success path. The `defu` call type-resolves to a wider partial
+	// because both sides declare `universeId` as optional; the cast collapses
+	// it to the resolved shape.
+	return defu(overlay ?? {}, base ?? {}) as ResolvedUniverseEntry;
 }
 
 function resolvePrefix(config: Config, entry: EnvironmentEntry): string | undefined {
@@ -253,9 +305,9 @@ function resolvePrefix(config: Config, entry: EnvironmentEntry): string | undefi
 }
 
 function applyUniversePrefix(
-	universe: undefined | UniverseEntry,
+	universe: ResolvedUniverseEntry | undefined,
 	prefix: string | undefined,
-): undefined | UniverseEntry {
+): ResolvedUniverseEntry | undefined {
 	if (universe === undefined || prefix === undefined || universe.displayName === undefined) {
 		return universe;
 	}
@@ -293,7 +345,12 @@ function projectConfig(inputs: ProjectInputs): ResolvedConfig {
 	const places = applyPlacesPrefix(mergedPlaces, prefix);
 	const state = entry.state ?? config.state;
 
-	const { places: _placesRoot, products: _productsRoot, ...rest } = config;
+	const {
+		places: _placesRoot,
+		products: _productsRoot,
+		universe: _universeRoot,
+		...rest
+	} = config;
 
 	return {
 		...rest,

--- a/packages/bedrock/src/core/validate-universe-xor.ts
+++ b/packages/bedrock/src/core/validate-universe-xor.ts
@@ -1,0 +1,87 @@
+import type { EnvironmentEntry, UniverseEntry } from "./schema.ts";
+
+/**
+ * Loose authored-shape that the runtime narrow operates on before the
+ * config gets cast to the discriminated `Config` union. Mirrors the
+ * arktype schema's inferred shape: every field is structurally a
+ * supertype of every `Config` variant arm, so the narrow can run before
+ * the XOR rule has discriminated the value into one arm.
+ */
+interface LooseConfigForValidation {
+	readonly environments: Record<string, EnvironmentEntry>;
+	readonly universe?: UniverseEntry;
+}
+
+interface UniverseIdIssue {
+	readonly message: string;
+	readonly path: ReadonlyArray<string>;
+}
+
+/**
+ * Walk the loose authored-shape and surface every place the
+ * universeId-XOR-between-root-and-env rule is violated. Pure: returns
+ * the issue list; the caller hands it to arktype's `ctx.reject` so each
+ * one lands at the offending config path. The schema's runtime narrow
+ * uses this to enforce the rule at validation time before the validated
+ * value is cast to the strict `Config` discriminated union.
+ *
+ * @param value - Parsed config the schema is validating.
+ * @returns Zero or more issues. Empty when the config satisfies the rule.
+ */
+export function collectUniverseIdIssues(
+	value: LooseConfigForValidation,
+): ReadonlyArray<UniverseIdIssue> {
+	const rootUniverseId = value.universe?.universeId;
+	const hasRootUniverseBlock = value.universe !== undefined;
+	const environmentEntries = Object.entries(value.environments);
+	const hasEnvironmentUniverseId = environmentEntries.some(
+		([, environment]) => environment.universe?.universeId !== undefined,
+	);
+
+	const environmentIssues = collectEnvironmentIssues(rootUniverseId, environmentEntries);
+	const rootIssues =
+		hasRootUniverseBlock && rootUniverseId === undefined && !hasEnvironmentUniverseId
+			? [
+					{
+						message:
+							"universeId must be declared on the root universe block, or on every environment that declares its own universe overlay.",
+						path: ["universe", "universeId"],
+					},
+				]
+			: [];
+
+	return [...environmentIssues, ...rootIssues];
+}
+
+function collectEnvironmentIssues(
+	rootUniverseId: string | undefined,
+	environmentEntries: ReadonlyArray<readonly [string, EnvironmentEntry]>,
+): ReadonlyArray<UniverseIdIssue> {
+	return environmentEntries.flatMap(([environmentName, environment]) => {
+		if (environment.universe === undefined) {
+			return [];
+		}
+
+		if (rootUniverseId !== undefined && environment.universe.universeId !== undefined) {
+			return [
+				{
+					message:
+						"universeId is declared at the root universe block; remove it from this environment overlay (root is authoritative) or remove it from the root and declare it on every environment.",
+					path: ["environments", environmentName, "universe", "universeId"],
+				},
+			];
+		}
+
+		if (rootUniverseId === undefined && environment.universe.universeId === undefined) {
+			return [
+				{
+					message:
+						"universeId must be declared on this environment overlay because the root universe block does not provide one.",
+					path: ["environments", environmentName, "universe", "universeId"],
+				},
+			];
+		}
+
+		return [];
+	});
+}

--- a/packages/bedrock/src/index.spec-d.ts
+++ b/packages/bedrock/src/index.spec-d.ts
@@ -150,6 +150,20 @@ describe(applyOps, () => {
 	});
 });
 
+type ExpectedDeployErrorKind =
+	| "applyFailed"
+	| "buildDesiredFailed"
+	| "configLoadFailed"
+	| "incompletePlaceEntry"
+	| "incompleteUniverseEntry"
+	| "missingCredential"
+	| "registryConfigMissing"
+	| "stateNotConfigured"
+	| "stateReadFailed"
+	| "stateWriteFailed"
+	| "unknownEnvironment"
+	| "unsupportedBackend";
+
 describe(deploy, () => {
 	it("should accept a single DeployOptions argument", () => {
 		expectTypeOf(deploy).parameter(0).toEqualTypeOf<DeployOptions>();
@@ -162,19 +176,7 @@ describe(deploy, () => {
 	});
 
 	it("should discriminate DeployError across the reconcile-stage and default-construction failure variants", () => {
-		expectTypeOf<DeployError["kind"]>().toEqualTypeOf<
-			| "applyFailed"
-			| "buildDesiredFailed"
-			| "configLoadFailed"
-			| "incompletePlaceEntry"
-			| "missingCredential"
-			| "registryConfigMissing"
-			| "stateNotConfigured"
-			| "stateReadFailed"
-			| "stateWriteFailed"
-			| "unknownEnvironment"
-			| "unsupportedBackend"
-		>();
+		expectTypeOf<DeployError["kind"]>().toEqualTypeOf<ExpectedDeployErrorKind>();
 	});
 
 	it("should attach unsavedState only to the stateWriteFailed variant", () => {
@@ -267,11 +269,10 @@ describe("ResolvedPlaceEntry", () => {
 });
 
 describe("ResolvedConfig", () => {
-	it("should narrow places to ResolvedPlaceEntry while keeping every other Config field", () => {
+	it("should narrow places to ResolvedPlaceEntry while keeping the loose authored shape on the other passthrough fields", () => {
 		expectTypeOf<ResolvedConfig["places"]>().toEqualTypeOf<
 			Record<string, ResolvedPlaceEntry> | undefined
 		>();
-		expectTypeOf<ResolvedConfig["environments"]>().toEqualTypeOf<Config["environments"]>();
 		expectTypeOf<ResolvedConfig["state"]>().toEqualTypeOf<Config["state"]>();
 	});
 });

--- a/packages/bedrock/src/index.ts
+++ b/packages/bedrock/src/index.ts
@@ -68,6 +68,8 @@ export {
 	isGistStateConfig,
 	validateConfig,
 	type Config,
+	type ConfigEnvironmentUniverseId,
+	type ConfigRootUniverseId,
 	type DeveloperProductEntry,
 	type DisplayNamePrefixConfig,
 	type EnvironmentEntry,
@@ -76,13 +78,17 @@ export {
 	type PlaceEntry,
 	type ResolvedConfig,
 	type ResolvedPlaceEntry,
+	type ResolvedUniverseEntry,
 	type ResourceEntryByKind,
 	type StateConfig,
 	type UniverseEntry,
+	type UniverseOverlayWithId,
+	type UniverseOverlayWithoutId,
 } from "./core/schema.ts";
 export {
 	selectEnvironment,
 	type IncompletePlaceEntryError,
+	type IncompleteUniverseEntryError,
 	type SelectEnvironmentError,
 	type UnknownEnvironmentError,
 } from "./core/select-environment.ts";

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -12,6 +12,7 @@ import type { ResourceCurrentState } from "../core/resources.ts";
 import type { Config, ResolvedConfig } from "../core/schema.ts";
 import {
 	type IncompletePlaceEntryError,
+	type IncompleteUniverseEntryError,
 	selectEnvironment,
 	type UnknownEnvironmentError,
 } from "../core/select-environment.ts";
@@ -58,11 +59,12 @@ export interface DeployOptions {
  * `kind` to distinguish reconciliation failures (`stateReadFailed`,
  * `applyFailed`, ...) from default-construction failures
  * (`configLoadFailed`, `stateNotConfigured`, `unknownEnvironment`,
- * `incompletePlaceEntry`, `missingCredential`, `unsupportedBackend`,
- * `registryConfigMissing`).
+ * `incompletePlaceEntry`, `incompleteUniverseEntry`, `missingCredential`,
+ * `unsupportedBackend`, `registryConfigMissing`).
  */
 export type DeployError =
 	| IncompletePlaceEntryError
+	| IncompleteUniverseEntryError
 	| MissingCredentialError
 	| RegistryConfigError
 	| StateNotConfiguredError

--- a/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/src/shell/migrate-mantle-state.spec.ts
@@ -729,8 +729,8 @@ describe(migrateMantleState, () => {
 		expect(result.err.available).toStrictEqual(["development", "production"]);
 	});
 
-	it("should seed the root config from the explicitly chosen primary environment", async () => {
-		expect.assertions(2);
+	it("should write per-environment universeId overlays for every environment when universes diverge across the input", async () => {
+		expect.assertions(3);
 
 		const result = await migrateMantleState({
 			configFormat: "typescript",
@@ -741,11 +741,13 @@ describe(migrateMantleState, () => {
 
 		assert(result.success);
 
-		expect(result.data.config.universe?.universeId).toBe("1111111111");
-		expect(Object.keys(result.data.statesByEnvironment)).toStrictEqual([
-			"development",
-			"production",
-		]);
+		expect(result.data.config.universe?.universeId).toBeUndefined();
+		expect(result.data.config.environments["development"]?.universe?.universeId).toBe(
+			"1111111111",
+		);
+		expect(result.data.config.environments["production"]?.universe?.universeId).toBe(
+			"6031475575",
+		);
 	});
 
 	it("should keep each environment's BedrockState truthful to its own deployed values", async () => {

--- a/packages/bedrock/src/shell/preview-diff.ts
+++ b/packages/bedrock/src/shell/preview-diff.ts
@@ -12,6 +12,7 @@ import { resolveStateConfig, type StateNotConfiguredError } from "../core/resolv
 import type { Config, ResolvedConfig } from "../core/schema.ts";
 import {
 	type IncompletePlaceEntryError,
+	type IncompleteUniverseEntryError,
 	selectEnvironment,
 	type UnknownEnvironmentError,
 } from "../core/select-environment.ts";
@@ -57,6 +58,7 @@ export interface PreviewDiffOptions {
  */
 export type PreviewDiffError =
 	| IncompletePlaceEntryError
+	| IncompleteUniverseEntryError
 	| MissingCredentialError
 	| StateNotConfiguredError
 	| UnknownEnvironmentError

--- a/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
+++ b/packages/bedrock/tests/integration/migrate-mantle-state.spec.ts
@@ -152,7 +152,7 @@ describe(migrateMantleState, () => {
 			assert(loaded.success);
 
 			expect(loaded.data).toStrictEqual(result.data.config);
-			expect(loaded.data.universe?.universeId).toBe("6110424408");
+			expect(loaded.data.environments["production"]?.universe?.universeId).toBe("6110424408");
 		});
 	});
 
@@ -181,7 +181,7 @@ describe(migrateMantleState, () => {
 
 			expect(loaded.data).toStrictEqual(yamlRun.data.config);
 			expect(loaded.data).toStrictEqual(typescriptRun.data.config);
-			expect(loaded.data.universe?.universeId).toBe("6110424408");
+			expect(loaded.data.environments["production"]?.universe?.universeId).toBe("6110424408");
 		});
 	});
 
@@ -518,8 +518,8 @@ describe(migrateMantleState, () => {
 		expect(result.data.summary.ambiguousCount).toBeGreaterThanOrEqual(1);
 	});
 
-	it("should fold every interpretive universe rule for the production primary", async () => {
-		expect.assertions(1);
+	it("should fold every interpretive universe rule for the production primary while leaving universeId on per-environment overlays", async () => {
+		expect.assertions(2);
 
 		const result = await migrateMantleState({
 			configFormat: "typescript",
@@ -542,13 +542,15 @@ describe(migrateMantleState, () => {
 				title: "Follow us on Twitter",
 				uri: "https://twitter.com/example",
 			},
-			universeId: "6110424408",
 			voiceChatEnabled: true,
+		});
+		expect(result.data.config.environments["production"]?.universe).toStrictEqual({
+			universeId: "6110424408",
 		});
 	});
 
-	it("should fold the development primary into a separate universe shape", async () => {
-		expect.assertions(1);
+	it("should fold the development primary into a separate universe shape while leaving universeId on per-environment overlays", async () => {
+		expect.assertions(2);
 
 		const result = await migrateMantleState({
 			configFormat: "typescript",
@@ -567,8 +569,10 @@ describe(migrateMantleState, () => {
 			mobileEnabled: true,
 			privateServerPriceRobux: 0,
 			tabletEnabled: true,
-			universeId: "6031475575",
 			voiceChatEnabled: true,
+		});
+		expect(result.data.config.environments["development"]?.universe).toStrictEqual({
+			universeId: "6031475575",
 		});
 	});
 


### PR DESCRIPTION
## Summary

Configs can no longer set `universe.universeId` at the root and on a per-environment overlay simultaneously. Authors declare it either at the root (root-authoritative; overlays may carry shared fields without re-asserting the id) or on every environment overlay (per-env; the root may still hold shared fields like device flags or social links). The schema rejects offending configs with path-attributed errors, and the `Config` type is now a discriminated union (`ConfigRootUniverseId | ConfigEnvironmentUniverseId`) so the both-set case is also a TypeScript compile error.

`bedrock migrate` honours the same rule: when source environments share a universe-id it lands at the root unchanged, but when they diverge the migrator strips `universeId` from the root universe block and writes it on every environment overlay. Other root universe fields (device flags, social links, display name, icon) continue to cascade root → per-env in both cases.

Adds a `ResolvedUniverseEntry` type (post-merge, `universeId` required) so downstream consumers see the resolution invariant in the type system, plus an `incompleteUniverseEntry` arm on `SelectEnvironmentError` as a typed safety net for callers that hand a `Config` in without first running it through `validateConfig`.

Documented as a 2026-05-05 amendment to ADR-020.

## Breaking changes

Pre-1.0 / unpublished, so no compatibility shim:
- Hand-written configs that set `universeId` in both root and per-env overlays now fail validation. Move to one of the two valid shapes.
- `UniverseEntry.universeId` is now `string | undefined` (was required `string`); post-merge consumers should use the new `ResolvedUniverseEntry` (re-exported from the main barrel and `@bedrock/core/config`).

## Test plan

- [x] `pnpm gen:example-tests`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test --run` (2656 + 14 skipped)
- [x] `pnpm build` (publint clean)
- [x] `pnpm mutate:changed` (100% on touched files)
- [x] Type-level XOR enforcement verified via `@ts-expect-error` tests in `schema.spec-d.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)