### PR TITLE
feat(ocale): add list-logs to luau-execution client

### DIFF
--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/builders.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/builders.spec.ts
@@ -1,0 +1,89 @@
+import { assert, describe, expect, it } from "vitest";
+
+import { ValidationError } from "../../../errors/validation.ts";
+import { buildListLogsRequest } from "./builders.ts";
+import type { LuauExecutionTaskRef } from "./types.ts";
+
+const FULL_REF: LuauExecutionTaskRef = Object.freeze({
+	placeId: "456",
+	sessionId: "session-1",
+	taskId: "task-1",
+	universeId: "123",
+	versionId: "789",
+});
+
+describe(buildListLogsRequest, () => {
+	it("should produce a GET request for the maximal /versions/.../sessions/.../tasks/{id}/logs URL with view=STRUCTURED when no page params are supplied", () => {
+		expect.assertions(3);
+
+		const result = buildListLogsRequest({ ref: FULL_REF });
+
+		assert(result.success);
+
+		expect(result.data.method).toBe("GET");
+		expect(result.data.url).toBe(
+			"/cloud/v2/universes/123/places/456/versions/789/luau-execution-sessions/session-1/tasks/task-1/logs?view=STRUCTURED",
+		);
+		expect(result.data.url).toContain("view=STRUCTURED");
+	});
+
+	it.for([
+		["versionId", { ...FULL_REF, versionId: undefined }],
+		["sessionId", { ...FULL_REF, sessionId: undefined }],
+	] as const)(
+		"should return ValidationError incomplete_ref naming the missing %s field",
+		([field, ref]) => {
+			expect.assertions(3);
+
+			const result = buildListLogsRequest({ ref });
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ValidationError);
+			expect(result.err.code).toBe("incomplete_ref");
+			expect(result.err.message).toContain(field);
+		},
+	);
+
+	it("should serialize pageSize as the wire's maxPageSize query parameter", () => {
+		expect.assertions(1);
+
+		const result = buildListLogsRequest({ pageSize: 100, ref: FULL_REF });
+
+		assert(result.success);
+
+		expect(result.data.url).toContain("maxPageSize=100");
+	});
+
+	it("should serialize pageToken verbatim as the pageToken query parameter", () => {
+		expect.assertions(1);
+
+		const result = buildListLogsRequest({ pageToken: "tok", ref: FULL_REF });
+
+		assert(result.success);
+
+		expect(result.data.url).toContain("pageToken=tok");
+	});
+
+	it("should omit pageSize and pageToken from the URL when neither is supplied", () => {
+		expect.assertions(2);
+
+		const result = buildListLogsRequest({ ref: FULL_REF });
+
+		assert(result.success);
+
+		expect(result.data.url).not.toContain("maxPageSize");
+		expect(result.data.url).not.toContain("pageToken");
+	});
+
+	it("should include both pageSize and pageToken when both are supplied", () => {
+		expect.assertions(2);
+
+		const result = buildListLogsRequest({ pageSize: 50, pageToken: "tok", ref: FULL_REF });
+
+		assert(result.success);
+
+		expect(result.data.url).toContain("maxPageSize=50");
+		expect(result.data.url).toContain("pageToken=tok");
+	});
+});

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/builders.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/builders.ts
@@ -1,0 +1,64 @@
+import type { HttpRequest } from "../../../client/types.ts";
+import { ValidationError } from "../../../errors/validation.ts";
+import type { Result } from "../../../types.ts";
+import type { ListLogsParameters } from "./types.ts";
+
+/**
+ * Builds a `GET` request for the Open Cloud "list Luau execution session
+ * task logs" endpoint. The endpoint requires the maximal x-aep-resource
+ * path shape (universe, place, version, session, task), so the supplied
+ * ref must include `versionId` and `sessionId`; refs extracted from the
+ * narrower path formats are rejected with a {@link ValidationError}.
+ *
+ * The `view` query parameter is hard-coded to `STRUCTURED` so callers
+ * always receive typed structured messages. No public `view` parameter
+ * is exposed.
+ *
+ * @param parameters - Task ref, and optional `pageSize` and `pageToken`
+ *   pagination controls.
+ * @returns A success result wrapping the request, or a
+ *   {@link ValidationError} when the ref is missing `versionId` or
+ *   `sessionId`.
+ */
+export function buildListLogsRequest(
+	parameters: ListLogsParameters,
+): Result<HttpRequest, ValidationError> {
+	const { pageSize, pageToken, ref } = parameters;
+	const { placeId, sessionId, taskId, universeId, versionId } = ref;
+
+	if (versionId === undefined) {
+		return {
+			err: new ValidationError("Task ref is missing versionId; cannot list logs", {
+				code: "incomplete_ref",
+			}),
+			success: false,
+		};
+	}
+
+	if (sessionId === undefined) {
+		return {
+			err: new ValidationError("Task ref is missing sessionId; cannot list logs", {
+				code: "incomplete_ref",
+			}),
+			success: false,
+		};
+	}
+
+	const base = `/cloud/v2/universes/${universeId}/places/${placeId}/versions/${versionId}/luau-execution-sessions/${sessionId}/tasks/${taskId}/logs`;
+	const url = `${base}?${buildQuery(pageSize, pageToken).toString()}`;
+	return { data: { method: "GET", url }, success: true };
+}
+
+function buildQuery(pageSize: number | undefined, pageToken: string | undefined): URLSearchParams {
+	const query = new URLSearchParams({ view: "STRUCTURED" });
+
+	if (pageSize !== undefined) {
+		query.append("maxPageSize", String(pageSize));
+	}
+
+	if (pageToken !== undefined) {
+		query.append("pageToken", pageToken);
+	}
+
+	return query;
+}

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/operations.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/operations.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { LIST_LOGS_OPERATION_LIMIT, LIST_LOGS_REQUIRED_SCOPES } from "./operations.ts";
+
+describe("luau-execution-task-logs list operation limit", () => {
+	it("should cap list-logs at 45 requests per minute under the luau-execution-task-logs.list key", () => {
+		expect.assertions(1);
+
+		expect(LIST_LOGS_OPERATION_LIMIT).toStrictEqual({
+			maxPerSecond: 45 / 60,
+			operationKey: "luau-execution-task-logs.list",
+		});
+	});
+});
+
+describe("luau-execution-task-logs required scopes", () => {
+	it("should require the :read scope to list a task's logs", () => {
+		expect.assertions(1);
+
+		expect(LIST_LOGS_REQUIRED_SCOPES).toStrictEqual([
+			"universe.place.luau-execution-session:read",
+		]);
+	});
+});

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/operations.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/operations.ts
@@ -1,0 +1,27 @@
+import type { OperationLimit } from "../../../internal/http/rate-limit-queue.ts";
+
+const LIST_LOGS_PER_MINUTE = 45;
+const SECONDS_PER_MINUTE = 60;
+
+/**
+ * Per-second request ceiling for listing Luau execution task logs,
+ * sourced from `x-roblox-rate-limits.perApiKeyOwner` on the
+ * `Cloud_ListLuauExecutionSessionTaskLogs` operation (45 requests per
+ * minute per API key owner).
+ */
+export const LIST_LOGS_OPERATION_LIMIT: OperationLimit = Object.freeze({
+	maxPerSecond: LIST_LOGS_PER_MINUTE / SECONDS_PER_MINUTE,
+	operationKey: "luau-execution-task-logs.list",
+});
+
+/**
+ * Scopes required to list Luau execution task logs, sourced from
+ * `x-roblox-scopes` on the list-logs operation in the vendored OpenAPI
+ * schema. Surfaced via the `requiredScopes` field of the per-method
+ * spec so a 401 or 403 ApiError is upgraded to a `PermissionError`
+ * naming the missing scope. Only `:read` is required as the
+ * minimum-privilege scope for this read-only operation.
+ */
+export const LIST_LOGS_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([
+	"universe.place.luau-execution-session:read",
+]);

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.spec.ts
@@ -1,25 +1,8 @@
+import { validLogPageBody } from "#tests/helpers/luau-execution-task-logs";
 import { assert, describe, expect, it } from "vitest";
 
 import { ApiError } from "../../../errors/api-error.ts";
 import { parseListLogsResponse } from "./parsers.ts";
-
-function validLogPageBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
-	return {
-		luauExecutionSessionTaskLogs: [
-			{
-				path: "universes/123/places/456/versions/789/luau-execution-sessions/session-1/tasks/task-1/logs/chunk-1",
-				structuredMessages: [
-					{
-						createTime: "2026-01-01T00:00:00Z",
-						message: "Hello from Luau",
-						messageType: "OUTPUT",
-					},
-				],
-			},
-		],
-		...overrides,
-	};
-}
 
 describe(parseListLogsResponse, () => {
 	it("should parse an empty page (no chunks, no nextPageToken) into messages: [] and nextPageToken: undefined", () => {
@@ -57,7 +40,7 @@ describe(parseListLogsResponse, () => {
 		expect.assertions(2);
 
 		const result = parseListLogsResponse({
-			body: validLogPageBody({
+			body: {
 				luauExecutionSessionTaskLogs: [
 					{
 						path: "chunk-path",
@@ -70,7 +53,7 @@ describe(parseListLogsResponse, () => {
 						],
 					},
 				],
-			}),
+			},
 			headers: {},
 			status: 200,
 		});
@@ -157,6 +140,30 @@ describe(parseListLogsResponse, () => {
 		assert(result.success);
 
 		expect(result.data.nextPageToken).toBeUndefined();
+	});
+
+	it("should treat a body that omits luauExecutionSessionTaskLogs as an empty page", () => {
+		expect.assertions(1);
+
+		const result = parseListLogsResponse({ body: {}, headers: {}, status: 200 });
+
+		assert(result.success);
+
+		expect(result.data.messages).toStrictEqual([]);
+	});
+
+	it("should skip a chunk whose structuredMessages field is omitted", () => {
+		expect.assertions(1);
+
+		const result = parseListLogsResponse({
+			body: { luauExecutionSessionTaskLogs: [{ path: "chunk-empty" }] },
+			headers: {},
+			status: 200,
+		});
+
+		assert(result.success);
+
+		expect(result.data.messages).toStrictEqual([]);
 	});
 
 	describe("malformed bodies", () => {

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.spec.ts
@@ -1,0 +1,278 @@
+import { assert, describe, expect, it } from "vitest";
+
+import { ApiError } from "../../../errors/api-error.ts";
+import { parseListLogsResponse } from "./parsers.ts";
+
+function validLogPageBody(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		luauExecutionSessionTaskLogs: [
+			{
+				path: "universes/123/places/456/versions/789/luau-execution-sessions/session-1/tasks/task-1/logs/chunk-1",
+				structuredMessages: [
+					{
+						createTime: "2026-01-01T00:00:00Z",
+						message: "Hello from Luau",
+						messageType: "OUTPUT",
+					},
+				],
+			},
+		],
+		...overrides,
+	};
+}
+
+describe(parseListLogsResponse, () => {
+	it("should parse an empty page (no chunks, no nextPageToken) into messages: [] and nextPageToken: undefined", () => {
+		expect.assertions(2);
+
+		const result = parseListLogsResponse({
+			body: { luauExecutionSessionTaskLogs: [] },
+			headers: {},
+			status: 200,
+		});
+
+		assert(result.success);
+
+		expect(result.data.messages).toStrictEqual([]);
+		expect(result.data.nextPageToken).toBeUndefined();
+	});
+
+	it("should map a single STRUCTURED message in a single chunk to a single LogMessage", () => {
+		expect.assertions(3);
+
+		const result = parseListLogsResponse({
+			body: validLogPageBody(),
+			headers: {},
+			status: 200,
+		});
+
+		assert(result.success);
+
+		expect(result.data.messages).toHaveLength(1);
+		expect(result.data.messages[0]?.message).toBe("Hello from Luau");
+		expect(result.data.messages[0]?.createTime).toBe("2026-01-01T00:00:00Z");
+	});
+
+	it("should reject a body whose message contains the MESSAGE_TYPE_UNSPECIFIED sentinel", () => {
+		expect.assertions(2);
+
+		const result = parseListLogsResponse({
+			body: validLogPageBody({
+				luauExecutionSessionTaskLogs: [
+					{
+						path: "chunk-path",
+						structuredMessages: [
+							{
+								createTime: "2026-01-01T00:00:00Z",
+								message: "x",
+								messageType: "MESSAGE_TYPE_UNSPECIFIED",
+							},
+						],
+					},
+				],
+			}),
+			headers: {},
+			status: 200,
+		});
+
+		assert(!result.success);
+
+		expect(result.err).toBeInstanceOf(ApiError);
+		expect(result.err.message).toContain("Malformed");
+	});
+
+	it("should flatten multiple chunks into a single messages array preserving server-batch order", () => {
+		expect.assertions(4);
+
+		const result = parseListLogsResponse({
+			body: {
+				luauExecutionSessionTaskLogs: [
+					{
+						path: "chunk-0",
+						structuredMessages: [
+							{
+								createTime: "2026-01-01T00:00:00Z",
+								message: "chunk0-msg0",
+								messageType: "OUTPUT",
+							},
+							{
+								createTime: "2026-01-01T00:00:01Z",
+								message: "chunk0-msg1",
+								messageType: "INFO",
+							},
+						],
+					},
+					{
+						path: "chunk-1",
+						structuredMessages: [
+							{
+								createTime: "2026-01-01T00:00:02Z",
+								message: "chunk1-msg0",
+								messageType: "WARNING",
+							},
+							{
+								createTime: "2026-01-01T00:00:03Z",
+								message: "chunk1-msg1",
+								messageType: "ERROR",
+							},
+						],
+					},
+				],
+			},
+			headers: {},
+			status: 200,
+		});
+
+		assert(result.success);
+
+		expect(result.data.messages).toHaveLength(4);
+		expect(result.data.messages[0]?.message).toBe("chunk0-msg0");
+		expect(result.data.messages[2]?.message).toBe("chunk1-msg0");
+		expect(result.data.messages[3]?.message).toBe("chunk1-msg1");
+	});
+
+	it("should surface nextPageToken when the body sets it", () => {
+		expect.assertions(1);
+
+		const result = parseListLogsResponse({
+			body: validLogPageBody({ nextPageToken: "tok-2" }),
+			headers: {},
+			status: 200,
+		});
+
+		assert(result.success);
+
+		expect(result.data.nextPageToken).toBe("tok-2");
+	});
+
+	it("should surface nextPageToken as undefined when the body omits it", () => {
+		expect.assertions(1);
+
+		const result = parseListLogsResponse({
+			body: { luauExecutionSessionTaskLogs: [] },
+			headers: {},
+			status: 200,
+		});
+
+		assert(result.success);
+
+		expect(result.data.nextPageToken).toBeUndefined();
+	});
+
+	describe("malformed bodies", () => {
+		it("should reject a non-record body", () => {
+			expect.assertions(2);
+
+			const result = parseListLogsResponse({
+				body: "not an object",
+				headers: {},
+				status: 200,
+			});
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+			expect(result.err.statusCode).toBe(200);
+		});
+
+		it("should reject a body whose luauExecutionSessionTaskLogs is not an array", () => {
+			expect.assertions(1);
+
+			const result = parseListLogsResponse({
+				body: { luauExecutionSessionTaskLogs: "not-an-array" },
+				headers: {},
+				status: 200,
+			});
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should reject a body whose nextPageToken is not a string", () => {
+			expect.assertions(1);
+
+			const result = parseListLogsResponse({
+				body: { luauExecutionSessionTaskLogs: [], nextPageToken: 42 },
+				headers: {},
+				status: 200,
+			});
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should reject a chunk that is not a record", () => {
+			expect.assertions(1);
+
+			const result = parseListLogsResponse({
+				body: { luauExecutionSessionTaskLogs: ["not-a-record"] },
+				headers: {},
+				status: 200,
+			});
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should reject a chunk whose structuredMessages is not an array", () => {
+			expect.assertions(1);
+
+			const result = parseListLogsResponse({
+				body: {
+					luauExecutionSessionTaskLogs: [
+						{ path: "chunk-path", structuredMessages: "not-an-array" },
+					],
+				},
+				headers: {},
+				status: 200,
+			});
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it.for([
+			{ createTime: 123, message: "x", messageType: "OUTPUT" },
+			{ message: "x", messageType: "OUTPUT" },
+			{ createTime: "2026-01-01T00:00:00Z", messageType: "OUTPUT" },
+			{ createTime: "2026-01-01T00:00:00Z", message: 42, messageType: "OUTPUT" },
+		] as const)(
+			"should reject a message whose required createTime/message fields are missing or non-string",
+			(badMessage) => {
+				expect.assertions(1);
+
+				const result = parseListLogsResponse({
+					body: {
+						luauExecutionSessionTaskLogs: [
+							{ path: "chunk-path", structuredMessages: [badMessage] },
+						],
+					},
+					headers: {},
+					status: 200,
+				});
+
+				assert(!result.success);
+
+				expect(result.err).toBeInstanceOf(ApiError);
+			},
+		);
+
+		it("should propagate the response status code on the returned ApiError", () => {
+			expect.assertions(1);
+
+			const result = parseListLogsResponse({
+				body: "nope",
+				headers: {},
+				status: 502,
+			});
+
+			assert(!result.success);
+
+			expect(result.err.statusCode).toBe(502);
+		});
+	});
+});

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.spec.ts
@@ -43,7 +43,6 @@ describe(parseListLogsResponse, () => {
 			body: {
 				luauExecutionSessionTaskLogs: [
 					{
-						path: "chunk-path",
 						structuredMessages: [
 							{
 								createTime: "2026-01-01T00:00:00Z",
@@ -71,7 +70,6 @@ describe(parseListLogsResponse, () => {
 			body: {
 				luauExecutionSessionTaskLogs: [
 					{
-						path: "chunk-0",
 						structuredMessages: [
 							{
 								createTime: "2026-01-01T00:00:00Z",
@@ -86,7 +84,6 @@ describe(parseListLogsResponse, () => {
 						],
 					},
 					{
-						path: "chunk-1",
 						structuredMessages: [
 							{
 								createTime: "2026-01-01T00:00:02Z",
@@ -156,7 +153,7 @@ describe(parseListLogsResponse, () => {
 		expect.assertions(1);
 
 		const result = parseListLogsResponse({
-			body: { luauExecutionSessionTaskLogs: [{ path: "chunk-empty" }] },
+			body: { luauExecutionSessionTaskLogs: [{}] },
 			headers: {},
 			status: 200,
 		});
@@ -229,9 +226,7 @@ describe(parseListLogsResponse, () => {
 
 			const result = parseListLogsResponse({
 				body: {
-					luauExecutionSessionTaskLogs: [
-						{ path: "chunk-path", structuredMessages: "not-an-array" },
-					],
+					luauExecutionSessionTaskLogs: [{ structuredMessages: "not-an-array" }],
 				},
 				headers: {},
 				status: 200,
@@ -254,9 +249,7 @@ describe(parseListLogsResponse, () => {
 
 				const result = parseListLogsResponse({
 					body: {
-						luauExecutionSessionTaskLogs: [
-							{ path: "chunk-path", structuredMessages: [badMessage] },
-						],
+						luauExecutionSessionTaskLogs: [{ structuredMessages: [badMessage] }],
 					},
 					headers: {},
 					status: 200,
@@ -267,6 +260,33 @@ describe(parseListLogsResponse, () => {
 				expect(result.err).toBeInstanceOf(ApiError);
 			},
 		);
+
+		it("should reject the whole page when any message in a chunk is invalid", () => {
+			expect.assertions(1);
+
+			const result = parseListLogsResponse({
+				body: {
+					luauExecutionSessionTaskLogs: [
+						{
+							structuredMessages: [
+								{
+									createTime: "2026-01-01T00:00:00Z",
+									message: "valid",
+									messageType: "OUTPUT",
+								},
+								{ createTime: "2026-01-01T00:00:01Z", messageType: "OUTPUT" },
+							],
+						},
+					],
+				},
+				headers: {},
+				status: 200,
+			});
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
 
 		it("should propagate the response status code on the returned ApiError", () => {
 			expect.assertions(1);

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.ts
@@ -65,11 +65,7 @@ function isOptionalStructuredMessages(
 }
 
 function isLogChunkWire(value: unknown): value is LogChunkWire {
-	return (
-		isRecord(value) &&
-		typeof value["path"] === "string" &&
-		isOptionalStructuredMessages(value["structuredMessages"])
-	);
+	return isRecord(value) && isOptionalStructuredMessages(value["structuredMessages"]);
 }
 
 function isOptionalLogChunks(value: unknown): value is ReadonlyArray<LogChunkWire> | undefined {

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.ts
@@ -1,0 +1,101 @@
+import type { HttpResponse } from "../../../client/types.ts";
+import { ApiError } from "../../../errors/api-error.ts";
+import { isRecord } from "../../../internal/utils/is-record.ts";
+import type { Result } from "../../../types.ts";
+import type { LogMessage, LogPage } from "./types.ts";
+import type { ListLogsResponseWire, LogChunkWire, LogMessageWire } from "./wire.ts";
+
+const MALFORMED_LOGS_MESSAGE = "Malformed list-luau-execution-task-logs response";
+
+/**
+ * Parses a successful Open Cloud list-luau-execution-task-logs response
+ * body into the public {@link LogPage} shape. Chunks are flattened into
+ * a single ordered array of {@link LogMessage} values. The
+ * `MESSAGE_TYPE_UNSPECIFIED` sentinel is rejected.
+ *
+ * @param response - The full {@link HttpResponse} from the Open Cloud API.
+ * @returns A success result wrapping the parsed {@link LogPage}, or an
+ *   {@link ApiError} when the body does not match a supported shape.
+ */
+export function parseListLogsResponse(response: HttpResponse): Result<LogPage, ApiError> {
+	const { body, status: statusCode } = response;
+	if (!isListLogsResponseWire(body)) {
+		return malformed(statusCode);
+	}
+
+	const chunks = body.luauExecutionSessionTaskLogs ?? [];
+	const messages: Array<LogMessage> = [];
+
+	for (const chunk of chunks) {
+		for (const wireMessage of chunk.structuredMessages ?? []) {
+			if (!isAcceptedMessageType(wireMessage.messageType)) {
+				return malformed(statusCode);
+			}
+
+			messages.push(mapMessage(wireMessage));
+		}
+	}
+
+	return {
+		data: { messages, nextPageToken: body.nextPageToken },
+		success: true,
+	};
+}
+
+function isAcceptedMessageType(value: unknown): value is "ERROR" | "INFO" | "OUTPUT" | "WARNING" {
+	return value === "OUTPUT" || value === "INFO" || value === "WARNING" || value === "ERROR";
+}
+
+function isLogMessageWire(value: unknown): value is LogMessageWire {
+	return (
+		isRecord(value) &&
+		typeof value["createTime"] === "string" &&
+		typeof value["message"] === "string" &&
+		(isAcceptedMessageType(value["messageType"]) ||
+			value["messageType"] === "MESSAGE_TYPE_UNSPECIFIED")
+	);
+}
+
+function isOptionalStructuredMessages(
+	value: unknown,
+): value is ReadonlyArray<LogMessageWire> | undefined {
+	return (
+		value === undefined ||
+		(Array.isArray(value) && value.every((item: unknown) => isLogMessageWire(item)))
+	);
+}
+
+function isLogChunkWire(value: unknown): value is LogChunkWire {
+	return (
+		isRecord(value) &&
+		typeof value["path"] === "string" &&
+		isOptionalStructuredMessages(value["structuredMessages"])
+	);
+}
+
+function isOptionalLogChunks(value: unknown): value is ReadonlyArray<LogChunkWire> | undefined {
+	return (
+		value === undefined ||
+		(Array.isArray(value) && value.every((item: unknown) => isLogChunkWire(item)))
+	);
+}
+
+function isListLogsResponseWire(body: unknown): body is ListLogsResponseWire {
+	return (
+		isRecord(body) &&
+		isOptionalLogChunks(body["luauExecutionSessionTaskLogs"]) &&
+		(body["nextPageToken"] === undefined || typeof body["nextPageToken"] === "string")
+	);
+}
+
+function malformed(statusCode: number): Result<LogPage, ApiError> {
+	return { err: new ApiError(MALFORMED_LOGS_MESSAGE, { statusCode }), success: false };
+}
+
+function mapMessage(wireMessage: LogMessageWire): LogMessage {
+	return {
+		createTime: wireMessage.createTime,
+		message: wireMessage.message,
+		messageType: wireMessage.messageType as "ERROR" | "INFO" | "OUTPUT" | "WARNING",
+	};
+}

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.ts
@@ -28,11 +28,11 @@ export function parseListLogsResponse(response: HttpResponse): Result<LogPage, A
 
 	for (const chunk of chunks) {
 		for (const wireMessage of chunk.structuredMessages ?? []) {
-			if (!isAcceptedMessageType(wireMessage.messageType)) {
-				return malformed(statusCode);
-			}
-
-			messages.push(mapMessage(wireMessage));
+			messages.push({
+				createTime: wireMessage.createTime,
+				message: wireMessage.message,
+				messageType: wireMessage.messageType,
+			});
 		}
 	}
 
@@ -42,7 +42,7 @@ export function parseListLogsResponse(response: HttpResponse): Result<LogPage, A
 	};
 }
 
-function isAcceptedMessageType(value: unknown): value is "ERROR" | "INFO" | "OUTPUT" | "WARNING" {
+function isAcceptedMessageType(value: unknown): value is LogMessageWire["messageType"] {
 	return value === "OUTPUT" || value === "INFO" || value === "WARNING" || value === "ERROR";
 }
 
@@ -51,8 +51,7 @@ function isLogMessageWire(value: unknown): value is LogMessageWire {
 		isRecord(value) &&
 		typeof value["createTime"] === "string" &&
 		typeof value["message"] === "string" &&
-		(isAcceptedMessageType(value["messageType"]) ||
-			value["messageType"] === "MESSAGE_TYPE_UNSPECIFIED")
+		isAcceptedMessageType(value["messageType"])
 	);
 }
 
@@ -90,12 +89,4 @@ function isListLogsResponseWire(body: unknown): body is ListLogsResponseWire {
 
 function malformed(statusCode: number): Result<LogPage, ApiError> {
 	return { err: new ApiError(MALFORMED_LOGS_MESSAGE, { statusCode }), success: false };
-}
-
-function mapMessage(wireMessage: LogMessageWire): LogMessage {
-	return {
-		createTime: wireMessage.createTime,
-		message: wireMessage.message,
-		messageType: wireMessage.messageType as "ERROR" | "INFO" | "OUTPUT" | "WARNING",
-	};
 }

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/specs.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/specs.spec.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { LIST_LOGS_OPERATION_LIMIT, LIST_LOGS_REQUIRED_SCOPES } from "./operations.ts";
+import { parseListLogsResponse } from "./parsers.ts";
+import { LIST_LOGS_SPEC } from "./specs.ts";
+
+describe("list-logs spec", () => {
+	it("should be an idempotent-kind spec wired to the list-logs limit, read scope, and shared parser", () => {
+		expect.assertions(4);
+
+		expect(LIST_LOGS_SPEC.methodKind).toBe("idempotent");
+		expect(LIST_LOGS_SPEC.operationLimit).toBe(LIST_LOGS_OPERATION_LIMIT);
+		expect(LIST_LOGS_SPEC.requiredScopes).toBe(LIST_LOGS_REQUIRED_SCOPES);
+		expect(LIST_LOGS_SPEC.parse).toBe(parseListLogsResponse);
+	});
+});

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/specs.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/specs.ts
@@ -1,0 +1,25 @@
+import { IDEMPOTENT_METHOD_DEFAULTS } from "../../../internal/http/retry.ts";
+import type { ResourceMethodSpec } from "../../../internal/resource-client.ts";
+import { buildListLogsRequest } from "./builders.ts";
+import { LIST_LOGS_OPERATION_LIMIT, LIST_LOGS_REQUIRED_SCOPES } from "./operations.ts";
+import { parseListLogsResponse } from "./parsers.ts";
+import type { ListLogsParameters, LogPage } from "./types.ts";
+
+function makeSpec<P>(spec: ResourceMethodSpec<P, LogPage>): ResourceMethodSpec<P, LogPage> {
+	return Object.freeze(spec);
+}
+
+/**
+ * Per-method dispatch spec for listing the structured log messages
+ * produced by a Luau execution task. Frozen at module scope so both
+ * the top-level `LuauExecutionClient` and the `luauExecution` Operation
+ * Group on `PlacesClient` share the same instance reference.
+ */
+export const LIST_LOGS_SPEC = makeSpec<ListLogsParameters>({
+	buildRequest: buildListLogsRequest,
+	methodDefaults: IDEMPOTENT_METHOD_DEFAULTS,
+	methodKind: "idempotent",
+	operationLimit: LIST_LOGS_OPERATION_LIMIT,
+	parse: parseListLogsResponse,
+	requiredScopes: LIST_LOGS_REQUIRED_SCOPES,
+});

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/types.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/types.ts
@@ -1,0 +1,56 @@
+import type { LuauExecutionTaskRef } from "../luau-execution-tasks/types.ts";
+
+export type { LuauExecutionTaskRef } from "../luau-execution-tasks/types.ts";
+
+/**
+ * Caller-supplied input for listing the structured log messages produced
+ * by a previously-submitted Luau execution task.
+ */
+export interface ListLogsParameters {
+	/**
+	 * Maximum number of log messages to return per page. The server
+	 * clamps this to the range [1, 10000]. When omitted, the server
+	 * applies its own default page size.
+	 */
+	readonly pageSize?: number | undefined;
+	/**
+	 * Opaque continuation token returned by the previous `listLogs`
+	 * call. Pass this to retrieve the next page of results.
+	 */
+	readonly pageToken?: string | undefined;
+	/** Reference to the task whose logs are being listed. */
+	readonly ref: LuauExecutionTaskRef;
+}
+
+/**
+ * A single structured log message produced by a Luau execution task.
+ * The `createTime` field is a raw ISO timestamp string, not a
+ * {@link Date}, so it can be serialized without conversion.
+ */
+export interface LogMessage {
+	/** ISO timestamp when the log message was produced. */
+	readonly createTime: string;
+	/** Human-readable log message text. */
+	readonly message: string;
+	/**
+	 * Categorical message type. The wire `MESSAGE_TYPE_UNSPECIFIED`
+	 * sentinel is rejected by the parser and never surfaces here.
+	 */
+	readonly messageType: "ERROR" | "INFO" | "OUTPUT" | "WARNING";
+}
+
+/**
+ * One page of structured log messages from a Luau execution task.
+ * Chunks are flattened by the parser; consumers see a single ordered
+ * array. When `nextPageToken` is present, pass it to the next
+ * `listLogs` call to retrieve the following page.
+ */
+export interface LogPage {
+	/** Flattened, ordered list of log messages from this page. */
+	readonly messages: ReadonlyArray<LogMessage>;
+	/**
+	 * Opaque token for the next page of results. `undefined` when this
+	 * is the last page.
+	 */
+	readonly nextPageToken?: string | undefined;
+}

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/wire.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/wire.ts
@@ -5,18 +5,16 @@
 /**
  * Wire shape of a single structured log message within a
  * {@link LogChunkWire}. The `MESSAGE_TYPE_UNSPECIFIED` sentinel is
- * included here to allow the type guard to reject it.
+ * deliberately excluded; the parser's type guard rejects it at the
+ * wire boundary so it never surfaces here.
  */
 export interface LogMessageWire {
 	/** ISO timestamp when the log message was produced. */
 	readonly createTime: string;
 	/** Human-readable log message text. */
 	readonly message: string;
-	/**
-	 * Wire enum value for the message type. `MESSAGE_TYPE_UNSPECIFIED`
-	 * is modelled so the parser can detect and reject it.
-	 */
-	readonly messageType: "ERROR" | "INFO" | "MESSAGE_TYPE_UNSPECIFIED" | "OUTPUT" | "WARNING";
+	/** Wire enum value for the message type. */
+	readonly messageType: "ERROR" | "INFO" | "OUTPUT" | "WARNING";
 }
 
 /**

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/wire.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/wire.ts
@@ -21,15 +21,11 @@ export interface LogMessageWire {
  * Wire shape of a single log chunk returned by the Open Cloud
  * list-logs endpoint. The `structuredMessages` array is populated
  * when `view=STRUCTURED` is requested (which is always the case in
- * this SDK).
+ * this SDK). Other wire fields (`path`, FLAT-mode `messages`) exist
+ * on the schema but are not modelled here because they are not
+ * surfaced on the public `LogPage` type.
  */
 export interface LogChunkWire {
-	/**
-	 * Resource path for this chunk. Required by the server schema;
-	 * not surfaced on the public `LogPage` type because chunks are
-	 * flattened before being returned to callers.
-	 */
-	readonly path: string;
 	/**
 	 * Structured log messages in this chunk. Optional on the wire;
 	 * absent when the chunk has no messages.

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/wire.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/wire.ts
@@ -1,0 +1,56 @@
+// Wire-level shape of the list-luau-execution-task-logs response body
+// returned by the Open Cloud `cloud/v2` luau-execution endpoints.
+// Internal to the sub-tree; not re-exported.
+
+/**
+ * Wire shape of a single structured log message within a
+ * {@link LogChunkWire}. The `MESSAGE_TYPE_UNSPECIFIED` sentinel is
+ * included here to allow the type guard to reject it.
+ */
+export interface LogMessageWire {
+	/** ISO timestamp when the log message was produced. */
+	readonly createTime: string;
+	/** Human-readable log message text. */
+	readonly message: string;
+	/**
+	 * Wire enum value for the message type. `MESSAGE_TYPE_UNSPECIFIED`
+	 * is modelled so the parser can detect and reject it.
+	 */
+	readonly messageType: "ERROR" | "INFO" | "MESSAGE_TYPE_UNSPECIFIED" | "OUTPUT" | "WARNING";
+}
+
+/**
+ * Wire shape of a single log chunk returned by the Open Cloud
+ * list-logs endpoint. The `structuredMessages` array is populated
+ * when `view=STRUCTURED` is requested (which is always the case in
+ * this SDK).
+ */
+export interface LogChunkWire {
+	/**
+	 * Resource path for this chunk. Required by the server schema;
+	 * not surfaced on the public `LogPage` type because chunks are
+	 * flattened before being returned to callers.
+	 */
+	readonly path: string;
+	/**
+	 * Structured log messages in this chunk. Optional on the wire;
+	 * absent when the chunk has no messages.
+	 */
+	readonly structuredMessages?: ReadonlyArray<LogMessageWire> | undefined;
+}
+
+/**
+ * Wire shape of the list-luau-execution-task-logs response body.
+ */
+export interface ListLogsResponseWire {
+	/**
+	 * Array of log chunks. Optional on the wire; absent on an empty
+	 * page.
+	 */
+	readonly luauExecutionSessionTaskLogs?: ReadonlyArray<LogChunkWire> | undefined;
+	/**
+	 * Opaque continuation token for the next page. Absent when this
+	 * is the last page.
+	 */
+	readonly nextPageToken?: string | undefined;
+}

--- a/packages/open-cloud/src/resources/luau-execution/client.ts
+++ b/packages/open-cloud/src/resources/luau-execution/client.ts
@@ -1,4 +1,9 @@
 import type { OpenCloudClientOptions, RequestOptions } from "../../client/types.ts";
+import { LIST_LOGS_SPEC } from "../../domains/cloud-v2/luau-execution-task-logs/specs.ts";
+import type {
+	ListLogsParameters,
+	LogPage,
+} from "../../domains/cloud-v2/luau-execution-task-logs/types.ts";
 import {
 	GET_SPEC,
 	SUBMIT_HEAD_SPEC,
@@ -16,8 +21,9 @@ import type { Result } from "../../types.ts";
 
 /**
  * Operation handle exposed by {@link LuauExecutionClient} as the
- * `tasks` namespace. Provides `submit` to queue a Luau script and
- * `get` to fetch a task's current state.
+ * `tasks` namespace. Provides `submit` to queue a Luau script, `get`
+ * to fetch a task's current state, and `listLogs` to retrieve
+ * structured log messages produced by a task.
  */
 export interface TasksHandle {
 	/**
@@ -36,6 +42,23 @@ export interface TasksHandle {
 		parameters: GetParameters,
 		options?: RequestOptions,
 	): Promise<Result<LuauExecutionTask, OpenCloudError>>;
+	/**
+	 * Lists one page of structured log messages produced by a
+	 * previously-submitted Luau execution task. Messages from multiple
+	 * server-side chunks are flattened into a single ordered array.
+	 * Uses idempotent retry semantics for both 429 and 5xx.
+	 *
+	 * @param parameters - The task ref and optional pagination controls
+	 *   (`pageSize`, `pageToken`).
+	 * @param options - Optional per-request overrides (e.g. A different
+	 *   {@link OpenCloudClientOptions.apiKey} for this call only).
+	 * @returns A {@link Result} wrapping the parsed {@link LogPage} or
+	 *   the {@link OpenCloudError} that caused the request to fail.
+	 */
+	listLogs(
+		parameters: ListLogsParameters,
+		options?: RequestOptions,
+	): Promise<Result<LogPage, OpenCloudError>>;
 	/**
 	 * Submits a Luau script for execution against a place. Dispatches
 	 * to the head-version URL when `versionId` is omitted, or to the
@@ -86,6 +109,9 @@ function createTasksHandle(inner: ResourceClient): TasksHandle {
 	return {
 		async get(parameters, options) {
 			return inner.execute({ options, parameters, spec: GET_SPEC });
+		},
+		async listLogs(parameters, options) {
+			return inner.execute({ options, parameters, spec: LIST_LOGS_SPEC });
 		},
 		async submit(parameters, options) {
 			if ("versionId" in parameters) {

--- a/packages/open-cloud/src/resources/luau-execution/index.ts
+++ b/packages/open-cloud/src/resources/luau-execution/index.ts
@@ -1,4 +1,9 @@
 export type {
+	ListLogsParameters,
+	LogMessage,
+	LogPage,
+} from "../../domains/cloud-v2/luau-execution-task-logs/types.ts";
+export type {
 	CompleteTask,
 	FailedTask,
 	GetParameters,

--- a/packages/open-cloud/src/resources/places/client.ts
+++ b/packages/open-cloud/src/resources/places/client.ts
@@ -1,4 +1,9 @@
 import type { OpenCloudClientOptions, RequestOptions } from "../../client/types.ts";
+import { LIST_LOGS_SPEC } from "../../domains/cloud-v2/luau-execution-task-logs/specs.ts";
+import type {
+	ListLogsParameters,
+	LogPage,
+} from "../../domains/cloud-v2/luau-execution-task-logs/types.ts";
 import {
 	GET_SPEC,
 	SUBMIT_HEAD_SPEC,
@@ -31,9 +36,10 @@ import type { Result } from "../../types.ts";
 
 /**
  * Operation Group exposed by {@link PlacesClient} as the
- * `luauExecution` namespace. Provides `submit` to queue a Luau script
- * and `get` to fetch a task's current state. Shares the same
- * dispatch wiring as the top-level `LuauExecutionClient` exposed at
+ * `luauExecution` namespace. Provides `submit` to queue a Luau script,
+ * `get` to fetch a task's current state, and `listLogs` to retrieve
+ * structured log messages. Shares the same dispatch wiring as the
+ * top-level `LuauExecutionClient` exposed at
  * `@bedrock-rbx/ocale/luau-execution`.
  */
 export interface LuauExecutionHandle {
@@ -53,6 +59,23 @@ export interface LuauExecutionHandle {
 		parameters: GetParameters,
 		options?: RequestOptions,
 	): Promise<Result<LuauExecutionTask, OpenCloudError>>;
+	/**
+	 * Lists one page of structured log messages produced by a
+	 * previously-submitted Luau execution task. Messages from multiple
+	 * server-side chunks are flattened into a single ordered array.
+	 * Uses idempotent retry semantics for both 429 and 5xx.
+	 *
+	 * @param parameters - The task ref and optional pagination controls
+	 *   (`pageSize`, `pageToken`).
+	 * @param options - Optional per-request overrides (e.g. A different
+	 *   {@link OpenCloudClientOptions.apiKey} for this call only).
+	 * @returns A {@link Result} wrapping the parsed {@link LogPage} or
+	 *   the {@link OpenCloudError} that caused the request to fail.
+	 */
+	listLogs(
+		parameters: ListLogsParameters,
+		options?: RequestOptions,
+	): Promise<Result<LogPage, OpenCloudError>>;
 	/**
 	 * Submits a Luau script for execution against a place. Dispatches
 	 * to the head-version URL when `versionId` is omitted, or to the
@@ -205,6 +228,9 @@ function createLuauExecutionHandle(inner: ResourceClient): LuauExecutionHandle {
 	return {
 		async get(parameters, options) {
 			return inner.execute({ options, parameters, spec: GET_SPEC });
+		},
+		async listLogs(parameters, options) {
+			return inner.execute({ options, parameters, spec: LIST_LOGS_SPEC });
 		},
 		async submit(parameters, options) {
 			if ("versionId" in parameters) {

--- a/packages/open-cloud/src/resources/places/index.ts
+++ b/packages/open-cloud/src/resources/places/index.ts
@@ -1,3 +1,8 @@
+export type {
+	ListLogsParameters,
+	LogMessage,
+	LogPage,
+} from "../../domains/cloud-v2/luau-execution-task-logs/types.ts";
 export type { Place, UpdatePlaceParameters } from "../../domains/cloud-v2/places/types.ts";
 export type { PlaceVersion, PublishParameters } from "../../domains/universes/places/types.ts";
 export { type LuauExecutionHandle, PlacesClient } from "./client.ts";

--- a/packages/open-cloud/tests/conformance/luau-execution-shared-specs.spec.ts
+++ b/packages/open-cloud/tests/conformance/luau-execution-shared-specs.spec.ts
@@ -1,3 +1,4 @@
+import { LIST_LOGS_SPEC } from "#src/domains/cloud-v2/luau-execution-task-logs/specs";
 import {
 	GET_SPEC,
 	SUBMIT_HEAD_SPEC,
@@ -10,6 +11,7 @@ describe("luau-execution specs are frozen module-scope singletons", () => {
 		["SUBMIT_HEAD_SPEC", SUBMIT_HEAD_SPEC],
 		["SUBMIT_VERSION_SPEC", SUBMIT_VERSION_SPEC],
 		["GET_SPEC", GET_SPEC],
+		["LIST_LOGS_SPEC", LIST_LOGS_SPEC],
 	] as const)(
 		"should be frozen so the dispatch wiring cannot be mutated at runtime",
 		([, spec]) => {

--- a/packages/open-cloud/tests/helpers/luau-execution-task-logs.ts
+++ b/packages/open-cloud/tests/helpers/luau-execution-task-logs.ts
@@ -1,0 +1,29 @@
+import type { ListLogsResponseWire } from "#src/domains/cloud-v2/luau-execution-task-logs/wire";
+
+/**
+ * Builds a minimally-valid {@link ListLogsResponseWire} body containing
+ * one chunk with one structured message. Pass an `overrides` object to
+ * tweak fields without re-stating the defaults.
+ *
+ * @param overrides - Fields to override on the default body.
+ * @returns A valid wire body with the overrides applied.
+ */
+export function validLogPageBody(
+	overrides: Partial<ListLogsResponseWire> = {},
+): ListLogsResponseWire {
+	return {
+		luauExecutionSessionTaskLogs: [
+			{
+				path: "universes/123/places/456/versions/789/luau-execution-sessions/session-1/tasks/task-1/logs/chunk-1",
+				structuredMessages: [
+					{
+						createTime: "2026-01-01T00:00:00Z",
+						message: "Hello from Luau",
+						messageType: "OUTPUT",
+					},
+				],
+			},
+		],
+		...overrides,
+	};
+}

--- a/packages/open-cloud/tests/helpers/luau-execution-task-logs.ts
+++ b/packages/open-cloud/tests/helpers/luau-execution-task-logs.ts
@@ -14,7 +14,6 @@ export function validLogPageBody(
 	return {
 		luauExecutionSessionTaskLogs: [
 			{
-				path: "universes/123/places/456/versions/789/luau-execution-sessions/session-1/tasks/task-1/logs/chunk-1",
 				structuredMessages: [
 					{
 						createTime: "2026-01-01T00:00:00Z",

--- a/packages/open-cloud/tests/integration/resources/luau-execution/client.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/luau-execution/client.spec.ts
@@ -1,6 +1,7 @@
 import { LuauExecutionClient } from "#src/resources/luau-execution/index";
 import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
+import { validLogPageBody } from "#tests/helpers/luau-execution-task-logs";
 import { validInProgressTaskBody } from "#tests/helpers/luau-execution-tasks";
 import { assert, describe, expect, it } from "vitest";
 
@@ -64,6 +65,38 @@ describe(LuauExecutionClient, () => {
 			expect(httpClient.requests[0]?.request.url).toBe(
 				"/cloud/v2/universes/123/places/456/versions/789/luau-execution-session-tasks",
 			);
+		});
+	});
+
+	describe("tasks.listLogs", () => {
+		it("should GET the maximal /logs URL with view=STRUCTURED and parse the response into a LogPage", async () => {
+			expect.assertions(3);
+
+			const httpClient = createFakeHttpClient().mockResponse({
+				body: validLogPageBody(),
+				status: 200,
+			});
+			const client = new LuauExecutionClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.tasks.listLogs({
+				ref: {
+					placeId: "456",
+					sessionId: "session-1",
+					taskId: "task-1",
+					universeId: "123",
+					versionId: "789",
+				},
+			});
+
+			assert(result.success);
+
+			expect(result.data.messages).toHaveLength(1);
+			expect(httpClient.requests[0]?.request.url).toContain("/tasks/task-1/logs");
+			expect(httpClient.requests[0]?.request.url).toContain("view=STRUCTURED");
 		});
 	});
 

--- a/packages/open-cloud/tests/integration/resources/places/luau-execution.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/places/luau-execution.spec.ts
@@ -1,6 +1,7 @@
 import { PlacesClient } from "#src/resources/places/index";
 import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
+import { validLogPageBody } from "#tests/helpers/luau-execution-task-logs";
 import { validInProgressTaskBody } from "#tests/helpers/luau-execution-tasks";
 import { assert, describe, expect, it } from "vitest";
 
@@ -63,6 +64,38 @@ describe(PlacesClient, () => {
 			expect(httpClient.requests[0]?.request.url).toBe(
 				"/cloud/v2/universes/123/places/456/versions/789/luau-execution-session-tasks",
 			);
+		});
+	});
+
+	describe("luauExecution.listLogs", () => {
+		it("should GET the maximal /logs URL when called via PlacesClient and parse the response into a LogPage", async () => {
+			expect.assertions(3);
+
+			const httpClient = createFakeHttpClient().mockResponse({
+				body: validLogPageBody(),
+				status: 200,
+			});
+			const client = new PlacesClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.luauExecution.listLogs({
+				ref: {
+					placeId: "456",
+					sessionId: "session-1",
+					taskId: "task-1",
+					universeId: "123",
+					versionId: "789",
+				},
+			});
+
+			assert(result.success);
+
+			expect(result.data.messages).toHaveLength(1);
+			expect(httpClient.requests[0]?.request.url).toContain("/tasks/task-1/logs");
+			expect(httpClient.requests[0]?.request.url).toContain("view=STRUCTURED");
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Add `tasks.listLogs` to `LuauExecutionClient` and `luauExecution.listLogs` to `PlacesClient`, returning a `LogPage` with flattened structured messages and an optional `nextPageToken`.
- Hard-codes `view=STRUCTURED` on the wire so callers never see the wire view selector; rejects `MESSAGE_TYPE_UNSPECIFIED` at the parser boundary.
- Public types `LogMessage`, `LogPage`, `ListLogsParameters` are exposed under both `@bedrock-rbx/ocale/luau-execution` and `@bedrock-rbx/ocale/places`. Both surfaces share one frozen `LIST_LOGS_SPEC`, pinned by the existing shared-singletons conformance test.

Closes #364

## Test plan

- [x] `pnpm test` passes for `@bedrock-rbx/ocale` (parser, builder, operations, specs, conformance, plus integration tests for both client surfaces).
- [x] 100% coverage on the new `luau-execution-task-logs` sub-tree (statements, branches, functions, lines).
- [x] 100% mutation score on touched files via `MUTATE_BASE_REF=origin/main pnpm mutate:changed`.
- [x] `hk run pre-push` is green (lint, typecheck, gen-example-tests, unused, build, test, mutate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)