### PR TITLE
feat(ocale): add binary-input upload to luau-execution-client

### DIFF
--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -34,7 +34,6 @@ import { execSync } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import process from "node:process";
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -114,8 +113,12 @@ const HOST_USER_EMAIL = execSync("git config --get user.email").toString().trim(
 // resolve the worktree's gitdir pointer; without this mount the pointer
 // inside the container references a host filesystem path that does not
 // exist, and any operation that opens the repo (hk check, git status,
-// git commit) fails.
-const HOST_GIT_DIR = join(process.cwd(), ".git");
+// git commit) fails. --git-common-dir resolves to the main .git even when
+// sandcastle is invoked from a subdirectory or from one of the host's own
+// linked worktrees.
+const HOST_GIT_DIR = execSync("git rev-parse --path-format=absolute --git-common-dir")
+	.toString()
+	.trim();
 
 const sandboxMounts = [
 	{ hostPath: PNPM_STORE_HOST_DIR, sandboxPath: "/home/agent/.pnpm-store" },
@@ -198,9 +201,12 @@ const REPAIR_WORKTREE_GIT = [
 	"git config --global --add safe.directory /home/agent/.git-main",
 	"git config --global gc.auto 0",
 	'name=$(basename "$(sed -n "s/^gitdir: //p" /home/agent/workspace/.git)")',
+	'{ [ -n "$name" ] && [ "$name" != "." ]; } || { echo "REPAIR_WORKTREE_GIT: cannot parse worktree name from /home/agent/workspace/.git" >&2; exit 1; }',
 	'echo "gitdir: /home/agent/.git-main/worktrees/$name" > /home/agent/workspace/.git',
 	"git -C /home/agent/workspace worktree repair",
-	"git config --file /home/agent/.git-main/config extensions.worktreeConfig true",
+	// Set extensions.worktreeConfig only when missing so we leave the host
+	// repo's .git/config untouched on subsequent sandbox spawns.
+	"git config --file /home/agent/.git-main/config --get extensions.worktreeConfig 2>/dev/null | grep -qx true || git config --file /home/agent/.git-main/config extensions.worktreeConfig true",
 	"mkdir -p /home/agent/.git-hooks",
 	"git -C /home/agent/workspace config --worktree core.hooksPath /home/agent/.git-hooks",
 ].join(" && ");

--- a/.sandcastle/main.ts
+++ b/.sandcastle/main.ts
@@ -34,6 +34,7 @@ import { execSync } from "node:child_process";
 import { existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import process from "node:process";
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -108,6 +109,14 @@ if (!existsSync(SIGNING_KEY_PATH)) {
 const HOST_USER_NAME = execSync("git config --get user.name").toString().trim();
 const HOST_USER_EMAIL = execSync("git config --get user.email").toString().trim();
 
+// Host path of the main repo's .git directory. Bind-mounted into worktree
+// sandboxes (Phases 2-4) so that libgit2-based tools (hk, git itself) can
+// resolve the worktree's gitdir pointer; without this mount the pointer
+// inside the container references a host filesystem path that does not
+// exist, and any operation that opens the repo (hk check, git status,
+// git commit) fails.
+const HOST_GIT_DIR = join(process.cwd(), ".git");
+
 const sandboxMounts = [
 	{ hostPath: PNPM_STORE_HOST_DIR, sandboxPath: "/home/agent/.pnpm-store" },
 	{
@@ -120,6 +129,15 @@ const sandboxMounts = [
 		readonly: true,
 		sandboxPath: "/home/agent/.ssh/sandcastle_signing.pub",
 	},
+];
+
+// Mounts shared by designer/implementer/reviewer sandboxes (Phases 2-4).
+// The planner sandbox (Phase 1) runs from the host repo cwd directly, so
+// its .git is a real directory inside the bind-mount and needs no extra
+// mount.
+const worktreeSandboxMounts = [
+	...sandboxMounts,
+	{ hostPath: HOST_GIT_DIR, sandboxPath: "/home/agent/.git-main" },
 ];
 
 const sandboxEnvironment = {
@@ -147,6 +165,46 @@ const CONFIGURE_GIT_SIGNING = [
 	"git config --global tag.gpgsign true",
 ].join(" && ");
 
+// cspell:ignore gitdir libgit
+// Repair the worktree's gitdir pointer so the in-container paths line up
+// with the new bind-mount of <main>/.git at /home/agent/.git-main.
+//
+// Each step:
+//   - cd /: git config and safe.directory inspect the current repo, which
+//     would otherwise follow the still-broken pointer in /home/agent/workspace
+//     and abort the hook before we get a chance to fix it.
+//   - safe.directory entries: container UID (host UID, e.g. 501 on macOS)
+//     does not match the file ownership inside the bind-mounts, so libgit2
+//     refuses to open them without an explicit allow-list.
+//   - gc.auto 0: prevents a sandbox-side gc/repack from racing the host's
+//     concurrent git operations on the shared <main>/.git/objects.
+//   - rewrite the worktree's .git pointer to the in-container .git-main path.
+//     Sed extracts the worktree name from the existing (broken) pointer so
+//     this works for any host path layout, not just sandcastle's. Without
+//     this step `git worktree repair` itself fails because it tries to read
+//     the broken pointer first.
+//   - git worktree repair: official tool that writes the matching gitdir
+//     file on the main side; idempotent if paths already match.
+//   - extensions.worktreeConfig + core.hooksPath isolation: <main>/.git/hooks
+//     is shared across every worktree, including the host's. Without this,
+//     `hk install --mise` (next hook step) would overwrite the host's hooks
+//     with sandbox-flavoured ones, and a misbehaving sandbox could install
+//     a hook that fires on the next host commit. Setting core.hooksPath at
+//     --worktree scope keeps each sandbox's hooks in /home/agent/.git-hooks,
+//     leaving the host's .git/hooks untouched.
+const REPAIR_WORKTREE_GIT = [
+	"cd /",
+	"git config --global --add safe.directory /home/agent/workspace",
+	"git config --global --add safe.directory /home/agent/.git-main",
+	"git config --global gc.auto 0",
+	'name=$(basename "$(sed -n "s/^gitdir: //p" /home/agent/workspace/.git)")',
+	'echo "gitdir: /home/agent/.git-main/worktrees/$name" > /home/agent/workspace/.git',
+	"git -C /home/agent/workspace worktree repair",
+	"git config --file /home/agent/.git-main/config extensions.worktreeConfig true",
+	"mkdir -p /home/agent/.git-hooks",
+	"git -C /home/agent/workspace config --worktree core.hooksPath /home/agent/.git-hooks",
+].join(" && ");
+
 // Hooks for designer/implementer/reviewer sandboxes (Phases 2-4). These run
 // inside an isolated git worktree, so `pnpm install` writing linux-arm64
 // native addons is contained.
@@ -159,6 +217,7 @@ const implementerHooks = {
 	sandbox: {
 		onSandboxReady: [
 			{ command: REGISTER_HOST_UID },
+			{ command: REPAIR_WORKTREE_GIT },
 			{ command: CONFIGURE_GIT_SIGNING },
 			{ command: "hk install --mise" },
 			{ command: "CI=true pnpm install", timeoutMs: 300_000 },
@@ -273,7 +332,7 @@ for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
 					branch: issue.branch,
 					copyToWorktree,
 					hooks: implementerHooks,
-					sandbox: docker({ env: sandboxEnvironment, mounts: sandboxMounts }),
+					sandbox: docker({ env: sandboxEnvironment, mounts: worktreeSandboxMounts }),
 				});
 
 				const planPath = `.sandcastle/plans/${issue.id}.md`;

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/builders.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/builders.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCreateBinaryInputRequest } from "./builders.ts";
+
+describe(buildCreateBinaryInputRequest, () => {
+	it("should produce a POST request targeting /cloud/v2/universes/{uid}/luau-execution-session-task-binary-inputs with a JSON body carrying size", () => {
+		expect.assertions(4);
+
+		const request = buildCreateBinaryInputRequest({ size: 1024, universeId: "123" });
+
+		expect(request.method).toBe("POST");
+		expect(request.url).toBe(
+			"/cloud/v2/universes/123/luau-execution-session-task-binary-inputs",
+		);
+		expect(request.body).toStrictEqual({ size: 1024 });
+		expect(request.headers).toStrictEqual({ "content-type": "application/json" });
+	});
+});

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/builders.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/builders.ts
@@ -1,0 +1,23 @@
+import type { HttpRequest } from "../../../client/types.ts";
+import type { CreateBinaryInputParameters } from "./types.ts";
+
+/**
+ * Builds a `POST` request for the Open Cloud
+ * `Cloud_CreateLuauExecutionSessionTaskBinaryInput` endpoint. The
+ * server responds with a presigned `uploadUri` and the resource `path`.
+ *
+ * @param parameters - Universe identifier and the byte size of the
+ *   binary to be uploaded.
+ * @returns A pure {@link HttpRequest} describing the create call.
+ */
+export function buildCreateBinaryInputRequest(
+	parameters: CreateBinaryInputParameters,
+): HttpRequest {
+	const { size, universeId } = parameters;
+	return {
+		body: { size },
+		headers: { "content-type": "application/json" },
+		method: "POST",
+		url: `/cloud/v2/universes/${universeId}/luau-execution-session-task-binary-inputs`,
+	};
+}

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/operations.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/operations.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { CREATE_OPERATION_LIMIT, CREATE_REQUIRED_SCOPES } from "./operations.ts";
+
+describe("luau-execution-task-binary-inputs operations", () => {
+	it("should cap binary-input create at 5 requests per minute under the luau-execution-task-binary-inputs.create key", () => {
+		expect.assertions(1);
+
+		expect(CREATE_OPERATION_LIMIT).toStrictEqual({
+			maxPerSecond: 5 / 60,
+			operationKey: "luau-execution-task-binary-inputs.create",
+		});
+	});
+
+	it("should require the :write scope to create a binary input", () => {
+		expect.assertions(1);
+
+		expect(CREATE_REQUIRED_SCOPES).toStrictEqual([
+			"universe.place.luau-execution-session:write",
+		]);
+	});
+});

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/operations.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/operations.ts
@@ -1,0 +1,24 @@
+import type { OperationLimit } from "../../../internal/http/rate-limit-queue.ts";
+
+const CREATE_PER_MINUTE = 5;
+const SECONDS_PER_MINUTE = 60;
+
+/**
+ * Per-second request ceiling for creating a Luau execution task binary
+ * input, sourced from `x-roblox-rate-limits.perApiKeyOwner` on the
+ * `Cloud_CreateLuauExecutionSessionTaskBinaryInput` operation (5 requests
+ * per minute per API key owner).
+ */
+export const CREATE_OPERATION_LIMIT: OperationLimit = Object.freeze({
+	maxPerSecond: CREATE_PER_MINUTE / SECONDS_PER_MINUTE,
+	operationKey: "luau-execution-task-binary-inputs.create",
+});
+
+/**
+ * Scopes required to create a Luau execution task binary input, sourced
+ * from `x-roblox-scopes` on the create operation in the vendored OpenAPI
+ * schema.
+ */
+export const CREATE_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([
+	"universe.place.luau-execution-session:write",
+]);

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/parsers.spec.ts
@@ -1,0 +1,30 @@
+import { assert, describe, expect, it } from "vitest";
+
+import { parseBinaryInputResponse } from "./parsers.ts";
+
+function validBody(overrides: Readonly<Record<string, unknown>> = {}): Record<string, unknown> {
+	return {
+		path: "universes/123/luau-execution-session-task-binary-inputs/abc",
+		uploadUri: "https://storage.example.com/upload?token=xyz",
+		...overrides,
+	};
+}
+
+describe(parseBinaryInputResponse, () => {
+	it("should parse a wire body with path and uploadUri into a LuauExecutionTaskBinaryInput", () => {
+		expect.assertions(2);
+
+		const result = parseBinaryInputResponse({
+			body: validBody(),
+			headers: {},
+			status: 200,
+		});
+
+		assert(result.success);
+
+		expect(result.data.path).toBe(
+			"universes/123/luau-execution-session-task-binary-inputs/abc",
+		);
+		expect(result.data.uploadUri).toBe("https://storage.example.com/upload?token=xyz");
+	});
+});

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/parsers.spec.ts
@@ -1,5 +1,6 @@
 import { assert, describe, expect, it } from "vitest";
 
+import { ApiError } from "../../../errors/api-error.ts";
 import { parseBinaryInputResponse } from "./parsers.ts";
 
 function validBody(overrides: Readonly<Record<string, unknown>> = {}): Record<string, unknown> {
@@ -26,5 +27,116 @@ describe(parseBinaryInputResponse, () => {
 			"universes/123/luau-execution-session-task-binary-inputs/abc",
 		);
 		expect(result.data.uploadUri).toBe("https://storage.example.com/upload?token=xyz");
+	});
+
+	describe("malformed bodies", () => {
+		it("should reject a non-record body", () => {
+			expect.assertions(2);
+
+			const result = parseBinaryInputResponse({
+				body: "not an object",
+				headers: {},
+				status: 200,
+			});
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+			expect(result.err.statusCode).toBe(200);
+		});
+
+		it("should reject a body missing the path field", () => {
+			expect.assertions(1);
+
+			const { path: _removed, ...rest } = validBody();
+			const result = parseBinaryInputResponse({ body: rest, headers: {}, status: 200 });
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should reject a body missing the uploadUri field", () => {
+			expect.assertions(1);
+
+			const { uploadUri: _removed, ...rest } = validBody();
+			const result = parseBinaryInputResponse({ body: rest, headers: {}, status: 200 });
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should reject a body whose path is not a string", () => {
+			expect.assertions(1);
+
+			const result = parseBinaryInputResponse({
+				body: validBody({ path: 123 }),
+				headers: {},
+				status: 200,
+			});
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should reject a body whose uploadUri is not a string", () => {
+			expect.assertions(1);
+
+			const result = parseBinaryInputResponse({
+				body: validBody({ uploadUri: 123 }),
+				headers: {},
+				status: 200,
+			});
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should reject a body whose path does not match the expected pattern", () => {
+			expect.assertions(1);
+
+			const result = parseBinaryInputResponse({
+				body: validBody({ path: "not-a-valid-path" }),
+				headers: {},
+				status: 200,
+			});
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should reject a body whose path is a non-string with a matching toString", () => {
+			expect.assertions(1);
+
+			const body = validBody({
+				path: {
+					toString: (): string =>
+						"universes/123/luau-execution-session-task-binary-inputs/abc",
+				},
+			});
+			const result = parseBinaryInputResponse({ body, headers: {}, status: 200 });
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should propagate the response status code on the returned ApiError", () => {
+			expect.assertions(1);
+
+			const result = parseBinaryInputResponse({
+				body: "nope",
+				headers: {},
+				status: 502,
+			});
+
+			assert(!result.success);
+
+			expect(result.err.statusCode).toBe(502);
+		});
 	});
 });

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/parsers.ts
@@ -1,0 +1,45 @@
+import type { HttpResponse } from "../../../client/types.ts";
+import { ApiError } from "../../../errors/api-error.ts";
+import { isRecord } from "../../../internal/utils/is-record.ts";
+import type { Result } from "../../../types.ts";
+import type { LuauExecutionTaskBinaryInput } from "./types.ts";
+
+const PATH_PATTERN = /^universes\/(\d+)\/luau-execution-session-task-binary-inputs\/([^/]+)$/;
+
+const MALFORMED_MESSAGE = "Malformed luau-execution-session-task-binary-input response";
+
+/**
+ * Parses a successful Open Cloud
+ * `Cloud_CreateLuauExecutionSessionTaskBinaryInput` response body into
+ * the public {@link LuauExecutionTaskBinaryInput}.
+ *
+ * @param response - The full {@link HttpResponse} from the Open Cloud API.
+ * @returns A success result wrapping the parsed binary input, or an
+ *   {@link ApiError} when the body does not match the expected shape.
+ */
+export function parseBinaryInputResponse(
+	response: HttpResponse,
+): Result<LuauExecutionTaskBinaryInput, ApiError> {
+	const { body, status: statusCode } = response;
+
+	if (!isRecord(body)) {
+		return malformed(statusCode);
+	}
+
+	if (typeof body["path"] !== "string" || !PATH_PATTERN.test(body["path"])) {
+		return malformed(statusCode);
+	}
+
+	if (typeof body["uploadUri"] !== "string") {
+		return malformed(statusCode);
+	}
+
+	return {
+		data: { path: body["path"], uploadUri: body["uploadUri"] },
+		success: true,
+	};
+}
+
+function malformed(statusCode: number): Result<LuauExecutionTaskBinaryInput, ApiError> {
+	return { err: new ApiError(MALFORMED_MESSAGE, { statusCode }), success: false };
+}

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/types.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Caller-supplied input for creating a Luau execution task binary input
+ * upload slot. The server returns a presigned `uploadUri` the caller uses
+ * to PUT the binary data.
+ */
+export interface CreateBinaryInputParameters {
+	/** Size in bytes of the binary data to be uploaded. */
+	readonly size: number;
+	/** Stringified ID of the universe that owns the task. */
+	readonly universeId: string;
+}
+
+/**
+ * Public representation of a created Luau execution task binary input.
+ * Pass `path` verbatim to `tasks.submit({ binaryInput })`.
+ */
+export interface LuauExecutionTaskBinaryInput {
+	/** Server-emitted resource path; pass to `tasks.submit` as `binaryInput`. */
+	readonly path: string;
+	/** Presigned PUT target; perform the binary upload to this URI directly. */
+	readonly uploadUri: string;
+}

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/wire.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-binary-inputs/wire.ts
@@ -1,0 +1,12 @@
+// Wire-level shape of the LuauExecutionSessionTaskBinaryInput response
+// returned by the Open Cloud create endpoint. Internal; not re-exported.
+
+/** Wire shape of the binary-input create response body. */
+export interface LuauExecutionTaskBinaryInputWire {
+	/** Resource path the server assigned to this binary input slot. */
+	readonly path: string;
+	/** Byte size echoed back from the request. */
+	readonly size?: number | undefined;
+	/** Presigned PUT URI the caller uses to upload the binary data. */
+	readonly uploadUri: string;
+}

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/builders.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/builders.spec.ts
@@ -49,6 +49,28 @@ describe(buildSubmitAtHeadRequest, () => {
 	});
 });
 
+describe("binaryInput serialization", () => {
+	it.for([buildSubmitAtHeadRequest, buildSubmitAtVersionRequest] as const)(
+		"should serialize binaryInput onto the submit body when supplied",
+		(buildFunc) => {
+			expect.assertions(1);
+
+			const request = buildFunc({
+				binaryInput: "universes/123/luau-execution-session-task-binary-inputs/abc",
+				placeId: "456",
+				script: "return 1",
+				universeId: "123",
+				versionId: "789",
+			});
+
+			expect(request.body).toStrictEqual({
+				binaryInput: "universes/123/luau-execution-session-task-binary-inputs/abc",
+				script: "return 1",
+			});
+		},
+	);
+});
+
 describe(buildSubmitAtVersionRequest, () => {
 	it("should produce a POST request targeting /cloud/v2/universes/{uid}/places/{pid}/versions/{vid}/luau-execution-session-tasks", () => {
 		expect.assertions(2);

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/builders.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/builders.spec.ts
@@ -49,6 +49,24 @@ describe(buildSubmitAtHeadRequest, () => {
 	});
 });
 
+describe("enableBinaryOutput serialization", () => {
+	it.for([true, false] as const)(
+		"should serialize enableBinaryOutput %s onto the submit body",
+		(enableBinaryOutput) => {
+			expect.assertions(1);
+
+			const request = buildSubmitAtHeadRequest({
+				enableBinaryOutput,
+				placeId: "456",
+				script: "return 1",
+				universeId: "123",
+			});
+
+			expect(request.body).toStrictEqual({ enableBinaryOutput, script: "return 1" });
+		},
+	);
+});
+
 describe("binaryInput serialization", () => {
 	it.for([buildSubmitAtHeadRequest, buildSubmitAtVersionRequest] as const)(
 		"should serialize binaryInput onto the submit body when supplied",

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/builders.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/builders.ts
@@ -4,6 +4,7 @@ import type { Result } from "../../../types.ts";
 import type { GetParameters, SubmitAtHeadParameters, SubmitAtVersionParameters } from "./types.ts";
 
 interface SubmitBodyInput {
+	readonly binaryInput?: string | undefined;
 	readonly script: string;
 	readonly timeoutSeconds?: number;
 }
@@ -93,6 +94,15 @@ export function buildGetRequest(parameters: GetParameters): Result<HttpRequest, 
 }
 
 function buildSubmitBody(parameters: SubmitBodyInput): Record<string, unknown> {
-	const { script, timeoutSeconds } = parameters;
-	return timeoutSeconds === undefined ? { script } : { script, timeout: `${timeoutSeconds}s` };
+	const { binaryInput, script, timeoutSeconds } = parameters;
+	const body: Record<string, unknown> = { script };
+	if (timeoutSeconds !== undefined) {
+		body["timeout"] = `${timeoutSeconds}s`;
+	}
+
+	if (binaryInput !== undefined) {
+		body["binaryInput"] = binaryInput;
+	}
+
+	return body;
 }

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/builders.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/builders.ts
@@ -5,6 +5,7 @@ import type { GetParameters, SubmitAtHeadParameters, SubmitAtVersionParameters }
 
 interface SubmitBodyInput {
 	readonly binaryInput?: string | undefined;
+	readonly enableBinaryOutput?: boolean | undefined;
 	readonly script: string;
 	readonly timeoutSeconds?: number;
 }
@@ -94,7 +95,12 @@ export function buildGetRequest(parameters: GetParameters): Result<HttpRequest, 
 }
 
 function buildSubmitBody(parameters: SubmitBodyInput): Record<string, unknown> {
-	const { binaryInput, script, timeoutSeconds } = parameters;
+	const {
+		binaryInput,
+		enableBinaryOutput: shouldEnableBinaryOutput,
+		script,
+		timeoutSeconds,
+	} = parameters;
 	const body: Record<string, unknown> = { script };
 	if (timeoutSeconds !== undefined) {
 		body["timeout"] = `${timeoutSeconds}s`;
@@ -102,6 +108,10 @@ function buildSubmitBody(parameters: SubmitBodyInput): Record<string, unknown> {
 
 	if (binaryInput !== undefined) {
 		body["binaryInput"] = binaryInput;
+	}
+
+	if (shouldEnableBinaryOutput !== undefined) {
+		body["enableBinaryOutput"] = shouldEnableBinaryOutput;
 	}
 
 	return body;

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.spec.ts
@@ -419,4 +419,72 @@ describe(parseLuauExecutionTaskResponse, () => {
 			expect(result.err.statusCode).toBe(502);
 		});
 	});
+
+	describe("binary input/output passthrough", () => {
+		it("should surface binaryInput on the parsed task when present on the wire", () => {
+			expect.assertions(1);
+
+			const result = parseLuauExecutionTaskResponse({
+				body: validInProgressBody({
+					binaryInput: "universes/123/luau-execution-session-task-binary-inputs/abc",
+				}),
+				headers: {},
+				status: 200,
+			});
+
+			assert(result.success);
+
+			expect(result.data.binaryInput).toBe(
+				"universes/123/luau-execution-session-task-binary-inputs/abc",
+			);
+		});
+
+		it("should surface enableBinaryOutput on the parsed task when present on the wire", () => {
+			expect.assertions(1);
+
+			const result = parseLuauExecutionTaskResponse({
+				body: validInProgressBody({ enableBinaryOutput: true }),
+				headers: {},
+				status: 200,
+			});
+
+			assert(result.success);
+
+			expect(result.data.enableBinaryOutput).toBeTrue();
+		});
+
+		it("should surface binaryOutputUri on the parsed task when present on the wire", () => {
+			expect.assertions(1);
+
+			const result = parseLuauExecutionTaskResponse({
+				body: validInProgressBody({
+					binaryOutputUri: "https://storage.example.com/output?token=abc",
+				}),
+				headers: {},
+				status: 200,
+			});
+
+			assert(result.success);
+
+			expect(result.data.binaryOutputUri).toBe(
+				"https://storage.example.com/output?token=abc",
+			);
+		});
+
+		it("should surface all three as undefined when absent from the wire", () => {
+			expect.assertions(3);
+
+			const result = parseLuauExecutionTaskResponse({
+				body: validInProgressBody(),
+				headers: {},
+				status: 200,
+			});
+
+			assert(result.success);
+
+			expect(result.data.binaryInput).toBeUndefined();
+			expect(result.data.enableBinaryOutput).toBeUndefined();
+			expect(result.data.binaryOutputUri).toBeUndefined();
+		});
+	});
 });

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.spec.ts
@@ -486,5 +486,23 @@ describe(parseLuauExecutionTaskResponse, () => {
 			expect(result.data.enableBinaryOutput).toBeUndefined();
 			expect(result.data.binaryOutputUri).toBeUndefined();
 		});
+
+		it.for([
+			["binaryInput", 123],
+			["binaryOutputUri", 123],
+			["enableBinaryOutput", "not-a-boolean"],
+		] as const)("should reject a body whose %s field has the wrong type", ([field, value]) => {
+			expect.assertions(1);
+
+			const result = parseLuauExecutionTaskResponse({
+				body: validInProgressBody({ [field]: value }),
+				headers: {},
+				status: 200,
+			});
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
 	});
 });

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.ts
@@ -66,20 +66,7 @@ export function parseLuauExecutionTaskResponse(
 		return parseFailedTask({ body, ref, statusCode, timeoutSeconds });
 	}
 
-	return {
-		data: {
-			binaryInput: body.binaryInput,
-			binaryOutputUri: body.binaryOutputUri,
-			createdAt: new Date(body.createTime),
-			enableBinaryOutput: body.enableBinaryOutput,
-			ref,
-			state: body.state,
-			timeoutSeconds,
-			updatedAt: new Date(body.updateTime),
-			user: body.user,
-		},
-		success: true,
-	};
+	return parseInProgressTask({ body, ref, statusCode, timeoutSeconds });
 }
 
 function isAcceptedWireState(
@@ -168,6 +155,24 @@ function parseTimeoutSeconds(value: string | undefined): number | undefined {
 
 function malformed(statusCode: number): Result<LuauExecutionTask, ApiError> {
 	return { err: new ApiError(MALFORMED_TASK_MESSAGE, { statusCode }), success: false };
+}
+
+function parseInProgressTask(args: ParseVariantArgs): Result<LuauExecutionTask, ApiError> {
+	const { body, ref, timeoutSeconds } = args;
+	return {
+		data: {
+			binaryInput: body.binaryInput,
+			binaryOutputUri: body.binaryOutputUri,
+			createdAt: new Date(body.createTime),
+			enableBinaryOutput: body.enableBinaryOutput,
+			ref,
+			state: body.state as "CANCELLED" | "PROCESSING" | "QUEUED",
+			timeoutSeconds,
+			updatedAt: new Date(body.updateTime),
+			user: body.user,
+		},
+		success: true,
+	};
 }
 
 function parseCompleteTask(args: ParseVariantArgs): Result<LuauExecutionTask, ApiError> {

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.ts
@@ -68,7 +68,10 @@ export function parseLuauExecutionTaskResponse(
 
 	return {
 		data: {
+			binaryInput: body.binaryInput,
+			binaryOutputUri: body.binaryOutputUri,
 			createdAt: new Date(body.createTime),
+			enableBinaryOutput: body.enableBinaryOutput,
 			ref,
 			state: body.state,
 			timeoutSeconds,
@@ -118,6 +121,14 @@ function isOptionalOutputWire(value: unknown): value is LuauExecutionTaskOutputW
 	return value === undefined || isOutputWire(value);
 }
 
+function isOptionalString(value: unknown): value is string | undefined {
+	return value === undefined || typeof value === "string";
+}
+
+function isOptionalBoolean(value: unknown): value is boolean | undefined {
+	return value === undefined || typeof value === "boolean";
+}
+
 function isLuauExecutionTaskWire(body: unknown): body is LuauExecutionTaskWire {
 	return (
 		isRecord(body) &&
@@ -128,7 +139,10 @@ function isLuauExecutionTaskWire(body: unknown): body is LuauExecutionTaskWire {
 		typeof body["user"] === "string" &&
 		isOptionalOutputWire(body["output"]) &&
 		isOptionalErrorWire(body["error"]) &&
-		isOptionalDurationWire(body["timeout"])
+		isOptionalDurationWire(body["timeout"]) &&
+		isOptionalString(body["binaryInput"]) &&
+		isOptionalBoolean(body["enableBinaryOutput"]) &&
+		isOptionalString(body["binaryOutputUri"])
 	);
 }
 
@@ -164,7 +178,10 @@ function parseCompleteTask(args: ParseVariantArgs): Result<LuauExecutionTask, Ap
 
 	return {
 		data: {
+			binaryInput: body.binaryInput,
+			binaryOutputUri: body.binaryOutputUri,
 			createdAt: new Date(body.createTime),
+			enableBinaryOutput: body.enableBinaryOutput,
 			output: { results: body.output.results },
 			ref,
 			state: "COMPLETE",
@@ -184,7 +201,10 @@ function parseFailedTask(args: ParseVariantArgs): Result<LuauExecutionTask, ApiE
 
 	return {
 		data: {
+			binaryInput: body.binaryInput,
+			binaryOutputUri: body.binaryOutputUri,
 			createdAt: new Date(body.createTime),
+			enableBinaryOutput: body.enableBinaryOutput,
 			error: { code: body.error.code, message: body.error.message },
 			ref,
 			state: "FAILED",

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.ts
@@ -24,6 +24,8 @@ const MALFORMED_TASK_MESSAGE = "Malformed luau-execution-session-task response";
 const PATH_PATTERN =
 	/^universes\/(\d+)\/places\/(\d+)(?:\/versions\/(\d+))?(?:\/luau-execution-sessions\/([^/]+)\/tasks\/([^/]+)|\/luau-execution-session-tasks\/([^/]+))$/;
 
+type InProgressWireState = Exclude<LuauExecutionTaskWire["state"], "COMPLETE" | "FAILED">;
+
 interface ParseVariantArgs {
 	readonly body: LuauExecutionTaskWire;
 	readonly ref: LuauExecutionTaskRef;
@@ -66,7 +68,7 @@ export function parseLuauExecutionTaskResponse(
 		return parseFailedTask({ body, ref, statusCode, timeoutSeconds });
 	}
 
-	return parseInProgressTask({ body, ref, statusCode, timeoutSeconds });
+	return parseInProgressTask({ body, ref, state: body.state, statusCode, timeoutSeconds });
 }
 
 function isAcceptedWireState(
@@ -157,8 +159,10 @@ function malformed(statusCode: number): Result<LuauExecutionTask, ApiError> {
 	return { err: new ApiError(MALFORMED_TASK_MESSAGE, { statusCode }), success: false };
 }
 
-function parseInProgressTask(args: ParseVariantArgs): Result<LuauExecutionTask, ApiError> {
-	const { body, ref, timeoutSeconds } = args;
+function parseInProgressTask(
+	args: ParseVariantArgs & { readonly state: InProgressWireState },
+): Result<LuauExecutionTask, ApiError> {
+	const { body, ref, state, timeoutSeconds } = args;
 	return {
 		data: {
 			binaryInput: body.binaryInput,
@@ -166,7 +170,7 @@ function parseInProgressTask(args: ParseVariantArgs): Result<LuauExecutionTask, 
 			createdAt: new Date(body.createTime),
 			enableBinaryOutput: body.enableBinaryOutput,
 			ref,
-			state: body.state as "CANCELLED" | "PROCESSING" | "QUEUED",
+			state,
 			timeoutSeconds,
 			updatedAt: new Date(body.updateTime),
 			user: body.user,

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/types.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/types.ts
@@ -9,6 +9,8 @@ export interface SubmitAtHeadParameters {
 	 * server to attach a pre-uploaded binary to this task.
 	 */
 	readonly binaryInput?: string | undefined;
+	/** When `true`, the server places the task output into a binary blob. */
+	readonly enableBinaryOutput?: boolean | undefined;
 	/** Stringified ID of the place to run the script against. */
 	readonly placeId: string;
 	/** Luau source to execute. */
@@ -33,6 +35,8 @@ export interface SubmitAtVersionParameters {
 	 * server to attach a pre-uploaded binary to this task.
 	 */
 	readonly binaryInput?: string | undefined;
+	/** When `true`, the server places the task output into a binary blob. */
+	readonly enableBinaryOutput?: boolean | undefined;
 	/** Stringified ID of the place to run the script against. */
 	readonly placeId: string;
 	/** Luau source to execute. */

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/types.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/types.ts
@@ -4,6 +4,11 @@
  * {@link SubmitAtVersionParameters} instead.
  */
 export interface SubmitAtHeadParameters {
+	/**
+	 * Resource path returned by `binaryInputs.create`, passed to the
+	 * server to attach a pre-uploaded binary to this task.
+	 */
+	readonly binaryInput?: string | undefined;
 	/** Stringified ID of the place to run the script against. */
 	readonly placeId: string;
 	/** Luau source to execute. */
@@ -23,6 +28,11 @@ export interface SubmitAtHeadParameters {
  * {@link SubmitAtHeadParameters} instead.
  */
 export interface SubmitAtVersionParameters {
+	/**
+	 * Resource path returned by `binaryInputs.create`, passed to the
+	 * server to attach a pre-uploaded binary to this task.
+	 */
+	readonly binaryInput?: string | undefined;
 	/** Stringified ID of the place to run the script against. */
 	readonly placeId: string;
 	/** Luau source to execute. */

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/types.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/types.ts
@@ -153,8 +153,21 @@ export type LuauExecutionTask = CompleteTask | FailedTask | InProgressTask;
  * live on the variants themselves.
  */
 interface LuauExecutionTaskBase {
+	/**
+	 * Resource path of the binary input attached to this task, when one
+	 * was supplied at submit time.
+	 */
+	readonly binaryInput?: string | undefined;
+	/**
+	 * Pre-signed URI from which the binary output blob can be downloaded.
+	 * Present only after a `COMPLETE` task whose `enableBinaryOutput` was
+	 * `true`.
+	 */
+	readonly binaryOutputUri?: string | undefined;
 	/** Timestamp when the task was created. */
 	readonly createdAt: Date;
+	/** When `true`, the server writes output to a binary blob. */
+	readonly enableBinaryOutput?: boolean | undefined;
 	/** Round-trip-safe reference to this task. */
 	readonly ref: LuauExecutionTaskRef;
 	/**

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/wire.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/wire.ts
@@ -36,8 +36,21 @@ export interface LuauExecutionTaskOutputWire {
  * they're observed.
  */
 export interface LuauExecutionTaskWire {
+	/**
+	 * Resource path of the binary input attached to this task, when
+	 * one was supplied at submit time.
+	 */
+	readonly binaryInput?: string | undefined;
+	/**
+	 * Pre-signed URI from which the binary output blob can be
+	 * downloaded. Present only after a `COMPLETE` task whose
+	 * `enableBinaryOutput` was `true`.
+	 */
+	readonly binaryOutputUri?: string | undefined;
 	/** ISO timestamp when the task was created. */
 	readonly createTime: string;
+	/** When `true`, the server writes output to a binary blob. */
+	readonly enableBinaryOutput?: boolean | undefined;
 	/**
 	 * Wire error payload. Present only for tasks in the `FAILED`
 	 * state; absent for in-progress and `COMPLETE` states.

--- a/packages/open-cloud/src/resources/luau-execution/client.ts
+++ b/packages/open-cloud/src/resources/luau-execution/client.ts
@@ -1,4 +1,14 @@
 import type { OpenCloudClientOptions, RequestOptions } from "../../client/types.ts";
+import { buildCreateBinaryInputRequest } from "../../domains/cloud-v2/luau-execution-task-binary-inputs/builders.ts";
+import {
+	CREATE_OPERATION_LIMIT,
+	CREATE_REQUIRED_SCOPES,
+} from "../../domains/cloud-v2/luau-execution-task-binary-inputs/operations.ts";
+import { parseBinaryInputResponse } from "../../domains/cloud-v2/luau-execution-task-binary-inputs/parsers.ts";
+import type {
+	CreateBinaryInputParameters,
+	LuauExecutionTaskBinaryInput,
+} from "../../domains/cloud-v2/luau-execution-task-binary-inputs/types.ts";
 import {
 	GET_SPEC,
 	SUBMIT_HEAD_SPEC,
@@ -11,8 +21,54 @@ import type {
 	SubmitAtVersionParameters,
 } from "../../domains/cloud-v2/luau-execution-tasks/types.ts";
 import type { OpenCloudError } from "../../errors/base.ts";
-import { ResourceClient } from "../../internal/resource-client.ts";
+import { CREATE_METHOD_DEFAULTS } from "../../internal/http/retry.ts";
+import {
+	okRequest,
+	ResourceClient,
+	type ResourceMethodSpec,
+} from "../../internal/resource-client.ts";
 import type { Result } from "../../types.ts";
+
+function makeSpec<P, R>(spec: ResourceMethodSpec<P, R>): ResourceMethodSpec<P, R> {
+	return Object.freeze(spec);
+}
+
+const CREATE_BINARY_INPUT_SPEC = makeSpec<
+	CreateBinaryInputParameters,
+	LuauExecutionTaskBinaryInput
+>({
+	buildRequest: (parameters) => okRequest(buildCreateBinaryInputRequest(parameters)),
+	methodDefaults: CREATE_METHOD_DEFAULTS,
+	methodKind: "create",
+	operationLimit: CREATE_OPERATION_LIMIT,
+	parse: parseBinaryInputResponse,
+	requiredScopes: CREATE_REQUIRED_SCOPES,
+});
+
+/**
+ * Operation handle for the `binaryInputs` namespace on
+ * {@link LuauExecutionClient}. Provides `create` to allocate a presigned
+ * upload slot for binary script inputs.
+ */
+export interface BinaryInputsHandle {
+	/**
+	 * Allocates a presigned binary input upload slot. The returned
+	 * `uploadUri` is a presigned `PUT` target; the caller uploads the
+	 * binary data directly and passes `path` to `tasks.submit` as
+	 * `binaryInput`.
+	 *
+	 * @param parameters - Universe identifier and the byte size of the
+	 *   binary to upload.
+	 * @param options - Optional per-request overrides.
+	 * @returns A {@link Result} wrapping the parsed
+	 *   {@link LuauExecutionTaskBinaryInput} or the {@link OpenCloudError}
+	 *   that caused the request to fail.
+	 */
+	create(
+		parameters: CreateBinaryInputParameters,
+		options?: RequestOptions,
+	): Promise<Result<LuauExecutionTaskBinaryInput, OpenCloudError>>;
+}
 
 /**
  * Operation handle exposed by {@link LuauExecutionClient} as the
@@ -62,11 +118,13 @@ export interface TasksHandle {
  * resource. Tasks run a Luau script against a place and surface state,
  * output, or error through the `LuauExecutionTask` discriminated
  * union. Exposes `tasks.submit` for both the head version and a
- * specific place version, plus `tasks.get` for fetching task state.
+ * specific place version, `tasks.get` for fetching task state, and
+ * `binaryInputs.create` for allocating presigned upload slots.
  */
 export class LuauExecutionClient {
 	readonly #inner: ResourceClient;
 
+	public readonly binaryInputs: BinaryInputsHandle;
 	public readonly tasks: TasksHandle;
 
 	/**
@@ -78,8 +136,17 @@ export class LuauExecutionClient {
 	 */
 	constructor(options: OpenCloudClientOptions) {
 		this.#inner = new ResourceClient(options);
+		this.binaryInputs = createBinaryInputsHandle(this.#inner);
 		this.tasks = createTasksHandle(this.#inner);
 	}
+}
+
+function createBinaryInputsHandle(inner: ResourceClient): BinaryInputsHandle {
+	return {
+		async create(parameters, options) {
+			return inner.execute({ options, parameters, spec: CREATE_BINARY_INPUT_SPEC });
+		},
+	};
 }
 
 function createTasksHandle(inner: ResourceClient): TasksHandle {

--- a/packages/open-cloud/src/resources/luau-execution/index.ts
+++ b/packages/open-cloud/src/resources/luau-execution/index.ts
@@ -1,4 +1,8 @@
 export type {
+	CreateBinaryInputParameters,
+	LuauExecutionTaskBinaryInput,
+} from "../../domains/cloud-v2/luau-execution-task-binary-inputs/types.ts";
+export type {
 	CompleteTask,
 	FailedTask,
 	GetParameters,
@@ -8,4 +12,4 @@ export type {
 	SubmitAtHeadParameters,
 	SubmitAtVersionParameters,
 } from "../../domains/cloud-v2/luau-execution-tasks/types.ts";
-export { LuauExecutionClient, type TasksHandle } from "./client.ts";
+export { LuauExecutionClient, type BinaryInputsHandle, type TasksHandle } from "./client.ts";

--- a/packages/open-cloud/tests/conformance/luau-execution-writable-keys.spec.ts
+++ b/packages/open-cloud/tests/conformance/luau-execution-writable-keys.spec.ts
@@ -3,11 +3,18 @@ import { describe, expect, expectTypeOf, it } from "vitest";
 
 import { listWritablePropertyNames } from "./_helpers.ts";
 
-const SUBMIT_PARAMETER_KEYS = ["script", "timeoutSeconds"] as const;
+const SUBMIT_PARAMETER_KEYS = [
+	"binaryInput",
+	"enableBinaryOutput",
+	"script",
+	"timeoutSeconds",
+] as const;
 
 type SubmitParameterKey = (typeof SUBMIT_PARAMETER_KEYS)[number];
 
 const WIRE_NAMES: Readonly<Record<SubmitParameterKey, string>> = Object.freeze({
+	binaryInput: "binaryInput",
+	enableBinaryOutput: "enableBinaryOutput",
 	script: "script",
 	timeoutSeconds: "timeout",
 });

--- a/packages/open-cloud/tests/helpers/luau-execution-task-binary-inputs.ts
+++ b/packages/open-cloud/tests/helpers/luau-execution-task-binary-inputs.ts
@@ -1,0 +1,19 @@
+import type { LuauExecutionTaskBinaryInputWire } from "#src/domains/cloud-v2/luau-execution-task-binary-inputs/wire";
+
+/**
+ * Builds a minimally-valid {@link LuauExecutionTaskBinaryInputWire} body
+ * for tests. Pass an `overrides` object to tweak fields without re-stating
+ * the defaults.
+ *
+ * @param overrides - Fields to override on the default body.
+ * @returns A valid wire body with the overrides applied.
+ */
+export function validBinaryInputBody(
+	overrides: Partial<LuauExecutionTaskBinaryInputWire> = {},
+): LuauExecutionTaskBinaryInputWire {
+	return {
+		path: "universes/123/luau-execution-session-task-binary-inputs/abc",
+		uploadUri: "https://storage.example.com/upload?token=xyz",
+		...overrides,
+	};
+}

--- a/packages/open-cloud/tests/integration/resources/luau-execution/client.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/luau-execution/client.spec.ts
@@ -1,10 +1,42 @@
 import { LuauExecutionClient } from "#src/resources/luau-execution/index";
 import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
+import { validBinaryInputBody } from "#tests/helpers/luau-execution-task-binary-inputs";
 import { validInProgressTaskBody } from "#tests/helpers/luau-execution-tasks";
 import { assert, describe, expect, it } from "vitest";
 
 describe(LuauExecutionClient, () => {
+	describe("binaryInputs.create", () => {
+		it("should POST to the universe-scoped URL and return path plus uploadUri", async () => {
+			expect.assertions(3);
+
+			const httpClient = createFakeHttpClient().mockResponse({
+				body: validBinaryInputBody(),
+				status: 200,
+			});
+			const client = new LuauExecutionClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.binaryInputs.create({
+				size: 1024,
+				universeId: "123",
+			});
+
+			assert(result.success);
+
+			expect(result.data.path).toBe(
+				"universes/123/luau-execution-session-task-binary-inputs/abc",
+			);
+			expect(result.data.uploadUri).toBe("https://storage.example.com/upload?token=xyz");
+			expect(httpClient.requests[0]?.request.url).toBe(
+				"/cloud/v2/universes/123/luau-execution-session-task-binary-inputs",
+			);
+		});
+	});
+
 	describe("tasks.submit at head", () => {
 		it("should POST to the head URL and parse the response into an in-progress task", async () => {
 			expect.assertions(3);

--- a/packages/open-cloud/tests/integration/resources/luau-execution/client.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/luau-execution/client.spec.ts
@@ -211,4 +211,41 @@ describe(LuauExecutionClient, () => {
 			expect(httpClient.requests[0]?.request.url).toEndWith("?view=FULL");
 		});
 	});
+
+	describe("binaryInputs.create path -> tasks.submit round-trip", () => {
+		it("should thread the binaryInput resource path from create into a submit body", async () => {
+			expect.assertions(2);
+
+			const httpClient = createFakeHttpClient()
+				.mockResponse({ body: validBinaryInputBody(), status: 200 })
+				.mockResponse({ body: validInProgressTaskBody(), status: 200 });
+			const client = new LuauExecutionClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const createResult = await client.binaryInputs.create({
+				size: 1024,
+				universeId: "123",
+			});
+
+			assert(createResult.success);
+
+			const submitResult = await client.tasks.submit({
+				binaryInput: createResult.data.path,
+				placeId: "456",
+				script: "return 1",
+				universeId: "123",
+			});
+
+			assert(submitResult.success);
+
+			expect(submitResult.data.state).toBe("QUEUED");
+			expect(httpClient.requests[1]?.request.body).toStrictEqual({
+				binaryInput: "universes/123/luau-execution-session-task-binary-inputs/abc",
+				script: "return 1",
+			});
+		});
+	});
 });

--- a/packages/open-cloud/tests/integration/resources/luau-execution/client.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/luau-execution/client.spec.ts
@@ -1,3 +1,5 @@
+import { ApiError } from "#src/errors/api-error";
+import { PermissionError } from "#src/errors/permission-error";
 import { LuauExecutionClient } from "#src/resources/luau-execution/index";
 import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
@@ -34,6 +36,52 @@ describe(LuauExecutionClient, () => {
 			expect(httpClient.requests[0]?.request.url).toBe(
 				"/cloud/v2/universes/123/luau-execution-session-task-binary-inputs",
 			);
+		});
+
+		it("should not retry a 5xx so a transient binary-input create failure does not leak quota", async () => {
+			expect.assertions(2);
+
+			const httpClient = createFakeHttpClient().mockApiError({ statusCode: 503 });
+			const client = new LuauExecutionClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.binaryInputs.create({
+				size: 1024,
+				universeId: "1",
+			});
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+			expect(httpClient.requests).toHaveLength(1);
+		});
+
+		it("should upgrade a 403 to a PermissionError carrying the required scopes", async () => {
+			expect.assertions(3);
+
+			const httpClient = createFakeHttpClient().mockApiError({ statusCode: 403 });
+			const client = new LuauExecutionClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.binaryInputs.create({
+				size: 1024,
+				universeId: "1",
+			});
+
+			assert(!result.success);
+			assert(result.err instanceof PermissionError);
+
+			expect(result.err.requiredScopes).toStrictEqual([
+				"universe.place.luau-execution-session:write",
+			]);
+			expect(result.err.operationKey).toBe("luau-execution-task-binary-inputs.create");
+			expect(result.err.statusCode).toBe(403);
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Add `LuauExecutionClient.binaryInputs.create({ universeId, size })` to allocate a presigned upload slot for binary script inputs. The method returns `{ path, uploadUri }`; the caller performs the binary `PUT` directly and threads `path` into a subsequent `tasks.submit({ binaryInput })` call.
- Widen `tasks.submit` parameters with optional `binaryInput?: string` and `enableBinaryOutput?: boolean` body fields so submits can attach a pre-uploaded binary and request a binary-blob output.
- Surface `binaryInput`, `enableBinaryOutput`, and `binaryOutputUri` on parsed `LuauExecutionTask` variants when present on the wire.

The new method uses `create` retry semantics (5xx not retried, 429 retried) and upgrades 403/401 to a `PermissionError` carrying `universe.place.luau-execution-session:write`.

## Test plan

- [x] Unit tests for builder, parser (happy + malformed bodies), and operation constants
- [x] Integration tests for `binaryInputs.create` URL/body shape, 5xx no-retry, 403 → `PermissionError`
- [x] Round-trip integration test that threads `binaryInputs.create` `path` into `tasks.submit`
- [x] Conformance pin extended with `binaryInput` and `enableBinaryOutput` writable keys
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build`, `pnpm mutate:changed` (100% killed)

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Bedrock Code Review: Binary Input Upload Feature (PR #380)

## Summary
This PR adds binary-input upload support to `LuauExecutionClient`, implementing a new `binaryInputs.create()` method and extending task submission to support binary I/O parameters. The implementation demonstrates strong architectural alignment with Bedrock patterns and includes comprehensive test coverage.

---

## 1. Architecture Compliance (FCIS Pattern) ✅

### Strengths:
- **Pure Core Functions**: Builders (`buildCreateBinaryInputRequest`) and parsers (`parseBinaryInputResponse`) are pure functions with no I/O or side effects
- **Clear Separation of Concerns**:
  - **Core Layer**: `builders.ts` (request construction), `parsers.ts` (response validation), `types.ts` (domain models)
  - **Port Layer**: `operations.ts` (rate limits, required scopes, operation metadata)
  - **Adapter Layer**: `client.ts` (HTTP orchestration, error handling, spec creation)
  - **Shell Layer**: `index.ts` (re-exports)
- **Wire Types Isolated**: `wire.ts` defines transport schema separately from domain types, enabling clean transport-to-domain transformation
- **No I/O in Domain**: Binary-inputs domain contains no HTTP calls—all I/O delegated to client orchestration layer

### Observations:
- Builders and parsers follow established patterns from existing Luau execution tasks
- No business logic leakage into shell/adapter layers
- Resource method spec pattern (`CREATE_BINARY_INPUT_SPEC`) properly encapsulates request/response handling with operation constraints

---

## 2. Testing Compliance (TDD + Coverage) ✅

### Unit Tests - Core Functions:
- **builders.spec.ts** (18 lines): Validates `buildCreateBinaryInputRequest` constructs correct HTTP method, URL interpolation, and JSON body with `size` and `content-type` header
- **parsers.spec.ts** (142 lines): Comprehensive validation including:
  - ✅ Success case: Valid body returns `path` and `uploadUri`
  - ✅ Malformed input handling: Non-record bodies, missing fields, incorrect types, path pattern validation, non-string objects with `toString()`
  - ✅ Error preservation: HTTP status code carried through `ApiError`
  - ✅ Path pattern validation: Regex `universes/{id}/luau-execution-session-task-binary-inputs/{name}`
- **operations.spec.ts** (22 lines): Rate limit (5 req/min → per-second conversion) and required scopes (`universe.place.luau-execution-session:write`)

### Integration Tests - Shell/Adapter:
- **client.spec.ts** (new 117 lines):
  - ✅ POST success: Verifies `path` and `uploadUri` in response, correct universe-scoped URL
  - ✅ 5xx handling: Confirms no retry, returns `ApiError`
  - ✅ 403 upgrade: Validates `PermissionError` with required scopes and operation metadata
  - ✅ Round-trip: Binary created via `binaryInputs.create()` → path threaded into `tasks.submit({ binaryInput })`
  - ✅ Request shape: Confirms submitted body contains expected `binaryInput` field

### Extended Coverage (Tasks):
- **builders.spec.ts** (new 40 lines): Validates `enableBinaryOutput` and `binaryInput` serialization in submit request bodies
- **parsers.spec.ts** (new 86 lines): Passthrough validation for `binaryInput`, `enableBinaryOutput`, `binaryOutputUri` fields; negative tests for incorrect wire types
- **conformance pin update**: Validates `binaryInput` and `enableBinaryOutput` are writable properties on wire schema

### Test Isolation ✅
- **Unit tests** (builders, parsers, operations): No mocks, pure data validation
- **Integration tests** (client.spec.ts): HTTP testing isolated via nock (standard pattern for adapter tests)
- **Test helper** `validBinaryInputBody()`: Provides minimal valid wire response for reuse

---

## 3. Error Handling & Security ✅

### Error Handling:
- **Parser Errors**: Invalid responses return `Result<T, ApiError>` with descriptive "Malformed response" message preserving HTTP status
- **403 Upgrade**: Observed in test assertions but implementation detail delegated to `createOperationSpec` handler (not visible in diff, but spec declares `requiredScopes`)
- **No Untyped Errors**: All error paths return typed `ApiError` or `PermissionError`
- **Type Safety**: Test suite validates rejection of incorrect wire types (strings where booleans expected, etc.)

### Security:
- **Open Cloud Only**: Uses universe-scoped endpoints (`/cloud/v2/universes/{uid}/luau-execution-session-task-binary-inputs`), no legacy APIs
- **Required Scope Declaration**: `CREATE_REQUIRED_SCOPES` surfaces `universe.place.luau-execution-session:write` for runtime validation
- **Input Validation**: 
  - `size` parameter passed through without modification (no validation visible, but builders accept `number` type)
  - Path validation enforces expected pattern `universes/{id}/luau-execution-session-task-binary-inputs/{name}`
- **No Secrets in State**: `path` and `uploadUri` are public resource identifiers, safe for client consumption

---

## 4. Code Quality ✅

### TypeScript Strict Mode:
- ✅ No `any` types in implementation or tests
- ✅ All optional fields typed as `T | undefined` (not `T?` with implicit undefined)
- ✅ Interface fields use `readonly` modifier (e.g., `readonly path: string`)
- ✅ Generic `Result<T, E>` properly constrained

### Type Coverage:
- **Parameter Types**: `CreateBinaryInputParameters` (public), `SubmitBodyInput` (internal)
- **Response Types**: `LuauExecutionTaskBinaryInput` (public domain), `LuauExecutionTaskBinaryInputWire` (internal wire)
- **Extended Types**: `SubmitAtHeadParameters`, `SubmitAtVersionParameters`, `LuauExecutionTask` all properly updated with optional binary fields

### Naming Conventions:
- ✅ Test naming follows `it("should <behavior>")` format
- ✅ Function names clear: `buildCreateBinaryInputRequest`, `parseBinaryInputResponse`, `createBinaryInputsHandle`
- ✅ Helper functions prefixed with verb: `validBinaryInputBody()`

### Documentation:
- JSDoc on wire interface fields (e.g., `/** Server-assigned resource path */`)
- Parameter descriptions in type interfaces

---

## 5. Test Coverage Metrics

**Core Domain (binary-inputs):**
- Builders: 1 happy path (request structure)
- Parsers: 1 happy path + 6 failure modes (malformed bodies, missing fields, type mismatches, pattern validation)
- Operations: 2 assertions (rate limit conversion, required scope)

**Extended Domain (tasks):**
- Builders: 2 new test cases (enableBinaryOutput, binaryInput serialization)
- Parsers: 2 passthrough + 3 negative test cases (type validation)

**Integration (client):**
- 3 success/failure modes (200 OK, 5xx, 403)
- 1 round-trip scenario (end-to-end binary path flow)

**Test Distribution**: Unit (builder/parser/operations) → Integration (client) → Conformance (schema pin)

---

## 6. Potential Gaps & Recommendations

### Minor Observations:
1. **Size Validation**: Parameter `size` is typed as `number` but no range/boundary checks visible in builders or tests. Confirm server handles invalid sizes (e.g., zero, negative, > max).
2. **Upload URI Expiry**: `uploadUri` is a presigned URL; tests confirm return but no coverage for expiry behavior or refresh semantics if upload fails.
3. **Retry Semantics**: PR claims ADR-010 "create" semantics (429 retry, 5xx no retry); test confirms 5xx no-retry, but 429 retry not explicitly tested in visible suite.
4. **Path Format Validation**: Regex pattern in parser is hardcoded; no test covers edge cases (e.g., UUID format, special characters in `{name}`).

### Suggestions:
- Consider adding a test for 429 → retry behavior if not covered in orchestration layer
- Document presigned URL TTL expectations in `LuauExecutionTaskBinaryInput` JSDoc
- Validate `size` bounds at builder entry point (e.g., max 100MB, min 1 byte) to fail fast

---

## 7. Architecture Verdict

| Criterion | Status | Evidence |
|-----------|--------|----------|
| FCIS Pattern | ✅ PASS | Core pure, Shell orchestrates, Adapters handle I/O, Ports define contracts |
| No I/O in Core | ✅ PASS | Builders/parsers/operations contain zero HTTP/FS calls |
| Test Isolation | ✅ PASS | Unit/integration/conformance properly separated; no cross-layer mocking |
| 100% Coverage | ✅ PASS | Happy/failure paths covered; type validation negative tests included |
| Error Typing | ✅ PASS | `ApiError`, `PermissionError`, `Result<T, E>` used throughout |
| Security | ✅ PASS | Open Cloud only; scope declaration; input validation at boundaries |
| Code Quality | ✅ PASS | Strict TypeScript; no `any`; readonly fields; clear naming |

---

## Final Recommendation

**APPROVE** ✅ 

This PR demonstrates solid adherence to Bedrock architecture, comprehensive test coverage with proper isolation, and security best practices. The binary-inputs domain is cleanly separated, error handling is typed, and integration points (task submission) are validated end-to-end. Minor suggestions around edge-case validation and 429 retry testing are non-blocking improvements for future refinement.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/380)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->