### PR TITLE
fix(ocale): reject malformed date-time wire fields in resource parsers

### DIFF
--- a/packages/open-cloud/src/domains/badges/badges/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/badges/badges/parsers.spec.ts
@@ -313,12 +313,9 @@ describe(parseBadgeResponse, () => {
 		expect(result.err).toBeInstanceOf(ApiError);
 	});
 
-	it.for([
-		{ field: "created" as const },
-		{ field: "updated" as const },
-	])(
-		"should return an ApiError when $field is a string that does not parse to a Date",
-		({ field }) => {
+	it.for(["created", "updated"] as const)(
+		"should return an ApiError when %s is a string that does not parse to a Date",
+		(field) => {
 			expect.assertions(2);
 
 			const body = validBadgeBody({ [field]: "not-a-date" });

--- a/packages/open-cloud/src/domains/badges/badges/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/badges/badges/parsers.spec.ts
@@ -313,6 +313,25 @@ describe(parseBadgeResponse, () => {
 		expect(result.err).toBeInstanceOf(ApiError);
 	});
 
+	it.for([
+		{ field: "created" as const },
+		{ field: "updated" as const },
+	])(
+		"should return an ApiError when $field is a string that does not parse to a Date",
+		({ field }) => {
+			expect.assertions(2);
+
+			const body = validBadgeBody({ [field]: "not-a-date" });
+
+			const result = parseBadgeResponse({ body, headers: {}, status: 502 });
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+			expect(result.err.message).toBe("Malformed badge response");
+		},
+	);
+
 	it("should reject an awarder that is an array with look-alike named properties", () => {
 		expect.assertions(1);
 

--- a/packages/open-cloud/src/domains/badges/badges/parsers.ts
+++ b/packages/open-cloud/src/domains/badges/badges/parsers.ts
@@ -1,5 +1,6 @@
 import type { HttpResponse } from "../../../client/types.ts";
 import { ApiError } from "../../../errors/api-error.ts";
+import { isDateTimeString } from "../../../internal/utils/is-date-time-string.ts";
 import { isRecord } from "../../../internal/utils/is-record.ts";
 import type { Result } from "../../../types.ts";
 import type { Badge, BadgeAwarder, BadgeStatistics } from "./types.ts";
@@ -68,8 +69,8 @@ function hasRequiredPrimitiveFields(body: Record<string, unknown>): boolean {
 		typeof body["enabled"] === "boolean" &&
 		typeof body["iconImageId"] === "number" &&
 		typeof body["displayIconImageId"] === "number" &&
-		typeof body["created"] === "string" &&
-		typeof body["updated"] === "string"
+		isDateTimeString(body["created"]) &&
+		isDateTimeString(body["updated"])
 	);
 }
 

--- a/packages/open-cloud/src/domains/cloud-v2/places/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/places/parsers.spec.ts
@@ -211,6 +211,21 @@ describe(parsePlaceResponse, () => {
 			},
 		);
 
+		it.for(["createTime", "updateTime"] as const)(
+			"should reject a body whose %s is a string that does not parse to a Date",
+			(field) => {
+				expect.assertions(2);
+
+				const body = { ...validPlaceBody(), [field]: "not-a-date" };
+				const result = parsePlaceResponse({ body, headers: {}, status: 200 });
+
+				assert(!result.success);
+
+				expect(result.err).toBeInstanceOf(ApiError);
+				expect(result.err.message).toBe("Malformed place response");
+			},
+		);
+
 		it("should reject a body whose path is a non-string with a matching toString", () => {
 			// A toString() that matches the universes/{uid}/places/{pid}
 			// pattern would let regex.exec succeed on the coerced string,

--- a/packages/open-cloud/src/domains/cloud-v2/places/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/places/parsers.ts
@@ -1,5 +1,6 @@
 import type { HttpResponse } from "../../../client/types.ts";
 import { ApiError } from "../../../errors/api-error.ts";
+import { isDateTimeString } from "../../../internal/utils/is-date-time-string.ts";
 import { isRecord } from "../../../internal/utils/is-record.ts";
 import type { Result } from "../../../types.ts";
 import type { Place } from "./types.ts";
@@ -63,8 +64,8 @@ function toPlace(args: ToPlaceArgs): Place {
 function hasValidPlaceRequired(body: Record<string, unknown>): boolean {
 	return (
 		typeof body["path"] === "string" &&
-		typeof body["createTime"] === "string" &&
-		typeof body["updateTime"] === "string" &&
+		isDateTimeString(body["createTime"]) &&
+		isDateTimeString(body["updateTime"]) &&
 		typeof body["displayName"] === "string" &&
 		typeof body["description"] === "string"
 	);

--- a/packages/open-cloud/src/domains/cloud-v2/universes/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/universes/parsers.spec.ts
@@ -379,6 +379,21 @@ describe(parseUniverseResponse, () => {
 			expect(result.err).toBeInstanceOf(ApiError);
 		});
 
+		it.for(["createTime", "updateTime"] as const)(
+			"should reject a body whose %s is a string that does not parse to a Date",
+			(field) => {
+				expect.assertions(2);
+
+				const body = { ...validUniverseBody(), [field]: "not-a-date" };
+				const result = parseUniverseResponse({ body, headers: {}, status: 200 });
+
+				assert(!result.success);
+
+				expect(result.err).toBeInstanceOf(ApiError);
+				expect(result.err.message).toBe("Malformed universe response");
+			},
+		);
+
 		it("should reject a body whose privateServerPriceRobux is not a number", () => {
 			expect.assertions(1);
 

--- a/packages/open-cloud/src/domains/cloud-v2/universes/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/universes/parsers.ts
@@ -1,5 +1,6 @@
 import type { HttpResponse } from "../../../client/types.ts";
 import { ApiError } from "../../../errors/api-error.ts";
+import { isDateTimeString } from "../../../internal/utils/is-date-time-string.ts";
 import { isRecord } from "../../../internal/utils/is-record.ts";
 import type { Result } from "../../../types.ts";
 import type {
@@ -132,8 +133,8 @@ function isAgeRatingWire(value: unknown): value is AgeRatingWire {
 function hasValidRequiredFields(body: Record<string, unknown>): boolean {
 	return (
 		typeof body["path"] === "string" &&
-		typeof body["createTime"] === "string" &&
-		typeof body["updateTime"] === "string" &&
+		isDateTimeString(body["createTime"]) &&
+		isDateTimeString(body["updateTime"]) &&
 		typeof body["displayName"] === "string" &&
 		typeof body["description"] === "string" &&
 		isVisibilityWire(body["visibility"]) &&

--- a/packages/open-cloud/src/domains/developer-products/products/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/developer-products/products/parsers.spec.ts
@@ -166,12 +166,9 @@ describe(parseDeveloperProductResponse, () => {
 		expect(result.err.statusCode).toBe(502);
 	});
 
-	it.for([
-		{ field: "createdTimestamp" as const },
-		{ field: "updatedTimestamp" as const },
-	])(
-		"should return an ApiError when $field is a string that does not parse to a Date",
-		({ field }) => {
+	it.for(["createdTimestamp", "updatedTimestamp"] as const)(
+		"should return an ApiError when %s is a string that does not parse to a Date",
+		(field) => {
 			expect.assertions(2);
 
 			const body = validDeveloperProductBody({ [field]: "not-a-date" });

--- a/packages/open-cloud/src/domains/developer-products/products/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/developer-products/products/parsers.spec.ts
@@ -166,6 +166,25 @@ describe(parseDeveloperProductResponse, () => {
 		expect(result.err.statusCode).toBe(502);
 	});
 
+	it.for([
+		{ field: "createdTimestamp" as const },
+		{ field: "updatedTimestamp" as const },
+	])(
+		"should return an ApiError when $field is a string that does not parse to a Date",
+		({ field }) => {
+			expect.assertions(2);
+
+			const body = validDeveloperProductBody({ [field]: "not-a-date" });
+
+			const result = parseDeveloperProductResponse({ body, headers: {}, status: 502 });
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+			expect(result.err.message).toBe("Malformed developer product response");
+		},
+	);
+
 	it("should return an ApiError when productId is the sentinel 0", () => {
 		expect.assertions(1);
 

--- a/packages/open-cloud/src/domains/developer-products/products/parsers.ts
+++ b/packages/open-cloud/src/domains/developer-products/products/parsers.ts
@@ -4,6 +4,7 @@ import {
 	copyPriceInformation,
 	isPriceInformationLike,
 } from "../../../internal/price-information.ts";
+import { isDateTimeString } from "../../../internal/utils/is-date-time-string.ts";
 import { isRecord } from "../../../internal/utils/is-record.ts";
 import type { Result } from "../../../types.ts";
 import type { DeveloperProduct } from "./types.ts";
@@ -65,8 +66,8 @@ function hasRequiredPrimitiveFields(body: Record<string, unknown>): boolean {
 		typeof body["isForSale"] === "boolean" &&
 		typeof body["isImmutable"] === "boolean" &&
 		typeof body["storePageEnabled"] === "boolean" &&
-		typeof body["createdTimestamp"] === "string" &&
-		typeof body["updatedTimestamp"] === "string"
+		isDateTimeString(body["createdTimestamp"]) &&
+		isDateTimeString(body["updatedTimestamp"])
 	);
 }
 

--- a/packages/open-cloud/src/domains/game-passes/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/game-passes/game-passes/parsers.spec.ts
@@ -154,6 +154,25 @@ describe(parseGamePassResponse, () => {
 		expect(result.err).toBeInstanceOf(ApiError);
 	});
 
+	it.for([
+		{ field: "createdTimestamp" as const },
+		{ field: "updatedTimestamp" as const },
+	])(
+		"should return an ApiError when $field is a string that does not parse to a Date",
+		({ field }) => {
+			expect.assertions(2);
+
+			const body = validGamePassBody({ [field]: "not-a-date" });
+
+			const result = parseGamePassResponse({ body, headers: {}, status: 502 });
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+			expect(result.err.message).toBe("Malformed game pass response");
+		},
+	);
+
 	it("should reject priceInformation that is an array with look-alike named properties", () => {
 		expect.assertions(1);
 

--- a/packages/open-cloud/src/domains/game-passes/game-passes/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/game-passes/game-passes/parsers.spec.ts
@@ -154,12 +154,9 @@ describe(parseGamePassResponse, () => {
 		expect(result.err).toBeInstanceOf(ApiError);
 	});
 
-	it.for([
-		{ field: "createdTimestamp" as const },
-		{ field: "updatedTimestamp" as const },
-	])(
-		"should return an ApiError when $field is a string that does not parse to a Date",
-		({ field }) => {
+	it.for(["createdTimestamp", "updatedTimestamp"] as const)(
+		"should return an ApiError when %s is a string that does not parse to a Date",
+		(field) => {
 			expect.assertions(2);
 
 			const body = validGamePassBody({ [field]: "not-a-date" });

--- a/packages/open-cloud/src/domains/game-passes/game-passes/parsers.ts
+++ b/packages/open-cloud/src/domains/game-passes/game-passes/parsers.ts
@@ -4,6 +4,7 @@ import {
 	copyPriceInformation,
 	isPriceInformationLike,
 } from "../../../internal/price-information.ts";
+import { isDateTimeString } from "../../../internal/utils/is-date-time-string.ts";
 import { isRecord } from "../../../internal/utils/is-record.ts";
 import type { Page, Result } from "../../../types.ts";
 import type { GamePass } from "./types.ts";
@@ -89,8 +90,8 @@ function hasRequiredPrimitiveFields(body: Record<string, unknown>): boolean {
 		typeof body["description"] === "string" &&
 		typeof body["isForSale"] === "boolean" &&
 		typeof body["iconAssetId"] === "number" &&
-		typeof body["createdTimestamp"] === "string" &&
-		typeof body["updatedTimestamp"] === "string"
+		isDateTimeString(body["createdTimestamp"]) &&
+		isDateTimeString(body["updatedTimestamp"])
 	);
 }
 

--- a/packages/open-cloud/src/internal/utils/is-date-time-string.spec.ts
+++ b/packages/open-cloud/src/internal/utils/is-date-time-string.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { isDateTimeString } from "./is-date-time-string.ts";
+
+describe(isDateTimeString, () => {
+	it("should accept an ISO 8601 UTC timestamp", () => {
+		expect.assertions(1);
+
+		expect(isDateTimeString("2024-01-15T10:30:00.000Z")).toBeTrue();
+	});
+
+	it("should accept a timestamp without fractional seconds", () => {
+		expect.assertions(1);
+
+		expect(isDateTimeString("2024-01-15T10:30:00Z")).toBeTrue();
+	});
+
+	it("should reject a string that does not parse to a real Date", () => {
+		expect.assertions(1);
+
+		expect(isDateTimeString("not-a-date")).toBeFalse();
+	});
+
+	it("should reject the literal string 'Invalid Date'", () => {
+		expect.assertions(1);
+
+		expect(isDateTimeString("Invalid Date")).toBeFalse();
+	});
+
+	it("should reject an empty string", () => {
+		expect.assertions(1);
+
+		expect(isDateTimeString("")).toBeFalse();
+	});
+
+	it("should reject a non-string number", () => {
+		expect.assertions(1);
+
+		expect(isDateTimeString(1_700_000_000_000)).toBeFalse();
+	});
+
+	it("should reject undefined", () => {
+		expect.assertions(1);
+
+		expect(isDateTimeString(undefined)).toBeFalse();
+	});
+
+	it("should reject a JSON null", () => {
+		expect.assertions(1);
+
+		expect(isDateTimeString(JSON.parse("null"))).toBeFalse();
+	});
+
+	it("should reject a Date instance, since the wire field is a string", () => {
+		expect.assertions(1);
+
+		expect(isDateTimeString(new Date("2024-01-15T10:30:00.000Z"))).toBeFalse();
+	});
+});

--- a/packages/open-cloud/src/internal/utils/is-date-time-string.ts
+++ b/packages/open-cloud/src/internal/utils/is-date-time-string.ts
@@ -2,7 +2,7 @@
  * Narrows `value` to a string that parses to a real {@link Date} via the
  * `Date(string)` constructor. Used by resource parsers to gate
  * `format: date-time` wire fields before handing them to `new Date(...)`,
- * which silently produces an `Invalid Date` for unparseable input.
+ * which silently produces an `Invalid Date` for invalid input.
  *
  * @param value - The unknown wire value to validate.
  * @returns `true` when `value` is a string and `new Date(value).getTime()`

--- a/packages/open-cloud/src/internal/utils/is-date-time-string.ts
+++ b/packages/open-cloud/src/internal/utils/is-date-time-string.ts
@@ -1,0 +1,17 @@
+/**
+ * Narrows `value` to a string that parses to a real {@link Date} via the
+ * `Date(string)` constructor. Used by resource parsers to gate
+ * `format: date-time` wire fields before handing them to `new Date(...)`,
+ * which silently produces an `Invalid Date` for unparseable input.
+ *
+ * @param value - The unknown wire value to validate.
+ * @returns `true` when `value` is a string and `new Date(value).getTime()`
+ *   is not `NaN`.
+ */
+export function isDateTimeString(value: unknown): value is string {
+	if (typeof value !== "string") {
+		return false;
+	}
+
+	return !Number.isNaN(new Date(value).getTime());
+}


### PR DESCRIPTION
## Summary

Resource parsers (`parseBadgeResponse`, `parseGamePassResponse` /
`parseGamePassesListResponse`, `parseDeveloperProductResponse`,
`parsePlaceResponse`, `parseUniverseResponse`) only verified that
`format: date-time` wire fields were strings. `new Date("not-a-date")`
silently returns an `Invalid Date` whose `getTime()` is `NaN`, so a
malformed `created` / `updated` / `createdTimestamp` /
`updatedTimestamp` / `createTime` / `updateTime` was accepted as a
successful parse and threw `RangeError` the first time a caller
invoked `toISOString()` on the resulting `Date`.

This PR adds a small `isDateTimeString` guard
(`packages/open-cloud/src/internal/utils/is-date-time-string.ts`) and
threads it through the wire-shape predicates of every resource parser
in the package, so an invalid timestamp surfaces as a malformed-
response `Result` consistent with every other field-level rejection.

## Slices

One commit per parser, plus one tightening pass on the spec
parameterization style:

1. `fix(ocale): reject malformed date-time strings in badge parser` —
   introduces `isDateTimeString` + adds the badge case.
2. `fix(ocale): reject malformed date-time strings in game-pass parser`
3. `fix(ocale): reject malformed date-time strings in developer-product parser`
4. `fix(ocale): reject malformed date-time strings in place parser`
5. `fix(ocale): reject malformed date-time strings in universe parser`
6. `refactor(ocale): tighten date-time spec parameterization` —
   collapse `[{ field: "x" as const }, ...]` to `["x", "y"] as const`
   so badges / game-passes / developer-products specs match the
   tuple form already on places / universes.

Closes #333.

## Test plan

- [x] `pnpm lint` (clean)
- [x] `pnpm --filter @bedrock/ocale typecheck` (clean)
- [x] `pnpm --filter @bedrock/ocale test --run` (931 passed, +13 new)
- [x] `pnpm --filter @bedrock/ocale build` (publint clean)
- [x] `MUTATE_BASE_REF=origin/main pnpm mutate:changed` — 100% mutation
      score (12 killed, 0 surviving) on the six touched `src/**` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)