### PR TITLE
ci: sign drift commits via github graphql api

### DIFF
--- a/.github/workflows/openapi-drift.yaml
+++ b/.github/workflows/openapi-drift.yaml
@@ -26,10 +26,14 @@ jobs:
       DRIFT_TITLE: "build(ocale): refresh vendored openapi spec"
       GH_TOKEN: ${{ github.token }}
     steps:
+      # Pin to `main` so a `workflow_dispatch` from a feature branch
+      # cannot accidentally use that branch's tip as the drift base.
+      # The drift PR always targets `main`, so the base must be `main`.
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
+          ref: main
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup

--- a/.github/workflows/openapi-drift.yaml
+++ b/.github/workflows/openapi-drift.yaml
@@ -47,17 +47,30 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Reset the drift branch to the current commit before the API
+      # commit lands. No new commits are introduced by this push, so
+      # the "signed commits" ruleset has nothing to verify; the spec
+      # diff lands in the next step as a GitHub-signed commit via the
+      # GraphQL API.
       - if: steps.diff.outputs.changed == 'true'
-        name: Open or update drift PR
+        name: Reset drift branch ref to base
+        run: git push --force origin "HEAD:refs/heads/$DRIFT_BRANCH"
+
+      - if: steps.diff.outputs.changed == 'true'
+        name: Commit refreshed spec via API
+        uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
+        with:
+          commit_message: ${{ env.DRIFT_TITLE }}
+          repo: ${{ github.repository }}
+          branch: ${{ env.DRIFT_BRANCH }}
+          file_pattern: packages/open-cloud/vendor
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: steps.diff.outputs.changed == 'true'
+        name: Open drift PR if missing
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B "$DRIFT_BRANCH"
-          git add packages/open-cloud/vendor/
-          git commit -m "$DRIFT_TITLE"
-          git push --force origin "$DRIFT_BRANCH"
-
           if gh pr view "$DRIFT_BRANCH" --json number >/dev/null 2>&1; then
             echo "existing drift PR refreshed with latest spec"
           else

--- a/.github/workflows/openapi-drift.yaml
+++ b/.github/workflows/openapi-drift.yaml
@@ -56,16 +56,16 @@ jobs:
         name: Reset drift branch ref to base
         run: git push --force origin "HEAD:refs/heads/$DRIFT_BRANCH"
 
-      - if: steps.diff.outputs.changed == 'true'
+      - env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: steps.diff.outputs.changed == 'true'
         name: Commit refreshed spec via API
         uses: planetscale/ghcommit-action@25309d8005ac7c3bcd61d3fe19b69e0fe47dbdde # v0.2.20
         with:
-          commit_message: ${{ env.DRIFT_TITLE }}
-          repo: ${{ github.repository }}
           branch: ${{ env.DRIFT_BRANCH }}
+          commit_message: ${{ env.DRIFT_TITLE }}
           file_pattern: packages/open-cloud/vendor
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.repository }}
 
       - if: steps.diff.outputs.changed == 'true'
         name: Open drift PR if missing


### PR DESCRIPTION
## Summary

The `openapi-drift` workflow's [latest run](https://github.com/christopher-buss/bedrock/actions/runs/25305577674/job/74180688325) failed at the push step:

```
remote: - Commits must have verified signatures.
remote:   Found 1 violation:
```

`git commit` inside the runner produces unsigned commits, which the repo ruleset rejects.

## Change

Land the spec refresh through `planetscale/ghcommit-action`, which calls GitHub's GraphQL `createCommitOnBranch`. The resulting commit is signed by GitHub's own key and shows up as **Verified ✓** — no key management, no bypass actor, ruleset still defends every other branch.

Flow:

1. **Reset drift branch ref to base** — `git push origin HEAD:refs/heads/$DRIFT_BRANCH`. HEAD is main's tip (already verified), so no new commits are introduced and the ruleset has nothing to check.
2. **Commit refreshed spec via API** — pinned to `planetscale/ghcommit-action@25309d8` (v0.2.20). Stages files matching `packages/open-cloud/vendor` and lands them as a single signed commit on the drift branch.
3. **Open drift PR if missing** — unchanged logic, just split out from the previous step.

The `git config user.name/email` block is gone (no local commit happens anymore).

## Test plan

- [ ] `gh workflow run openapi-drift.yaml` and confirm the resulting drift PR's commit shows **Verified**
- [ ] If no drift exists upstream, manually edit `vendor/openapi.json` on a throwaway branch and dispatch to force the change path

🤖 Generated with [Claude Code](https://claude.com/claude-code)