### PR TITLE
ci: quote scientific-notation hex color in labels config

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -2,7 +2,9 @@
 # Source of truth. Synced to the repo by .github/workflows/labels.yaml on
 # pushes to main that touch this file, and on manual workflow_dispatch.
 # Edit this file to add, remove, or recolor labels.
-# Hex color codes must be quoted: YAML parses all-digit values as numbers.
+# Hex color codes must be quoted when they look like a YAML number, i.e.
+# all-digit values (like "008672") or scientific notation patterns like
+# "5319e7" (digits + e + digits).
 
 - name: bug
   color: d73a4a
@@ -77,5 +79,5 @@
   description: Needs human implementation
 
 - name: sandcastle
-  color: 5319e7
+  color: "5319e7"
   description: PR opened by the sandcastle agent (already reviewed in-sandbox)


### PR DESCRIPTION
## Summary

The label-sync workflow has been failing on `main` since #297 added the `sandcastle` label. The color `5319e7` matched YAML's scientific-notation pattern (digits + `e` + digits) and got parsed as `5319 * 10^7 = 53190000000`, so EndBug/label-sync rejected it with `.color should be a string (received: number, index: 18)`.

Quote the value like the existing all-digit entries (`"008672"`, `"666666"`) and broaden the inline comment so future hex codes get the right treatment.

Failing run: https://github.com/christopher-buss/bedrock/actions/runs/25408796930/job/74525632945

## Test plan

- [ ] After merge, the `Sync labels` workflow runs cleanly on `main`