### PR TITLE
chore: repair worktree gitdir pointer in sandcastle sandboxes

### DIFF
--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -34,7 +34,6 @@ import { execSync } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import process from "node:process";
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -114,8 +113,12 @@ const HOST_USER_EMAIL = execSync("git config --get user.email").toString().trim(
 // resolve the worktree's gitdir pointer; without this mount the pointer
 // inside the container references a host filesystem path that does not
 // exist, and any operation that opens the repo (hk check, git status,
-// git commit) fails.
-const HOST_GIT_DIR = join(process.cwd(), ".git");
+// git commit) fails. --git-common-dir resolves to the main .git even when
+// sandcastle is invoked from a subdirectory or from one of the host's own
+// linked worktrees.
+const HOST_GIT_DIR = execSync("git rev-parse --path-format=absolute --git-common-dir")
+	.toString()
+	.trim();
 
 const sandboxMounts = [
 	{ hostPath: PNPM_STORE_HOST_DIR, sandboxPath: "/home/agent/.pnpm-store" },
@@ -198,9 +201,12 @@ const REPAIR_WORKTREE_GIT = [
 	"git config --global --add safe.directory /home/agent/.git-main",
 	"git config --global gc.auto 0",
 	'name=$(basename "$(sed -n "s/^gitdir: //p" /home/agent/workspace/.git)")',
+	'{ [ -n "$name" ] && [ "$name" != "." ]; } || { echo "REPAIR_WORKTREE_GIT: cannot parse worktree name from /home/agent/workspace/.git" >&2; exit 1; }',
 	'echo "gitdir: /home/agent/.git-main/worktrees/$name" > /home/agent/workspace/.git',
 	"git -C /home/agent/workspace worktree repair",
-	"git config --file /home/agent/.git-main/config extensions.worktreeConfig true",
+	// Set extensions.worktreeConfig only when missing so we leave the host
+	// repo's .git/config untouched on subsequent sandbox spawns.
+	"git config --file /home/agent/.git-main/config --get extensions.worktreeConfig 2>/dev/null | grep -qx true || git config --file /home/agent/.git-main/config extensions.worktreeConfig true",
 	"mkdir -p /home/agent/.git-hooks",
 	"git -C /home/agent/workspace config --worktree core.hooksPath /home/agent/.git-hooks",
 ].join(" && ");

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -34,6 +34,7 @@ import { execSync } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import process from "node:process";
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -108,6 +109,14 @@ if (!existsSync(SIGNING_KEY_PATH)) {
 const HOST_USER_NAME = execSync("git config --get user.name").toString().trim();
 const HOST_USER_EMAIL = execSync("git config --get user.email").toString().trim();
 
+// Host path of the main repo's .git directory. Bind-mounted into worktree
+// sandboxes (Phases 2-4) so that libgit2-based tools (hk, git itself) can
+// resolve the worktree's gitdir pointer; without this mount the pointer
+// inside the container references a host filesystem path that does not
+// exist, and any operation that opens the repo (hk check, git status,
+// git commit) fails.
+const HOST_GIT_DIR = join(process.cwd(), ".git");
+
 const sandboxMounts = [
 	{ hostPath: PNPM_STORE_HOST_DIR, sandboxPath: "/home/agent/.pnpm-store" },
 	{
@@ -120,6 +129,15 @@ const sandboxMounts = [
 		readonly: true,
 		sandboxPath: "/home/agent/.ssh/sandcastle_signing.pub",
 	},
+];
+
+// Mounts shared by designer/implementer/reviewer sandboxes (Phases 2-4).
+// The planner sandbox (Phase 1) runs from the host repo cwd directly, so
+// its .git is a real directory inside the bind-mount and needs no extra
+// mount.
+const worktreeSandboxMounts = [
+	...sandboxMounts,
+	{ hostPath: HOST_GIT_DIR, sandboxPath: "/home/agent/.git-main" },
 ];
 
 const sandboxEnvironment = {
@@ -147,6 +165,46 @@ const CONFIGURE_GIT_SIGNING = [
 	"git config --global tag.gpgsign true",
 ].join(" && ");
 
+// cspell:ignore gitdir libgit
+// Repair the worktree's gitdir pointer so the in-container paths line up
+// with the new bind-mount of <main>/.git at /home/agent/.git-main.
+//
+// Each step:
+//   - cd /: git config and safe.directory inspect the current repo, which
+//     would otherwise follow the still-broken pointer in /home/agent/workspace
+//     and abort the hook before we get a chance to fix it.
+//   - safe.directory entries: container UID (host UID, e.g. 501 on macOS)
+//     does not match the file ownership inside the bind-mounts, so libgit2
+//     refuses to open them without an explicit allow-list.
+//   - gc.auto 0: prevents a sandbox-side gc/repack from racing the host's
+//     concurrent git operations on the shared <main>/.git/objects.
+//   - rewrite the worktree's .git pointer to the in-container .git-main path.
+//     Sed extracts the worktree name from the existing (broken) pointer so
+//     this works for any host path layout, not just sandcastle's. Without
+//     this step `git worktree repair` itself fails because it tries to read
+//     the broken pointer first.
+//   - git worktree repair: official tool that writes the matching gitdir
+//     file on the main side; idempotent if paths already match.
+//   - extensions.worktreeConfig + core.hooksPath isolation: <main>/.git/hooks
+//     is shared across every worktree, including the host's. Without this,
+//     `hk install --mise` (next hook step) would overwrite the host's hooks
+//     with sandbox-flavoured ones, and a misbehaving sandbox could install
+//     a hook that fires on the next host commit. Setting core.hooksPath at
+//     --worktree scope keeps each sandbox's hooks in /home/agent/.git-hooks,
+//     leaving the host's .git/hooks untouched.
+const REPAIR_WORKTREE_GIT = [
+	"cd /",
+	"git config --global --add safe.directory /home/agent/workspace",
+	"git config --global --add safe.directory /home/agent/.git-main",
+	"git config --global gc.auto 0",
+	'name=$(basename "$(sed -n "s/^gitdir: //p" /home/agent/workspace/.git)")',
+	'echo "gitdir: /home/agent/.git-main/worktrees/$name" > /home/agent/workspace/.git',
+	"git -C /home/agent/workspace worktree repair",
+	"git config --file /home/agent/.git-main/config extensions.worktreeConfig true",
+	"mkdir -p /home/agent/.git-hooks",
+	"git -C /home/agent/workspace config --worktree core.hooksPath /home/agent/.git-hooks",
+].join(" && ");
+
 // Hooks for designer/implementer/reviewer sandboxes (Phases 2-4). These run
 // inside an isolated git worktree, so `pnpm install` writing linux-arm64
 // native addons is contained.
@@ -159,6 +217,7 @@ const implementerHooks = {
 	sandbox: {
 		onSandboxReady: [
 			{ command: REGISTER_HOST_UID },
+			{ command: REPAIR_WORKTREE_GIT },
 			{ command: CONFIGURE_GIT_SIGNING },
 			{ command: "hk install --mise" },
 			{ command: "CI=true pnpm install", timeoutMs: 300_000 },
@@ -273,7 +332,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
 					branch: issue.branch,
 					copyToWorktree,
 					hooks: implementerHooks,
-					sandbox: docker({ env: sandboxEnvironment, mounts: sandboxMounts }),
+					sandbox: docker({ env: sandboxEnvironment, mounts: worktreeSandboxMounts }),
 				});
 
 				const planPath = `.sandcastle/plans/${issue.id}.md`;


### PR DESCRIPTION
## Summary

- `hk` and any libgit2-based tool fail inside sandcastle worktree sandboxes because the worktree's `.git` pointer file embeds an absolute host path (`/Users/.../bedrock/.sandcastle/worktrees/...`) that does not exist inside the container. Anything that opens the repo (`hk check`, `git status`, `git commit`, lint-staged) errors out with `failed to open directory '/Users/.../...'`.
- Bind-mount the host's main `.git` at `/home/agent/.git-main` and add an `onSandboxReady` step that rewrites the worktree's `.git` pointer to the in-container path, then runs `git worktree repair` to update the matching `gitdir` file on the main side. `git worktree repair` is git's official tool for exactly this, and is idempotent if paths already match.
- Isolate each sandbox's hooks via per-worktree `core.hooksPath` (under `extensions.worktreeConfig`) so `hk install --mise` writes to `/home/agent/.git-hooks/` instead of the shared `<main>/.git/hooks/` that the host also uses. Without this, a misbehaving sandbox could install a hook that fires on the host's next git operation.
- Add `safe.directory` entries for both bind-mounts (host UID does not match the in-container file ownership) and `gc.auto=0` to avoid a sandbox-side gc/repack racing the host on the shared object database.
- The planner sandbox is unchanged: it bind-mounts the host repo cwd directly, so its `.git` is a real directory and needs no repair.

## Test plan

- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` (3075 pass), `pnpm build`, `pnpm mutate:changed` (all green via pre-commit `hk`).
- [x] End-to-end test inside a fresh `sandcastle:bedrock` container against a throwaway worktree:
  - hook sequence completes cleanly
  - `git status` works inside the container
  - `hk install --mise` writes hooks to `/home/agent/.git-hooks/`, not to the shared `<main>/.git/hooks/`
  - host's `.git/hooks/` unchanged after the run
  - hook is idempotent on a second invocation
- [ ] Spawn a real sandcastle issue sandbox after merge and confirm `hk check` succeeds inside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Bedrock Code Review - PR #378: Repair Worktree Gitdir Pointer

## 🔴 CRITICAL ISSUE: Test Coverage Requirement Violated

**Severity: REJECT - Non-negotiable per Bedrock standards**

This PR implements infrastructure code (sandcastle configuration) that affects the entire CI/CD pipeline but contains **zero automated tests**. Per the root [CLAUDE.md](./CLAUDE.md) and [ADR-003](./docs/adr/003-testing-strategy.md):

> Every line of production code must be written in response to a failing test.

**Current state:**
- `.sandcastle/main.ts`: 414 lines, all modified code has **0% test coverage**
- No test files exist for sandcastle configuration
- No integration tests validate hook execution order
- No snapshot/contract tests for mount point configuration
- Manual "E2E test inside a fresh sandcastle container" is not captured in the test suite

**Why this matters:**
This code:
- Runs in every sandcastle sandbox (Phases 2-4: Designer/Implementer/Reviewer)
- Modifies git configuration on the shared object database
- Isolates hooks via non-standard git configuration
- Must be idempotent across concurrent sandbox invocations

Manual testing is insufficient for code that controls production infrastructure and executes on every agent invocation.

### Required Tests Before Merge

1. **Unit tests** for command string construction
   - `REPAIR_WORKTREE_GIT` commands are correctly ordered
   - Sed pattern correctly extracts worktree name from broken pointer
   - `safe.directory` entries prevent libgit2 permission errors
   
2. **Integration tests** mocking sandcastle execution
   - Hook sequence executes in correct order: `REGISTER_HOST_UID` → `REPAIR_WORKTREE_GIT` → `CONFIGURE_GIT_SIGNING` → `hk install --mise` → `pnpm install`
   - Mount configuration (`worktreeSandboxMounts`) is correctly passed to docker sandbox
   - Planner sandbox still uses `sandboxMounts` (regression test)
   
3. **Contract tests** for git state
   - `extensions.worktreeConfig` enables per-worktree git config
   - `core.hooksPath` points to `/home/agent/.git-hooks` (isolated from host)
   - `gc.auto=0` prevents concurrent garbage collection
   
4. **Error handling tests**
   - Behavior when worktree `.git` pointer doesn't exist
   - Behavior when `git worktree repair` fails
   - Idempotency: second invocation succeeds without errors

---

## Architecture Analysis (FCIS Pattern)

### ⚠️ Configuration as Code vs. Pure Data

The file mixes three layers:
- **Data**: `HOST_GIT_DIR`, `worktreeSandboxMounts` (mount configuration)
- **Orchestration**: `REPAIR_WORKTREE_GIT` command sequences (shell script logic)
- **Execution wiring**: Hook chain in `implementerHooks` object

**Current structure:** Configuration object containing shell command strings

**FCIS-compliant alternative** (consider for follow-up refactoring):
- **Core**: Pure function `buildWorktreeRepairCommands(gitMainPath, worktreePath)` → command array
- **Shell**: Wire the pure function output into the hook configuration
- **Validation**: Type-safe command ordering, not runtime string concatenation

**Current code is acceptable** because:
- `.sandcastle/main.ts` is orchestration/shell layer (not core business logic)
- No I/O side effects in configuration construction
- Strings are declarative (what commands to run, not how to run them)

But the lack of tests means the command ordering and logic cannot be verified at build time.

---

## Code Quality: Strengths

### ✅ Documentation
- Comprehensive inline comments explaining each `REPAIR_WORKTREE_GIT` step (lines 168–194)
- Clear explanation of `safe.directory` requirement and UID mismatch issue
- Rationale for `gc.auto=0` to prevent host/sandbox race
- Comments on hook isolation strategy to protect host `.git/hooks`

### ✅ Idempotency
- `git worktree repair` is idempotent (paths already matching succeeds)
- `grep -q` check prevents duplicate entries in `/etc/passwd`
- `--add safe.directory` is safe to repeat
- Design prevents sandbox corruption on retry

### ✅ Security
- `SIGNING_KEY_PATH` is readonly in mount config (line 123)
- Host UID is auto-detected and registered (not hardcoded)
- Per-worktree `core.hooksPath` isolation prevents hook injection to host
- SSH signing key is signing-only, not auth-capable

---

## Code Quality: Concerns

### ⚠️ Error Handling
- **No error propagation** from shell command failures
- Sed pattern `sed -n "s/^gitdir: //p"` could return empty string if format changes
- If `git worktree repair` fails, the error is not captured or logged
- No validation that `/home/agent/.git-main` mount was successful before using it

**Recommended addition to tests:**
```typescript
it("should fail gracefully when git pointer is malformed", () => {
  // Simulate missing .git pointer file
  // Verify command fails clearly, not with a cryptic sed error
});
```

### ⚠️ Path Validation
- Assumes `git config --file /home/agent/.git-main/config` exists and is writable
- No check that `extensions.worktreeConfig` write succeeded before proceeding
- Order dependency: `extensions.worktreeConfig` must be set BEFORE worktree-scoped config

### ⚠️ Type Safety
- `implementerHooks.sandbox.onSandboxReady` is an array of command objects
- No validation that command strings are syntactically correct shell
- Could benefit from a builder function to ensure proper ordering

---

## Design Feedback

### ✅ Planner Isolation (Correct)
The planner phase correctly remains unchanged:
- Uses `sandboxMounts` (not `worktreeSandboxMounts`)
- No `REPAIR_WORKTREE_GIT` hook (runs against host repo directly)
- Prevents rewriting host node_modules with linux-arm64 native bindings

This is the right trade-off and the test suite should verify this regression protection.

### ⚠️ Concurrent Sandbox Safety
Multiple sandboxes (Phases 2-4) run in parallel (`Promise.allSettled`, `MAX_PARALLEL=4`):
- Each runs `git worktree repair` against the **same shared `<main>/.git`**
- The `extensions.worktreeConfig` write (line 203) is racy: last sandbox to execute wins
- If worktrees have different names, ordering doesn't matter; but if they reuse names, there's potential conflict

**Question for maintainer:** Is the shared object database assumed to be on a network mount with proper locking, or is this only safe in local dev? Integration tests should clarify this assumption.

---

## Security Review: Pass

- ✅ SSH signing key properly scoped (signing-only, not auth)
- ✅ Read-only mounts for credentials
- ✅ Host `.git/hooks` protected from sandbox contamination
- ✅ Safe.directory entries prevent libgit2 permission bypass
- ✅ No secrets in config strings
- ✅ GIT environment variables follow git best practices

---

## Summary

**This PR solves a real infrastructure problem** (worktree gitdir pointer failures causing libgit2 and git operations to fail in sandboxes) **with a technically sound solution** (bind-mount + pointer repair + hook isolation). The code is well-documented and defensive.

**However, it violates Bedrock's non-negotiable TDD-first requirement.** Configuration code that runs in production CI/CD pipelines MUST have automated test coverage before merge. Manual testing demonstrates the fix works in one scenario but doesn't prove:
- Correct behavior under all mount configurations
- Idempotency across concurrent invocations
- Graceful failure modes
- Hook execution ordering
- Regression prevention (planner phase unchanged)

**Recommendation:** Request author add a test suite covering the items listed in "Required Tests Before Merge" above. Once tests are in place, this PR is ready to land.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/378)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->