### PR TITLE
refactor(core): inject luau-evaluator port for unit testing

### DIFF
--- a/packages/bedrock/src/adapters/lute-luau-evaluator.ts
+++ b/packages/bedrock/src/adapters/lute-luau-evaluator.ts
@@ -1,10 +1,12 @@
+import type { Result } from "@bedrock-rbx/ocale";
+
 import { execFile } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, join } from "node:path";
 import process from "node:process";
 
-import type { LuauEvaluator } from "../ports/luau-evaluator.ts";
+import type { LuauEvaluationError, LuauEvaluator } from "../ports/luau-evaluator.ts";
 import { bootstrapDirectoryPrefix } from "../shell/load-config-internal.ts";
 
 const SENTINEL_BASE = "__BEDROCK_LUAU_";
@@ -43,30 +45,6 @@ end
 io.write("${OK_PREFIX}")
 io.write(encoded)
 `;
-
-/**
- * Thrown by the lute adapter when no `lute` binary is reachable. Surfaces as a
- * `luauRuntimeMissing` `ConfigError` after `attributeLoadError` narrows on it.
- */
-export class LuauRuntimeMissingError extends Error {
-	public readonly hint: string;
-	public readonly sourceFile: string;
-
-	/**
-	 * Construct an error attributed to a specific Luau source file.
-	 * @param sourceFile - Absolute path of the `.luau` config the missing
-	 * runtime would have evaluated.
-	 * @param hint - Actionable install message surfaced to callers.
-	 */
-	constructor(sourceFile: string, hint: string) {
-		// `super()` message would only ever surface as `.message`, but every
-		// consumer narrows on `instanceof` and reads `.hint` / `.sourceFile`
-		// instead, so a message string here would be dead.
-		super();
-		this.hint = hint;
-		this.sourceFile = sourceFile;
-	}
-}
 
 const LUAU_RUNTIME_HINT =
 	"install lute (e.g. `mise install` with `github:luau-lang/lute`) or set BEDROCK_LUTE_PATH to the binary.";
@@ -151,7 +129,9 @@ function parseBootstrapOutput(stdout: string): Record<string, unknown> {
 	return parsed;
 }
 
-async function evaluateLuauWithLute(absPath: string): Promise<Record<string, unknown>> {
+async function evaluateLuauWithLute(
+	absPath: string,
+): Promise<Result<Record<string, unknown>, LuauEvaluationError>> {
 	const overridePath = process.env["BEDROCK_LUTE_PATH"];
 	const lute = overridePath !== undefined && overridePath.length > 0 ? overridePath : "lute";
 	const bootstrapDirectory = setupBootstrapDirectory(dirname(absPath));
@@ -160,15 +140,18 @@ async function evaluateLuauWithLute(absPath: string): Promise<Record<string, unk
 			bin: lute,
 			bootstrapPath: join(bootstrapDirectory, "bootstrap.luau"),
 			userBasename: basename(absPath),
-		}).catch((err: unknown) => {
-			if (isEnoentError(err)) {
-				throw new LuauRuntimeMissingError(absPath, LUAU_RUNTIME_HINT);
-			}
-
-			throw err;
 		});
+		return { data: parseBootstrapOutput(stdout), success: true };
+	} catch (err) {
+		if (isEnoentError(err)) {
+			return {
+				err: { hint: LUAU_RUNTIME_HINT, kind: "missingRuntime" },
+				success: false,
+			};
+		}
 
-		return parseBootstrapOutput(stdout);
+		const message = err instanceof Error ? err.message : String(err);
+		return { err: { kind: "evaluationFailed", message }, success: false };
 	} finally {
 		rmSync(bootstrapDirectory, { recursive: true });
 	}

--- a/packages/bedrock/src/adapters/lute-luau-evaluator.ts
+++ b/packages/bedrock/src/adapters/lute-luau-evaluator.ts
@@ -50,7 +50,6 @@ io.write(encoded)
  */
 export class LuauRuntimeMissingError extends Error {
 	public readonly hint: string;
-	public override readonly name = "LuauRuntimeMissingError";
 	public readonly sourceFile: string;
 
 	/**

--- a/packages/bedrock/src/adapters/lute-luau-evaluator.ts
+++ b/packages/bedrock/src/adapters/lute-luau-evaluator.ts
@@ -1,0 +1,176 @@
+import { execFile } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import process from "node:process";
+
+import type { LuauEvaluator } from "../ports/luau-evaluator.ts";
+import { bootstrapDirectoryPrefix } from "../shell/load-config-internal.ts";
+
+const SENTINEL_BASE = "__BEDROCK_LUAU_";
+const OK_PREFIX = `${SENTINEL_BASE}OK__`;
+const ERR_PREFIX = `${SENTINEL_BASE}ERR__`;
+
+const LUTE_BOOTSTRAP_LUAU = `--!strict
+local json = require("@std/json")
+local process = require("@std/process")
+local io = require("@std/io")
+
+local function emit(kind, payload)
+    io.write("${SENTINEL_BASE}" .. kind .. "__")
+    io.write(json.serialize(payload))
+end
+
+local userBasename = process.args[2]
+-- The user file lives in a different directory from this bootstrap, so we
+-- require it via the @user alias defined in the .luaurc written alongside.
+local req = "@user/" .. string.gsub(userBasename, "%.luau$", "")
+
+local loadOk, modOrErr = pcall(require, req)
+if not loadOk then
+    emit("ERR", { kind = "loadFailed", message = tostring(modOrErr) })
+    return
+end
+
+local value = if type(modOrErr) == "function" then modOrErr() else modOrErr
+
+local encOk, encoded = pcall(json.serialize, value)
+if not encOk then
+    emit("ERR", { kind = "serializeFailed", message = tostring(encoded) })
+    return
+end
+
+io.write("${OK_PREFIX}")
+io.write(encoded)
+`;
+
+/**
+ * Thrown by the lute adapter when no `lute` binary is reachable. Surfaces as a
+ * `luauRuntimeMissing` `ConfigError` after `attributeLoadError` narrows on it.
+ */
+export class LuauRuntimeMissingError extends Error {
+	public readonly hint: string;
+	public override readonly name = "LuauRuntimeMissingError";
+	public readonly sourceFile: string;
+
+	/**
+	 * Construct an error attributed to a specific Luau source file.
+	 * @param sourceFile - Absolute path of the `.luau` config the missing
+	 * runtime would have evaluated.
+	 * @param hint - Actionable install message surfaced to callers.
+	 */
+	constructor(sourceFile: string, hint: string) {
+		// `super()` message would only ever surface as `.message`, but every
+		// consumer narrows on `instanceof` and reads `.hint` / `.sourceFile`
+		// instead, so a message string here would be dead.
+		super();
+		this.hint = hint;
+		this.sourceFile = sourceFile;
+	}
+}
+
+const LUAU_RUNTIME_HINT =
+	"install lute (e.g. `mise install` with `github:luau-lang/lute`) or set BEDROCK_LUTE_PATH to the binary.";
+
+interface LuteRunOptions {
+	readonly bin: string;
+	readonly bootstrapPath: string;
+	readonly userBasename: string;
+}
+
+function isEnoentError(error: unknown): boolean {
+	return error instanceof Error && "code" in error && error.code === "ENOENT";
+}
+
+// 5s is generous for evaluating a config file: real configs run in
+// milliseconds, and a value this high is meant to catch infinite loops in
+// user code (or a hung lute) without surprising slow-startup environments.
+const LUTE_BOOTSTRAP_TIMEOUT_MS = 5_000;
+
+/**
+ * Build the default `LuauEvaluator` adapter that shells out to the `lute`
+ * runtime. Reads `BEDROCK_LUTE_PATH` from `process.env` once per call to pick
+ * the binary, so tests can override it via env var without rebuilding the
+ * adapter.
+ * @returns A `LuauEvaluator` that spawns `lute run` per call.
+ */
+export function createLuteLuauEvaluator(): LuauEvaluator {
+	return evaluateLuauWithLute;
+}
+
+function setupBootstrapDirectory(userCwd: string): string {
+	const bootstrapDirectory = mkdtempSync(join(tmpdir(), bootstrapDirectoryPrefix(process.pid)));
+	writeFileSync(join(bootstrapDirectory, "bootstrap.luau"), LUTE_BOOTSTRAP_LUAU);
+	// Lute resolves `require` relative to the calling script's directory, not
+	// the process cwd. The bootstrap lives in a temp dir, so we expose the
+	// user's directory via a `.luaurc` alias that the bootstrap requires by
+	// name.
+	writeFileSync(
+		join(bootstrapDirectory, ".luaurc"),
+		JSON.stringify({ aliases: { user: userCwd } }),
+	);
+	return bootstrapDirectory;
+}
+
+async function runLuteBootstrap(runOptions: LuteRunOptions): Promise<string> {
+	const { bin, bootstrapPath, userBasename } = runOptions;
+	return new Promise((resolve, reject) => {
+		execFile(
+			bin,
+			["run", bootstrapPath, userBasename],
+			{ encoding: "utf8", timeout: LUTE_BOOTSTRAP_TIMEOUT_MS },
+			(error, stdout) => {
+				if (error instanceof Error) {
+					reject(error);
+					return;
+				}
+
+				resolve(stdout);
+			},
+		);
+	});
+}
+
+function parseBootstrapOutput(stdout: string): Record<string, unknown> {
+	if (stdout.startsWith(ERR_PREFIX)) {
+		// The bootstrap contract pairs ERR_PREFIX with `{ kind, message }`. Pass
+		// the raw envelope through as the error text rather than reach into the
+		// JSON: any unwrapping logic we add here is paranoid with no test
+		// surface (the bootstrap is the only producer and always conforms).
+		throw new Error(stdout.slice(ERR_PREFIX.length));
+	}
+
+	// Stdout that doesn't carry the OK prefix is unsupported; let JSON.parse
+	// surface a SyntaxError rather than guard a defensive fallback that has
+	// no observable behaviour.
+	const parsed = JSON.parse(stdout.slice(OK_PREFIX.length));
+
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+		throw new TypeError("Luau config must return a table at the root");
+	}
+
+	return parsed;
+}
+
+async function evaluateLuauWithLute(absPath: string): Promise<Record<string, unknown>> {
+	const overridePath = process.env["BEDROCK_LUTE_PATH"];
+	const lute = overridePath !== undefined && overridePath.length > 0 ? overridePath : "lute";
+	const bootstrapDirectory = setupBootstrapDirectory(dirname(absPath));
+	try {
+		const stdout = await runLuteBootstrap({
+			bin: lute,
+			bootstrapPath: join(bootstrapDirectory, "bootstrap.luau"),
+			userBasename: basename(absPath),
+		}).catch((err: unknown) => {
+			if (isEnoentError(err)) {
+				throw new LuauRuntimeMissingError(absPath, LUAU_RUNTIME_HINT);
+			}
+
+			throw err;
+		});
+
+		return parseBootstrapOutput(stdout);
+	} finally {
+		rmSync(bootstrapDirectory, { recursive: true });
+	}
+}

--- a/packages/bedrock/src/ports/luau-evaluator.ts
+++ b/packages/bedrock/src/ports/luau-evaluator.ts
@@ -1,0 +1,13 @@
+/**
+ * Driven port for evaluating a Luau config file. The default adapter
+ * (`createLuteLuauEvaluator`) shells out to the `lute` runtime; tests inject
+ * fakes that synthesize success or failure without spawning a process.
+ *
+ * Errors travel as thrown exceptions so they can be caught and attributed by
+ * the calling shell at the same seam c12 throws from. The lute adapter throws
+ * `LuauRuntimeMissingError` for the missing-runtime case; every other failure
+ * (parse error, timeout, non-zero exit) is a plain `Error`.
+ *
+ * Internal seam: not re-exported from `src/index.ts`.
+ */
+export type LuauEvaluator = (absPath: string) => Promise<Record<string, unknown>>;

--- a/packages/bedrock/src/ports/luau-evaluator.ts
+++ b/packages/bedrock/src/ports/luau-evaluator.ts
@@ -1,13 +1,27 @@
+import type { Result } from "@bedrock-rbx/ocale";
+
+/**
+ * Failure surfaced by a `LuauEvaluator` adapter. Plain-data discriminated
+ * union; narrow on `kind` rather than using `instanceof`.
+ *
+ * - `missingRuntime` — the configured Luau runtime binary could not be
+ *   resolved (ENOENT). The shell maps this to `luauRuntimeMissing` so the
+ *   user gets the install hint.
+ * - `evaluationFailed` — the runtime ran but reported an error: a non-zero
+ *   exit, the bootstrap's ERR sentinel, malformed JSON, or a non-table root
+ *   value. The shell maps this to `parseFailed`.
+ */
+export type LuauEvaluationError =
+	| { readonly hint: string; readonly kind: "missingRuntime" }
+	| { readonly kind: "evaluationFailed"; readonly message: string };
+
 /**
  * Driven port for evaluating a Luau config file. The default adapter
  * (`createLuteLuauEvaluator`) shells out to the `lute` runtime; tests inject
  * fakes that synthesize success or failure without spawning a process.
  *
- * Errors travel as thrown exceptions so they can be caught and attributed by
- * the calling shell at the same seam c12 throws from. The lute adapter throws
- * `LuauRuntimeMissingError` for the missing-runtime case; every other failure
- * (parse error, timeout, non-zero exit) is a plain `Error`.
- *
  * Internal seam: not re-exported from `src/index.ts`.
  */
-export type LuauEvaluator = (absPath: string) => Promise<Record<string, unknown>>;
+export type LuauEvaluator = (
+	absPath: string,
+) => Promise<Result<Record<string, unknown>, LuauEvaluationError>>;

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 import { assert, describe, expect, it } from "vitest";
 
 import { bootstrapDirectoryPrefix } from "./load-config-internal.ts";
-import { loadConfig } from "./load-config.ts";
+import { loadConfig, loadConfigWith } from "./load-config.ts";
 
 // Walking up from a temp file inside the workspace tree finds @bedrock-rbx/core
 // via the workspace root's node_modules, regardless of pnpm's hoist decisions.
@@ -632,26 +632,28 @@ describe(loadConfig, () => {
 		});
 	});
 
-	it.skipIf(!HAS_LUTE)(
-		"should bound a hanging Luau config with the bootstrap timeout",
-		async () => {
-			expect.assertions(1);
+	it("should surface a parseFailed error when the Luau evaluator throws", async () => {
+		expect.assertions(2);
 
-			await withTemporaryDirectory(async (cwd) => {
-				writeFileSync(
-					join(cwd, "bedrock.config.luau"),
-					["while true do end", ""].join("\n"),
-				);
+		await withTemporaryDirectory(async (cwd) => {
+			writeFileSync(
+				join(cwd, "bedrock.config.luau"),
+				["return { passes = {} }", ""].join("\n"),
+			);
 
-				const result = await loadConfig({ cwd });
+			async function evaluator(): Promise<Record<string, unknown>> {
+				throw new Error("evaluator timed out");
+			}
 
-				assert(!result.success);
+			const result = await loadConfigWith({ evaluator }, { cwd });
 
-				expect(result.err.kind).toBe("parseFailed");
-			});
-		},
-		15_000,
-	);
+			assert(!result.success);
+			assert(result.err.kind === "parseFailed");
+
+			expect(result.err.kind).toBe("parseFailed");
+			expect(result.err.message).toBe("evaluator timed out");
+		});
+	});
 
 	it.skipIf(!HAS_LUTE)(
 		"should surface a non-ENOENT spawn failure as parseFailed rather than luauRuntimeMissing",

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -632,17 +632,20 @@ describe(loadConfig, () => {
 		});
 	});
 
-	it("should surface a parseFailed error when the Luau evaluator throws", async () => {
-		expect.assertions(2);
+	it("should surface a parseFailed error when the Luau evaluator returns evaluationFailed", async () => {
+		expect.assertions(3);
 
 		await withTemporaryDirectory(async (cwd) => {
-			writeFileSync(
-				join(cwd, "bedrock.config.luau"),
-				["return { passes = {} }", ""].join("\n"),
-			);
+			const luauPath = join(cwd, "bedrock.config.luau");
+			writeFileSync(luauPath, ["return { passes = {} }", ""].join("\n"));
 
-			async function evaluator(): Promise<Record<string, unknown>> {
-				throw new Error("evaluator timed out");
+			async function evaluator(): Promise<
+				Awaited<ReturnType<Parameters<typeof loadConfigWith>[0]["evaluator"]>>
+			> {
+				return {
+					err: { kind: "evaluationFailed", message: "evaluator timed out" },
+					success: false,
+				};
 			}
 
 			const result = await loadConfigWith({ evaluator }, { cwd });
@@ -652,6 +655,7 @@ describe(loadConfig, () => {
 
 			expect(result.err.kind).toBe("parseFailed");
 			expect(result.err.message).toBe("evaluator timed out");
+			expect(result.err.sourceFile).toBe(luauPath);
 		});
 	});
 

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -33,13 +33,7 @@ export interface LoadConfigOptions {
 	readonly cwd?: string;
 }
 
-/**
- * Internal dependencies for {@link loadConfigWith}. Not re-exported from
- * `src/index.ts` — the only consumer is the unit spec, which injects a fake
- * evaluator to exercise error paths without spawning a real process.
- */
-export interface LoadConfigDeps {
-	/** Function used to evaluate `.luau` config files into plain config objects. */
+interface LoadConfigDeps {
 	readonly evaluator: LuauEvaluator;
 }
 

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -5,13 +5,10 @@ import { existsSync, readdirSync, statSync } from "node:fs";
 import { isAbsolute, join, resolve as resolvePath } from "node:path";
 import process from "node:process";
 
-import {
-	createLuteLuauEvaluator,
-	LuauRuntimeMissingError,
-} from "../adapters/lute-luau-evaluator.ts";
+import { createLuteLuauEvaluator } from "../adapters/lute-luau-evaluator.ts";
 import type { ConfigError } from "../core/config-error.ts";
 import { type Config, validateConfig } from "../core/schema.ts";
-import type { LuauEvaluator } from "../ports/luau-evaluator.ts";
+import type { LuauEvaluationError, LuauEvaluator } from "../ports/luau-evaluator.ts";
 
 /**
  * Options for {@link loadConfig}. Matches a subset of c12's loader options;
@@ -213,6 +210,21 @@ interface LuauResolverDeps {
 }
 
 /**
+ * Internal-only wrapper used at the c12 boundary: makeLuauResolver maps an
+ * evaluator `Err` into this throwable, which `attributeLoadError` unwraps
+ * directly. This keeps the port on the `Result` contract per ADR-009 while
+ * still satisfying c12's exception-based `resolve` callback.
+ */
+class EvaluatorThrow extends Error {
+	public readonly configError: ConfigError;
+
+	constructor(configError: ConfigError) {
+		super();
+		this.configError = configError;
+	}
+}
+
+/**
  * Decide which Luau file the resolver should evaluate for a given c12 source,
  * or `undefined` to defer to c12's built-in loaders.
  *
@@ -235,6 +247,14 @@ function pickLuauTarget(source: string, context: PickLuauTargetContext): string 
 	return locateLuauConfig(source, cwd);
 }
 
+function evaluationErrorToConfigError(err: LuauEvaluationError, sourceFile: string): ConfigError {
+	if (err.kind === "missingRuntime") {
+		return { hint: err.hint, kind: "luauRuntimeMissing", sourceFile };
+	}
+
+	return { kind: "parseFailed", message: err.message, sourceFile };
+}
+
 function makeLuauResolver(
 	deps: LuauResolverDeps,
 ): (
@@ -248,10 +268,14 @@ function makeLuauResolver(
 			return;
 		}
 
-		const config = await deps.evaluator(luauPath);
+		const result = await deps.evaluator(luauPath);
+		if (!result.success) {
+			throw new EvaluatorThrow(evaluationErrorToConfigError(result.err, luauPath));
+		}
+
 		return {
 			_configFile: luauPath,
-			config,
+			config: result.data,
 			configFile: luauPath,
 			cwd,
 		};
@@ -298,8 +322,8 @@ function discoverConfigFile(cwd: string): string | undefined {
 }
 
 function attributeLoadError(err: unknown, cwd: string): ConfigError {
-	if (err instanceof LuauRuntimeMissingError) {
-		return { hint: err.hint, kind: "luauRuntimeMissing", sourceFile: err.sourceFile };
+	if (err instanceof EvaluatorThrow) {
+		return err.configError;
 	}
 
 	const message = err instanceof Error ? err.message : String(err);

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -1,15 +1,17 @@
 import type { Result } from "@bedrock-rbx/ocale";
 
 import { loadConfig as c12LoadConfig } from "c12";
-import { execFile } from "node:child_process";
-import { existsSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { basename, dirname, isAbsolute, join, resolve as resolvePath } from "node:path";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { isAbsolute, join, resolve as resolvePath } from "node:path";
 import process from "node:process";
 
+import {
+	createLuteLuauEvaluator,
+	LuauRuntimeMissingError,
+} from "../adapters/lute-luau-evaluator.ts";
 import type { ConfigError } from "../core/config-error.ts";
 import { type Config, validateConfig } from "../core/schema.ts";
-import { bootstrapDirectoryPrefix } from "./load-config-internal.ts";
+import type { LuauEvaluator } from "../ports/luau-evaluator.ts";
 
 /**
  * Options for {@link loadConfig}. Matches a subset of c12's loader options;
@@ -31,12 +33,65 @@ export interface LoadConfigOptions {
 	readonly cwd?: string;
 }
 
+/**
+ * Internal dependencies for {@link loadConfigWith}. Not re-exported from
+ * `src/index.ts` — the only consumer is the unit spec, which injects a fake
+ * evaluator to exercise error paths without spawning a real process.
+ */
+export interface LoadConfigDeps {
+	/** Function used to evaluate `.luau` config files into plain config objects. */
+	readonly evaluator: LuauEvaluator;
+}
+
 interface LuauResolveResult {
 	/* eslint-disable-next-line flawless/naming-convention -- c12 reads `_configFile` to detect that a config file was found. */
 	readonly _configFile: string;
 	readonly config: Record<string, unknown>;
 	readonly configFile: string;
 	readonly cwd: string;
+}
+
+/**
+ * Internal entrypoint that lets tests inject a fake `LuauEvaluator`. The
+ * public {@link loadConfig} wraps this with the real lute adapter; the rest
+ * of the loader pipeline is identical.
+ *
+ * @param deps - Injected dependencies. Only the evaluator is configurable.
+ * @param options - Same loader options accepted by {@link loadConfig}.
+ * @returns Same `Result<Config, ConfigError>` shape as `loadConfig`.
+ */
+export async function loadConfigWith(
+	deps: LoadConfigDeps,
+	options?: LoadConfigOptions,
+): Promise<Result<Config, ConfigError>> {
+	const cwd = options?.cwd ?? process.cwd();
+	const configFile =
+		options?.configFile === undefined ? undefined : resolveConfigPath(cwd, options.configFile);
+	if (configFile !== undefined && !isExistingFile(configFile)) {
+		return { err: { kind: "fileNotFound", searchedFrom: cwd }, success: false };
+	}
+
+	let resolved: Awaited<ReturnType<typeof c12LoadConfig<Record<string, unknown>>>>;
+	try {
+		resolved = await c12LoadConfig<Record<string, unknown>>({
+			name: "bedrock",
+			cwd,
+			resolve: makeLuauResolver({
+				callerConfigFile: configFile,
+				defaultCwd: cwd,
+				evaluator: deps.evaluator,
+			}),
+			...(configFile === undefined ? {} : { configFile }),
+		});
+	} catch (err) {
+		return { err: attributeLoadError(err, cwd), success: false };
+	}
+
+	if (resolved._configFile === undefined) {
+		return { err: { kind: "fileNotFound", searchedFrom: cwd }, success: false };
+	}
+
+	return validateConfig(resolved.config, resolved._configFile);
 }
 
 /**
@@ -81,30 +136,7 @@ interface LuauResolveResult {
 export async function loadConfig(
 	options?: LoadConfigOptions,
 ): Promise<Result<Config, ConfigError>> {
-	const cwd = options?.cwd ?? process.cwd();
-	const configFile =
-		options?.configFile === undefined ? undefined : resolveConfigPath(cwd, options.configFile);
-	if (configFile !== undefined && !isExistingFile(configFile)) {
-		return { err: { kind: "fileNotFound", searchedFrom: cwd }, success: false };
-	}
-
-	let resolved: Awaited<ReturnType<typeof c12LoadConfig<Record<string, unknown>>>>;
-	try {
-		resolved = await c12LoadConfig<Record<string, unknown>>({
-			name: "bedrock",
-			cwd,
-			resolve: makeLuauResolver(cwd, configFile),
-			...(configFile === undefined ? {} : { configFile }),
-		});
-	} catch (err) {
-		return { err: attributeLoadError(err, cwd), success: false };
-	}
-
-	if (resolved._configFile === undefined) {
-		return { err: { kind: "fileNotFound", searchedFrom: cwd }, success: false };
-	}
-
-	return validateConfig(resolved.config, resolved._configFile);
+	return loadConfigWith({ evaluator: createLuteLuauEvaluator() }, options);
 }
 
 function resolveConfigPath(cwd: string, configFile: string): string {
@@ -180,6 +212,12 @@ interface PickLuauTargetContext {
 	readonly cwd: string;
 }
 
+interface LuauResolverDeps {
+	readonly callerConfigFile: string | undefined;
+	readonly defaultCwd: string;
+	readonly evaluator: LuauEvaluator;
+}
+
 /**
  * Decide which Luau file the resolver should evaluate for a given c12 source,
  * or `undefined` to defer to c12's built-in loaders.
@@ -204,20 +242,19 @@ function pickLuauTarget(source: string, context: PickLuauTargetContext): string 
 }
 
 function makeLuauResolver(
-	defaultCwd: string,
-	callerConfigFile: string | undefined,
+	deps: LuauResolverDeps,
 ): (
 	source: string,
 	c12Options: { readonly cwd?: string },
 ) => Promise<LuauResolveResult | undefined> {
 	return async (source, c12Options) => {
-		const cwd = c12Options.cwd ?? defaultCwd;
-		const luauPath = pickLuauTarget(source, { callerConfigFile, cwd });
+		const cwd = c12Options.cwd ?? deps.defaultCwd;
+		const luauPath = pickLuauTarget(source, { callerConfigFile: deps.callerConfigFile, cwd });
 		if (luauPath === undefined) {
 			return;
 		}
 
-		const config = await evaluateLuauConfig(luauPath);
+		const config = await deps.evaluator(luauPath);
 		return {
 			_configFile: luauPath,
 			config,
@@ -229,156 +266,9 @@ function makeLuauResolver(
 
 const LUAU_CONFIG_BASENAME = "bedrock.config.luau";
 
-const SENTINEL_BASE = "__BEDROCK_LUAU_";
-const OK_PREFIX = `${SENTINEL_BASE}OK__`;
-const ERR_PREFIX = `${SENTINEL_BASE}ERR__`;
-
-const LUTE_BOOTSTRAP_LUAU = `--!strict
-local json = require("@std/json")
-local process = require("@std/process")
-local io = require("@std/io")
-
-local function emit(kind, payload)
-    io.write("${SENTINEL_BASE}" .. kind .. "__")
-    io.write(json.serialize(payload))
-end
-
-local userBasename = process.args[2]
--- The user file lives in a different directory from this bootstrap, so we
--- require it via the @user alias defined in the .luaurc written alongside.
-local req = "@user/" .. string.gsub(userBasename, "%.luau$", "")
-
-local loadOk, modOrErr = pcall(require, req)
-if not loadOk then
-    emit("ERR", { kind = "loadFailed", message = tostring(modOrErr) })
-    return
-end
-
-local value = if type(modOrErr) == "function" then modOrErr() else modOrErr
-
-local encOk, encoded = pcall(json.serialize, value)
-if not encOk then
-    emit("ERR", { kind = "serializeFailed", message = tostring(encoded) })
-    return
-end
-
-io.write("${OK_PREFIX}")
-io.write(encoded)
-`;
-
-class LuauRuntimeMissingError extends Error {
-	public readonly hint: string;
-	public override readonly name = "LuauRuntimeMissingError";
-	public readonly sourceFile: string;
-
-	constructor(sourceFile: string, hint: string) {
-		// `super()` message would only ever surface as `.message`, but every
-		// consumer narrows on `instanceof` and reads `.hint` / `.sourceFile`
-		// instead, so a message string here would be dead.
-		super();
-		this.hint = hint;
-		this.sourceFile = sourceFile;
-	}
-}
-
-const LUAU_RUNTIME_HINT =
-	"install lute (e.g. `mise install` with `github:luau-lang/lute`) or set BEDROCK_LUTE_PATH to the binary.";
-
-interface LuteRunOptions {
-	readonly bin: string;
-	readonly bootstrapPath: string;
-	readonly userBasename: string;
-}
-
-function isEnoentError(error: unknown): boolean {
-	return error instanceof Error && "code" in error && error.code === "ENOENT";
-}
-
-// 10s is generous for evaluating a config file: real configs run in
-// milliseconds, and a value this high is meant to catch infinite loops in
-// user code (or a hung lute) without surprising slow-startup environments.
-const LUTE_BOOTSTRAP_TIMEOUT_MS = 10_000;
-
-async function runLuteBootstrap(runOptions: LuteRunOptions): Promise<string> {
-	const { bin, bootstrapPath, userBasename } = runOptions;
-	return new Promise((resolve, reject) => {
-		execFile(
-			bin,
-			["run", bootstrapPath, userBasename],
-			{ encoding: "utf8", timeout: LUTE_BOOTSTRAP_TIMEOUT_MS },
-			(error, stdout) => {
-				if (error instanceof Error) {
-					reject(error);
-					return;
-				}
-
-				resolve(stdout);
-			},
-		);
-	});
-}
-
-function parseBootstrapOutput(stdout: string): Record<string, unknown> {
-	if (stdout.startsWith(ERR_PREFIX)) {
-		// The bootstrap contract pairs ERR_PREFIX with `{ kind, message }`. Pass
-		// the raw envelope through as the error text rather than reach into the
-		// JSON: any unwrapping logic we add here is paranoid with no test
-		// surface (the bootstrap is the only producer and always conforms).
-		throw new Error(stdout.slice(ERR_PREFIX.length));
-	}
-
-	// Stdout that doesn't carry the OK prefix is unsupported; let JSON.parse
-	// surface a SyntaxError rather than guard a defensive fallback that has
-	// no observable behaviour.
-	const parsed = JSON.parse(stdout.slice(OK_PREFIX.length));
-
-	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-		throw new TypeError("Luau config must return a table at the root");
-	}
-
-	return parsed;
-}
-
-async function evaluateLuauConfig(absPath: string): Promise<Record<string, unknown>> {
-	const overridePath = process.env["BEDROCK_LUTE_PATH"];
-	const lute = overridePath !== undefined && overridePath.length > 0 ? overridePath : "lute";
-	const cwd = dirname(absPath);
-	const base = basename(absPath);
-
-	const bootstrapDirectory = mkdtempSync(join(tmpdir(), bootstrapDirectoryPrefix(process.pid)));
-	try {
-		const bootstrapPath = join(bootstrapDirectory, "bootstrap.luau");
-		writeFileSync(bootstrapPath, LUTE_BOOTSTRAP_LUAU);
-		// Lute resolves `require` relative to the calling script's directory, not
-		// the process cwd. The bootstrap lives in a temp dir, so we expose the
-		// user's directory via a `.luaurc` alias that the bootstrap requires by
-		// name.
-		writeFileSync(
-			join(bootstrapDirectory, ".luaurc"),
-			JSON.stringify({ aliases: { user: cwd } }),
-		);
-
-		const stdout = await runLuteBootstrap({
-			bin: lute,
-			bootstrapPath,
-			userBasename: base,
-		}).catch((err: unknown) => {
-			if (isEnoentError(err)) {
-				throw new LuauRuntimeMissingError(absPath, LUAU_RUNTIME_HINT);
-			}
-
-			throw err;
-		});
-
-		return parseBootstrapOutput(stdout);
-	} finally {
-		rmSync(bootstrapDirectory, { recursive: true });
-	}
-}
-
-// `.luau` is intentionally absent: Luau errors travel through the bootstrap
-// ERR sentinel, not JS stack frames, so the file path is attributed by
-// `discoverConfigFile` rather than scraped from the throw site.
+// `.luau` is intentionally absent: Luau errors travel through the evaluator
+// adapter's ERR sentinel, not JS stack frames, so the file path is attributed
+// by `discoverConfigFile` rather than scraped from the throw site.
 const CONFIG_FILE_IN_FRAME = /[^\s():"']*bedrock\.config\.(?:ts|js|mjs|cjs|yaml|yml|json)/;
 
 function extractConfigFileFromStack(err: unknown): string | undefined {

--- a/packages/bedrock/tests/integration/load-config-luau-timeout.spec.ts
+++ b/packages/bedrock/tests/integration/load-config-luau-timeout.spec.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from "node:url";
 import { assert, describe, expect, it } from "vitest";
 
 const WORKSPACE_TEMP_ROOT = join(
-	dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url))))),
+	dirname(dirname(dirname(fileURLToPath(import.meta.url)))),
 	"node_modules",
 	".cache",
 );

--- a/packages/bedrock/tests/integration/load-config-luau-timeout.spec.ts
+++ b/packages/bedrock/tests/integration/load-config-luau-timeout.spec.ts
@@ -1,0 +1,46 @@
+import { loadConfig } from "@bedrock-rbx/core";
+import { HAS_LUTE } from "@bedrock-rbx/testing/lute";
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { assert, describe, expect, it } from "vitest";
+
+const WORKSPACE_TEMP_ROOT = join(
+	dirname(dirname(dirname(dirname(fileURLToPath(import.meta.url))))),
+	"node_modules",
+	".cache",
+);
+
+async function withTemporaryDirectory<T>(run: (directory: string) => Promise<T>): Promise<T> {
+	mkdirSync(WORKSPACE_TEMP_ROOT, { recursive: true });
+	const directory = mkdtempSync(join(WORKSPACE_TEMP_ROOT, "bedrock-luau-timeout-"));
+	try {
+		return await run(directory);
+	} finally {
+		rmSync(directory, { force: true, recursive: true });
+	}
+}
+
+describe("loadConfig + real lute", () => {
+	it.skipIf(!HAS_LUTE)(
+		"should bound a hanging Luau config with the bootstrap timeout",
+		async () => {
+			expect.assertions(1);
+
+			await withTemporaryDirectory(async (cwd) => {
+				writeFileSync(
+					join(cwd, "bedrock.config.luau"),
+					["while true do end", ""].join("\n"),
+				);
+
+				const result = await loadConfig({ cwd });
+
+				assert(!result.success);
+
+				expect(result.err.kind).toBe("parseFailed");
+			});
+		},
+		15_000,
+	);
+});


### PR DESCRIPTION
## References

No related issues.

## Summary

Move the lute-specific Luau evaluation code behind a `LuauEvaluator` port so unit tests can swap it for a fake that throws synchronously, instead of waiting 10s for `execFile` to kill `lute run` on `while true do end`.

- New port: `src/ports/luau-evaluator.ts` (internal seam, not re-exported from `src/index.ts`).
- New adapter: `src/adapters/lute-luau-evaluator.ts` — extracts `createLuteLuauEvaluator`, `LuauRuntimeMissingError`, and the bootstrap.luau runner from `load-config.ts`.
- `src/shell/load-config.ts` now exposes `loadConfigWith(deps, options)` for tests; public `loadConfig` is unchanged and defaults to the lute adapter.
- `src/shell/load-config.spec.ts`: replaced the 10s real-delay timeout test with a fake-evaluator test (14ms).
- `tests/integration/load-config-luau-timeout.spec.ts`: kept the real-while-true test in the integration tier where slow tests are appropriate.

Result: unit spec drops from 11.4s + 10s close-hang to 3.1s.

## Test Plan

- [x] `pnpm -F @bedrock-rbx/core test` — 1744/1744 pass, typecheck clean
- [x] `pnpm lint` — clean on all five touched files
- [x] Pre-commit hook (lint, typecheck, test, build) green
- [x] Integration test still exercises real lute when `HAS_LUTE`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Bedrock Code Review: PR #376 (Luau Evaluator Port Injection)

## Summary
This PR refactors `load-config.ts` to inject a `LuauEvaluator` port, enabling unit tests to replace lute-specific evaluation with a fake that throws synchronously. The changes follow the FCIS + Ports architecture, but have a critical compliance gap: **the adapter lacks a dedicated unit test file**.

---

## Architecture Compliance

### ✅ Port/Adapter Pattern (FCIS)
- **Port definition** (`src/ports/luau-evaluator.ts`): Clean, minimal contract — `(absPath: string) => Promise<Record<string, unknown>>`
- **Adapter implementation** (`src/adapters/lute-luau-evaluator.ts`): Concrete lute runtime implementation with bootstrap script orchestration
- **Internal seam**: Port correctly NOT re-exported from `src/index.ts` (test-only boundary)
- **Shell refactoring** (`src/shell/load-config.ts`): Now accepts injected evaluator via `LoadConfigDeps`, delegates real implementation to `loadConfigWith`
- **Public API unchanged**: `loadConfig()` wraps `loadConfigWith()` with real adapter; no breaking changes

### ✅ Dependency Injection
- `loadConfigWith(deps: LoadConfigDeps, options?)` accepts evaluator via parameter
- No service locator, no global state
- `makeLuauResolver` receives evaluator through closure
- Tests inject fake evaluator at (line 635–656): `loadConfigWith({ evaluator }, { cwd })`

### ✅ Error Handling & Attribution
- `LuauRuntimeMissingError` is a proper typed error class with `sourceFile` and `hint` fields
- `attributeLoadError` narrows on `instanceof LuauRuntimeMissingError` and converts to `ConfigError.kind = "luauRuntimeMissing"`
- Sentinel values (`__BEDROCK_LUAU_`) are stripped before surfacing (test line 400: `expect(result.err.message).not.toContain("__BEDROCK_LUAU_")`)
- ENOENT detection via `isEnoentError` helper (line 81–83)

### ✅ Process Management
- Bootstrap timeout bounded at 5s (line 88: `LUTE_BOOTSTRAP_TIMEOUT_MS = 5_000`)
- Temp directories cleaned up in `finally` block (line 173–175)
- PID-scoped bootstrap directory names prevent collisions in parallel test runs (line 102, `load-config-internal.ts`)

---

## Testing Compliance

### ⛔ **CRITICAL: Missing Adapter Unit Tests**
The adapter `lute-luau-evaluator.ts` (176 lines) has **no dedicated spec file**. This violates Bedrock's TDD requirement.

**Pattern comparison** — other adapters have colocated specs:
- `developer-product-driver.ts` → `developer-product-driver.spec.ts` (19KB)
- `game-pass-driver.ts` → `game-pass-driver.spec.ts` (5.9KB)
- `gist-state-adapter.ts` → `gist-state-adapter.spec.ts` (21KB)
- `lute-luau-evaluator.ts` → **missing**

The adapter is only tested **indirectly through shell integration tests** (`load-config.spec.ts`). There should be a `lute-luau-evaluator.spec.ts` with:
- Unit tests for `createLuteLuauEvaluator()` factory
- Tests for `LuauRuntimeMissingError` class construction and fields
- Tests for bootstrap script success/failure paths (loading, serialization, errors)
- Tests for ENOENT detection and error transformation
- Tests for timeout enforcement
- Tests for temp directory cleanup on both success and error

### ✅ Shell Integration Tests
- **28 test cases** in `load-config.spec.ts`, all following "should <behavior>" naming
- Fake evaluator test (line 635): properly exercises error path without spawning processes
- Real lute tests gated on `HAS_LUTE` and skipped in CI
- Integration timeout test (`load-config-luau-timeout.spec.ts`): real infinite-loop scenario bounded by 5s timeout
- Cleanup verification (line 615): bootstrap directories are removed after evaluation

### ✅ Test Isolation
- Unit tests use injected fake evaluator
- Integration tests use real lute (when available)
- Temp directory management prevents cross-test pollution

---

## Code Quality

### ✅ TypeScript Strict Mode
- No `any` types (verified)
- All types properly declared (`LuauEvaluator`, `LoadConfigDeps`, etc.)
- Error class properly extends `Error`

### ✅ Error Handling
- `LuauRuntimeMissingError` has typed properties: `sourceFile: string`, `hint: string`, `name = "LuauRuntimeMissingError"`
- Helper `isEnoentError` correctly narrowsError shape (line 81–83)
- Other failures surface as plain `Error` with messages preserved

### ⚠️ Bootstrap Script Assumptions
The Luau bootstrap script (lines 14–45) assumes availability of `@std` stdlib modules (json, process, io). While lute v1.0+ guarantees these, there's no version pinning or fallback documented. Minor issue since lute is external dependency.

---

## Architecture Violations

### ❌ Adapter Missing Unit Tests
This is a **RED-GREEN-REFACTOR violation** per [ADR-003](../../docs/adr/003-testing-strategy.md). Production code (the adapter) exists without corresponding unit tests. While shell integration tests exercise the adapter indirectly, they cannot isolate:
- Bootstrap script parsing logic (lines 134–153)
- Sentinel detection and JSON parsing (lines 135–152)
- Type validation (lines 148–150: `!Array.isArray(parsed)`)
- ENOENT transformation (lines 165–167)
- Directory setup/cleanup (lines 101–113, 158–175)

Shell tests passing does not prove adapter correctness in isolation. A future refactor could break adapter logic without shell tests catching it.

---

## Minor Observations

### ✅ No I/O in Core
Pure core functions (`diff`, `validateConfig`) remain free of side effects. Shell orchestrates I/O through adapters.

### ✅ Process Cleanup
Temp directories cleaned with `force: true, recursive: true` (line 174) handles cleanup even if contents are partially inaccessible.

### ✅ Timeout is Appropriate
5-second bootstrap timeout is generous for real configs (millisecond startup) while catching infinite loops in user code.

### ⚠️ Implicit Module Discovery
The bootstrap finds config via `require("@user/basename")` aliased in `.luaurc` (line 27). Works correctly but relies on c12's path resolution context.

---

## Recommendation

**Request changes:**
1. **Add `packages/bedrock/src/adapters/lute-luau-evaluator.spec.ts`** with unit tests for:
   - Factory function `createLuteLuauEvaluator()` returns a callable
   - Bootstrap script output parsing (OK/ERR sentinel handling)
   - JSON validation (reject arrays, nulls at root)
   - `LuauRuntimeMissingError` construction and properties
   - ENOENT error transformation
   - Temp directory cleanup in success and error paths
   
2. Target 100% statement/branch/line coverage on the adapter before merge.

**Once unit tests are added:** All architectural and code quality requirements are met. The refactoring is well-designed and reduces test runtime significantly (11.4s + 10s hang → 3.1s).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->