### PR TITLE
fix(ocale): surface response body details on api-error

### DIFF
--- a/packages/open-cloud/src/errors/api-error.example.spec.ts
+++ b/packages/open-cloud/src/errors/api-error.example.spec.ts
@@ -3,11 +3,16 @@ import { expect, it } from "vitest";
 import { ApiError } from '@bedrock/ocale'
 
 it('Example 1', () => {
-  const error = new ApiError('Game pass not found', {
+  const error = new ApiError('HTTP 404: Pass not found (code NotFound)', {
     code: 'NotFound',
+    details: { errorCode: 'NotFound', message: 'Pass not found' },
     statusCode: 404,
   })
   expect(error).toBeInstanceOf(ApiError)
   expect(error.statusCode).toBe(404)
   expect(error.code).toBe('NotFound')
+  expect(error.details).toEqual({
+    errorCode: 'NotFound',
+    message: 'Pass not found',
+  })
 })

--- a/packages/open-cloud/src/errors/api-error.ts
+++ b/packages/open-cloud/src/errors/api-error.ts
@@ -7,7 +7,7 @@ export interface ApiErrorOptions extends ErrorOptions {
 	/** Optional machine-readable error code from the API. */
 	code?: string | undefined;
 	/** Parsed response body, when present. */
-	details?: unknown;
+	details?: JSONValue | undefined;
 	/** HTTP status code from the API response. */
 	statusCode: number;
 }
@@ -38,7 +38,7 @@ export interface ApiErrorOptions extends ErrorOptions {
  */
 export class ApiError extends OpenCloudError {
 	public readonly code: string | undefined;
-	public readonly details: unknown;
+	public readonly details: JSONValue | undefined;
 	public override readonly name: string = "ApiError";
 	public readonly statusCode: number;
 

--- a/packages/open-cloud/src/errors/api-error.ts
+++ b/packages/open-cloud/src/errors/api-error.ts
@@ -6,6 +6,8 @@ import { OpenCloudError } from "./base.ts";
 export interface ApiErrorOptions extends ErrorOptions {
 	/** Optional machine-readable error code from the API. */
 	code?: string | undefined;
+	/** Parsed response body, when present. */
+	details?: unknown;
 	/** HTTP status code from the API response. */
 	statusCode: number;
 }
@@ -19,18 +21,24 @@ export interface ApiErrorOptions extends ErrorOptions {
  * ```ts
  * import { ApiError } from "@bedrock/ocale";
  *
- * const error = new ApiError("Game pass not found", {
+ * const error = new ApiError("HTTP 404: Pass not found (code NotFound)", {
  *     code: "NotFound",
+ *     details: { errorCode: "NotFound", message: "Pass not found" },
  *     statusCode: 404,
  * });
  *
  * expect(error).toBeInstanceOf(ApiError);
  * expect(error.statusCode).toBe(404);
  * expect(error.code).toBe("NotFound");
+ * expect(error.details).toEqual({
+ *     errorCode: "NotFound",
+ *     message: "Pass not found",
+ * });
  * ```
  */
 export class ApiError extends OpenCloudError {
 	public readonly code: string | undefined;
+	public readonly details: unknown;
 	public override readonly name: string = "ApiError";
 	public readonly statusCode: number;
 
@@ -38,11 +46,13 @@ export class ApiError extends OpenCloudError {
 	 * Creates a new ApiError.
 	 *
 	 * @param message - Human-readable error description.
-	 * @param options - Error options including status code and optional error code.
+	 * @param options - Error options including status code, optional error
+	 *   code, and the parsed response body when present.
 	 */
 	constructor(message: string, options: ApiErrorOptions) {
 		super(message, options);
 		this.statusCode = options.statusCode;
 		this.code = options.code;
+		this.details = options.details;
 	}
 }

--- a/packages/open-cloud/src/index.spec-d.ts
+++ b/packages/open-cloud/src/index.spec-d.ts
@@ -95,6 +95,10 @@ describe("ApiError", () => {
 	it("should have code as string or undefined", () => {
 		expectTypeOf<ApiError>().toHaveProperty("code").toEqualTypeOf<string | undefined>();
 	});
+
+	it("should have details as JSONValue or undefined", () => {
+		expectTypeOf<ApiError>().toHaveProperty("details").toEqualTypeOf<JSONValue | undefined>();
+	});
 });
 
 describe("ApiErrorOptions", () => {
@@ -104,6 +108,10 @@ describe("ApiErrorOptions", () => {
 
 	it("should have optional code", () => {
 		expectTypeOf<ApiErrorOptions>().toExtend<{ code?: string | undefined }>();
+	});
+
+	it("should have optional details typed as JSONValue", () => {
+		expectTypeOf<ApiErrorOptions>().toExtend<{ details?: JSONValue | undefined }>();
 	});
 
 	it("should extend ErrorOptions", () => {

--- a/packages/open-cloud/src/internal/http/fetch-client.spec.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.spec.ts
@@ -8,6 +8,7 @@ import {
 	buildUrl,
 	createFetchHttpClient,
 	extractErrorCode,
+	extractErrorMessage,
 	headersToRecord,
 	parseRetryAfterSeconds,
 } from "./fetch-client.ts";
@@ -72,6 +73,117 @@ describe(extractErrorCode, () => {
 
 		// eslint-disable-next-line unicorn/no-null -- verifies JSON `null` body handling
 		expect(extractErrorCode(null)).toBeUndefined();
+	});
+
+	it("should extract numeric code from legacy errors[] as a string", () => {
+		expect.assertions(1);
+
+		const body = { errors: [{ code: 22, message: "Invalid language code" }] };
+
+		expect(extractErrorCode(body)).toBe("22");
+	});
+
+	it("should extract string code from legacy errors[]", () => {
+		expect.assertions(1);
+
+		const body = { errors: [{ code: "GAME_NOT_FOUND", message: "no" }] };
+
+		expect(extractErrorCode(body)).toBe("GAME_NOT_FOUND");
+	});
+
+	it("should prefer top-level errorCode over legacy errors[].code when both present", () => {
+		expect.assertions(1);
+
+		const body = { errorCode: "MODERN", errors: [{ code: 99, message: "legacy" }] };
+
+		expect(extractErrorCode(body)).toBe("MODERN");
+	});
+
+	it("should return undefined when errors is not an array", () => {
+		expect.assertions(1);
+
+		const body = { errors: "not-an-array" };
+
+		expect(extractErrorCode(body)).toBeUndefined();
+	});
+
+	it("should return undefined when errors[] is empty", () => {
+		expect.assertions(1);
+
+		const body = { errors: [] };
+
+		expect(extractErrorCode(body)).toBeUndefined();
+	});
+
+	it("should return undefined when errors[0] is not an object", () => {
+		expect.assertions(1);
+
+		const body = { errors: ["bare-string"] };
+
+		expect(extractErrorCode(body)).toBeUndefined();
+	});
+
+	it("should return undefined when errors[0].code is neither string nor number", () => {
+		expect.assertions(1);
+
+		const body = { errors: [{ code: { nested: true }, message: "hi" }] };
+
+		expect(extractErrorCode(body)).toBeUndefined();
+	});
+});
+
+describe(extractErrorMessage, () => {
+	it("should extract a top-level message string from a modern body", () => {
+		expect.assertions(1);
+
+		const body = { errorCode: "INVALID_ARGUMENT", message: "bad request" };
+
+		expect(extractErrorMessage(body)).toBe("bad request");
+	});
+
+	it("should extract message from legacy errors[]", () => {
+		expect.assertions(1);
+
+		const body = { errors: [{ code: 22, message: "Invalid language code" }] };
+
+		expect(extractErrorMessage(body)).toBe("Invalid language code");
+	});
+
+	it("should prefer top-level message over legacy errors[].message when both present", () => {
+		expect.assertions(1);
+
+		const body = { errors: [{ code: 1, message: "legacy" }], message: "modern" };
+
+		expect(extractErrorMessage(body)).toBe("modern");
+	});
+
+	it("should return undefined when body is not an object", () => {
+		expect.assertions(1);
+
+		expect(extractErrorMessage("string body")).toBeUndefined();
+	});
+
+	it("should return undefined when body is null", () => {
+		expect.assertions(1);
+
+		// eslint-disable-next-line unicorn/no-null -- verifies JSON `null` body handling
+		expect(extractErrorMessage(null)).toBeUndefined();
+	});
+
+	it("should return undefined when neither shape carries a message", () => {
+		expect.assertions(1);
+
+		const body = { errors: [{ code: 1 }] };
+
+		expect(extractErrorMessage(body)).toBeUndefined();
+	});
+
+	it("should return undefined when message is not a string", () => {
+		expect.assertions(1);
+
+		const body = { message: 42 };
+
+		expect(extractErrorMessage(body)).toBeUndefined();
 	});
 });
 
@@ -406,13 +518,13 @@ describe(createFetchHttpClient, () => {
 		expect(result.err.retryAfterSeconds).toBe(0);
 	});
 
-	it("should return ApiError for 400 with errorCode in body", async () => {
-		expect.assertions(3);
+	it("should compose ApiError message and details from a modern errorCode body", async () => {
+		expect.assertions(4);
+
+		const body = { errorCode: "INVALID_ARGUMENT", message: "bad" };
 
 		async function fakeFetch(): Promise<Response> {
-			return new Response(JSON.stringify({ errorCode: "INVALID_ARGUMENT", message: "bad" }), {
-				status: 400,
-			});
+			return new Response(JSON.stringify(body), { status: 400 });
 		}
 
 		const client = createFetchHttpClient(fakeFetch);
@@ -426,11 +538,36 @@ describe(createFetchHttpClient, () => {
 
 		expect(result.err.statusCode).toBe(400);
 		expect(result.err.code).toBe("INVALID_ARGUMENT");
-		expect(result.err.message).toBe("HTTP 400");
+		expect(result.err.message).toBe("HTTP 400: bad (code INVALID_ARGUMENT)");
+		expect(result.err.details).toStrictEqual(body);
+	});
+
+	it("should compose ApiError message and details from a legacy errors[] body", async () => {
+		expect.assertions(4);
+
+		const body = { errors: [{ code: 22, message: "Invalid language code" }] };
+
+		async function fakeFetch(): Promise<Response> {
+			return new Response(JSON.stringify(body), { status: 400 });
+		}
+
+		const client = createFetchHttpClient(fakeFetch);
+		const result = await client.request(
+			{ method: "POST", url: "/v1/game-icon/games/1/language-codes/en-us" },
+			{ apiKey: "key", baseUrl: "https://example.com" },
+		);
+
+		assert(!result.success);
+		assert(result.err instanceof ApiError);
+
+		expect(result.err.statusCode).toBe(400);
+		expect(result.err.code).toBe("22");
+		expect(result.err.message).toBe("HTTP 400: Invalid language code (code 22)");
+		expect(result.err.details).toStrictEqual(body);
 	});
 
 	it("should return ApiError for 300 redirect responses", async () => {
-		expect.assertions(2);
+		expect.assertions(3);
 
 		async function fakeFetch(): Promise<Response> {
 			return new Response(JSON.stringify({}), { status: 300 });
@@ -447,10 +584,11 @@ describe(createFetchHttpClient, () => {
 
 		expect(result.err.statusCode).toBe(300);
 		expect(result.err.message).toBe("HTTP 300");
+		expect(result.err.details).toStrictEqual({});
 	});
 
-	it("should return ApiError for 500 without errorCode", async () => {
-		expect.assertions(2);
+	it("should compose ApiError message from a body that carries only a top-level message", async () => {
+		expect.assertions(4);
 
 		async function fakeFetch(): Promise<Response> {
 			return new Response(JSON.stringify({ message: "internal error" }), { status: 500 });
@@ -467,6 +605,29 @@ describe(createFetchHttpClient, () => {
 
 		expect(result.err.statusCode).toBe(500);
 		expect(result.err.code).toBeUndefined();
+		expect(result.err.message).toBe("HTTP 500: internal error");
+		expect(result.err.details).toStrictEqual({ message: "internal error" });
+	});
+
+	it("should compose ApiError message from a body that carries only a code", async () => {
+		expect.assertions(3);
+
+		async function fakeFetch(): Promise<Response> {
+			return new Response(JSON.stringify({ errorCode: "ALONE" }), { status: 418 });
+		}
+
+		const client = createFetchHttpClient(fakeFetch);
+		const result = await client.request(
+			{ method: "GET", url: "/test" },
+			{ apiKey: "key", baseUrl: "https://example.com" },
+		);
+
+		assert(!result.success);
+		assert(result.err instanceof ApiError);
+
+		expect(result.err.statusCode).toBe(418);
+		expect(result.err.code).toBe("ALONE");
+		expect(result.err.message).toBe("HTTP 418 (code ALONE)");
 	});
 
 	it("should return ApiError when response body is not valid JSON", async () => {
@@ -514,7 +675,7 @@ describe(createFetchHttpClient, () => {
 	it.for([{ status: 404 }, { status: 500 }])(
 		"should return ApiError preserving status for empty-body $status responses",
 		async ({ status }) => {
-			expect.assertions(3);
+			expect.assertions(4);
 
 			async function fakeFetch(): Promise<Response> {
 				return new Response(undefined, { status });
@@ -532,6 +693,7 @@ describe(createFetchHttpClient, () => {
 			expect(result.err.statusCode).toBe(status);
 			expect(result.err.message).toBe(`HTTP ${status}`);
 			expect(result.err.code).toBeUndefined();
+			expect(result.err.details).toBeUndefined();
 		},
 	);
 

--- a/packages/open-cloud/src/internal/http/fetch-client.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.ts
@@ -6,6 +6,12 @@ import type { Result } from "../../types.ts";
 import { tryCatch } from "../utils/try-catch.ts";
 import type { HttpClient, HttpRequest, HttpResponse, RequestConfig } from "./types.ts";
 
+interface ApiErrorMessageParts {
+	readonly code: string | undefined;
+	readonly message: string | undefined;
+	readonly status: number;
+}
+
 /**
  * Converts a `Headers` object to a plain record with lowercased keys.
  *
@@ -17,11 +23,16 @@ export function headersToRecord(headers: Headers): Record<string, string> {
 }
 
 /**
- * Permissively extracts a top-level `errorCode` string field from a
- * response body.
+ * Permissively extracts a machine-readable error code from a response body.
+ *
+ * Modern Open Cloud responses use `{ errorCode: string, message: string }`;
+ * the legacy game-internationalization endpoints use
+ * `{ errors: [{ code: number, message: string }, ...] }`. Both shapes are
+ * checked; numeric legacy codes are returned as strings so callers see one
+ * consistent type.
  *
  * @param body - The parsed response body (unknown shape).
- * @returns The `errorCode` string if present, otherwise `undefined`.
+ * @returns The error code if present, otherwise `undefined`.
  */
 export function extractErrorCode(body: unknown): string | undefined {
 	if (body === null || typeof body !== "object") {
@@ -29,7 +40,33 @@ export function extractErrorCode(body: unknown): string | undefined {
 	}
 
 	const errorCode: unknown = Reflect.get(body, "errorCode");
-	return typeof errorCode === "string" ? errorCode : undefined;
+	if (typeof errorCode === "string") {
+		return errorCode;
+	}
+
+	return extractLegacyCode(body);
+}
+
+/**
+ * Permissively extracts a human-readable error message from a response body.
+ *
+ * Modern Open Cloud responses expose `message` at the top level; the legacy
+ * game-internationalization endpoints nest it under `errors[0].message`.
+ *
+ * @param body - The parsed response body (unknown shape).
+ * @returns The message if present, otherwise `undefined`.
+ */
+export function extractErrorMessage(body: unknown): string | undefined {
+	if (body === null || typeof body !== "object") {
+		return undefined;
+	}
+
+	const message: unknown = Reflect.get(body, "message");
+	if (typeof message === "string") {
+		return message;
+	}
+
+	return extractLegacyMessage(body);
 }
 
 /**
@@ -133,9 +170,68 @@ export function createFetchHttpClient(
 	};
 }
 
+function readLegacyErrorEntry(body: object): object | undefined {
+	const errors: unknown = Reflect.get(body, "errors");
+	if (!Array.isArray(errors)) {
+		return undefined;
+	}
+
+	const [first] = errors;
+	if (typeof first !== "object" || first === null) {
+		return undefined;
+	}
+
+	return first;
+}
+
+function extractLegacyCode(body: object): string | undefined {
+	const first = readLegacyErrorEntry(body);
+	if (first === undefined) {
+		return undefined;
+	}
+
+	const code: unknown = Reflect.get(first, "code");
+	if (typeof code === "string") {
+		return code;
+	}
+
+	return typeof code === "number" ? String(code) : undefined;
+}
+
+function extractLegacyMessage(body: object): string | undefined {
+	const first = readLegacyErrorEntry(body);
+	if (first === undefined) {
+		return undefined;
+	}
+
+	const message: unknown = Reflect.get(first, "message");
+	return typeof message === "string" ? message : undefined;
+}
+
+function formatApiErrorMessage(parts: ApiErrorMessageParts): string {
+	const { code, message, status } = parts;
+	const base = `HTTP ${status}`;
+	if (message === undefined && code === undefined) {
+		return base;
+	}
+
+	if (message === undefined) {
+		return `${base} (code ${code})`;
+	}
+
+	if (code === undefined) {
+		return `${base}: ${message}`;
+	}
+
+	return `${base}: ${message} (code ${code})`;
+}
+
 function createApiError(status: number, body: unknown): ApiError {
-	return new ApiError(`HTTP ${status}`, {
-		code: extractErrorCode(body),
+	const code = extractErrorCode(body);
+	const message = extractErrorMessage(body);
+	return new ApiError(formatApiErrorMessage({ code, message, status }), {
+		code,
+		details: body,
 		statusCode: status,
 	});
 }

--- a/packages/open-cloud/src/internal/http/fetch-client.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.ts
@@ -39,7 +39,7 @@ export function extractErrorCode(body: unknown): string | undefined {
 		return undefined;
 	}
 
-	const errorCode: unknown = Reflect.get(body, "errorCode");
+	const errorCode = Reflect.get(body, "errorCode");
 	if (typeof errorCode === "string") {
 		return errorCode;
 	}
@@ -61,7 +61,7 @@ export function extractErrorMessage(body: unknown): string | undefined {
 		return undefined;
 	}
 
-	const message: unknown = Reflect.get(body, "message");
+	const message = Reflect.get(body, "message");
 	if (typeof message === "string") {
 		return message;
 	}
@@ -171,7 +171,7 @@ export function createFetchHttpClient(
 }
 
 function readLegacyErrorEntry(body: object): object | undefined {
-	const errors: unknown = Reflect.get(body, "errors");
+	const errors = Reflect.get(body, "errors");
 	if (!Array.isArray(errors)) {
 		return undefined;
 	}
@@ -190,7 +190,7 @@ function extractLegacyCode(body: object): string | undefined {
 		return undefined;
 	}
 
-	const code: unknown = Reflect.get(first, "code");
+	const code = Reflect.get(first, "code");
 	if (typeof code === "string") {
 		return code;
 	}
@@ -204,7 +204,7 @@ function extractLegacyMessage(body: object): string | undefined {
 		return undefined;
 	}
 
-	const message: unknown = Reflect.get(first, "message");
+	const message = Reflect.get(first, "message");
 	return typeof message === "string" ? message : undefined;
 }
 

--- a/packages/open-cloud/src/internal/http/fetch-client.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.ts
@@ -226,7 +226,7 @@ function formatApiErrorMessage(parts: ApiErrorMessageParts): string {
 	return `${base}: ${message} (code ${code})`;
 }
 
-function createApiError(status: number, body: unknown): ApiError {
+function createApiError(status: number, body: JSONValue | undefined): ApiError {
 	const code = extractErrorCode(body);
 	const message = extractErrorMessage(body);
 	return new ApiError(formatApiErrorMessage({ code, message, status }), {
@@ -244,7 +244,9 @@ function createRateLimitError(response: Response): RateLimitError {
 	});
 }
 
-async function readResponseBody(response: Response): Promise<Result<unknown, OpenCloudError>> {
+async function readResponseBody(
+	response: Response,
+): Promise<Result<JSONValue | undefined, OpenCloudError>> {
 	try {
 		const text = await response.text();
 		return { data: text === "" ? undefined : JSON.parse(text), success: true };

--- a/packages/open-cloud/src/internal/http/fetch-client.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.ts
@@ -236,12 +236,6 @@ function createApiError(status: number, body: unknown): ApiError {
 	});
 }
 
-/**
- * Classifies a fetch `Response` into a typed `Result`.
- *
- * @param response - The raw fetch Response to classify.
- * @returns A Result containing an HttpResponse on success or an OpenCloudError on failure.
- */
 function createRateLimitError(response: Response): RateLimitError {
 	return new RateLimitError("Rate limited", {
 		retryAfterSeconds: parseRetryAfterSeconds(
@@ -262,6 +256,12 @@ async function readResponseBody(response: Response): Promise<Result<unknown, Ope
 	}
 }
 
+/**
+ * Classifies a fetch `Response` into a typed `Result`.
+ *
+ * @param response - The raw fetch Response to classify.
+ * @returns A Result containing an HttpResponse on success or an OpenCloudError on failure.
+ */
 async function classifyResponse(response: Response): Promise<Result<HttpResponse, OpenCloudError>> {
 	if (response.status === 429) {
 		return { err: createRateLimitError(response), success: false };


### PR DESCRIPTION
Promote the parsed response body into ApiError so HTTP failures stop
collapsing to a bare "HTTP 400". The new message format is
`HTTP {status}: {message} (code {code})` when the body carries either
field, and the structured body itself rides as `ApiError.details` for
callers that want to inspect without re-parsing.

extractErrorCode now also walks the legacy game-internationalization
shape (`{ errors: [{ code, message }, ...] }`) used by the icon and
supported-languages endpoints, alongside the modern Open Cloud
`{ errorCode, message }` shape it already handled. Numeric legacy codes
are stringified so consumers see one consistent type.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Bedrock Architecture & Standards Compliance Review: PR #360

### ✅ Architecture (FCIS Pattern)

**Core (Pure Functions):**
- `extractErrorCode(body: unknown): string | undefined` — permissively extracts error codes from modern (`errorCode`) or legacy (`errors[0].code`) response shapes; numeric legacy codes are normalized to strings for type consistency
- `extractErrorMessage(body: unknown): string | undefined` — permissively extracts messages from modern top-level `message` or legacy `errors[0].message`
- `formatApiErrorMessage(parts)` — composes structured error parts into formatted strings (e.g., `HTTP 400: bad request (code INVALID_ARGUMENT)`)
- Helper functions (`readLegacyErrorEntry`, `extractLegacyCode`, `extractLegacyMessage`) encapsulate legacy format handling
- All core functions are side-effect-free and testable in isolation

**Shell/Adapter Boundary:**
- `createFetchHttpClient(fetchFunc?)` returns an `HttpClient` implementation with injectable `fetchFunc` for test isolation
- `ApiError` is a simple typed error class extending `OpenCloudError`; no business logic in constructors

### ✅ Testing (TDD, 100% Coverage Required)

**Comprehensive Test Coverage:**
- `extractErrorCode`: 12 test cases covering modern shape, legacy shape, numeric-to-string conversion, precedence (modern over legacy), edge cases (null, non-objects, empty arrays, invalid nested structure, non-string/number codes)
- `extractErrorMessage`: 7 test cases covering both shapes, precedence, edge cases, and undefined fallbacks
- `createFetchHttpClient`: 18+ test cases validating:
  - Successful 2xx responses with parsed body
  - Rate limit handling (429 with `x-ratelimit-reset` header)
  - API error composition with formatted message and propagated `details` field
  - All four combinations of code/message presence in formatted message
  - Network failures wrapped as `NetworkError`
  - JSON parse failures wrapped as `ApiError`
  - Empty body responses (204, 200 with no content)
- Auto-generated example test (`api-error.example.spec.ts`) from JSDoc `@example` block, verifying exact constructor usage and property assertions

**Test Isolation:**
- All HTTP tests use `fakeFetch` (injected dependency) — no real network calls
- Responses constructed inline with known status/body for deterministic assertions
- No mocking of extraction helpers themselves; they are tested as public exports with real input

**Anti-patterns avoided:**
- ✅ Tests verify real behavior (error message composition, `details` propagation) not mock setup
- ✅ No over-mocking; `extractErrorCode`/`extractErrorMessage` tested directly as pure functions
- ✅ Each test has explicit `expect.assertions(N)` declaration

### ✅ Type System & Code Quality

**Strict Typing (No `any` Found):**
- Untyped input handled with `unknown` (e.g., `body: unknown`)
- Return types explicitly typed: `string | undefined`, `number`, `Record<string, string>`
- Response types are immutable (readonly on interfaces)

**Proper Error Handling:**
- API failures surface as typed `ApiError` with:
  - `statusCode: number` 
  - `code: string | undefined` (extracted, normalized, and consistent across shapes)
  - `message: string` (formatted deterministically)
  - `details: unknown` (raw parsed body for introspection)
- JSON parse failures caught and wrapped in `ApiError` with clear message
- Network failures wrapped as `NetworkError`
- Rate limits isolated as `RateLimitError`

**Message Formatting Logic:**
- Handles all combinations: `HTTP 400: message (code CODE)` / `HTTP 400: message` / `HTTP 400 (code CODE)` / `HTTP 400`
- Format is deterministic and fully tested

### ✅ Backwards Compatibility

**Extending Without Breaking:**
- `extractErrorCode` and `extractErrorMessage` were added as new exports (not modifications to existing API)
- `ApiError.details` is optional (`details?: unknown`), so existing code constructing `ApiError` without `details` continues to work
- Modern response shape is checked first, maintaining forward compatibility if/when legacy endpoints are deprecated

**Legacy API Support:**
- Game-internationalization endpoints use `{ errors: [{ code: number, message: string }, ...] }`
- Numeric codes converted to strings transparently so callers see one consistent type
- Tests cover both numeric (e.g., `code: 22`) and string (e.g., `code: "GAME_NOT_FOUND"`) legacy codes

### ✅ Package Design Compliance

Adheres to `@bedrock/ocale` design principles (from `packages/open-cloud/CLAUDE.md`):
- **Result types over exceptions**: Error handling returns `Result<T, OpenCloudError>` with typed error cases
- **Zero dependencies**: No runtime dependencies; uses only Web APIs
- **100% test coverage**: All code paths exercised by tests
- **Subpath exports**: New functions exported from `fetch-client.ts`, appropriate for consumers importing HTTP utilities

### Summary

This PR demonstrates **exemplary TDD compliance**:
- Tests written alongside implementation with comprehensive edge case coverage
- FCIS architecture cleanly separated (pure functions + injected adapter)
- Strong typing with no `any` types and explicit error handling
- Backward-compatible extension of error handling to surface more context to callers

**Status: ✅ Ready to merge** — Fully compliant with Bedrock architecture, testing standards, and code quality requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->