### PR TITLE
feat(ocale): publish testing subpath with mock helpers

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -44,6 +44,7 @@ const config: KnipConfig = {
 				"scripts/**/*.ts",
 				"src/**/index.ts",
 				"tests/helpers/index.ts",
+				"tests/helpers/lite.ts",
 			],
 		},
 		"packages/testing": {},

--- a/packages/open-cloud/package.json
+++ b/packages/open-cloud/package.json
@@ -111,6 +111,7 @@
 			"./package.json": "./package.json",
 			"./places": "./dist/places.mjs",
 			"./storage": "./dist/storage.mjs",
+			"./testing": "./dist/testing.mjs",
 			"./universes": "./dist/universes.mjs"
 		}
 	}

--- a/packages/open-cloud/src/internal/http/resolve-dependencies.spec.ts
+++ b/packages/open-cloud/src/internal/http/resolve-dependencies.spec.ts
@@ -1,5 +1,5 @@
 import { resolveDependencies } from "#src/internal/http/resolve-dependencies";
-import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
+import { createFakeHttpClient } from "#tests/helpers/fake-http-client-validated";
 import { setTimeout } from "node:timers/promises";
 import { describe, expect, it } from "vitest";
 

--- a/packages/open-cloud/src/internal/resource-client.spec.ts
+++ b/packages/open-cloud/src/internal/resource-client.spec.ts
@@ -1,5 +1,8 @@
 import { createFakeClock } from "#tests/helpers/fake-clock";
-import { createFakeHttpClient, type FakeHttpClient } from "#tests/helpers/fake-http-client";
+import {
+	createFakeHttpClient,
+	type FakeHttpClient,
+} from "#tests/helpers/fake-http-client-validated";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
 import { assert, describe, expect, it, vi } from "vitest";
 

--- a/packages/open-cloud/tests/helpers/fake-http-client-validated.spec.ts
+++ b/packages/open-cloud/tests/helpers/fake-http-client-validated.spec.ts
@@ -1,0 +1,158 @@
+import type { HttpRequest, RequestConfig } from "#src/internal/http/types";
+import { assert, describe, expect, it } from "vitest";
+
+import { createFakeHttpClient, FakeHttpClientContractError } from "./fake-http-client-validated.ts";
+import { validGamePassBody } from "./game-passes.ts";
+
+const config: RequestConfig = { apiKey: "test", baseUrl: "https://apis.roblox.test" };
+
+const gamePassGet: HttpRequest = {
+	method: "GET",
+	url: "/game-passes/v1/universes/42/game-passes/999/creator",
+};
+
+describe("createFakeHttpClient schema validation", () => {
+	describe("off", () => {
+		it("should accept any body unchanged", async () => {
+			expect.assertions(2);
+
+			const fake = createFakeHttpClient({ schemaValidation: "off" }).mockResponse({
+				body: { completely: "invalid" },
+				status: 200,
+			});
+
+			const result = await fake.request(gamePassGet, config);
+
+			assert(result.success);
+
+			expect(result.data.body).toStrictEqual({ completely: "invalid" });
+			expect(fake.schemaViolations).toStrictEqual([]);
+		});
+	});
+
+	describe("strict (default)", () => {
+		it("should reject an invalid body when no mode is passed", async () => {
+			expect.assertions(1);
+
+			const fake = createFakeHttpClient().mockResponse({
+				body: { completely: "invalid" },
+				status: 200,
+			});
+
+			await expect(fake.request(gamePassGet, config)).rejects.toBeInstanceOf(
+				FakeHttpClientContractError,
+			);
+		});
+
+		it("should throw on a response body that violates the operation schema", async () => {
+			expect.assertions(1);
+
+			const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
+				body: { completely: "invalid" },
+				status: 200,
+			});
+
+			await expect(fake.request(gamePassGet, config)).rejects.toBeInstanceOf(
+				FakeHttpClientContractError,
+			);
+		});
+
+		it("should throw on a request body that violates the operation schema", async () => {
+			expect.assertions(1);
+
+			const patchUniverse: HttpRequest = {
+				body: { displayName: 42 },
+				method: "PATCH",
+				url: "/cloud/v2/universes/42",
+			};
+			const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
+				body: {},
+				status: 200,
+			});
+
+			await expect(fake.request(patchUniverse, config)).rejects.toMatchObject({
+				violation: { direction: "request" },
+			});
+		});
+
+		it("should throw on an unknown url with a helpful message", async () => {
+			expect.assertions(1);
+
+			const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
+				body: {},
+				status: 200,
+			});
+
+			await expect(
+				fake.request({ method: "GET", url: "/does-not-exist/1" }, config),
+			).rejects.toThrowWithMessage(
+				FakeHttpClientContractError,
+				/no operation matches GET \/does-not-exist\/1/,
+			);
+		});
+
+		it("should pass through a schema-valid response body", async () => {
+			expect.assertions(2);
+
+			const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
+				body: validGamePassBody(),
+				status: 200,
+			});
+
+			const result = await fake.request(gamePassGet, config);
+
+			assert(result.success);
+
+			expect(result.data.status).toBe(200);
+			expect(fake.schemaViolations).toStrictEqual([]);
+		});
+
+		it("should attach the offending violation to the thrown error", async () => {
+			expect.assertions(1);
+
+			const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
+				body: { completely: "invalid" },
+				status: 200,
+			});
+
+			await expect(fake.request(gamePassGet, config)).rejects.toMatchObject({
+				violation: {
+					direction: "response",
+					pathTemplate:
+						"/game-passes/v1/universes/{universeId}/game-passes/{gamePassId}/creator",
+				},
+			});
+		});
+	});
+
+	describe("warn", () => {
+		it("should record violations without throwing", async () => {
+			expect.assertions(2);
+
+			const fake = createFakeHttpClient({ schemaValidation: "warn" }).mockResponse({
+				body: { completely: "invalid" },
+				status: 200,
+			});
+
+			const result = await fake.request(gamePassGet, config);
+
+			assert(result.success);
+
+			expect(fake.schemaViolations).toHaveLength(1);
+			expect(fake.schemaViolations[0]?.direction).toBe("response");
+		});
+
+		it("should stay silent on a schema-valid response", async () => {
+			expect.assertions(1);
+
+			const fake = createFakeHttpClient({ schemaValidation: "warn" }).mockResponse({
+				body: validGamePassBody(),
+				status: 200,
+			});
+
+			await fake.request(gamePassGet, config);
+
+			expect(fake.schemaViolations).toStrictEqual([]);
+		});
+	});
+});

--- a/packages/open-cloud/tests/helpers/fake-http-client-validated.spec.ts
+++ b/packages/open-cloud/tests/helpers/fake-http-client-validated.spec.ts
@@ -11,148 +11,150 @@ const gamePassGet: HttpRequest = {
 	url: "/game-passes/v1/universes/42/game-passes/999/creator",
 };
 
-describe("createFakeHttpClient schema validation", () => {
-	describe("off", () => {
-		it("should accept any body unchanged", async () => {
-			expect.assertions(2);
+describe(createFakeHttpClient, () => {
+	describe("schema validation", () => {
+		describe("off", () => {
+			it("should accept any body unchanged", async () => {
+				expect.assertions(2);
 
-			const fake = createFakeHttpClient({ schemaValidation: "off" }).mockResponse({
-				body: { completely: "invalid" },
-				status: 200,
-			});
+				const fake = createFakeHttpClient({ schemaValidation: "off" }).mockResponse({
+					body: { completely: "invalid" },
+					status: 200,
+				});
 
-			const result = await fake.request(gamePassGet, config);
+				const result = await fake.request(gamePassGet, config);
 
-			assert(result.success);
+				assert(result.success);
 
-			expect(result.data.body).toStrictEqual({ completely: "invalid" });
-			expect(fake.schemaViolations).toStrictEqual([]);
-		});
-	});
-
-	describe("strict (default)", () => {
-		it("should reject an invalid body when no mode is passed", async () => {
-			expect.assertions(1);
-
-			const fake = createFakeHttpClient().mockResponse({
-				body: { completely: "invalid" },
-				status: 200,
-			});
-
-			await expect(fake.request(gamePassGet, config)).rejects.toBeInstanceOf(
-				FakeHttpClientContractError,
-			);
-		});
-
-		it("should throw on a response body that violates the operation schema", async () => {
-			expect.assertions(1);
-
-			const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
-				body: { completely: "invalid" },
-				status: 200,
-			});
-
-			await expect(fake.request(gamePassGet, config)).rejects.toBeInstanceOf(
-				FakeHttpClientContractError,
-			);
-		});
-
-		it("should throw on a request body that violates the operation schema", async () => {
-			expect.assertions(1);
-
-			const patchUniverse: HttpRequest = {
-				body: { displayName: 42 },
-				method: "PATCH",
-				url: "/cloud/v2/universes/42",
-			};
-			const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
-				body: {},
-				status: 200,
-			});
-
-			await expect(fake.request(patchUniverse, config)).rejects.toMatchObject({
-				violation: { direction: "request" },
+				expect(result.data.body).toStrictEqual({ completely: "invalid" });
+				expect(fake.schemaViolations).toStrictEqual([]);
 			});
 		});
 
-		it("should throw on an unknown url with a helpful message", async () => {
-			expect.assertions(1);
+		describe("strict (default)", () => {
+			it("should reject an invalid body when no mode is passed", async () => {
+				expect.assertions(1);
 
-			const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
-				body: {},
-				status: 200,
+				const fake = createFakeHttpClient().mockResponse({
+					body: { completely: "invalid" },
+					status: 200,
+				});
+
+				await expect(fake.request(gamePassGet, config)).rejects.toBeInstanceOf(
+					FakeHttpClientContractError,
+				);
 			});
 
-			await expect(
-				fake.request({ method: "GET", url: "/does-not-exist/1" }, config),
-			).rejects.toThrowWithMessage(
-				FakeHttpClientContractError,
-				/no operation matches GET \/does-not-exist\/1/,
-			);
+			it("should throw on a response body that violates the operation schema", async () => {
+				expect.assertions(1);
+
+				const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
+					body: { completely: "invalid" },
+					status: 200,
+				});
+
+				await expect(fake.request(gamePassGet, config)).rejects.toBeInstanceOf(
+					FakeHttpClientContractError,
+				);
+			});
+
+			it("should throw on a request body that violates the operation schema", async () => {
+				expect.assertions(1);
+
+				const patchUniverse: HttpRequest = {
+					body: { displayName: 42 },
+					method: "PATCH",
+					url: "/cloud/v2/universes/42",
+				};
+				const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
+					body: {},
+					status: 200,
+				});
+
+				await expect(fake.request(patchUniverse, config)).rejects.toMatchObject({
+					violation: { direction: "request" },
+				});
+			});
+
+			it("should throw on an unknown url with a helpful message", async () => {
+				expect.assertions(1);
+
+				const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
+					body: {},
+					status: 200,
+				});
+
+				await expect(
+					fake.request({ method: "GET", url: "/does-not-exist/1" }, config),
+				).rejects.toThrowWithMessage(
+					FakeHttpClientContractError,
+					/no operation matches GET \/does-not-exist\/1/,
+				);
+			});
+
+			it("should pass through a schema-valid response body", async () => {
+				expect.assertions(2);
+
+				const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
+					body: validGamePassBody(),
+					status: 200,
+				});
+
+				const result = await fake.request(gamePassGet, config);
+
+				assert(result.success);
+
+				expect(result.data.status).toBe(200);
+				expect(fake.schemaViolations).toStrictEqual([]);
+			});
+
+			it("should attach the offending violation to the thrown error", async () => {
+				expect.assertions(1);
+
+				const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
+					body: { completely: "invalid" },
+					status: 200,
+				});
+
+				await expect(fake.request(gamePassGet, config)).rejects.toMatchObject({
+					violation: {
+						direction: "response",
+						pathTemplate:
+							"/game-passes/v1/universes/{universeId}/game-passes/{gamePassId}/creator",
+					},
+				});
+			});
 		});
 
-		it("should pass through a schema-valid response body", async () => {
-			expect.assertions(2);
+		describe("warn", () => {
+			it("should record violations without throwing", async () => {
+				expect.assertions(2);
 
-			const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
-				body: validGamePassBody(),
-				status: 200,
+				const fake = createFakeHttpClient({ schemaValidation: "warn" }).mockResponse({
+					body: { completely: "invalid" },
+					status: 200,
+				});
+
+				const result = await fake.request(gamePassGet, config);
+
+				assert(result.success);
+
+				expect(fake.schemaViolations).toHaveLength(1);
+				expect(fake.schemaViolations[0]?.direction).toBe("response");
 			});
 
-			const result = await fake.request(gamePassGet, config);
+			it("should stay silent on a schema-valid response", async () => {
+				expect.assertions(1);
 
-			assert(result.success);
+				const fake = createFakeHttpClient({ schemaValidation: "warn" }).mockResponse({
+					body: validGamePassBody(),
+					status: 200,
+				});
 
-			expect(result.data.status).toBe(200);
-			expect(fake.schemaViolations).toStrictEqual([]);
-		});
+				await fake.request(gamePassGet, config);
 
-		it("should attach the offending violation to the thrown error", async () => {
-			expect.assertions(1);
-
-			const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
-				body: { completely: "invalid" },
-				status: 200,
+				expect(fake.schemaViolations).toStrictEqual([]);
 			});
-
-			await expect(fake.request(gamePassGet, config)).rejects.toMatchObject({
-				violation: {
-					direction: "response",
-					pathTemplate:
-						"/game-passes/v1/universes/{universeId}/game-passes/{gamePassId}/creator",
-				},
-			});
-		});
-	});
-
-	describe("warn", () => {
-		it("should record violations without throwing", async () => {
-			expect.assertions(2);
-
-			const fake = createFakeHttpClient({ schemaValidation: "warn" }).mockResponse({
-				body: { completely: "invalid" },
-				status: 200,
-			});
-
-			const result = await fake.request(gamePassGet, config);
-
-			assert(result.success);
-
-			expect(fake.schemaViolations).toHaveLength(1);
-			expect(fake.schemaViolations[0]?.direction).toBe("response");
-		});
-
-		it("should stay silent on a schema-valid response", async () => {
-			expect.assertions(1);
-
-			const fake = createFakeHttpClient({ schemaValidation: "warn" }).mockResponse({
-				body: validGamePassBody(),
-				status: 200,
-			});
-
-			await fake.request(gamePassGet, config);
-
-			expect(fake.schemaViolations).toStrictEqual([]);
 		});
 	});
 });

--- a/packages/open-cloud/tests/helpers/fake-http-client-validated.ts
+++ b/packages/open-cloud/tests/helpers/fake-http-client-validated.ts
@@ -1,17 +1,11 @@
-import type { ApiError } from "#src/errors/api-error";
 import type { OpenCloudError } from "#src/errors/base";
-import type { NetworkError } from "#src/errors/network-error";
-import type { RateLimitError } from "#src/errors/rate-limit";
-import type {
-	HttpClient,
-	HttpRequest,
-	HttpResponse,
-	RequestConfig,
-} from "#src/internal/http/types";
+import type { HttpRequest, HttpResponse, RequestConfig } from "#src/internal/http/types";
 import type { Result } from "#src/types";
 
-import { createFakeHttpClient as createLiteFakeHttpClient } from "./fake-http-client.ts";
-import type { CapturedRequest } from "./fake-http-client.ts";
+import {
+	createFakeHttpClient as createLiteFakeHttpClient,
+	type FakeHttpClient as LiteFakeHttpClient,
+} from "./fake-http-client.ts";
 import {
 	FakeHttpClientContractError,
 	type SchemaValidationMode,
@@ -28,29 +22,11 @@ export {
 } from "./schema-contract.ts";
 
 /**
- * A fluent fake for the {@link HttpClient} boundary with contract
- * validation against the vendored OpenAPI spec. See
- * {@link createFakeHttpClient} for the wrapping semantics.
+ * A fluent fake for the HTTP-client boundary with contract validation
+ * against the vendored OpenAPI spec. Inherits the lite fake's mock
+ * surface and adds `schemaViolations` for `"warn"` mode assertions.
  */
-export interface FakeHttpClient extends HttpClient {
-	/** Queues an {@link ApiError} with the given status code and optional message/code. */
-	mockApiError(options: { code?: string; message?: string; statusCode: number }): FakeHttpClient;
-	/** Queues an error Result with the given error instance. */
-	mockError(error: OpenCloudError): FakeHttpClient;
-	/** Queues a {@link NetworkError}. Preserves `cause` when provided. */
-	mockNetworkError(options?: { cause?: unknown; message?: string }): FakeHttpClient;
-	/** Queues a {@link RateLimitError} with the given retry hint. */
-	mockRateLimit(options: { message?: string; retryAfterSeconds: number }): FakeHttpClient;
-	/** Queues a successful {@link HttpResponse}. Body defaults to `{}`; headers default to `{}`. */
-	mockResponse(options: {
-		body?: unknown;
-		headers?: Readonly<Record<string, string>>;
-		status: number;
-	}): FakeHttpClient;
-	/** Number of queued mocks that have not yet been consumed. */
-	readonly pendingMocks: number;
-	/** Chronological log of every `(request, config)` pair the fake received. */
-	readonly requests: ReadonlyArray<CapturedRequest>;
+export interface FakeHttpClient extends LiteFakeHttpClient {
 	/**
 	 * Schema violations observed under `"warn"` mode. In `"strict"`
 	 * mode the fake throws before this array can grow; in `"off"` mode
@@ -71,8 +47,6 @@ interface ViolationState {
 	readonly mode: SchemaValidationMode;
 	readonly violations: Array<SchemaViolation>;
 }
-
-type LiteFakeHttpClient = ReturnType<typeof createLiteFakeHttpClient>;
 
 /**
  * Creates a fluent {@link FakeHttpClient} that wraps the lite fake with
@@ -98,13 +72,8 @@ export function createFakeHttpClient(fakeOptions: FakeHttpClientOptions = {}): F
 	return buildWrapped(lite, state);
 }
 
-function forward(call: () => unknown, wrapped: FakeHttpClient): FakeHttpClient {
-	call();
-	return wrapped;
-}
-
 function recordViolations(state: ViolationState, violations: ReadonlyArray<SchemaViolation>): void {
-	const [first, ...rest] = violations;
+	const [first] = violations;
 	if (first === undefined) {
 		return;
 	}
@@ -113,26 +82,32 @@ function recordViolations(state: ViolationState, violations: ReadonlyArray<Schem
 		throw new FakeHttpClientContractError(first);
 	}
 
-	state.violations.push(first, ...rest);
+	state.violations.push(...violations);
 }
 
 async function validatingRequest(options: {
 	readonly config: RequestConfig;
-	readonly lite: ReturnType<typeof createLiteFakeHttpClient>;
+	readonly lite: LiteFakeHttpClient;
 	readonly request: HttpRequest;
 	readonly state: ViolationState;
 }): Promise<Result<HttpResponse, OpenCloudError>> {
 	const { config, lite, request, state } = options;
-	if (state.mode !== "off") {
-		recordViolations(state, validateRequestContract(request));
+	if (state.mode === "off") {
+		return lite.request(request, config);
 	}
 
+	recordViolations(state, validateRequestContract(request));
 	const result = await lite.request(request, config);
-	if (state.mode !== "off" && result.success) {
+	if (result.success) {
 		recordViolations(state, validateResponseContract(request, result.data));
 	}
 
 	return result;
+}
+
+function forward(call: () => unknown, wrapped: FakeHttpClient): FakeHttpClient {
+	call();
+	return wrapped;
 }
 
 function buildWrapped(lite: LiteFakeHttpClient, state: ViolationState): FakeHttpClient {

--- a/packages/open-cloud/tests/helpers/fake-http-client-validated.ts
+++ b/packages/open-cloud/tests/helpers/fake-http-client-validated.ts
@@ -1,0 +1,157 @@
+import type { ApiError } from "#src/errors/api-error";
+import type { OpenCloudError } from "#src/errors/base";
+import type { NetworkError } from "#src/errors/network-error";
+import type { RateLimitError } from "#src/errors/rate-limit";
+import type {
+	HttpClient,
+	HttpRequest,
+	HttpResponse,
+	RequestConfig,
+} from "#src/internal/http/types";
+import type { Result } from "#src/types";
+
+import { createFakeHttpClient as createLiteFakeHttpClient } from "./fake-http-client.ts";
+import type { CapturedRequest } from "./fake-http-client.ts";
+import {
+	FakeHttpClientContractError,
+	type SchemaValidationMode,
+	type SchemaViolation,
+	validateRequestContract,
+	validateResponseContract,
+} from "./schema-contract.ts";
+
+export { type CapturedRequest, FakeHttpClientError } from "./fake-http-client.ts";
+export {
+	FakeHttpClientContractError,
+	type SchemaValidationMode,
+	type SchemaViolation,
+} from "./schema-contract.ts";
+
+/**
+ * A fluent fake for the {@link HttpClient} boundary with contract
+ * validation against the vendored OpenAPI spec. See
+ * {@link createFakeHttpClient} for the wrapping semantics.
+ */
+export interface FakeHttpClient extends HttpClient {
+	/** Queues an {@link ApiError} with the given status code and optional message/code. */
+	mockApiError(options: { code?: string; message?: string; statusCode: number }): FakeHttpClient;
+	/** Queues an error Result with the given error instance. */
+	mockError(error: OpenCloudError): FakeHttpClient;
+	/** Queues a {@link NetworkError}. Preserves `cause` when provided. */
+	mockNetworkError(options?: { cause?: unknown; message?: string }): FakeHttpClient;
+	/** Queues a {@link RateLimitError} with the given retry hint. */
+	mockRateLimit(options: { message?: string; retryAfterSeconds: number }): FakeHttpClient;
+	/** Queues a successful {@link HttpResponse}. Body defaults to `{}`; headers default to `{}`. */
+	mockResponse(options: {
+		body?: unknown;
+		headers?: Readonly<Record<string, string>>;
+		status: number;
+	}): FakeHttpClient;
+	/** Number of queued mocks that have not yet been consumed. */
+	readonly pendingMocks: number;
+	/** Chronological log of every `(request, config)` pair the fake received. */
+	readonly requests: ReadonlyArray<CapturedRequest>;
+	/**
+	 * Schema violations observed under `"warn"` mode. In `"strict"`
+	 * mode the fake throws before this array can grow; in `"off"` mode
+	 * it remains empty.
+	 */
+	readonly schemaViolations: ReadonlyArray<SchemaViolation>;
+}
+
+/**
+ * Options accepted by {@link createFakeHttpClient}.
+ */
+export interface FakeHttpClientOptions {
+	/** How strictly to enforce the vendored OpenAPI spec. Defaults to `"strict"`. */
+	readonly schemaValidation?: SchemaValidationMode;
+}
+
+interface ViolationState {
+	readonly mode: SchemaValidationMode;
+	readonly violations: Array<SchemaViolation>;
+}
+
+type LiteFakeHttpClient = ReturnType<typeof createLiteFakeHttpClient>;
+
+/**
+ * Creates a fluent {@link FakeHttpClient} that wraps the lite fake with
+ * contract validation against the vendored OpenAPI spec. Use for
+ * integration tests where you want every request and response checked
+ * against the spec.
+ *
+ * Defaults to `"strict"` so every new resource client inherits
+ * protection automatically. Pass `{ schemaValidation: "off" }` to opt
+ * out for tests that exercise the fake's own mechanics with synthetic
+ * URLs.
+ *
+ * @param fakeOptions - Behaviour flags; `schemaValidation` overrides
+ *   the default `"strict"` contract checking.
+ * @returns A fresh fake with an empty mock queue.
+ */
+export function createFakeHttpClient(fakeOptions: FakeHttpClientOptions = {}): FakeHttpClient {
+	const lite = createLiteFakeHttpClient();
+	const state: ViolationState = {
+		mode: fakeOptions.schemaValidation ?? "strict",
+		violations: [],
+	};
+	return buildWrapped(lite, state);
+}
+
+function forward(call: () => unknown, wrapped: FakeHttpClient): FakeHttpClient {
+	call();
+	return wrapped;
+}
+
+function recordViolations(state: ViolationState, violations: ReadonlyArray<SchemaViolation>): void {
+	const [first, ...rest] = violations;
+	if (first === undefined) {
+		return;
+	}
+
+	if (state.mode === "strict") {
+		throw new FakeHttpClientContractError(first);
+	}
+
+	state.violations.push(first, ...rest);
+}
+
+async function validatingRequest(options: {
+	readonly config: RequestConfig;
+	readonly lite: ReturnType<typeof createLiteFakeHttpClient>;
+	readonly request: HttpRequest;
+	readonly state: ViolationState;
+}): Promise<Result<HttpResponse, OpenCloudError>> {
+	const { config, lite, request, state } = options;
+	if (state.mode !== "off") {
+		recordViolations(state, validateRequestContract(request));
+	}
+
+	const result = await lite.request(request, config);
+	if (state.mode !== "off" && result.success) {
+		recordViolations(state, validateResponseContract(request, result.data));
+	}
+
+	return result;
+}
+
+function buildWrapped(lite: LiteFakeHttpClient, state: ViolationState): FakeHttpClient {
+	const wrapped: FakeHttpClient = {
+		mockApiError: (options) => forward(() => lite.mockApiError(options), wrapped),
+		mockError: (error) => forward(() => lite.mockError(error), wrapped),
+		mockNetworkError: (options) => forward(() => lite.mockNetworkError(options), wrapped),
+		mockRateLimit: (options) => forward(() => lite.mockRateLimit(options), wrapped),
+		mockResponse: (options) => forward(() => lite.mockResponse(options), wrapped),
+		get pendingMocks() {
+			return lite.pendingMocks;
+		},
+		request: async (request, config) => validatingRequest({ config, lite, request, state }),
+		get requests() {
+			return lite.requests;
+		},
+		get schemaViolations() {
+			return state.violations;
+		},
+	};
+	return wrapped;
+}

--- a/packages/open-cloud/tests/helpers/fake-http-client.spec.ts
+++ b/packages/open-cloud/tests/helpers/fake-http-client.spec.ts
@@ -5,12 +5,7 @@ import { RateLimitError } from "#src/errors/rate-limit";
 import type { HttpRequest, RequestConfig } from "#src/internal/http/types";
 import { assert, describe, expect, it } from "vitest";
 
-import {
-	createFakeHttpClient,
-	FakeHttpClientContractError,
-	FakeHttpClientError,
-} from "./fake-http-client.ts";
-import { validGamePassBody } from "./game-passes.ts";
+import { createFakeHttpClient, FakeHttpClientError } from "./fake-http-client.ts";
 
 const getRequest: HttpRequest = { method: "GET", url: "/v1/ping" };
 const postRequest: HttpRequest = {
@@ -28,7 +23,7 @@ describe(createFakeHttpClient, () => {
 	it("should record both request and config on each call", async () => {
 		expect.assertions(1);
 
-		const fake = createFakeHttpClient({ schemaValidation: "off" })
+		const fake = createFakeHttpClient()
 			.mockResponse({ status: 200 })
 			.mockResponse({ status: 201 });
 
@@ -44,7 +39,7 @@ describe(createFakeHttpClient, () => {
 	it("should default mockResponse body and headers when omitted", async () => {
 		expect.assertions(1);
 
-		const fake = createFakeHttpClient({ schemaValidation: "off" }).mockResponse({
+		const fake = createFakeHttpClient().mockResponse({
 			status: 204,
 		});
 
@@ -59,7 +54,7 @@ describe(createFakeHttpClient, () => {
 	it("should replay mockResponse with provided body and headers", async () => {
 		expect.assertions(1);
 
-		const fake = createFakeHttpClient({ schemaValidation: "off" }).mockResponse({
+		const fake = createFakeHttpClient().mockResponse({
 			body: { id: "abc" },
 			headers: { "x-custom": "1" },
 			status: 200,
@@ -77,7 +72,7 @@ describe(createFakeHttpClient, () => {
 		expect.assertions(1);
 
 		const error = new OpenCloudError("boom");
-		const fake = createFakeHttpClient({ schemaValidation: "off" }).mockError(error);
+		const fake = createFakeHttpClient().mockError(error);
 
 		const result = await fake.request(getRequest, config);
 
@@ -89,7 +84,7 @@ describe(createFakeHttpClient, () => {
 	it("should replay mockRateLimit as RateLimitError with retryAfterSeconds", async () => {
 		expect.assertions(2);
 
-		const fake = createFakeHttpClient({ schemaValidation: "off" })
+		const fake = createFakeHttpClient()
 			.mockRateLimit({ retryAfterSeconds: 2 })
 			.mockRateLimit({ message: "slow down", retryAfterSeconds: 5 });
 
@@ -108,7 +103,7 @@ describe(createFakeHttpClient, () => {
 	it("should replay mockApiError as ApiError with statusCode and optional code", async () => {
 		expect.assertions(3);
 
-		const fake = createFakeHttpClient({ schemaValidation: "off" })
+		const fake = createFakeHttpClient()
 			.mockApiError({ statusCode: 500 })
 			.mockApiError({ code: "BAD_INPUT", message: "bad input", statusCode: 400 });
 
@@ -130,7 +125,7 @@ describe(createFakeHttpClient, () => {
 		expect.assertions(3);
 
 		const cause = new Error("ECONNREFUSED");
-		const fake = createFakeHttpClient({ schemaValidation: "off" })
+		const fake = createFakeHttpClient()
 			.mockNetworkError()
 			.mockNetworkError({ cause, message: "dial failed" });
 
@@ -148,7 +143,7 @@ describe(createFakeHttpClient, () => {
 	it("should consume mocks FIFO across mixed error types", async () => {
 		expect.assertions(3);
 
-		const fake = createFakeHttpClient({ schemaValidation: "off" })
+		const fake = createFakeHttpClient()
 			.mockResponse({ status: 200 })
 			.mockApiError({ statusCode: 500 })
 			.mockRateLimit({ retryAfterSeconds: 1 })
@@ -170,7 +165,7 @@ describe(createFakeHttpClient, () => {
 	it("should reflect queue depth in pendingMocks", async () => {
 		expect.assertions(3);
 
-		const fake = createFakeHttpClient({ schemaValidation: "off" });
+		const fake = createFakeHttpClient();
 
 		expect(fake.pendingMocks).toBe(0);
 
@@ -186,7 +181,7 @@ describe(createFakeHttpClient, () => {
 	it("should throw FakeHttpClientError naming method, url, and consumed count when queue is empty", async () => {
 		expect.assertions(1);
 
-		const fake = createFakeHttpClient({ schemaValidation: "off" }).mockResponse({
+		const fake = createFakeHttpClient().mockResponse({
 			status: 200,
 		});
 		await fake.request(getRequest, config);
@@ -204,156 +199,5 @@ describe(createFakeHttpClient, () => {
 
 		expect(error).toBeInstanceOf(Error);
 		expect(error.name).toBe("FakeHttpClientError");
-	});
-});
-
-const gamePassGet: HttpRequest = {
-	method: "GET",
-	url: "/game-passes/v1/universes/42/game-passes/999/creator",
-};
-
-describe("createFakeHttpClient schema validation", () => {
-	describe("off", () => {
-		it("should accept any body unchanged", async () => {
-			expect.assertions(2);
-
-			const fake = createFakeHttpClient({ schemaValidation: "off" }).mockResponse({
-				body: { completely: "invalid" },
-				status: 200,
-			});
-
-			const result = await fake.request(gamePassGet, config);
-
-			assert(result.success);
-
-			expect(result.data.body).toStrictEqual({ completely: "invalid" });
-			expect(fake.schemaViolations).toStrictEqual([]);
-		});
-	});
-
-	describe("strict (default)", () => {
-		it("should reject an invalid body when no mode is passed", async () => {
-			expect.assertions(1);
-
-			const fake = createFakeHttpClient().mockResponse({
-				body: { completely: "invalid" },
-				status: 200,
-			});
-
-			await expect(fake.request(gamePassGet, config)).rejects.toBeInstanceOf(
-				FakeHttpClientContractError,
-			);
-		});
-
-		it("should throw on a response body that violates the operation schema", async () => {
-			expect.assertions(1);
-
-			const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
-				body: { completely: "invalid" },
-				status: 200,
-			});
-
-			await expect(fake.request(gamePassGet, config)).rejects.toBeInstanceOf(
-				FakeHttpClientContractError,
-			);
-		});
-
-		it("should throw on a request body that violates the operation schema", async () => {
-			expect.assertions(1);
-
-			const patchUniverse: HttpRequest = {
-				body: { displayName: 42 },
-				method: "PATCH",
-				url: "/cloud/v2/universes/42",
-			};
-			const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
-				body: {},
-				status: 200,
-			});
-
-			await expect(fake.request(patchUniverse, config)).rejects.toMatchObject({
-				violation: { direction: "request" },
-			});
-		});
-
-		it("should throw on an unknown url with a helpful message", async () => {
-			expect.assertions(1);
-
-			const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
-				body: {},
-				status: 200,
-			});
-
-			await expect(
-				fake.request({ method: "GET", url: "/does-not-exist/1" }, config),
-			).rejects.toThrowWithMessage(
-				FakeHttpClientContractError,
-				/no operation matches GET \/does-not-exist\/1/,
-			);
-		});
-
-		it("should pass through a schema-valid response body", async () => {
-			expect.assertions(2);
-
-			const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
-				body: validGamePassBody(),
-				status: 200,
-			});
-
-			const result = await fake.request(gamePassGet, config);
-
-			assert(result.success);
-
-			expect(result.data.status).toBe(200);
-			expect(fake.schemaViolations).toStrictEqual([]);
-		});
-
-		it("should attach the offending violation to the thrown error", async () => {
-			expect.assertions(1);
-
-			const fake = createFakeHttpClient({ schemaValidation: "strict" }).mockResponse({
-				body: { completely: "invalid" },
-				status: 200,
-			});
-
-			await expect(fake.request(gamePassGet, config)).rejects.toMatchObject({
-				violation: {
-					direction: "response",
-					pathTemplate:
-						"/game-passes/v1/universes/{universeId}/game-passes/{gamePassId}/creator",
-				},
-			});
-		});
-	});
-
-	describe("warn", () => {
-		it("should record violations without throwing", async () => {
-			expect.assertions(2);
-
-			const fake = createFakeHttpClient({ schemaValidation: "warn" }).mockResponse({
-				body: { completely: "invalid" },
-				status: 200,
-			});
-
-			const result = await fake.request(gamePassGet, config);
-
-			assert(result.success);
-
-			expect(fake.schemaViolations).toHaveLength(1);
-			expect(fake.schemaViolations[0]?.direction).toBe("response");
-		});
-
-		it("should stay silent on a schema-valid response", async () => {
-			expect.assertions(1);
-
-			const fake = createFakeHttpClient({ schemaValidation: "warn" }).mockResponse({
-				body: validGamePassBody(),
-				status: 200,
-			});
-
-			await fake.request(gamePassGet, config);
-
-			expect(fake.schemaViolations).toStrictEqual([]);
-		});
 	});
 });

--- a/packages/open-cloud/tests/helpers/fake-http-client.ts
+++ b/packages/open-cloud/tests/helpers/fake-http-client.ts
@@ -30,19 +30,19 @@ export interface CapturedRequest {
  */
 export interface FakeHttpClient extends HttpClient {
 	/** Queues an {@link ApiError} with the given status code and optional message/code. */
-	mockApiError(options: { code?: string; message?: string; statusCode: number }): FakeHttpClient;
+	mockApiError(options: { code?: string; message?: string; statusCode: number }): this;
 	/** Queues an error Result with the given error instance. */
-	mockError(error: OpenCloudError): FakeHttpClient;
+	mockError(error: OpenCloudError): this;
 	/** Queues a {@link NetworkError}. Preserves `cause` when provided. */
-	mockNetworkError(options?: { cause?: unknown; message?: string }): FakeHttpClient;
+	mockNetworkError(options?: { cause?: unknown; message?: string }): this;
 	/** Queues a {@link RateLimitError} with the given retry hint. */
-	mockRateLimit(options: { message?: string; retryAfterSeconds: number }): FakeHttpClient;
+	mockRateLimit(options: { message?: string; retryAfterSeconds: number }): this;
 	/** Queues a successful {@link HttpResponse}. Body defaults to `{}`; headers default to `{}`. */
 	mockResponse(options: {
 		body?: unknown;
 		headers?: Readonly<Record<string, string>>;
 		status: number;
-	}): FakeHttpClient;
+	}): this;
 	/** Number of queued mocks that have not yet been consumed. */
 	readonly pendingMocks: number;
 	/** Chronological log of every `(request, config)` pair the fake received. */

--- a/packages/open-cloud/tests/helpers/fake-http-client.ts
+++ b/packages/open-cloud/tests/helpers/fake-http-client.ts
@@ -10,20 +10,6 @@ import type {
 } from "#src/internal/http/types";
 import type { Result } from "#src/types";
 
-import {
-	FakeHttpClientContractError,
-	type SchemaValidationMode,
-	type SchemaViolation,
-	validateRequestContract,
-	validateResponseContract,
-} from "./schema-contract.ts";
-
-export {
-	FakeHttpClientContractError,
-	type SchemaValidationMode,
-	type SchemaViolation,
-} from "./schema-contract.ts";
-
 /**
  * A request captured by {@link FakeHttpClient} for later assertion.
  */
@@ -61,20 +47,6 @@ export interface FakeHttpClient extends HttpClient {
 	readonly pendingMocks: number;
 	/** Chronological log of every `(request, config)` pair the fake received. */
 	readonly requests: ReadonlyArray<CapturedRequest>;
-	/**
-	 * Schema violations observed under `"warn"` mode. In `"strict"`
-	 * mode the fake throws before this array can grow; in `"off"` mode
-	 * it remains empty.
-	 */
-	readonly schemaViolations: ReadonlyArray<SchemaViolation>;
-}
-
-/**
- * Options accepted by {@link createFakeHttpClient}.
- */
-export interface FakeHttpClientOptions {
-	/** How strictly to enforce the vendored OpenAPI spec. Defaults to `"strict"`. */
-	readonly schemaValidation?: SchemaValidationMode;
 }
 
 type ErrorResult = Result<HttpResponse, OpenCloudError> & { success: false };
@@ -83,7 +55,6 @@ interface FakeState {
 	readonly captured: Array<CapturedRequest>;
 	consumed: number;
 	readonly queue: Array<Result<HttpResponse, OpenCloudError>>;
-	readonly violations: Array<SchemaViolation>;
 }
 
 /**
@@ -100,18 +71,10 @@ export class FakeHttpClientError extends Error {
  * {@link HttpClient} seam. Use for integration tests where you need to
  * assert per-request config (apiKey, baseUrl) flows through to HTTP.
  *
- * Defaults to `"strict"` contract validation against the vendored
- * OpenAPI spec so every new resource client inherits protection
- * automatically. Pass `{ schemaValidation: "off" }` to opt out for
- * tests that exercise the fake's own mechanics with synthetic URLs.
- *
- * @param fakeOptions - Behaviour flags; `schemaValidation` overrides
- *   the default `"strict"` contract checking.
  * @returns A fresh fake with an empty mock queue.
  */
-export function createFakeHttpClient(fakeOptions: FakeHttpClientOptions = {}): FakeHttpClient {
-	const mode: SchemaValidationMode = fakeOptions.schemaValidation ?? "strict";
-	const state: FakeState = { captured: [], consumed: 0, queue: [], violations: [] };
+export function createFakeHttpClient(): FakeHttpClient {
+	const state: FakeState = { captured: [], consumed: 0, queue: [] };
 	function enqueue(result: Result<HttpResponse, OpenCloudError>): FakeHttpClient {
 		state.queue.push(result);
 		return fake;
@@ -126,33 +89,13 @@ export function createFakeHttpClient(fakeOptions: FakeHttpClientOptions = {}): F
 		get pendingMocks() {
 			return state.queue.length;
 		},
-		request: async (request, config) => handleRequest({ config, mode, request, state }),
+		request: async (request, config) => handleRequest({ config, request, state }),
 		get requests() {
 			return state.captured;
-		},
-		get schemaViolations() {
-			return state.violations;
 		},
 	};
 
 	return fake;
-}
-
-function recordViolations(options: {
-	readonly mode: SchemaValidationMode;
-	readonly state: FakeState;
-	readonly violations: ReadonlyArray<SchemaViolation>;
-}): void {
-	const [first, ...rest] = options.violations;
-	if (first === undefined) {
-		return;
-	}
-
-	if (options.mode === "strict") {
-		throw new FakeHttpClientContractError(first);
-	}
-
-	options.state.violations.push(first, ...rest);
 }
 
 function consumeNextMock(
@@ -172,26 +115,12 @@ function consumeNextMock(
 
 async function handleRequest(options: {
 	readonly config: RequestConfig;
-	readonly mode: SchemaValidationMode;
 	readonly request: HttpRequest;
 	readonly state: FakeState;
 }): Promise<Result<HttpResponse, OpenCloudError>> {
-	const { config, mode, request, state } = options;
+	const { config, request, state } = options;
 	state.captured.push({ config, request });
-	if (mode !== "off") {
-		recordViolations({ mode, state, violations: validateRequestContract(request) });
-	}
-
-	const result = consumeNextMock(state, request);
-	if (mode !== "off" && result.success) {
-		recordViolations({
-			mode,
-			state,
-			violations: validateResponseContract(request, result.data),
-		});
-	}
-
-	return result;
+	return consumeNextMock(state, request);
 }
 
 function successResult(options: {

--- a/packages/open-cloud/tests/helpers/lite.ts
+++ b/packages/open-cloud/tests/helpers/lite.ts
@@ -4,12 +4,8 @@ export {
 	type CapturedRequest,
 	createFakeHttpClient,
 	type FakeHttpClient,
-	FakeHttpClientContractError,
 	FakeHttpClientError,
-	type FakeHttpClientOptions,
-	type SchemaValidationMode,
-	type SchemaViolation,
-} from "./fake-http-client-validated.ts";
+} from "./fake-http-client.ts";
 export { createFakeSend, type FakeSend, type SendFunc } from "./fake-send.ts";
 export { createFakeSleep, type FakeSleep } from "./fake-sleep.ts";
 export { validIconListBody, validLocalizedIcon } from "./game-icon.ts";

--- a/packages/open-cloud/tests/integration/resources/badges/client.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/badges/client.spec.ts
@@ -4,7 +4,10 @@ import { PermissionError } from "#src/errors/permission-error";
 import { BadgesClient } from "#src/resources/badges/index";
 import { validBadgeBody } from "#tests/helpers/badges";
 import { createFakeClock } from "#tests/helpers/fake-clock";
-import { createFakeHttpClient, type FakeHttpClient } from "#tests/helpers/fake-http-client";
+import {
+	createFakeHttpClient,
+	type FakeHttpClient,
+} from "#tests/helpers/fake-http-client-validated";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
 import { assert, describe, expect, it, vi } from "vitest";
 

--- a/packages/open-cloud/tests/integration/resources/badges/localization.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/badges/localization.spec.ts
@@ -2,7 +2,7 @@ import { ApiError } from "#src/errors/api-error";
 import { PermissionError } from "#src/errors/permission-error";
 import { BadgesClient } from "#src/resources/badges/index";
 import { createFakeClock } from "#tests/helpers/fake-clock";
-import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
+import { createFakeHttpClient } from "#tests/helpers/fake-http-client-validated";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
 import { assert, describe, expect, it } from "vitest";
 

--- a/packages/open-cloud/tests/integration/resources/developer-products/client.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/developer-products/client.spec.ts
@@ -4,7 +4,10 @@ import { PermissionError } from "#src/errors/permission-error";
 import { DeveloperProductsClient } from "#src/resources/developer-products/index";
 import { validDeveloperProductBody } from "#tests/helpers/developer-products";
 import { createFakeClock } from "#tests/helpers/fake-clock";
-import { createFakeHttpClient, type FakeHttpClient } from "#tests/helpers/fake-http-client";
+import {
+	createFakeHttpClient,
+	type FakeHttpClient,
+} from "#tests/helpers/fake-http-client-validated";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
 import { assert, describe, expect, it, vi } from "vitest";
 

--- a/packages/open-cloud/tests/integration/resources/developer-products/localization.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/developer-products/localization.spec.ts
@@ -2,7 +2,7 @@ import { ApiError } from "#src/errors/api-error";
 import { PermissionError } from "#src/errors/permission-error";
 import { DeveloperProductsClient } from "#src/resources/developer-products/index";
 import { createFakeClock } from "#tests/helpers/fake-clock";
-import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
+import { createFakeHttpClient } from "#tests/helpers/fake-http-client-validated";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
 import { assert, describe, expect, it } from "vitest";
 

--- a/packages/open-cloud/tests/integration/resources/game-passes/client.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/game-passes/client.spec.ts
@@ -3,7 +3,10 @@ import { ApiError } from "#src/errors/api-error";
 import { PermissionError } from "#src/errors/permission-error";
 import { GamePassesClient } from "#src/resources/game-passes/index";
 import { createFakeClock } from "#tests/helpers/fake-clock";
-import { createFakeHttpClient, type FakeHttpClient } from "#tests/helpers/fake-http-client";
+import {
+	createFakeHttpClient,
+	type FakeHttpClient,
+} from "#tests/helpers/fake-http-client-validated";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
 import { validGamePassBody, validListGamePassesBody } from "#tests/helpers/game-passes";
 import { assert, describe, expect, it, vi } from "vitest";

--- a/packages/open-cloud/tests/integration/resources/game-passes/localization.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/game-passes/localization.spec.ts
@@ -2,7 +2,7 @@ import { ApiError } from "#src/errors/api-error";
 import { PermissionError } from "#src/errors/permission-error";
 import { GamePassesClient } from "#src/resources/game-passes/index";
 import { createFakeClock } from "#tests/helpers/fake-clock";
-import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
+import { createFakeHttpClient } from "#tests/helpers/fake-http-client-validated";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
 import { assert, describe, expect, it } from "vitest";
 

--- a/packages/open-cloud/tests/integration/resources/luau-execution/client.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/luau-execution/client.spec.ts
@@ -2,7 +2,7 @@ import { ApiError } from "#src/errors/api-error";
 import { PermissionError } from "#src/errors/permission-error";
 import { LuauExecutionClient } from "#src/resources/luau-execution/index";
 import type { LuauExecutionTaskRef } from "#src/resources/luau-execution/index";
-import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
+import { createFakeHttpClient } from "#tests/helpers/fake-http-client-validated";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
 import { validBinaryInputBody } from "#tests/helpers/luau-execution-task-binary-inputs";
 import { validLogPageBody } from "#tests/helpers/luau-execution-task-logs";

--- a/packages/open-cloud/tests/integration/resources/places/client.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/places/client.spec.ts
@@ -4,7 +4,7 @@ import { PermissionError } from "#src/errors/permission-error";
 import { ValidationError } from "#src/errors/validation";
 import { PlacesClient } from "#src/resources/places/client";
 import { createFakeClock } from "#tests/helpers/fake-clock";
-import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
+import { createFakeHttpClient } from "#tests/helpers/fake-http-client-validated";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
 import {
 	rbxlBody,

--- a/packages/open-cloud/tests/integration/resources/places/luau-execution.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/places/luau-execution.spec.ts
@@ -1,6 +1,6 @@
 import type { LuauExecutionTaskRef } from "#src/resources/luau-execution/index";
 import { PlacesClient } from "#src/resources/places/index";
-import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
+import { createFakeHttpClient } from "#tests/helpers/fake-http-client-validated";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
 import { validLogPageBody } from "#tests/helpers/luau-execution-task-logs";
 import { validInProgressTaskBody } from "#tests/helpers/luau-execution-tasks";

--- a/packages/open-cloud/tests/integration/resources/storage/client.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/storage/client.spec.ts
@@ -1,7 +1,7 @@
 import { ApiError } from "#src/errors/api-error";
 import { PermissionError } from "#src/errors/permission-error";
 import { StorageClient } from "#src/resources/storage/client";
-import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
+import { createFakeHttpClient } from "#tests/helpers/fake-http-client-validated";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
 import { validDequeueBody, validQueueItemBody } from "#tests/helpers/memory-store-queues";
 import { assert, describe, expect, it } from "vitest";

--- a/packages/open-cloud/tests/integration/resources/universes/client.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/universes/client.spec.ts
@@ -4,7 +4,7 @@ import { PermissionError } from "#src/errors/permission-error";
 import { ValidationError } from "#src/errors/validation";
 import { UniversesClient } from "#src/resources/universes/client";
 import { createFakeClock } from "#tests/helpers/fake-clock";
-import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
+import { createFakeHttpClient } from "#tests/helpers/fake-http-client-validated";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
 import { validUniverseBody } from "#tests/helpers/universes";
 import { assert, describe, expect, it, vi } from "vitest";

--- a/packages/open-cloud/tests/integration/resources/universes/icon.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/universes/icon.spec.ts
@@ -1,7 +1,7 @@
 import { ApiError } from "#src/errors/api-error";
 import { PermissionError } from "#src/errors/permission-error";
 import { UniversesClient } from "#src/resources/universes/index";
-import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
+import { createFakeHttpClient } from "#tests/helpers/fake-http-client-validated";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
 import { validIconListBody, validLocalizedIcon } from "#tests/helpers/game-icon";
 import { assert, describe, expect, it } from "vitest";

--- a/packages/open-cloud/tests/integration/resources/universes/thumbnails.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/universes/thumbnails.spec.ts
@@ -2,7 +2,7 @@ import { ApiError } from "#src/errors/api-error";
 import { PermissionError } from "#src/errors/permission-error";
 import { ValidationError } from "#src/errors/validation";
 import { UniversesClient } from "#src/resources/universes/index";
-import { createFakeHttpClient } from "#tests/helpers/fake-http-client";
+import { createFakeHttpClient } from "#tests/helpers/fake-http-client-validated";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
 import { validThumbnailUploadBody } from "#tests/helpers/game-thumbnails";
 import { assert, describe, expect, it } from "vitest";

--- a/packages/open-cloud/vite.config.ts
+++ b/packages/open-cloud/vite.config.ts
@@ -8,9 +8,12 @@ type CustomExportsFunc = Extract<
 	(...args: never) => unknown
 >;
 
-function addTestingSubpath(
-	exportsMap: Parameters<CustomExportsFunc>[0],
-	context: Parameters<CustomExportsFunc>[1],
+type ExportsMap = Parameters<CustomExportsFunc>[0];
+type ExportsContext = Parameters<CustomExportsFunc>[1];
+
+function pinTestingSourceToValidated(
+	exportsMap: ExportsMap,
+	context: ExportsContext,
 ): ReturnType<CustomExportsFunc> {
 	if (!context.isPublish) {
 		exportsMap["./testing"] = {
@@ -33,10 +36,11 @@ export default mergeConfig(sharedConfig, {
 			"luau-execution": "src/resources/luau-execution/index.ts",
 			"places": "src/resources/places/index.ts",
 			"storage": "src/resources/storage/index.ts",
+			"testing": "tests/helpers/lite.ts",
 			"universes": "src/resources/universes/index.ts",
 		},
 		exports: {
-			customExports: addTestingSubpath,
+			customExports: pinTestingSourceToValidated,
 		},
 	},
 });


### PR DESCRIPTION
## Summary

- Expose `@bedrock-rbx/ocale/testing` so external packages can mock the SDK in their tests.
- Split the fake HTTP client into a lite version (no validation) and a validating wrapper. The published bundle ships the lite version (zero ajv, zero vendored OpenAPI); workspace consumers (e.g. `@bedrock-rbx/core`) still resolve to the validating fake so driver tests keep contract checking against the spec.

## Implementation notes

- `tests/helpers/fake-http-client.ts` is now the lite fake: queue + mocks + capture, no `schemaValidation` option, no `schemaViolations`, no `schema-contract` import.
- `tests/helpers/fake-http-client-validated.ts` is a new wrapper that composes the lite fake with `validateRequestContract` / `validateResponseContract`. Same `createFakeHttpClient(options?)` surface as before.
- 15 internal ocale spec files switched their import path from `#tests/helpers/fake-http-client` to `#tests/helpers/fake-http-client-validated`. All 209 call sites are byte-identical.
- `tests/helpers/index.ts` is the workspace barrel that re-exports the validating fake (and is what `./testing` resolves to via the `source` / `default` conditions in workspace dev).
- `tests/helpers/lite.ts` is the build entry that re-exports the lite fake (and is what `./dist/testing.mjs` bundles).
- `vite.config.ts` overrides the `./testing` export in non-publish flows so workspace dev resolves to `tests/helpers/index.ts`; publish flow keeps the auto-generated `./dist/testing.mjs`.

## Test plan

- [x] `pnpm test` — 3177 passing across the repo (lite spec, validating spec, ocale integration tests, bedrock driver tests).
- [x] `pnpm lint` clean.
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` clean, `publint` happy.
- [x] `dist/testing.mjs` is ~12 KB with zero references to `ajv`, `schema-contract`, `openapi-operations`, or vendor JSON.
- [x] `publishConfig.exports` includes `"./testing": "./dist/testing.mjs"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/384)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->