### PR TITLE
feat(ocale): expose per-locale localization on badges

### DIFF
--- a/packages/open-cloud/src/domains/game-internationalization/badge-icon/builders.spec.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/badge-icon/builders.spec.ts
@@ -1,0 +1,93 @@
+import { assert, describe, expect, it } from "vitest";
+
+import { buildUploadIconRequest } from "./builders.ts";
+import type { UploadBadgeIconLocalizationParameters } from "./types.ts";
+
+describe(buildUploadIconRequest, () => {
+	it("should use the POST method", () => {
+		expect.assertions(1);
+
+		const parameters = {
+			badgeId: "12345",
+			image: new Uint8Array([1, 2, 3]),
+			languageCode: "en-us",
+		} satisfies UploadBadgeIconLocalizationParameters;
+
+		const request = buildUploadIconRequest(parameters);
+
+		expect(request.method).toBe("POST");
+	});
+
+	it("should interpolate badgeId and languageCode into the upload URL", () => {
+		expect.assertions(1);
+
+		const parameters = {
+			badgeId: "12345",
+			image: new Uint8Array([1, 2, 3]),
+			languageCode: "fr-fr",
+		} satisfies UploadBadgeIconLocalizationParameters;
+
+		const request = buildUploadIconRequest(parameters);
+
+		expect(request.url).toBe(
+			"/legacy-game-internationalization/v1/badges/12345/icons/language-codes/fr-fr",
+		);
+	});
+
+	it("should append the image as the `Files` field on a FormData body", () => {
+		expect.assertions(1);
+
+		const parameters = {
+			badgeId: "12345",
+			image: new Uint8Array([1, 2, 3]),
+			languageCode: "en-us",
+		} satisfies UploadBadgeIconLocalizationParameters;
+
+		const request = buildUploadIconRequest(parameters);
+
+		assert(request.body instanceof FormData);
+
+		expect(request.body.has("Files")).toBeTrue();
+	});
+
+	it("should wrap a Uint8Array image into a Blob preserving its bytes", () => {
+		expect.assertions(2);
+
+		const image = new Uint8Array([1, 2, 3, 4]);
+		const parameters = {
+			badgeId: "12345",
+			image,
+			languageCode: "en-us",
+		} satisfies UploadBadgeIconLocalizationParameters;
+
+		const request = buildUploadIconRequest(parameters);
+
+		assert(request.body instanceof FormData);
+
+		const appended = request.body.get("Files");
+		assert(appended instanceof Blob);
+
+		expect(appended).toBeInstanceOf(Blob);
+		expect(appended.size).toBe(image.byteLength);
+	});
+
+	it("should preserve the MIME type of a Blob image", () => {
+		expect.assertions(1);
+
+		const image = new Blob([new Uint8Array([1, 2, 3, 4])], { type: "image/png" });
+		const parameters = {
+			badgeId: "12345",
+			image,
+			languageCode: "en-us",
+		} satisfies UploadBadgeIconLocalizationParameters;
+
+		const request = buildUploadIconRequest(parameters);
+
+		assert(request.body instanceof FormData);
+
+		const appended = request.body.get("Files");
+		assert(appended instanceof Blob);
+
+		expect(appended.type).toBe("image/png");
+	});
+});

--- a/packages/open-cloud/src/domains/game-internationalization/badge-icon/builders.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/badge-icon/builders.ts
@@ -1,0 +1,25 @@
+import type { HttpRequest } from "../../../internal/http/types.ts";
+import { toBlob } from "../../../internal/utils/to-blob.ts";
+import type { UploadBadgeIconLocalizationParameters } from "./types.ts";
+
+/**
+ * Builds a `POST` request for the localized "upload badge icon" endpoint. A
+ * successful upload replaces any existing icon for the same
+ * `(badgeId, languageCode)` pair.
+ *
+ * @param parameters - Badge and language identifiers plus the image bytes
+ *   to upload.
+ * @returns A pure {@link HttpRequest} describing the upload call.
+ */
+export function buildUploadIconRequest(
+	parameters: UploadBadgeIconLocalizationParameters,
+): HttpRequest {
+	const body = new FormData();
+	body.append("Files", toBlob(parameters.image));
+
+	return {
+		body,
+		method: "POST",
+		url: `/legacy-game-internationalization/v1/badges/${parameters.badgeId}/icons/language-codes/${parameters.languageCode}`,
+	};
+}

--- a/packages/open-cloud/src/domains/game-internationalization/badge-icon/types.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/badge-icon/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Parameters for uploading or replacing the per-locale icon registered
+ * against a badge. A subsequent upload for the same `(badgeId, languageCode)`
+ * pair replaces the existing icon for that locale. Source-language icons
+ * are managed through `BadgesClient.uploadIcon`.
+ */
+export interface UploadBadgeIconLocalizationParameters {
+	/** Stringified ID of the badge whose icon is being uploaded. */
+	readonly badgeId: string;
+	/** Image bytes to upload. PNG and JPEG are accepted by the server. */
+	readonly image: Blob | Uint8Array;
+	/** BCP-47 language code the icon is being uploaded for (e.g. `fr-fr`). */
+	readonly languageCode: string;
+}

--- a/packages/open-cloud/src/domains/game-internationalization/badge-name-description/builders.spec.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/badge-name-description/builders.spec.ts
@@ -1,0 +1,86 @@
+import { assert, describe, expect, it } from "vitest";
+
+import { buildUpdateRequest } from "./builders.ts";
+import type { UpdateBadgeNameDescriptionParameters } from "./types.ts";
+
+describe(buildUpdateRequest, () => {
+	it("should use the PATCH method", () => {
+		expect.assertions(1);
+
+		const parameters = {
+			name: "First Goal",
+			badgeId: "12345",
+			languageCode: "en-us",
+		} satisfies UpdateBadgeNameDescriptionParameters;
+
+		const request = buildUpdateRequest(parameters);
+
+		expect(request.method).toBe("PATCH");
+	});
+
+	it("should interpolate badgeId and languageCode into the URL", () => {
+		expect.assertions(1);
+
+		const parameters = {
+			name: "First Goal",
+			badgeId: "12345",
+			languageCode: "fr-fr",
+		} satisfies UpdateBadgeNameDescriptionParameters;
+
+		const request = buildUpdateRequest(parameters);
+
+		expect(request.url).toBe(
+			"/legacy-game-internationalization/v1/badges/12345/name-description/language-codes/fr-fr",
+		);
+	});
+
+	it.for<
+		[
+			name: string | undefined,
+			description: string | undefined,
+			expected: Record<string, string>,
+		]
+	>([
+		[
+			"First Goal",
+			"Awarded on first login.",
+			{ name: "First Goal", description: "Awarded on first login." },
+		],
+		["First Goal", undefined, { name: "First Goal" }],
+		[undefined, "Awarded on first login.", { description: "Awarded on first login." }],
+		[undefined, undefined, {}],
+	])(
+		"should include name=%j description=%j in the JSON body",
+		([name, description, expected]) => {
+			expect.assertions(1);
+
+			const parameters = {
+				badgeId: "12345",
+				languageCode: "en-us",
+				...(name === undefined ? {} : { name }),
+				...(description === undefined ? {} : { description }),
+			} satisfies UpdateBadgeNameDescriptionParameters;
+
+			const request = buildUpdateRequest(parameters);
+
+			expect(request.body).toStrictEqual(expected);
+		},
+	);
+
+	it("should produce a JSON-shaped body, not FormData", () => {
+		expect.assertions(2);
+
+		const parameters = {
+			name: "First Goal",
+			badgeId: "12345",
+			languageCode: "en-us",
+		} satisfies UpdateBadgeNameDescriptionParameters;
+
+		const request = buildUpdateRequest(parameters);
+
+		assert(typeof request.body === "object");
+
+		expect(request.body).not.toBeInstanceOf(FormData);
+		expect(request.body).toStrictEqual({ name: "First Goal" });
+	});
+});

--- a/packages/open-cloud/src/domains/game-internationalization/badge-name-description/builders.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/badge-name-description/builders.ts
@@ -1,0 +1,29 @@
+import type { HttpRequest } from "../../../internal/http/types.ts";
+import type { UpdateBadgeNameDescriptionParameters } from "./types.ts";
+
+/**
+ * Builds a `PATCH` request for the localized "update badge name/description"
+ * endpoint. Either `name`, `description`, or both may be supplied; omitted
+ * fields are not included in the JSON body so the server leaves the existing
+ * value for that locale untouched.
+ *
+ * @param parameters - Badge and language identifiers plus the optional
+ *   replacement values.
+ * @returns A pure {@link HttpRequest} describing the update call.
+ */
+export function buildUpdateRequest(parameters: UpdateBadgeNameDescriptionParameters): HttpRequest {
+	const body: Record<string, string> = {};
+	if (parameters.name !== undefined) {
+		body["name"] = parameters.name;
+	}
+
+	if (parameters.description !== undefined) {
+		body["description"] = parameters.description;
+	}
+
+	return {
+		body,
+		method: "PATCH",
+		url: `/legacy-game-internationalization/v1/badges/${parameters.badgeId}/name-description/language-codes/${parameters.languageCode}`,
+	};
+}

--- a/packages/open-cloud/src/domains/game-internationalization/badge-name-description/operations.spec.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/badge-name-description/operations.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { LOCALIZATION_OPERATION_LIMIT, LOCALIZATION_REQUIRED_SCOPES } from "./operations.ts";
+
+describe("badge localization operation limit", () => {
+	it("should cap the service at 100 requests per minute under one shared key", () => {
+		expect.assertions(1);
+
+		expect(LOCALIZATION_OPERATION_LIMIT).toStrictEqual({
+			maxPerSecond: 100 / 60,
+			operationKey: "badge-localization",
+		});
+	});
+
+	it("should freeze the operation limit so callers cannot mutate the registry", () => {
+		expect.assertions(1);
+
+		expect(Object.isFrozen(LOCALIZATION_OPERATION_LIMIT)).toBeTrue();
+	});
+});
+
+describe("badge localization required scopes", () => {
+	it("should require legacy-badge:manage", () => {
+		expect.assertions(1);
+
+		expect(LOCALIZATION_REQUIRED_SCOPES).toStrictEqual(["legacy-badge:manage"]);
+	});
+
+	it("should freeze the required-scopes list so callers cannot mutate it", () => {
+		expect.assertions(1);
+
+		expect(Object.isFrozen(LOCALIZATION_REQUIRED_SCOPES)).toBeTrue();
+	});
+});

--- a/packages/open-cloud/src/domains/game-internationalization/badge-name-description/operations.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/badge-name-description/operations.ts
@@ -1,0 +1,23 @@
+import type { OperationLimit } from "../../../internal/http/rate-limit-queue.ts";
+
+/**
+ * Per-second request ceiling for every badge localization Operation. The
+ * legacy `gameinternationalization` service caps each API key at 100
+ * requests per minute *shared across the entire service* (see the
+ * `x-roblox-rate-limits` extension on every operation in the vendored
+ * Open Cloud spec), so all badge localization methods queue against the
+ * same operation key.
+ */
+export const LOCALIZATION_OPERATION_LIMIT: OperationLimit = Object.freeze({
+	maxPerSecond: 100 / 60,
+	operationKey: "badge-localization",
+});
+
+/**
+ * Scopes required for every badge localization operation, sourced from
+ * `x-roblox-scopes` on the legacy `gameinternationalization` badge
+ * endpoints in the vendored OpenAPI schema.
+ */
+export const LOCALIZATION_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([
+	"legacy-badge:manage",
+]);

--- a/packages/open-cloud/src/domains/game-internationalization/badge-name-description/types.ts
+++ b/packages/open-cloud/src/domains/game-internationalization/badge-name-description/types.ts
@@ -1,0 +1,16 @@
+/**
+ * Parameters for updating the per-locale name and/or description registered
+ * against a badge. Both `name` and `description` are optional; fields omitted
+ * from the call are not included in the JSON body so the server leaves the
+ * existing value for that locale untouched.
+ */
+export interface UpdateBadgeNameDescriptionParameters {
+	/** Replacement display name for the supplied locale. */
+	readonly name?: string;
+	/** Stringified ID of the badge whose localization is being updated. */
+	readonly badgeId: string;
+	/** Replacement description for the supplied locale. */
+	readonly description?: string;
+	/** BCP-47 language code being updated (e.g. `fr-fr`). */
+	readonly languageCode: string;
+}

--- a/packages/open-cloud/src/domains/publish/badge-icon/types.ts
+++ b/packages/open-cloud/src/domains/publish/badge-icon/types.ts
@@ -3,7 +3,7 @@
  * registered against a badge. A subsequent upload for the same badge
  * replaces the existing source icon; per-locale icon overlays live
  * under a separate `legacy-game-internationalization` endpoint and
- * are not exposed on the badges client today.
+ * are managed through `BadgesClient.localization.uploadIcon`.
  */
 export interface UploadBadgeIconParameters {
 	/** Stringified ID of the badge whose icon is being uploaded. */

--- a/packages/open-cloud/src/resources/badges/client.ts
+++ b/packages/open-cloud/src/resources/badges/client.ts
@@ -12,6 +12,14 @@ import type {
 	CreateBadgeParameters,
 	UpdateBadgeParameters,
 } from "../../domains/badges/badges/types.ts";
+import { buildUploadIconRequest as buildLocaleUploadIconRequest } from "../../domains/game-internationalization/badge-icon/builders.ts";
+import type { UploadBadgeIconLocalizationParameters } from "../../domains/game-internationalization/badge-icon/types.ts";
+import { buildUpdateRequest as buildLocaleNameDescRequest } from "../../domains/game-internationalization/badge-name-description/builders.ts";
+import {
+	LOCALIZATION_OPERATION_LIMIT,
+	LOCALIZATION_REQUIRED_SCOPES,
+} from "../../domains/game-internationalization/badge-name-description/operations.ts";
+import type { UpdateBadgeNameDescriptionParameters } from "../../domains/game-internationalization/badge-name-description/types.ts";
 import { buildUploadIconRequest } from "../../domains/publish/badge-icon/builders.ts";
 import {
 	UPLOAD_ICON_OPERATION_LIMIT,
@@ -59,6 +67,61 @@ const UPLOAD_ICON_SPEC = makeSpec<UploadBadgeIconParameters, undefined>({
 	requiredScopes: UPLOAD_ICON_REQUIRED_SCOPES,
 });
 
+const UPDATE_NAME_DESCRIPTION_SPEC = makeSpec<UpdateBadgeNameDescriptionParameters, undefined>({
+	buildRequest: (parameters) => okRequest(buildLocaleNameDescRequest(parameters)),
+	methodDefaults: IDEMPOTENT_METHOD_DEFAULTS,
+	methodKind: "idempotent",
+	operationLimit: LOCALIZATION_OPERATION_LIMIT,
+	parse: parseEmptyResponse,
+	requiredScopes: LOCALIZATION_REQUIRED_SCOPES,
+});
+
+const UPLOAD_LOCALIZED_ICON_SPEC = makeSpec<UploadBadgeIconLocalizationParameters, undefined>({
+	buildRequest: (parameters) => okRequest(buildLocaleUploadIconRequest(parameters)),
+	methodDefaults: CREATE_METHOD_DEFAULTS,
+	methodKind: "create",
+	operationLimit: LOCALIZATION_OPERATION_LIMIT,
+	parse: parseEmptyResponse,
+	requiredScopes: LOCALIZATION_REQUIRED_SCOPES,
+});
+
+interface BadgeLocalizationHandle {
+	/**
+	 * Updates the per-locale display name and/or description registered against
+	 * a badge. Either `name`, `description`, or both may be supplied; omitted
+	 * fields are not forwarded so the server leaves the existing value for
+	 * that locale untouched. Mirrors the upstream `200 OK` echo body as
+	 * `undefined` data.
+	 *
+	 * @param parameters - Badge and language identifiers plus the optional
+	 *   replacement values.
+	 * @param options - Optional per-request overrides.
+	 * @returns A success {@link Result} with no payload, or the
+	 *   {@link OpenCloudError} that caused the request to fail.
+	 */
+	updateNameDescription: (
+		parameters: UpdateBadgeNameDescriptionParameters,
+		options?: RequestOptions,
+	) => Promise<Result<undefined, OpenCloudError>>;
+	/**
+	 * Uploads or replaces the per-locale icon for a badge. A subsequent
+	 * upload for the same `(badgeId, languageCode)` pair replaces the
+	 * existing icon for that locale. Does not retry on 5xx so a duplicate
+	 * upload cannot be created if the server fails mid-write. Source-language
+	 * icons remain on {@link BadgesClient.uploadIcon}.
+	 *
+	 * @param parameters - Badge and language identifiers plus the image bytes
+	 *   to upload.
+	 * @param options - Optional per-request overrides.
+	 * @returns A success {@link Result} with no payload, or the
+	 *   {@link OpenCloudError} that caused the request to fail.
+	 */
+	uploadIcon: (
+		parameters: UploadBadgeIconLocalizationParameters,
+		options?: RequestOptions,
+	) => Promise<Result<undefined, OpenCloudError>>;
+}
+
 /**
  * Public client for the Roblox Open Cloud Badges API. Covers programmatic
  * badge creation under a universe, partial updates of badge configuration
@@ -83,6 +146,17 @@ export class BadgesClient {
 	readonly #inner: ResourceClient;
 
 	/**
+	 * Operation Group exposing per-locale localization Operations
+	 * (`updateNameDescription`, `uploadIcon`) backed by the
+	 * `legacy-game-internationalization` domain. Source-language values
+	 * remain on {@link BadgesClient.update} and
+	 * {@link BadgesClient.uploadIcon}; methods on this group set per-locale
+	 * overlays on top. Shares the parent client's HTTP, rate-limit, and
+	 * retry plumbing.
+	 */
+	public readonly localization: BadgeLocalizationHandle;
+
+	/**
 	 * Creates a new {@link BadgesClient}. Configuration is frozen on
 	 * construction; per-request overrides are accepted on each method.
 	 *
@@ -90,6 +164,7 @@ export class BadgesClient {
 	 */
 	constructor(options: OpenCloudClientOptions) {
 		this.#inner = new ResourceClient(options);
+		this.localization = createLocalizationHandle(this.#inner);
 	}
 
 	/**
@@ -143,4 +218,15 @@ export class BadgesClient {
 	): Promise<Result<undefined, OpenCloudError>> {
 		return this.#inner.execute({ options, parameters, spec: UPLOAD_ICON_SPEC });
 	}
+}
+
+function createLocalizationHandle(inner: ResourceClient): BadgeLocalizationHandle {
+	return {
+		async updateNameDescription(parameters, options) {
+			return inner.execute({ options, parameters, spec: UPDATE_NAME_DESCRIPTION_SPEC });
+		},
+		async uploadIcon(parameters, options) {
+			return inner.execute({ options, parameters, spec: UPLOAD_LOCALIZED_ICON_SPEC });
+		},
+	};
 }

--- a/packages/open-cloud/src/resources/badges/index.spec-d.ts
+++ b/packages/open-cloud/src/resources/badges/index.spec-d.ts
@@ -8,7 +8,9 @@ import type {
 	BadgePaymentSource,
 	BadgesClient,
 	CreateBadgeParameters,
+	UpdateBadgeNameDescriptionParameters,
 	UpdateBadgeParameters,
+	UploadBadgeIconLocalizationParameters,
 	UploadBadgeIconParameters,
 } from "./index.ts";
 
@@ -78,6 +80,45 @@ describe("UploadBadgeIconParameters", () => {
 	});
 });
 
+describe("UpdateBadgeNameDescriptionParameters", () => {
+	it("should require badgeId and languageCode", () => {
+		expectTypeOf<UpdateBadgeNameDescriptionParameters>().toExtend<{
+			badgeId: string;
+			languageCode: string;
+		}>();
+	});
+
+	it("should accept identifiers without name or description", () => {
+		const parameters: UpdateBadgeNameDescriptionParameters = {
+			badgeId: "12345",
+			languageCode: "fr-fr",
+		};
+
+		expectTypeOf(parameters).toExtend<UpdateBadgeNameDescriptionParameters>();
+	});
+
+	it("should accept name and description as optional fields", () => {
+		const parameters: UpdateBadgeNameDescriptionParameters = {
+			name: "Localized Goal",
+			badgeId: "12345",
+			description: "Awarded on first login.",
+			languageCode: "fr-fr",
+		};
+
+		expectTypeOf(parameters).toExtend<UpdateBadgeNameDescriptionParameters>();
+	});
+});
+
+describe("UploadBadgeIconLocalizationParameters", () => {
+	it("should require badgeId, languageCode, and image", () => {
+		expectTypeOf<UploadBadgeIconLocalizationParameters>().toExtend<{
+			badgeId: string;
+			image: Blob | Uint8Array;
+			languageCode: string;
+		}>();
+	});
+});
+
 describe("Badge", () => {
 	it("should expose stringified ids and Date timestamps", () => {
 		expectTypeOf<Badge>().toExtend<{
@@ -115,6 +156,18 @@ describe("BadgesClient", () => {
 
 	it("should resolve uploadIcon() to Result<undefined, OpenCloudError>", () => {
 		expectTypeOf<BadgesClient["uploadIcon"]>().returns.resolves.toEqualTypeOf<
+			Result<undefined, OpenCloudError>
+		>();
+	});
+
+	it("should resolve localization.updateNameDescription() to Result<undefined, OpenCloudError>", () => {
+		expectTypeOf<
+			BadgesClient["localization"]["updateNameDescription"]
+		>().returns.resolves.toEqualTypeOf<Result<undefined, OpenCloudError>>();
+	});
+
+	it("should resolve localization.uploadIcon() to Result<undefined, OpenCloudError>", () => {
+		expectTypeOf<BadgesClient["localization"]["uploadIcon"]>().returns.resolves.toEqualTypeOf<
 			Result<undefined, OpenCloudError>
 		>();
 	});

--- a/packages/open-cloud/src/resources/badges/index.ts
+++ b/packages/open-cloud/src/resources/badges/index.ts
@@ -7,5 +7,7 @@ export type {
 	CreateBadgeParameters,
 	UpdateBadgeParameters,
 } from "../../domains/badges/badges/types.ts";
+export type { UploadBadgeIconLocalizationParameters } from "../../domains/game-internationalization/badge-icon/types.ts";
+export type { UpdateBadgeNameDescriptionParameters } from "../../domains/game-internationalization/badge-name-description/types.ts";
 export type { UploadBadgeIconParameters } from "../../domains/publish/badge-icon/types.ts";
 export { BadgesClient } from "./client.ts";

--- a/packages/open-cloud/tests/integration/resources/badges/localization.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/badges/localization.spec.ts
@@ -1,0 +1,272 @@
+import { ApiError } from "#src/errors/api-error";
+import { PermissionError } from "#src/errors/permission-error";
+import { BadgesClient } from "#src/resources/badges/index";
+import { createFakeClock } from "#tests/helpers/fake-clock";
+import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
+import { createFakeSleep } from "#tests/helpers/fake-sleep";
+import { assert, describe, expect, it } from "vitest";
+
+const VALID_NAME_DESCRIPTION_BODY = {
+	name: "First Goal",
+	description: "Awarded on first login.",
+};
+
+describe(BadgesClient, () => {
+	describe("localization", () => {
+		describe("updateNameDescription", () => {
+			it("should return success with no payload when the server returns 200", async () => {
+				expect.assertions(1);
+
+				const httpClient = createFakeHttpClient().mockResponse({
+					body: VALID_NAME_DESCRIPTION_BODY,
+					status: 200,
+				});
+				const client = new BadgesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				const result = await client.localization.updateNameDescription({
+					name: "First Goal",
+					badgeId: "12345",
+					languageCode: "fr-fr",
+				});
+
+				assert(result.success);
+
+				expect(result.data).toBeUndefined();
+			});
+
+			it("should send a PATCH with a JSON body to the localized name-description URL", async () => {
+				expect.assertions(3);
+
+				const httpClient = createFakeHttpClient().mockResponse({
+					body: VALID_NAME_DESCRIPTION_BODY,
+					status: 200,
+				});
+				const client = new BadgesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				await client.localization.updateNameDescription({
+					name: "First Goal",
+					badgeId: "12345",
+					description: "Awarded on first login.",
+					languageCode: "fr-fr",
+				});
+
+				expect(httpClient.requests[0]?.request.method).toBe("PATCH");
+				expect(httpClient.requests[0]?.request.url).toBe(
+					"/legacy-game-internationalization/v1/badges/12345/name-description/language-codes/fr-fr",
+				);
+				expect(httpClient.requests[0]?.request.body).toStrictEqual({
+					name: "First Goal",
+					description: "Awarded on first login.",
+				});
+			});
+
+			it("should retry a 5xx since the PATCH is idempotent", async () => {
+				expect.assertions(1);
+
+				const httpClient = createFakeHttpClient()
+					.mockApiError({ statusCode: 500 })
+					.mockResponse({ body: VALID_NAME_DESCRIPTION_BODY, status: 200 });
+				const client = new BadgesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				const result = await client.localization.updateNameDescription({
+					name: "First Goal",
+					badgeId: "12345",
+					languageCode: "fr-fr",
+				});
+
+				assert(result.success);
+
+				expect(httpClient.requests).toHaveLength(2);
+			});
+
+			it("should surface a 403 as a PermissionError naming legacy-badge:manage", async () => {
+				expect.assertions(2);
+
+				const httpClient = createFakeHttpClient().mockApiError({ statusCode: 403 });
+				const client = new BadgesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				const result = await client.localization.updateNameDescription({
+					name: "First Goal",
+					badgeId: "12345",
+					languageCode: "fr-fr",
+				});
+
+				assert(!result.success);
+				assert(result.err instanceof PermissionError);
+
+				expect(result.err.requiredScopes).toStrictEqual(["legacy-badge:manage"]);
+				expect(result.err.operationKey).toBe("badge-localization");
+			});
+
+			it("should propagate a 404 as an ApiError", async () => {
+				expect.assertions(2);
+
+				const httpClient = createFakeHttpClient().mockApiError({
+					message: "Badge not found",
+					statusCode: 404,
+				});
+				const client = new BadgesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				const result = await client.localization.updateNameDescription({
+					name: "First Goal",
+					badgeId: "12345",
+					languageCode: "fr-fr",
+				});
+
+				assert(!result.success);
+
+				expect(result.err).toBeInstanceOf(ApiError);
+				expect(result.err).toHaveProperty("statusCode", 404);
+			});
+		});
+
+		describe("uploadIcon", () => {
+			it("should return success with no payload when the server returns 200", async () => {
+				expect.assertions(1);
+
+				const httpClient = createFakeHttpClient().mockResponse({ body: {}, status: 200 });
+				const client = new BadgesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				const result = await client.localization.uploadIcon({
+					badgeId: "12345",
+					image: new Uint8Array([1, 2, 3]),
+					languageCode: "fr-fr",
+				});
+
+				assert(result.success);
+
+				expect(result.data).toBeUndefined();
+			});
+
+			it("should send a POST with multipart FormData to the localized icon URL", async () => {
+				expect.assertions(3);
+
+				const httpClient = createFakeHttpClient().mockResponse({ body: {}, status: 200 });
+				const client = new BadgesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				await client.localization.uploadIcon({
+					badgeId: "12345",
+					image: new Uint8Array([1, 2, 3]),
+					languageCode: "fr-fr",
+				});
+
+				expect(httpClient.requests[0]?.request.method).toBe("POST");
+				expect(httpClient.requests[0]?.request.url).toBe(
+					"/legacy-game-internationalization/v1/badges/12345/icons/language-codes/fr-fr",
+				);
+				expect(httpClient.requests[0]?.request.body).toBeInstanceOf(FormData);
+			});
+
+			it("should not retry a 5xx so a duplicate icon upload can't be created", async () => {
+				expect.assertions(2);
+
+				const httpClient = createFakeHttpClient()
+					.mockApiError({ statusCode: 500 })
+					.mockResponse({ body: {}, status: 200 });
+				const client = new BadgesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				const result = await client.localization.uploadIcon({
+					badgeId: "12345",
+					image: new Uint8Array([1, 2, 3]),
+					languageCode: "fr-fr",
+				});
+
+				assert(!result.success);
+
+				expect(result.err).toBeInstanceOf(ApiError);
+				expect(httpClient.requests).toHaveLength(1);
+			});
+
+			it("should surface a 403 as a PermissionError naming legacy-badge:manage", async () => {
+				expect.assertions(2);
+
+				const httpClient = createFakeHttpClient().mockApiError({ statusCode: 403 });
+				const client = new BadgesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: createFakeSleep(),
+				});
+
+				const result = await client.localization.uploadIcon({
+					badgeId: "12345",
+					image: new Uint8Array([1, 2, 3]),
+					languageCode: "fr-fr",
+				});
+
+				assert(!result.success);
+				assert(result.err instanceof PermissionError);
+
+				expect(result.err.requiredScopes).toStrictEqual(["legacy-badge:manage"]);
+				expect(result.err.operationKey).toBe("badge-localization");
+			});
+		});
+
+		describe("shared rate-limit bucket", () => {
+			it("should serialize updateNameDescription and uploadIcon through the same per-API-key queue", async () => {
+				expect.assertions(2);
+
+				// At 100/60 per second the bucket holds one full token (600ms
+				// of latency budget) of headroom, so the first call goes
+				// through immediately and the second pays a 200ms wait
+				// against the drained shared bucket. Two independent buckets
+				// would each go through wait-free, so the recorded wait
+				// proves the methods queue against one operationKey.
+				const httpClient = createFakeHttpClient()
+					.mockResponse({ body: VALID_NAME_DESCRIPTION_BODY, status: 200 })
+					.mockResponse({ body: {}, status: 200 });
+				const clock = createFakeClock();
+				const client = new BadgesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: clock.sleep,
+				});
+
+				await client.localization.updateNameDescription({
+					name: "First Goal",
+					badgeId: "12345",
+					languageCode: "fr-fr",
+				});
+				await client.localization.uploadIcon({
+					badgeId: "12345",
+					image: new Uint8Array([1, 2, 3]),
+					languageCode: "fr-fr",
+				});
+
+				expect(httpClient.requests).toHaveLength(2);
+				expect(clock.waits).toStrictEqual([200]);
+			});
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds the per-locale name-description and icon overrides on `BadgesClient`, sitting under a new `localization` Operation Group. Closes #226.

```ts
import { BadgesClient } from "@bedrock/ocale/badges";

const client = new BadgesClient({ apiKey: "..." });

await client.localization.updateNameDescription({
    badgeId: "12345",
    languageCode: "fr-fr",
    name: "Premier objectif",
    description: "Décerné à la première connexion.",
});

await client.localization.uploadIcon({
    badgeId: "12345",
    languageCode: "fr-fr",
    image: new Uint8Array(/* png bytes */),
});
```

Source-language values continue to flow through `BadgesClient.update` and `BadgesClient.uploadIcon`; the new methods set per-locale overlays on top. Both methods queue against a shared `badge-localization` rate-limit bucket (100/min, per the legacy `gameinternationalization` cap).

## Endpoints wired

| Method | URL |
| --- | --- |
| `PATCH` | `/legacy-game-internationalization/v1/badges/{badgeId}/name-description/language-codes/{lang}` |
| `POST` | `/legacy-game-internationalization/v1/badges/{badgeId}/icons/language-codes/{lang}` |

Both surface as `Result<undefined, OpenCloudError>`. The PATCH echoes `{ name, description }` on success; the SDK parses the body via `parseEmptyResponse` to keep symmetry with the existing source-language `update`. The icon POST uses `CREATE_METHOD_DEFAULTS` so a 5xx is not retried, preventing a duplicate upload mid-write.

## Wire layout

Two new sub-trees under `src/domains/game-internationalization/`, mirroring the dev-products precedent shipped in #328:

- `badge-name-description/` (PATCH builder, shared rate-limit constants)
- `badge-icon/` (POST builder, types only — operations re-use the shared constants)

The new localization icon parameter type is named `UploadBadgeIconLocalizationParameters` to disambiguate it from the existing source-language `UploadBadgeIconParameters` (different folder, different field shape: `image` vs `icon`). Both are re-exported from `@bedrock/ocale/badges`.

## Out of scope

DELETE variants for both endpoints exist in the spec but are deferred per the issue body. Source-language `name`/`description` updates still flow through `BadgesClient.update`. No `@bedrock/core` kind/driver changes; the localization umbrella that consumes these client methods is tracked under PRD #116.

## Test plan

- [x] `pnpm gen:example-tests`
- [x] `pnpm lint` (clean)
- [x] `pnpm typecheck` (clean across all packages)
- [x] `pnpm --filter @bedrock/ocale test` (944 passed, +33 new)
- [x] `pnpm --filter @bedrock/ocale build` (clean, publint OK)
- [x] `MUTATE_BASE_REF=origin/main pnpm mutate:changed` — 100% mutation score on touched files, zero survivors

🤖 Generated with [Claude Code](https://claude.com/claude-code)