### PR TITLE
chore: fall back to local mutation when remote offload fails

### DIFF
--- a/scripts/mutate-remote.ts
+++ b/scripts/mutate-remote.ts
@@ -229,6 +229,59 @@ function runLocal(): number {
 	return result.status ?? 1;
 }
 
+function containerSeesWorktree(config: RemoteConfig): boolean {
+	const result = spawnSync(
+		"ssh",
+		[
+			...SSH_OPTS,
+			config.host,
+			"docker",
+			"exec",
+			config.container,
+			"test",
+			"-d",
+			`/data/worktrees/${config.worktree}`,
+		],
+		{ stdio: ["ignore", "ignore", "pipe"] },
+	);
+	return result.status === 0;
+}
+
+function setupRemote(config: RemoteConfig): string | undefined {
+	const upStatus = rsyncUp(config);
+	if (upStatus !== 0) {
+		return `rsync to ${config.host} failed (status ${String(upStatus)})`;
+	}
+
+	if (!containerSeesWorktree(config)) {
+		return (
+			`${config.container} cannot see /data/worktrees/${config.worktree} after rsync; ` +
+			`bind mount may be detached. Fix: docker rm -f ${config.container}, then re-run ` +
+			`with -v ${config.stage}:/data/worktrees so Docker Desktop re-establishes the WSL share.`
+		);
+	}
+
+	const diff = computeDiff();
+	const diffStatus = writeFileToContainer(config, diff, REMOTE_DIFF_PATH);
+	if (diffStatus !== 0) {
+		return `writing diff to ${config.container} failed (status ${String(diffStatus)})`;
+	}
+
+	return undefined;
+}
+
+function reportLoudFailure(reason: string): void {
+	const banner = "=".repeat(64);
+	process.stderr.write(
+		`\n${banner}\nREMOTE MUTATION OFFLOAD FAILED; running mutation locally\n` +
+			`${banner}\n${reason}\n${banner}\n\n`,
+	);
+}
+
+function reportLoudFailureTrailer(reason: string): void {
+	process.stderr.write(`\n[remote offload was unavailable for this run: ${reason}]\n\n`);
+}
+
 function main(): number {
 	const config = readConfig();
 	if (config === undefined) {
@@ -242,18 +295,12 @@ function main(): number {
 		return runLocal();
 	}
 
-	const diff = computeDiff();
-
-	const upStatus = rsyncUp(config);
-	if (upStatus !== 0) {
-		console.error(`rsync to ${config.host} failed; aborting offload`);
-		return upStatus;
-	}
-
-	const diffStatus = writeFileToContainer(config, diff, REMOTE_DIFF_PATH);
-	if (diffStatus !== 0) {
-		console.error(`failed to write diff to ${config.container}; aborting offload`);
-		return diffStatus;
+	const failure = setupRemote(config);
+	if (failure !== undefined) {
+		reportLoudFailure(failure);
+		const status = runLocal();
+		reportLoudFailureTrailer(failure);
+		return status;
 	}
 
 	const execStatus = execMutate(config);

--- a/scripts/mutate-remote.ts
+++ b/scripts/mutate-remote.ts
@@ -242,7 +242,7 @@ function containerSeesWorktree(config: RemoteConfig): boolean {
 			"-d",
 			`/data/worktrees/${config.worktree}`,
 		],
-		{ stdio: ["ignore", "ignore", "pipe"] },
+		{ stdio: ["ignore", "ignore", "inherit"] },
 	);
 	return result.status === 0;
 }


### PR DESCRIPTION
## Summary

Hardens `scripts/mutate-remote.ts` against silent infrastructure rot in the SSH/Docker mutation-offload path. Three pre-execution failure modes (rsync failure, container bind mount detached from host source, diff write failure) previously aborted the commit hook with cryptic errors. They now fall back to in-process mutation with a loud banner plus an end-of-run trailer, so the commit proceeds and the agent reading tool output can't miss that the offload silently degraded.

Adds a new `containerSeesWorktree` check after rsync to catch the case where the container's `/data/worktrees` bind mount has detached from its host source. For example, after Docker Desktop's WSL bind-mount proxy goes stale, the diff write previously failed with the inscrutable `tee: No such file or directory`. The new check confirms the synced worktree is visible inside the container before attempting the diff write, and the error message embeds the exact `docker rm -f` recovery command for the next person to hit it.

Probe failure stays quiet (`note:` warning, no banner) because the host PC being off is an expected state, not a degradation.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm exec eslint scripts/mutate-remote.ts` clean
- [x] End-to-end smoke against the live container: `pnpm mutate:changed` from a clean worktree exercised the new code path (rsync, containerSeesWorktree, diff write, exec); confirmed by `cwd: /data/worktrees/<worktree>` in the script output.
- [x] Pre-commit hook green: build, mutate, and commitlint all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)