### PR TITLE
feat(core)!: read api key from bedrock-api-key env var

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -38,9 +38,9 @@ jobs:
         uses: ./.github/actions/setup
 
       - env:
+          BEDROCK_API_KEY: ${{ secrets.ROBLOX_API_KEY }}
           BEDROCK_TEST_GIST_ID: ${{ secrets.BEDROCK_TEST_GIST_ID }}
           GITHUB_TOKEN: ${{ secrets.GIST_TOKEN }}
-          ROBLOX_API_KEY: ${{ secrets.ROBLOX_API_KEY }}
           ROBLOX_TEST_PLACE_ID: ${{ secrets.ROBLOX_TEST_PLACE_ID }}
           ROBLOX_TEST_UNIVERSE_ID: ${{ secrets.ROBLOX_TEST_UNIVERSE_ID }}
         name: Run smoke test

--- a/apps/e2e/tests/smoke/cli-deploy.spec.ts
+++ b/apps/e2e/tests/smoke/cli-deploy.spec.ts
@@ -10,7 +10,7 @@ import { assert, describe, expect, it } from "vitest";
 import { pruneStateGist } from "../helpers/prune-state-gist.ts";
 
 const TOKEN = process.env["GITHUB_TOKEN"];
-const API_KEY = process.env["ROBLOX_API_KEY"];
+const API_KEY = process.env["BEDROCK_API_KEY"];
 const GIST_ID = process.env["BEDROCK_TEST_GIST_ID"];
 const PLACE_ID_ENV = process.env["ROBLOX_TEST_PLACE_ID"];
 const UNIVERSE_ID_ENV = process.env["ROBLOX_TEST_UNIVERSE_ID"];

--- a/apps/e2e/tests/smoke/cli-diff.spec.ts
+++ b/apps/e2e/tests/smoke/cli-diff.spec.ts
@@ -10,7 +10,7 @@ import { assert, describe, expect, it } from "vitest";
 import { pruneStateGist } from "../helpers/prune-state-gist.ts";
 
 const TOKEN = process.env["GITHUB_TOKEN"];
-const API_KEY = process.env["ROBLOX_API_KEY"];
+const API_KEY = process.env["BEDROCK_API_KEY"];
 const GIST_ID = process.env["BEDROCK_TEST_GIST_ID"];
 const PLACE_ID_ENV = process.env["ROBLOX_TEST_PLACE_ID"];
 

--- a/apps/e2e/tests/smoke/deploy-place.spec.ts
+++ b/apps/e2e/tests/smoke/deploy-place.spec.ts
@@ -19,7 +19,7 @@ import { pruneStateGist } from "../helpers/prune-state-gist.ts";
 
 const FIXTURE_PATH = join(dirname(fileURLToPath(import.meta.url)), "fixtures", "place.rbxlx");
 
-const API_KEY = process.env["ROBLOX_API_KEY"];
+const API_KEY = process.env["BEDROCK_API_KEY"];
 const UNIVERSE_ID_ENV = process.env["ROBLOX_TEST_UNIVERSE_ID"];
 const PLACE_ID_ENV = process.env["ROBLOX_TEST_PLACE_ID"];
 const TOKEN = process.env["GITHUB_TOKEN"];
@@ -49,7 +49,7 @@ describe("deploy place to real Roblox", () => {
 			// The skipIf above guarantees these are defined at runtime, but the
 			// type system cannot see through that, so we re-assert here to keep
 			// the rest of the test free of non-null assertions or casts.
-			assert(API_KEY !== undefined, "ROBLOX_API_KEY must be set");
+			assert(API_KEY !== undefined, "BEDROCK_API_KEY must be set");
 			assert(UNIVERSE_ID_ENV !== undefined, "ROBLOX_TEST_UNIVERSE_ID must be set");
 			assert(PLACE_ID_ENV !== undefined, "ROBLOX_TEST_PLACE_ID must be set");
 			assert(TOKEN !== undefined, "GITHUB_TOKEN must be set");

--- a/apps/website/docs/bedrock/guide/getting-started.md
+++ b/apps/website/docs/bedrock/guide/getting-started.md
@@ -117,9 +117,9 @@ import { GamePassesClient } from "@bedrock/ocale/game-passes";
 
 import { applyOps, type DriverRegistry } from "bedrock";
 
-const apiKey = process.env.ROBLOX_API_KEY;
+const apiKey = process.env.BEDROCK_API_KEY;
 if (apiKey === undefined) {
-	throw new Error("ROBLOX_API_KEY is not set");
+	throw new Error("BEDROCK_API_KEY is not set");
 }
 
 const client = new GamePassesClient({ apiKey });

--- a/packages/bedrock/src/cli/commands/deploy.spec.ts
+++ b/packages/bedrock/src/cli/commands/deploy.spec.ts
@@ -228,7 +228,7 @@ describe(deployCommand, () => {
 			const deps = makeDeps({ deploy, loadConfig });
 
 			await deployCommand(deps)({
-				"api-key": "ROBLOX_OVERRIDE",
+				"api-key": "BEDROCK_OVERRIDE",
 				"env": "production",
 				"github-token": "GH_OVERRIDE",
 			});
@@ -240,7 +240,7 @@ describe(deployCommand, () => {
 
 			const [call] = firstCall;
 
-			expect(call.getEnv?.("ROBLOX_API_KEY")).toBe("ROBLOX_OVERRIDE");
+			expect(call.getEnv?.("BEDROCK_API_KEY")).toBe("BEDROCK_OVERRIDE");
 			expect(call.getEnv?.("GITHUB_TOKEN")).toBe("GH_OVERRIDE");
 			expect(call.getEnv?.("UNRELATED_VAR")).toBe("from-process-unrelated");
 		} finally {
@@ -251,7 +251,7 @@ describe(deployCommand, () => {
 	it("should overlay each credential flag only on its named slot, not the other", async () => {
 		expect.assertions(3);
 
-		vi.stubEnv("ROBLOX_API_KEY", "from-process-roblox");
+		vi.stubEnv("BEDROCK_API_KEY", "from-process-bedrock");
 		vi.stubEnv("GITHUB_TOKEN", "from-process-github");
 
 		try {
@@ -259,14 +259,14 @@ describe(deployCommand, () => {
 			const deploy = fakeDeploy([{ data: bedrockState("production"), success: true }]);
 			const deps = makeDeps({ deploy, loadConfig });
 
-			await deployCommand(deps)({ "api-key": "FLAG_ROBLOX", "env": "production" });
+			await deployCommand(deps)({ "api-key": "FLAG_BEDROCK", "env": "production" });
 
 			const firstCall = vi.mocked(deploy).mock.calls[0];
 			assert(firstCall !== undefined);
 
 			const [call] = firstCall;
 
-			expect(call.getEnv?.("ROBLOX_API_KEY")).toBe("FLAG_ROBLOX");
+			expect(call.getEnv?.("BEDROCK_API_KEY")).toBe("FLAG_BEDROCK");
 			expect(call.getEnv?.("GITHUB_TOKEN")).toBe("from-process-github");
 			expect(call.getEnv?.("UNRELATED_VAR")).toBeUndefined();
 		} finally {
@@ -277,7 +277,7 @@ describe(deployCommand, () => {
 	it("should fall back to process.env when neither --api-key nor --github-token is supplied", async () => {
 		expect.assertions(2);
 
-		vi.stubEnv("ROBLOX_API_KEY", "process-roblox");
+		vi.stubEnv("BEDROCK_API_KEY", "process-bedrock");
 		vi.stubEnv("GITHUB_TOKEN", "process-github");
 
 		try {
@@ -292,7 +292,7 @@ describe(deployCommand, () => {
 
 			const [call] = firstCall;
 
-			expect(call.getEnv?.("ROBLOX_API_KEY")).toBe("process-roblox");
+			expect(call.getEnv?.("BEDROCK_API_KEY")).toBe("process-bedrock");
 			expect(call.getEnv?.("GITHUB_TOKEN")).toBe("process-github");
 		} finally {
 			vi.unstubAllEnvs();

--- a/packages/bedrock/src/cli/commands/deploy.ts
+++ b/packages/bedrock/src/cli/commands/deploy.ts
@@ -83,7 +83,7 @@ async function dispatchEnvironments(inputs: DispatchInputs): Promise<ReadonlyArr
 
 function buildGetEnvironment(parsed: CommonOptions): (name: string) => string | undefined {
 	return (name) => {
-		if (name === "ROBLOX_API_KEY" && parsed.apiKey !== undefined) {
+		if (name === "BEDROCK_API_KEY" && parsed.apiKey !== undefined) {
 			return parsed.apiKey;
 		}
 

--- a/packages/bedrock/src/cli/commands/diff.spec.ts
+++ b/packages/bedrock/src/cli/commands/diff.spec.ts
@@ -290,7 +290,7 @@ describe(diffCommand, () => {
 			const deps = makeDeps({ loadConfig, previewDiff });
 
 			await diffCommand(deps)({
-				"api-key": "ROBLOX_OVERRIDE",
+				"api-key": "BEDROCK_OVERRIDE",
 				"env": "production",
 				"github-token": "GH_OVERRIDE",
 			});
@@ -302,7 +302,7 @@ describe(diffCommand, () => {
 
 			const [call] = firstCall;
 
-			expect(call.getEnv?.("ROBLOX_API_KEY")).toBe("ROBLOX_OVERRIDE");
+			expect(call.getEnv?.("BEDROCK_API_KEY")).toBe("BEDROCK_OVERRIDE");
 			expect(call.getEnv?.("GITHUB_TOKEN")).toBe("GH_OVERRIDE");
 			expect(call.getEnv?.("UNRELATED_VAR")).toBe("from-process-unrelated");
 		} finally {
@@ -313,7 +313,7 @@ describe(diffCommand, () => {
 	it("should overlay each credential flag only on its named slot, not the other", async () => {
 		expect.assertions(3);
 
-		vi.stubEnv("ROBLOX_API_KEY", "from-process-roblox");
+		vi.stubEnv("BEDROCK_API_KEY", "from-process-bedrock");
 		vi.stubEnv("GITHUB_TOKEN", "from-process-github");
 
 		try {
@@ -321,14 +321,14 @@ describe(diffCommand, () => {
 			const previewDiff = fakePreview([preview("production", [])]);
 			const deps = makeDeps({ loadConfig, previewDiff });
 
-			await diffCommand(deps)({ "api-key": "FLAG_ROBLOX", "env": "production" });
+			await diffCommand(deps)({ "api-key": "FLAG_BEDROCK", "env": "production" });
 
 			const firstCall = vi.mocked(previewDiff).mock.calls[0];
 			assert(firstCall !== undefined);
 
 			const [call] = firstCall;
 
-			expect(call.getEnv?.("ROBLOX_API_KEY")).toBe("FLAG_ROBLOX");
+			expect(call.getEnv?.("BEDROCK_API_KEY")).toBe("FLAG_BEDROCK");
 			expect(call.getEnv?.("GITHUB_TOKEN")).toBe("from-process-github");
 			expect(call.getEnv?.("UNRELATED_VAR")).toBeUndefined();
 		} finally {
@@ -339,7 +339,7 @@ describe(diffCommand, () => {
 	it("should fall back to process.env when neither --api-key nor --github-token is supplied", async () => {
 		expect.assertions(2);
 
-		vi.stubEnv("ROBLOX_API_KEY", "process-roblox");
+		vi.stubEnv("BEDROCK_API_KEY", "process-bedrock");
 		vi.stubEnv("GITHUB_TOKEN", "process-github");
 
 		try {
@@ -354,7 +354,7 @@ describe(diffCommand, () => {
 
 			const [call] = firstCall;
 
-			expect(call.getEnv?.("ROBLOX_API_KEY")).toBe("process-roblox");
+			expect(call.getEnv?.("BEDROCK_API_KEY")).toBe("process-bedrock");
 			expect(call.getEnv?.("GITHUB_TOKEN")).toBe("process-github");
 		} finally {
 			vi.unstubAllEnvs();

--- a/packages/bedrock/src/cli/commands/diff.ts
+++ b/packages/bedrock/src/cli/commands/diff.ts
@@ -68,7 +68,7 @@ function loadOptionsFor(parsed: CommonOptions): LoadConfigOptions | undefined {
 
 function buildGetEnvironment(parsed: CommonOptions): (name: string) => string | undefined {
 	return (name) => {
-		if (name === "ROBLOX_API_KEY" && parsed.apiKey !== undefined) {
+		if (name === "BEDROCK_API_KEY" && parsed.apiKey !== undefined) {
 			return parsed.apiKey;
 		}
 

--- a/packages/bedrock/src/cli/index.ts
+++ b/packages/bedrock/src/cli/index.ts
@@ -62,7 +62,7 @@ export function createProg(deps: ProgDeps = {}): Sade {
 		.describe("Reconcile a project's resources against the configured environment(s)")
 		.option("--env", "Target environment (repeat for multiple)")
 		.option("--config", "Config file path (overrides discovery)")
-		.option("--api-key", "Override the ROBLOX_API_KEY environment variable")
+		.option("--api-key", "Override the BEDROCK_API_KEY environment variable")
 		.option("--github-token", "Override the GITHUB_TOKEN environment variable")
 		.action(deployCommand(deps));
 
@@ -70,7 +70,7 @@ export function createProg(deps: ProgDeps = {}): Sade {
 		.describe("Preview the operations a deploy would apply, without writing state")
 		.option("--env", "Target environment (repeat for multiple)")
 		.option("--config", "Config file path (overrides discovery)")
-		.option("--api-key", "Override the ROBLOX_API_KEY environment variable")
+		.option("--api-key", "Override the BEDROCK_API_KEY environment variable")
 		.option("--github-token", "Override the GITHUB_TOKEN environment variable")
 		.action(diffCommand(deps));
 

--- a/packages/bedrock/src/cli/parse-options.ts
+++ b/packages/bedrock/src/cli/parse-options.ts
@@ -7,7 +7,7 @@ import process from "node:process";
  * been validated and normalized.
  */
 export interface CommonOptions {
-	/** Roblox Open Cloud API key override; falls back to ROBLOX_API_KEY when undefined. */
+	/** Roblox Open Cloud API key override; falls back to BEDROCK_API_KEY when undefined. */
 	readonly apiKey?: string;
 	/** Explicit config file path; when undefined the loader's discovery rules apply. */
 	readonly configFile?: string;

--- a/packages/bedrock/src/shell/build-default-registry.spec.ts
+++ b/packages/bedrock/src/shell/build-default-registry.spec.ts
@@ -22,12 +22,12 @@ async function neverReadFile(): Promise<Uint8Array> {
 }
 
 describe(buildDefaultRegistry, () => {
-	it("should construct gamePass, place, and universe drivers when ROBLOX_API_KEY and config.universe.universeId are present", () => {
+	it("should construct gamePass, place, and universe drivers when BEDROCK_API_KEY and config.universe.universeId are present", () => {
 		expect.assertions(3);
 
 		const result = buildDefaultRegistry({
 			config: configWithUniverse(),
-			getEnv: environmentFrom({ ROBLOX_API_KEY: "rbx-test" }),
+			getEnv: environmentFrom({ BEDROCK_API_KEY: "rbx-test" }),
 			readFile: neverReadFile,
 		});
 
@@ -38,7 +38,7 @@ describe(buildDefaultRegistry, () => {
 		expect(result.data.universe).toBeObject();
 	});
 
-	it("should return Err(missingCredential) when ROBLOX_API_KEY is unset", () => {
+	it("should return Err(missingCredential) when BEDROCK_API_KEY is unset", () => {
 		expect.assertions(3);
 
 		const result = buildDefaultRegistry({
@@ -51,7 +51,7 @@ describe(buildDefaultRegistry, () => {
 		assert(result.err.kind === "missingCredential");
 
 		expect(result.err.kind).toBe("missingCredential");
-		expect(result.err.variable).toBe("ROBLOX_API_KEY");
+		expect(result.err.variable).toBe("BEDROCK_API_KEY");
 		expect(result.err.purpose).toBe("registry");
 	});
 
@@ -60,7 +60,7 @@ describe(buildDefaultRegistry, () => {
 
 		const result = buildDefaultRegistry({
 			config: { environments: { production: {} }, state: STATE_CONFIG },
-			getEnv: environmentFrom({ ROBLOX_API_KEY: "rbx-test" }),
+			getEnv: environmentFrom({ BEDROCK_API_KEY: "rbx-test" }),
 			readFile: neverReadFile,
 		});
 
@@ -72,7 +72,7 @@ describe(buildDefaultRegistry, () => {
 		expect(result.err.kind).toBe("registryConfigMissing");
 	});
 
-	it("should not invoke getEnv beyond ROBLOX_API_KEY on the happy path", () => {
+	it("should not invoke getEnv beyond BEDROCK_API_KEY on the happy path", () => {
 		expect.assertions(2);
 
 		const reads: Array<string> = [];
@@ -80,14 +80,14 @@ describe(buildDefaultRegistry, () => {
 			config: configWithUniverse(),
 			getEnv: (name) => {
 				reads.push(name);
-				return name === "ROBLOX_API_KEY" ? "rbx-test" : undefined;
+				return name === "BEDROCK_API_KEY" ? "rbx-test" : undefined;
 			},
 			readFile: neverReadFile,
 		});
 
 		assert(result.success);
 
-		expect(reads).toStrictEqual(["ROBLOX_API_KEY"]);
+		expect(reads).toStrictEqual(["BEDROCK_API_KEY"]);
 		expect(result.data).toBeObject();
 	});
 });

--- a/packages/bedrock/src/shell/build-default-registry.ts
+++ b/packages/bedrock/src/shell/build-default-registry.ts
@@ -46,7 +46,7 @@ interface AssembleRegistryInputs {
 
 /**
  * Construct the default `DriverRegistry` from `config.universe.universeId`
- * and `ROBLOX_API_KEY`. Reads the API key via the injected `getEnv` seam
+ * and `BEDROCK_API_KEY`. Reads the API key via the injected `getEnv` seam
  * and surfaces `missingCredential` or `registryConfigMissing` as typed
  * Results instead of throwing.
  *
@@ -75,7 +75,7 @@ interface AssembleRegistryInputs {
 export function buildDefaultRegistry(
 	deps: BuildDefaultRegistryDeps,
 ): Result<DriverRegistry, MissingCredentialError | RegistryConfigError> {
-	const apiKey = deps.getEnv("ROBLOX_API_KEY");
+	const apiKey = deps.getEnv("BEDROCK_API_KEY");
 	if (apiKey === undefined) {
 		return missingApiKey();
 	}
@@ -100,7 +100,7 @@ function missingApiKey(): Result<DriverRegistry, MissingCredentialError> {
 		err: {
 			kind: "missingCredential",
 			purpose: "registry",
-			variable: "ROBLOX_API_KEY",
+			variable: "BEDROCK_API_KEY",
 		},
 		success: false,
 	};

--- a/packages/bedrock/src/shell/deploy.spec.ts
+++ b/packages/bedrock/src/shell/deploy.spec.ts
@@ -667,7 +667,7 @@ describe(deploy, () => {
 		expect(result.err.purpose).toBe("stateBackend");
 	});
 
-	it("should default-construct the registry from ROBLOX_API_KEY when registry is omitted", async () => {
+	it("should default-construct the registry from BEDROCK_API_KEY when registry is omitted", async () => {
 		expect.assertions(1);
 
 		// Provide prior universe state so the diff is a noop and the real
@@ -686,7 +686,7 @@ describe(deploy, () => {
 				universe: { universeId: "1" },
 			},
 			environment: "production",
-			getEnv: environmentFrom({ GITHUB_TOKEN: "ghp_test", ROBLOX_API_KEY: "rbx-test" }),
+			getEnv: environmentFrom({ BEDROCK_API_KEY: "rbx-test", GITHUB_TOKEN: "ghp_test" }),
 			readFile: readIcon,
 			statePort: port,
 		});
@@ -696,7 +696,7 @@ describe(deploy, () => {
 		expect(result.data.environment).toBe("production");
 	});
 
-	it("should return Err(missingCredential) when ROBLOX_API_KEY is unset on the default-construction registry path", async () => {
+	it("should return Err(missingCredential) when BEDROCK_API_KEY is unset on the default-construction registry path", async () => {
 		expect.assertions(2);
 
 		const result = await deploy({
@@ -714,7 +714,7 @@ describe(deploy, () => {
 		assert(!result.success);
 		assert(result.err.kind === "missingCredential");
 
-		expect(result.err.variable).toBe("ROBLOX_API_KEY");
+		expect(result.err.variable).toBe("BEDROCK_API_KEY");
 		expect(result.err.purpose).toBe("registry");
 	});
 
@@ -727,7 +727,7 @@ describe(deploy, () => {
 				state: { backend: "gist", gistId: "abc" },
 			},
 			environment: "production",
-			getEnv: environmentFrom({ GITHUB_TOKEN: "ghp_test", ROBLOX_API_KEY: "rbx-test" }),
+			getEnv: environmentFrom({ BEDROCK_API_KEY: "rbx-test", GITHUB_TOKEN: "ghp_test" }),
 			readFile: readIcon,
 			statePort: inMemoryStatePort().port,
 		});
@@ -788,7 +788,7 @@ describe(deploy, () => {
 	it("should default getEnv to process.env when getEnv is not supplied", async () => {
 		expect.assertions(1);
 
-		vi.stubEnv("ROBLOX_API_KEY", "rbx-stub");
+		vi.stubEnv("BEDROCK_API_KEY", "rbx-stub");
 		try {
 			// Prior universe state keeps the diff at noop so the
 			// default-constructed universe driver never hits Open Cloud.

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -33,7 +33,7 @@ import { loadConfig as defaultLoadConfig, type LoadConfigOptions } from "./load-
 /**
  * Inputs for `deploy`. Every field except `environment` is optional;
  * omitted dependencies are default-constructed from the project config
- * and the environment variables `GITHUB_TOKEN` and `ROBLOX_API_KEY`.
+ * and the environment variables `GITHUB_TOKEN` and `BEDROCK_API_KEY`.
  */
 export interface DeployOptions {
 	/** Pre-loaded, optionally-mutated project config. Omit to call `loadConfig()` automatically. */
@@ -48,7 +48,7 @@ export interface DeployOptions {
 	readonly loadConfig?: (options?: LoadConfigOptions) => Promise<Result<Config, ConfigError>>;
 	/** Reads file bytes for resources that have file-backed inputs. Defaults to `node:fs/promises.readFile`. */
 	readonly readFile?: (path: string) => Promise<Uint8Array>;
-	/** Per-kind driver table consulted for create / update dispatch. Default-constructed from `ROBLOX_API_KEY` when omitted. */
+	/** Per-kind driver table consulted for create / update dispatch. Default-constructed from `BEDROCK_API_KEY` when omitted. */
 	readonly registry?: DriverRegistry;
 	/** Backend used to read the prior snapshot and persist the new one. Default-constructed from `config.state` and `GITHUB_TOKEN` when omitted. */
 	readonly statePort?: StatePort;
@@ -108,7 +108,7 @@ interface PickRegistryInputs {
 /**
  * Run a full reconcile end-to-end. Default-constructs missing deps from
  * the project config and the environment variables `GITHUB_TOKEN` and
- * `ROBLOX_API_KEY`; never reads `process.env` when `statePort`,
+ * `BEDROCK_API_KEY`; never reads `process.env` when `statePort`,
  * `registry`, and `config` are all supplied explicitly.
  *
  * @param options - Target environment plus optional overrides.

--- a/packages/bedrock/tests/integration/cli/index.spec.ts
+++ b/packages/bedrock/tests/integration/cli/index.spec.ts
@@ -133,7 +133,7 @@ describe("cli program factory", () => {
 			expect(captured).toContain("Reconcile");
 			expect(captured).toContain("Target environment");
 			expect(captured).toContain("Config file path");
-			expect(captured).toContain("ROBLOX_API_KEY");
+			expect(captured).toContain("BEDROCK_API_KEY");
 			expect(captured).toContain("GITHUB_TOKEN");
 		}
 	});
@@ -153,7 +153,7 @@ describe("cli program factory", () => {
 			expect(captured).toContain("Preview the operations");
 			expect(captured).toContain("Target environment");
 			expect(captured).toContain("Config file path");
-			expect(captured).toContain("ROBLOX_API_KEY");
+			expect(captured).toContain("BEDROCK_API_KEY");
 			expect(captured).toContain("GITHUB_TOKEN");
 		}
 	});


### PR DESCRIPTION
## Summary

- Rename the env var bedrock reads from `ROBLOX_API_KEY` to `BEDROCK_API_KEY`. The previous name read like a generic Roblox-ecosystem convention rather than something owned by bedrock; the new name aligns with `BEDROCK_TEST_GIST_ID` / `BEDROCK_ENVIRONMENT` already in use.
- Clean swap, no fallback chain. Bedrock is pre-1.0 and unpublished, so deprecation aliasing would be permanent code complexity for no real migration cost. The CLI's `--api-key` flag continues to override (its name was already generic).
- `@bedrock/ocale` is unaffected. ocale is publishable independently of bedrock, so its JSDoc `@example` blocks and `apps/website/docs/ocale/` continue to use `ROBLOX_API_KEY` as a placeholder for ocale-only consumers.
- The CI smoke workflow continues to read the existing GitHub repo secret named `ROBLOX_API_KEY` and exposes it to the test process under the new `BEDROCK_API_KEY` env var. No GitHub UI action required.

## Migration

- Local shell: `export BEDROCK_API_KEY=$ROBLOX_API_KEY` (or set fresh).
- Or pass `--api-key` on `bedrock deploy` / `bedrock diff`.
- Programmatic consumers of `deploy()` / `buildDefaultRegistry()` that pass an explicit `getEnv` should rename the key in the lookup map; any direct `process.env.ROBLOX_API_KEY` reads should move to `process.env.BEDROCK_API_KEY`.

## Test plan

- [x] `pnpm gen:example-tests` (no diff under `*.example.spec.ts`)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (2751 passing, 14 skipped — the smoke specs gated on real secrets)
- [x] `pnpm build`
- [x] `pnpm mutate:changed` (100.00 score on the 6 touched `src/**` files; 22 mutants killed, 0 survived)
- [ ] CI Smoke job exercises the renamed env var end-to-end against real Roblox Open Cloud

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Bedrock PR Review: Environment Variable Renaming (ROBLOX_API_KEY → BEDROCK_API_KEY)

## Architecture Compliance ✅

**FCIS Pattern Adherence:**
- **Shell Layer**: Properly delegates to Core functions (`buildDefaultRegistry`, `deploy`). No business logic violations detected in orchestration changes.
- **Core/Shell Boundary**: Changes maintain the separation—environment variable reading remains in Shell adapters, Core functions remain pure.
- **Adapter Pattern**: Environment variables are read at adapter boundaries (CLI commands, build-default-registry), not deep in Core logic.
- **No I/O Violations**: The renaming is surface-level; no new I/O operations introduced.

**Design Consistency:**
- Aligns the API key environment variable naming with the broader `BEDROCK_*` convention (e.g., `BEDROCK_TEST_GIST_ID`, `BEDROCK_ENVIRONMENT`).
- Clean semantic migration: `ROBLOX_API_KEY` → `BEDROCK_API_KEY` makes the contract explicit and avoids confusion with generic Roblox APIs.

---

## Testing Coverage ✅

**Test-Driven Verification:**
- All affected implementation files have corresponding spec files with updated test cases.
- Test naming follows the required format (e.g., `it("should...")`).
- Tests exercise the new environment variable flow end-to-end:
  - `deploy.spec.ts`: Tests verify `BEDROCK_API_KEY` propagation through `getEnv`.
  - `diff.spec.ts`: Tests validate credential overlay precedence and fallback behavior.
  - `build-default-registry.spec.ts`: Tests confirm registry construction from `BEDROCK_API_KEY`.
  - `deploy.spec.ts` (shell): Tests verify default registry construction from `BEDROCK_API_KEY`.

**Integration Test Alignment:**
- E2E smoke tests (`cli-deploy.spec.ts`, `cli-diff.spec.ts`, `deploy-place.spec.ts`) updated to read from `BEDROCK_API_KEY`.
- Integration tests (`packages/bedrock/tests/integration/cli/index.spec.ts`) verify help output references the new environment variable.
- CI workflow (`smoke.yaml`) correctly exposes `ROBLOX_API_KEY` GitHub secret as `BEDROCK_API_KEY` for test execution.

---

## Test Isolation & Layer Separation ✅

- **CLI Layer**: Tests use mocked `getEnv` to isolate from actual environment, proper for unit testing.
- **Shell Layer**: Integration tests with fake adapters; environment credential mocking prevents side effects.
- **Adapter Boundaries**: HTTP/file I/O tests use appropriate fixtures.

---

## Security & Constraints ✅

**Secret Management:**
- No secrets persisted in state files; API key remains an ephemeral credential passed via environment variables or CLI flags.
- CLI flag `--api-key` maintains override capability, preserving flexibility.
- GitHub Actions secret (`ROBLOX_API_KEY`) correctly mapped to `BEDROCK_API_KEY` at the point of use.

**Scope Compliance:**
- Changes remain within the Bedrock CLI/SDK layer; no introduction of legacy Roblox APIs or ROBLOSECURITY.
- `@bedrock/ocale` intentionally left unchanged (per PR objectives), preserving backward compatibility for ocale-only consumers.

---

## Code Quality ✅

- **TypeScript Compliance**: All changes use typed parameters and return values; no introduction of `any` types.
- **Error Handling**: Error messages and metadata (e.g., `missingCredential.variable`) correctly reference `BEDROCK_API_KEY`.
- **Documentation Updates**: Comments in source files and help text updated to reflect the new variable name.
- **Consistency**: Systematic replacement across CLI, Shell, and test layers; no orphaned references to the old variable in Bedrock packages.

---

## Key Observations

1. **Intentional Omission**: `@bedrock/ocale` continues to reference `ROBLOX_API_KEY` per design—correct for backward compatibility.
2. **No Breaking API Changes**: The change is a clean rename with test coverage. CLI flags (`--api-key`) preserve generic naming for flexibility.
3. **Migration Path Clear**: PR objectives provide actionable guidance (export variable or use CLI flag).
4. **CI Compatibility**: Smoke workflow correctly bridges the GitHub secret and environment variable naming.

---

## Verdict

✅ **Approved for merge.** The PR demonstrates proper TDD practices, maintains FCIS architectural boundaries, preserves security constraints, and achieves full test coverage. The renaming is systematic and intentional, with clear documentation and backward-compatible migration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->