### PR TITLE
chore: add sandcastle:build script with explicit dockerfile flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"lint:unused": "knip --cache",
 		"mutate:changed": "bun scripts/mutate-changed.ts",
 		"sandcastle": "node .sandcastle/main.ts",
+		"sandcastle:build": "sandcastle docker build-image --dockerfile .sandcastle/Dockerfile",
 		"test": "vp test",
 		"test:affected": "vp test",
 		"test:ci": "vp test --coverage && pnpm coverage:merge",


### PR DESCRIPTION
## Summary

- Add `pnpm sandcastle:build` that runs `sandcastle docker build-image --dockerfile .sandcastle/Dockerfile`. The bare CLI defaults the build context to `.sandcastle/`, which makes the Dockerfile's `COPY mise.toml` / `COPY package.json` steps fail; passing `--dockerfile` flips the context to the repo root.

## Test plan

- [x] `pnpm sandcastle:build` produces the `sandcastle:bedrock` image end-to-end.
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`, `pnpm mutate:changed` (all green via pre-push `hk`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)