### PR TITLE
build(deps): upgrade to pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
 		"vite-plus": "catalog:build",
 		"vitest": "catalog:test"
 	},
-	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
+	"packageManager": "pnpm@11.1.0+sha512.0c44e842e5686b2c061a81adda8b2258bd8818e9704b2cf2c63d56b931a7b2e910092e085027003b96ca3911ab56a07f6df5abaed2be9925034cdd686a535b14",
 	"engines": {
 		"bun": ">=1.3.0"
 	}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -100,11 +100,9 @@ catalogs:
     "@typescript/native-preview": 7.0.0-dev.20260428.1
     type-fest: 5.6.0
 
-configDependencies:
-  "@pnpm/trusted-deps": 0.1.1+sha512-jI3PWNv2zCg9+KHI3qQTsa534c5nisZQrHFeWSyyHoUXcuzvjkXxQKPFLJ/qtNAF+PtKHDlRntO2aZKb3VDuHQ==
+allowBuilds:
+  "@parcel/watcher": true
+  esbuild: true
+  msgpackr-extract: true
 
-onlyBuiltDependencies:
-  - unrs-resolver
-
-onlyBuiltDependenciesFile: node_modules/.pnpm-config/@pnpm/trusted-deps/allow.json
 trustPolicyIgnoreAfter: 10080 # 7 days


### PR DESCRIPTION
## Summary

- Bump `packageManager` in [package.json](package.json) from pnpm@10.33.0 to pnpm@11.1.0 (with corepack integrity hash).
- Migrate [pnpm-workspace.yaml](pnpm-workspace.yaml) to the v11 build-script model: drop `onlyBuiltDependencies`, `onlyBuiltDependenciesFile`, and the `@pnpm/trusted-deps` configDependency; add an explicit `allowBuilds` map for the three deps pnpm 11 detected in the current tree (`@parcel/watcher`, `esbuild`, `msgpackr-extract`).
- `unrs-resolver` is no longer in the dep tree; the v10 entry was vestigial and is not carried over.

The official [v10→v11 codemod](https://codemod.com/registry/pnpm-v10-to-v11) was used as a sanity check but reverted: it inlines the entire 367-entry `@pnpm/trusted-deps/allow.json` into `allowBuilds`, which defeats the v11 explicit-allow model and re-indents `package.json` from tabs to spaces. Hand-edits keep `allowBuilds` scoped to what the workspace actually needs.

No other v11 breaking changes apply: no `.npmrc`, no `package.json#pnpm`, no `npm_config_*` env vars, no `pnpm server` / `pnpm install -g <pkg>` / `pnpm link <pkg-name>` usage, no `ignorePatchFailures`, no `useNodeVersion`, no package-manager strictness settings. Node 22 LTS via [mise.toml](mise.toml) already meets the v11 minimum.

Lockfile is unchanged: `patchedDependencies` source form in `pnpm-workspace.yaml` was already `selector: path`, and removing `configDependencies` skips the integrity-doc auto-migration.

See https://pnpm.io/migration for the full v11 change list.

## Test plan

- [x] `corepack pnpm --version` reports 11.1.0
- [x] `rm -rf node_modules && pnpm install --frozen-lockfile --ignore-scripts` succeeds (CI parity)
- [x] `rm -rf node_modules && pnpm install` succeeds and only runs build scripts for the three packages in `allowBuilds`
- [x] `pnpm gen:example-tests && pnpm lint && pnpm build && pnpm test && pnpm typecheck && pnpm mutate:changed` all pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)