### PR TITLE
feat(ocale): expose per-locale localization on game-passes

### DIFF
--- a/packages/open-cloud/src/domains/game-internationalization/game-pass-icon/builders.spec.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/game-pass-icon/builders.spec.ts
@@ -1,0 +1,93 @@
+import { assert, describe, expect, it } from "vitest";
+
+import { buildUploadIconRequest } from "./builders.ts";
+import type { UploadGamePassIconParameters } from "./types.ts";
+
+describe(buildUploadIconRequest, () => {
+	it("should use the POST method", () => {
+		expect.assertions(1);
+
+		const parameters = {
+			gamePassId: "12345",
+			image: new Uint8Array([1, 2, 3]),
+			languageCode: "en-us",
+		} satisfies UploadGamePassIconParameters;
+
+		const request = buildUploadIconRequest(parameters);
+
+		expect(request.method).toBe("POST");
+	});
+
+	it("should interpolate gamePassId and languageCode into the upload URL", () => {
+		expect.assertions(1);
+
+		const parameters = {
+			gamePassId: "12345",
+			image: new Uint8Array([1, 2, 3]),
+			languageCode: "fr-fr",
+		} satisfies UploadGamePassIconParameters;
+
+		const request = buildUploadIconRequest(parameters);
+
+		expect(request.url).toBe(
+			"/legacy-game-internationalization/v1/game-passes/12345/icons/language-codes/fr-fr",
+		);
+	});
+
+	it("should append the image as the `Files` field on a FormData body", () => {
+		expect.assertions(1);
+
+		const parameters = {
+			gamePassId: "12345",
+			image: new Uint8Array([1, 2, 3]),
+			languageCode: "en-us",
+		} satisfies UploadGamePassIconParameters;
+
+		const request = buildUploadIconRequest(parameters);
+
+		assert(request.body instanceof FormData);
+
+		expect(request.body.has("Files")).toBeTrue();
+	});
+
+	it("should wrap a Uint8Array image into a Blob preserving its bytes", () => {
+		expect.assertions(2);
+
+		const image = new Uint8Array([1, 2, 3, 4]);
+		const parameters = {
+			gamePassId: "12345",
+			image,
+			languageCode: "en-us",
+		} satisfies UploadGamePassIconParameters;
+
+		const request = buildUploadIconRequest(parameters);
+
+		assert(request.body instanceof FormData);
+
+		const appended = request.body.get("Files");
+		assert(appended instanceof Blob);
+
+		expect(appended).toBeInstanceOf(Blob);
+		expect(appended.size).toBe(image.byteLength);
+	});
+
+	it("should preserve the MIME type of a Blob image", () => {
+		expect.assertions(1);
+
+		const image = new Blob([new Uint8Array([1, 2, 3, 4])], { type: "image/png" });
+		const parameters = {
+			gamePassId: "12345",
+			image,
+			languageCode: "en-us",
+		} satisfies UploadGamePassIconParameters;
+
+		const request = buildUploadIconRequest(parameters);
+
+		assert(request.body instanceof FormData);
+
+		const appended = request.body.get("Files");
+		assert(appended instanceof Blob);
+
+		expect(appended.type).toBe("image/png");
+	});
+});

--- a/packages/open-cloud/src/domains/game-internationalization/game-pass-icon/builders.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/game-pass-icon/builders.ts
@@ -1,0 +1,23 @@
+import type { HttpRequest } from "../../../internal/http/types.ts";
+import { toBlob } from "../../../internal/utils/to-blob.ts";
+import type { UploadGamePassIconParameters } from "./types.ts";
+
+/**
+ * Builds a `POST` request for the localized "upload game-pass icon"
+ * endpoint. A successful upload replaces any existing icon for the same
+ * `(gamePassId, languageCode)` pair.
+ *
+ * @param parameters - Game pass and language identifiers plus the image
+ *   bytes to upload.
+ * @returns A pure {@link HttpRequest} describing the upload call.
+ */
+export function buildUploadIconRequest(parameters: UploadGamePassIconParameters): HttpRequest {
+	const body = new FormData();
+	body.append("Files", toBlob(parameters.image));
+
+	return {
+		body,
+		method: "POST",
+		url: `/legacy-game-internationalization/v1/game-passes/${parameters.gamePassId}/icons/language-codes/${parameters.languageCode}`,
+	};
+}

--- a/packages/open-cloud/src/domains/game-internationalization/game-pass-icon/types.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/game-pass-icon/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Parameters for uploading or replacing the per-locale icon registered
+ * against a game pass. A subsequent upload for the same
+ * `(gamePassId, languageCode)` pair replaces the existing icon for that
+ * locale.
+ */
+export interface UploadGamePassIconParameters {
+	/** Stringified ID of the game pass whose icon is being uploaded. */
+	readonly gamePassId: string;
+	/** Image bytes to upload. PNG and JPEG are accepted by the server. */
+	readonly image: Blob | Uint8Array;
+	/** BCP-47 language code the icon is being uploaded for (e.g. `fr-fr`). */
+	readonly languageCode: string;
+}

--- a/packages/open-cloud/src/domains/game-internationalization/game-pass-name-description/builders.spec.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/game-pass-name-description/builders.spec.ts
@@ -1,0 +1,82 @@
+import { assert, describe, expect, it } from "vitest";
+
+import { buildUpdateRequest } from "./builders.ts";
+import type { UpdateGamePassNameDescriptionParameters } from "./types.ts";
+
+describe(buildUpdateRequest, () => {
+	it("should use the PATCH method", () => {
+		expect.assertions(1);
+
+		const parameters = {
+			name: "Epic Pass",
+			gamePassId: "12345",
+			languageCode: "en-us",
+		} satisfies UpdateGamePassNameDescriptionParameters;
+
+		const request = buildUpdateRequest(parameters);
+
+		expect(request.method).toBe("PATCH");
+	});
+
+	it("should interpolate gamePassId and languageCode into the URL", () => {
+		expect.assertions(1);
+
+		const parameters = {
+			name: "Pass Épique",
+			gamePassId: "12345",
+			languageCode: "fr-fr",
+		} satisfies UpdateGamePassNameDescriptionParameters;
+
+		const request = buildUpdateRequest(parameters);
+
+		expect(request.url).toBe(
+			"/legacy-game-internationalization/v1/game-passes/12345/name-description/language-codes/fr-fr",
+		);
+	});
+
+	it.for<
+		[
+			name: string | undefined,
+			description: string | undefined,
+			expected: Record<string, string>,
+		]
+	>([
+		["Epic Pass", "Unlocks epic stuff", { name: "Epic Pass", description: "Unlocks epic stuff" }],
+		["Epic Pass", undefined, { name: "Epic Pass" }],
+		[undefined, "Unlocks epic stuff", { description: "Unlocks epic stuff" }],
+		[undefined, undefined, {}],
+	])(
+		"should include name=%j description=%j in the JSON body",
+		([name, description, expected]) => {
+			expect.assertions(1);
+
+			const parameters = {
+				gamePassId: "12345",
+				languageCode: "en-us",
+				...(name === undefined ? {} : { name }),
+				...(description === undefined ? {} : { description }),
+			} satisfies UpdateGamePassNameDescriptionParameters;
+
+			const request = buildUpdateRequest(parameters);
+
+			expect(request.body).toStrictEqual(expected);
+		},
+	);
+
+	it("should produce a JSON-shaped body, not FormData", () => {
+		expect.assertions(2);
+
+		const parameters = {
+			name: "Epic Pass",
+			gamePassId: "12345",
+			languageCode: "en-us",
+		} satisfies UpdateGamePassNameDescriptionParameters;
+
+		const request = buildUpdateRequest(parameters);
+
+		assert(typeof request.body === "object");
+
+		expect(request.body).not.toBeInstanceOf(FormData);
+		expect(request.body).toStrictEqual({ name: "Epic Pass" });
+	});
+});

--- a/packages/open-cloud/src/domains/game-internationalization/game-pass-name-description/builders.spec.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/game-pass-name-description/builders.spec.ts
@@ -22,7 +22,7 @@ describe(buildUpdateRequest, () => {
 		expect.assertions(1);
 
 		const parameters = {
-			name: "Pass Épique",
+			name: "Epic Pass FR",
 			gamePassId: "12345",
 			languageCode: "fr-fr",
 		} satisfies UpdateGamePassNameDescriptionParameters;
@@ -41,7 +41,11 @@ describe(buildUpdateRequest, () => {
 			expected: Record<string, string>,
 		]
 	>([
-		["Epic Pass", "Unlocks epic stuff", { name: "Epic Pass", description: "Unlocks epic stuff" }],
+		[
+			"Epic Pass",
+			"Unlocks epic stuff",
+			{ name: "Epic Pass", description: "Unlocks epic stuff" },
+		],
 		["Epic Pass", undefined, { name: "Epic Pass" }],
 		[undefined, "Unlocks epic stuff", { description: "Unlocks epic stuff" }],
 		[undefined, undefined, {}],

--- a/packages/open-cloud/src/domains/game-internationalization/game-pass-name-description/builders.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/game-pass-name-description/builders.ts
@@ -1,0 +1,31 @@
+import type { HttpRequest } from "../../../internal/http/types.ts";
+import type { UpdateGamePassNameDescriptionParameters } from "./types.ts";
+
+/**
+ * Builds a `PATCH` request for the localized "update game-pass
+ * name/description" endpoint. Either `name`, `description`, or both may be
+ * supplied; omitted fields are not included in the JSON body so the server
+ * leaves the existing value for that locale untouched.
+ *
+ * @param parameters - Game pass and language identifiers plus the optional
+ *   replacement values.
+ * @returns A pure {@link HttpRequest} describing the update call.
+ */
+export function buildUpdateRequest(
+	parameters: UpdateGamePassNameDescriptionParameters,
+): HttpRequest {
+	const body: Record<string, string> = {};
+	if (parameters.name !== undefined) {
+		body["name"] = parameters.name;
+	}
+
+	if (parameters.description !== undefined) {
+		body["description"] = parameters.description;
+	}
+
+	return {
+		body,
+		method: "PATCH",
+		url: `/legacy-game-internationalization/v1/game-passes/${parameters.gamePassId}/name-description/language-codes/${parameters.languageCode}`,
+	};
+}

--- a/packages/open-cloud/src/domains/game-internationalization/game-pass-name-description/operations.spec.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/game-pass-name-description/operations.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { LOCALIZATION_OPERATION_LIMIT, LOCALIZATION_REQUIRED_SCOPES } from "./operations.ts";
+
+describe("game-pass localization operation limit", () => {
+	it("should cap the service at 100 requests per minute under one shared key", () => {
+		expect.assertions(1);
+
+		expect(LOCALIZATION_OPERATION_LIMIT).toStrictEqual({
+			maxPerSecond: 100 / 60,
+			operationKey: "game-pass-localization",
+		});
+	});
+
+	it("should freeze the operation limit so callers cannot mutate the registry", () => {
+		expect.assertions(1);
+
+		expect(Object.isFrozen(LOCALIZATION_OPERATION_LIMIT)).toBeTrue();
+	});
+});
+
+describe("game-pass localization required scopes", () => {
+	it("should require legacy-game-pass:manage", () => {
+		expect.assertions(1);
+
+		expect(LOCALIZATION_REQUIRED_SCOPES).toStrictEqual(["legacy-game-pass:manage"]);
+	});
+
+	it("should freeze the required-scopes list so callers cannot mutate it", () => {
+		expect.assertions(1);
+
+		expect(Object.isFrozen(LOCALIZATION_REQUIRED_SCOPES)).toBeTrue();
+	});
+});

--- a/packages/open-cloud/src/domains/game-internationalization/game-pass-name-description/operations.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/game-pass-name-description/operations.ts
@@ -1,0 +1,23 @@
+import type { OperationLimit } from "../../../internal/http/rate-limit-queue.ts";
+
+/**
+ * Per-second request ceiling for every game-pass localization Operation.
+ * The legacy `gameinternationalization` service caps each API key at 100
+ * requests per minute *shared across the entire service* (see the
+ * `x-roblox-rate-limits` extension on every operation in the vendored Open
+ * Cloud spec), so all game-pass localization methods queue against the same
+ * operation key.
+ */
+export const LOCALIZATION_OPERATION_LIMIT: OperationLimit = Object.freeze({
+	maxPerSecond: 100 / 60,
+	operationKey: "game-pass-localization",
+});
+
+/**
+ * Scopes required for every game-pass localization operation, sourced
+ * from `x-roblox-scopes` on the legacy `gameinternationalization`
+ * game-pass endpoints in the vendored OpenAPI schema.
+ */
+export const LOCALIZATION_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([
+	"legacy-game-pass:manage",
+]);

--- a/packages/open-cloud/src/domains/game-internationalization/game-pass-name-description/types.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/game-pass-name-description/types.ts
@@ -1,0 +1,16 @@
+/**
+ * Parameters for updating the per-locale name and/or description registered
+ * against a game pass. Both `name` and `description` are optional; fields
+ * omitted from the call are not included in the JSON body so the server
+ * leaves the existing value for that locale untouched.
+ */
+export interface UpdateGamePassNameDescriptionParameters {
+	/** Replacement display name for the supplied locale. */
+	readonly name?: string;
+	/** Replacement description for the supplied locale. */
+	readonly description?: string;
+	/** Stringified ID of the game pass whose localization is being updated. */
+	readonly gamePassId: string;
+	/** BCP-47 language code being updated (e.g. `fr-fr`). */
+	readonly languageCode: string;
+}

--- a/packages/open-cloud/src/resources/game-passes/client.ts
+++ b/packages/open-cloud/src/resources/game-passes/client.ts
@@ -1,4 +1,12 @@
 import type { OpenCloudClientOptions, RequestOptions } from "../../client/types.ts";
+import { buildUploadIconRequest } from "../../domains/game-internationalization/game-pass-icon/builders.ts";
+import type { UploadGamePassIconParameters } from "../../domains/game-internationalization/game-pass-icon/types.ts";
+import { buildUpdateRequest as buildLocaleNameDescRequest } from "../../domains/game-internationalization/game-pass-name-description/builders.ts";
+import {
+	LOCALIZATION_OPERATION_LIMIT,
+	LOCALIZATION_REQUIRED_SCOPES,
+} from "../../domains/game-internationalization/game-pass-name-description/operations.ts";
+import type { UpdateGamePassNameDescriptionParameters } from "../../domains/game-internationalization/game-pass-name-description/types.ts";
 import {
 	buildCreateRequest,
 	buildGetRequest,
@@ -76,6 +84,60 @@ const LIST_SPEC = makeSpec<ListGamePassesParameters, Page<GamePass>>({
 	requiredScopes: LIST_REQUIRED_SCOPES,
 });
 
+const UPDATE_NAME_DESCRIPTION_SPEC = makeSpec<UpdateGamePassNameDescriptionParameters, undefined>({
+	buildRequest: (parameters) => okRequest(buildLocaleNameDescRequest(parameters)),
+	methodDefaults: IDEMPOTENT_METHOD_DEFAULTS,
+	methodKind: "idempotent",
+	operationLimit: LOCALIZATION_OPERATION_LIMIT,
+	parse: parseEmptyResponse,
+	requiredScopes: LOCALIZATION_REQUIRED_SCOPES,
+});
+
+const UPLOAD_ICON_SPEC = makeSpec<UploadGamePassIconParameters, undefined>({
+	buildRequest: (parameters) => okRequest(buildUploadIconRequest(parameters)),
+	methodDefaults: CREATE_METHOD_DEFAULTS,
+	methodKind: "create",
+	operationLimit: LOCALIZATION_OPERATION_LIMIT,
+	parse: parseEmptyResponse,
+	requiredScopes: LOCALIZATION_REQUIRED_SCOPES,
+});
+
+interface GamePassLocalizationHandle {
+	/**
+	 * Updates the per-locale display name and/or description registered against
+	 * a game pass. Either `name`, `description`, or both may be supplied;
+	 * omitted fields are not forwarded so the server leaves the existing value
+	 * for that locale untouched. Mirrors the upstream `200 OK` echo body as
+	 * `undefined` data.
+	 *
+	 * @param parameters - Game pass and language identifiers plus the optional
+	 *   replacement values.
+	 * @param options - Optional per-request overrides.
+	 * @returns A success {@link Result} with no payload, or the
+	 *   {@link OpenCloudError} that caused the request to fail.
+	 */
+	updateNameDescription: (
+		parameters: UpdateGamePassNameDescriptionParameters,
+		options?: RequestOptions,
+	) => Promise<Result<undefined, OpenCloudError>>;
+	/**
+	 * Uploads or replaces the per-locale icon for a game pass. A subsequent
+	 * upload for the same `(gamePassId, languageCode)` pair replaces the
+	 * existing icon for that locale. Does not retry on 5xx so a duplicate
+	 * upload cannot be created if the server fails mid-write.
+	 *
+	 * @param parameters - Game pass and language identifiers plus the image
+	 *   bytes to upload.
+	 * @param options - Optional per-request overrides.
+	 * @returns A success {@link Result} with no payload, or the
+	 *   {@link OpenCloudError} that caused the request to fail.
+	 */
+	uploadIcon: (
+		parameters: UploadGamePassIconParameters,
+		options?: RequestOptions,
+	) => Promise<Result<undefined, OpenCloudError>>;
+}
+
 /**
  * Public client for the Roblox Open Cloud Game Passes API.
  *
@@ -124,6 +186,16 @@ export class GamePassesClient {
 	readonly #inner: ResourceClient;
 
 	/**
+	 * Operation Group exposing per-locale localization Operations
+	 * (`updateNameDescription`, `uploadIcon`) backed by the
+	 * `legacy-game-internationalization` domain. Source-language values
+	 * remain on {@link GamePassesClient.update}; methods on this group set
+	 * per-locale overlays on top. Shares the parent client's HTTP,
+	 * rate-limit, and retry plumbing.
+	 */
+	public readonly localization: GamePassLocalizationHandle;
+
+	/**
 	 * Creates a new {@link GamePassesClient}. Configuration is frozen on
 	 * construction; per-request overrides are accepted on each method.
 	 *
@@ -131,6 +203,7 @@ export class GamePassesClient {
 	 */
 	constructor(options: OpenCloudClientOptions) {
 		this.#inner = new ResourceClient(options);
+		this.localization = createLocalizationHandle(this.#inner);
 	}
 
 	/**
@@ -201,4 +274,15 @@ export class GamePassesClient {
 	): Promise<Result<undefined, OpenCloudError>> {
 		return this.#inner.execute({ options, parameters, spec: UPDATE_SPEC });
 	}
+}
+
+function createLocalizationHandle(inner: ResourceClient): GamePassLocalizationHandle {
+	return {
+		async updateNameDescription(parameters, options) {
+			return inner.execute({ options, parameters, spec: UPDATE_NAME_DESCRIPTION_SPEC });
+		},
+		async uploadIcon(parameters, options) {
+			return inner.execute({ options, parameters, spec: UPLOAD_ICON_SPEC });
+		},
+	};
 }

--- a/packages/open-cloud/src/resources/game-passes/index.spec-d.ts
+++ b/packages/open-cloud/src/resources/game-passes/index.spec-d.ts
@@ -6,7 +6,9 @@ import type {
 	GamePass,
 	GamePassesClient,
 	ListGamePassesParameters,
+	UpdateGamePassNameDescriptionParameters,
 	UpdateGamePassParameters,
+	UploadGamePassIconParameters,
 } from "./index.ts";
 
 describe("UpdateGamePassParameters", () => {
@@ -69,6 +71,45 @@ describe("ListGamePassesParameters", () => {
 	});
 });
 
+describe("UpdateGamePassNameDescriptionParameters", () => {
+	it("should require gamePassId and languageCode", () => {
+		expectTypeOf<UpdateGamePassNameDescriptionParameters>().toExtend<{
+			gamePassId: string;
+			languageCode: string;
+		}>();
+	});
+
+	it("should accept identifiers without name or description", () => {
+		const parameters: UpdateGamePassNameDescriptionParameters = {
+			gamePassId: "12345",
+			languageCode: "fr-fr",
+		};
+
+		expectTypeOf(parameters).toExtend<UpdateGamePassNameDescriptionParameters>();
+	});
+
+	it("should accept name and description as optional fields", () => {
+		const parameters: UpdateGamePassNameDescriptionParameters = {
+			name: "Epic Pass",
+			description: "Unlocks epic stuff",
+			gamePassId: "12345",
+			languageCode: "fr-fr",
+		};
+
+		expectTypeOf(parameters).toExtend<UpdateGamePassNameDescriptionParameters>();
+	});
+});
+
+describe("UploadGamePassIconParameters", () => {
+	it("should require gamePassId, languageCode, and image", () => {
+		expectTypeOf<UploadGamePassIconParameters>().toExtend<{
+			gamePassId: string;
+			image: Blob | Uint8Array;
+			languageCode: string;
+		}>();
+	});
+});
+
 describe("GamePassesClient", () => {
 	it("should resolve update() to Result<undefined, OpenCloudError>", () => {
 		expectTypeOf<GamePassesClient["update"]>().returns.resolves.toEqualTypeOf<
@@ -80,5 +121,17 @@ describe("GamePassesClient", () => {
 		expectTypeOf<GamePassesClient["list"]>().returns.resolves.toEqualTypeOf<
 			Result<Page<GamePass>, OpenCloudError>
 		>();
+	});
+
+	it("should resolve localization.updateNameDescription() to Result<undefined, OpenCloudError>", () => {
+		expectTypeOf<
+			GamePassesClient["localization"]["updateNameDescription"]
+		>().returns.resolves.toEqualTypeOf<Result<undefined, OpenCloudError>>();
+	});
+
+	it("should resolve localization.uploadIcon() to Result<undefined, OpenCloudError>", () => {
+		expectTypeOf<
+			GamePassesClient["localization"]["uploadIcon"]
+		>().returns.resolves.toEqualTypeOf<Result<undefined, OpenCloudError>>();
 	});
 });

--- a/packages/open-cloud/src/resources/game-passes/index.ts
+++ b/packages/open-cloud/src/resources/game-passes/index.ts
@@ -1,3 +1,5 @@
+export type { UploadGamePassIconParameters } from "../../domains/game-internationalization/game-pass-icon/types.ts";
+export type { UpdateGamePassNameDescriptionParameters } from "../../domains/game-internationalization/game-pass-name-description/types.ts";
 export type {
 	CreateGamePassParameters,
 	GamePass,

--- a/packages/open-cloud/tests/integration/resources/game-passes/localization.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/game-passes/localization.spec.ts
@@ -1,0 +1,269 @@
+import { ApiError } from "#src/errors/api-error";
+import { PermissionError } from "#src/errors/permission-error";
+import { GamePassesClient } from "#src/resources/game-passes/index";
+import { createFakeClock } from "#tests/helpers/fake-clock";
+import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
+import { createFakeSleep } from "#tests/helpers/fake-sleep";
+import { assert, describe, expect, it } from "vitest";
+
+const VALID_NAME_DESCRIPTION_BODY = { name: "Epic Pass", description: "Unlocks epic stuff" };
+
+describe(GamePassesClient, () => {
+	describe("localization", () => {
+		describe("updateNameDescription", () => {
+			it("should return success with no payload when the server returns 200", async () => {
+				expect.assertions(1);
+
+				const httpClient = createFakeHttpClient().mockResponse({
+					body: VALID_NAME_DESCRIPTION_BODY,
+					status: 200,
+				});
+				const client = new GamePassesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				const result = await client.localization.updateNameDescription({
+					name: "Epic Pass",
+					gamePassId: "12345",
+					languageCode: "fr-fr",
+				});
+
+				assert(result.success);
+
+				expect(result.data).toBeUndefined();
+			});
+
+			it("should send a PATCH with a JSON body to the localized name-description URL", async () => {
+				expect.assertions(3);
+
+				const httpClient = createFakeHttpClient().mockResponse({
+					body: VALID_NAME_DESCRIPTION_BODY,
+					status: 200,
+				});
+				const client = new GamePassesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				await client.localization.updateNameDescription({
+					name: "Epic Pass",
+					description: "Unlocks epic stuff",
+					gamePassId: "12345",
+					languageCode: "fr-fr",
+				});
+
+				expect(httpClient.requests[0]?.request.method).toBe("PATCH");
+				expect(httpClient.requests[0]?.request.url).toBe(
+					"/legacy-game-internationalization/v1/game-passes/12345/name-description/language-codes/fr-fr",
+				);
+				expect(httpClient.requests[0]?.request.body).toStrictEqual({
+					name: "Epic Pass",
+					description: "Unlocks epic stuff",
+				});
+			});
+
+			it("should retry a 5xx since the PATCH is idempotent", async () => {
+				expect.assertions(1);
+
+				const httpClient = createFakeHttpClient()
+					.mockApiError({ statusCode: 500 })
+					.mockResponse({ body: VALID_NAME_DESCRIPTION_BODY, status: 200 });
+				const client = new GamePassesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				const result = await client.localization.updateNameDescription({
+					name: "Epic Pass",
+					gamePassId: "12345",
+					languageCode: "fr-fr",
+				});
+
+				assert(result.success);
+
+				expect(httpClient.requests).toHaveLength(2);
+			});
+
+			it("should surface a 403 as a PermissionError naming legacy-game-pass:manage", async () => {
+				expect.assertions(2);
+
+				const httpClient = createFakeHttpClient().mockApiError({ statusCode: 403 });
+				const client = new GamePassesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				const result = await client.localization.updateNameDescription({
+					name: "Epic Pass",
+					gamePassId: "12345",
+					languageCode: "fr-fr",
+				});
+
+				assert(!result.success);
+				assert(result.err instanceof PermissionError);
+
+				expect(result.err.requiredScopes).toStrictEqual(["legacy-game-pass:manage"]);
+				expect(result.err.operationKey).toBe("game-pass-localization");
+			});
+
+			it("should propagate a 404 as an ApiError", async () => {
+				expect.assertions(2);
+
+				const httpClient = createFakeHttpClient().mockApiError({
+					message: "Game pass not found",
+					statusCode: 404,
+				});
+				const client = new GamePassesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				const result = await client.localization.updateNameDescription({
+					name: "Epic Pass",
+					gamePassId: "12345",
+					languageCode: "fr-fr",
+				});
+
+				assert(!result.success);
+
+				expect(result.err).toBeInstanceOf(ApiError);
+				expect(result.err).toHaveProperty("statusCode", 404);
+			});
+		});
+
+		describe("uploadIcon", () => {
+			it("should return success with no payload when the server returns 200", async () => {
+				expect.assertions(1);
+
+				const httpClient = createFakeHttpClient().mockResponse({ body: {}, status: 200 });
+				const client = new GamePassesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				const result = await client.localization.uploadIcon({
+					gamePassId: "12345",
+					image: new Uint8Array([1, 2, 3]),
+					languageCode: "fr-fr",
+				});
+
+				assert(result.success);
+
+				expect(result.data).toBeUndefined();
+			});
+
+			it("should send a POST with multipart FormData to the localized icon URL", async () => {
+				expect.assertions(3);
+
+				const httpClient = createFakeHttpClient().mockResponse({ body: {}, status: 200 });
+				const client = new GamePassesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				await client.localization.uploadIcon({
+					gamePassId: "12345",
+					image: new Uint8Array([1, 2, 3]),
+					languageCode: "fr-fr",
+				});
+
+				expect(httpClient.requests[0]?.request.method).toBe("POST");
+				expect(httpClient.requests[0]?.request.url).toBe(
+					"/legacy-game-internationalization/v1/game-passes/12345/icons/language-codes/fr-fr",
+				);
+				expect(httpClient.requests[0]?.request.body).toBeInstanceOf(FormData);
+			});
+
+			it("should not retry a 5xx so a duplicate icon upload can't be created", async () => {
+				expect.assertions(2);
+
+				const httpClient = createFakeHttpClient()
+					.mockApiError({ statusCode: 500 })
+					.mockResponse({ body: {}, status: 200 });
+				const client = new GamePassesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				const result = await client.localization.uploadIcon({
+					gamePassId: "12345",
+					image: new Uint8Array([1, 2, 3]),
+					languageCode: "fr-fr",
+				});
+
+				assert(!result.success);
+
+				expect(result.err).toBeInstanceOf(ApiError);
+				expect(httpClient.requests).toHaveLength(1);
+			});
+
+			it("should surface a 403 as a PermissionError naming legacy-game-pass:manage", async () => {
+				expect.assertions(2);
+
+				const httpClient = createFakeHttpClient().mockApiError({ statusCode: 403 });
+				const client = new GamePassesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				const result = await client.localization.uploadIcon({
+					gamePassId: "12345",
+					image: new Uint8Array([1, 2, 3]),
+					languageCode: "fr-fr",
+				});
+
+				assert(!result.success);
+				assert(result.err instanceof PermissionError);
+
+				expect(result.err.requiredScopes).toStrictEqual(["legacy-game-pass:manage"]);
+				expect(result.err.operationKey).toBe("game-pass-localization");
+			});
+		});
+
+		describe("shared rate-limit bucket", () => {
+			it("should serialize updateNameDescription and uploadIcon through the same per-API-key queue", async () => {
+				expect.assertions(2);
+
+				// At 100/60 per second the bucket holds one full token (600ms
+				// of latency budget) of headroom, so the first call goes
+				// through immediately and the second pays a 200ms wait
+				// against the drained shared bucket. Two independent buckets
+				// would each go through wait-free, so the recorded wait
+				// proves the methods queue against one operationKey.
+				const httpClient = createFakeHttpClient()
+					.mockResponse({ body: VALID_NAME_DESCRIPTION_BODY, status: 200 })
+					.mockResponse({ body: {}, status: 200 });
+				const clock = createFakeClock();
+				const client = new GamePassesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: clock.sleep,
+				});
+
+				await client.localization.updateNameDescription({
+					name: "Epic Pass",
+					gamePassId: "12345",
+					languageCode: "fr-fr",
+				});
+				await client.localization.uploadIcon({
+					gamePassId: "12345",
+					image: new Uint8Array([1, 2, 3]),
+					languageCode: "fr-fr",
+				});
+
+				expect(httpClient.requests).toHaveLength(2);
+				expect(clock.waits).toStrictEqual([200]);
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds the per-locale name-description and icon overrides on
`GamePassesClient`, sitting under a new `localization` Operation Group.
Closes #225.

```ts
import { GamePassesClient } from "@bedrock/ocale/game-passes";

const client = new GamePassesClient({ apiKey: "..." });

await client.localization.updateNameDescription({
    gamePassId: "9876543210",
    languageCode: "fr-fr",
    name: "Pass Épique",
    description: "Débloque des trucs épiques.",
});

await client.localization.uploadIcon({
    gamePassId: "9876543210",
    languageCode: "fr-fr",
    image: new Uint8Array(/* png bytes */),
});
```

Source-language values continue to flow through `GamePassesClient.update`;
the new methods set per-locale overlays on top. Both methods queue
against a shared `game-pass-localization` rate-limit bucket (100/min,
per the legacy `gameinternationalization` cap).

## Endpoints wired

| Method | URL |
| --- | --- |
| `PATCH` | `/legacy-game-internationalization/v1/game-passes/{id}/name-description/language-codes/{lang}` |
| `POST` | `/legacy-game-internationalization/v1/game-passes/{id}/icons/language-codes/{lang}` |

Both surface as `Result<undefined, OpenCloudError>`. The PATCH echoes
`{ name, description }` on success; the SDK parses the body via
`parseEmptyResponse` to keep symmetry with the existing 204-style
`update`. The icon `POST` uses `CREATE_METHOD_DEFAULTS` so a 5xx is not
retried, preventing a duplicate upload mid-write.

## Wire layout

Two new sub-trees under `src/domains/game-internationalization/`,
mirroring the per-shape grouping shipped in #328 for developer-products:

- `game-pass-name-description/` (PATCH builder, shared rate-limit constants)
- `game-pass-icon/` (POST builder, types only — re-uses the shared
  constants from the sibling)

Multipart icon-upload uses the `Files` field name per the OpenAPI shared
`postV1Badges_badgeid_iconsLanguageCodes_languagecode_` requestBody.

## Slices

Each commit is one TDD slice with RED + GREEN together:

1. `chore(ocale): add game-pass-name-description domain` — pure PATCH
   builder, types, and the shared `LOCALIZATION_OPERATION_LIMIT` /
   `LOCALIZATION_REQUIRED_SCOPES` constants.
2. `chore(ocale): add game-pass-icon domain` — pure POST multipart
   builder and types, using the same `toBlob` helper as the
   developer-product mirror.
3. `feat(ocale): expose per-locale localization on game-passes` —
   wires the `localization` handle on `GamePassesClient`, adds type-test
   coverage in `index.spec-d.ts`, and lands the integration suite under
   `tests/integration/resources/game-passes/localization.spec.ts`.

## Test plan

- [x] `pnpm gen:example-tests`
- [x] `pnpm lint` (clean)
- [x] `pnpm typecheck` (clean across packages)
- [x] `pnpm test` (2794 passed, 4 skipped — full workspace)
- [x] `pnpm build` (publint clean; dist artifacts unchanged shape)
- [x] `MUTATE_BASE_REF=origin/main pnpm mutate:changed` — 100% mutation
      score on touched files (7 killed, 0 surviving)

## Out of scope

- DELETE variants for both endpoints exist in the spec but are deferred
  per the issue body, mirroring #328.
- Source-language `name`/`description` updates still flow through
  `GamePassesClient.update`. No `@bedrock/core` kind/driver changes; the
  localization umbrella that consumes these client methods is tracked
  under PRD #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)