### PR TITLE
fix(core): poll gist visibility after write

### DIFF
--- a/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
@@ -530,9 +530,13 @@ describe(createGistStateAdapter, () => {
 
 	describe("write", () => {
 		it("should PATCH the gist with the serialized state file on write", async () => {
-			expect.assertions(4);
+			expect.assertions(3);
 
-			const { calls, fetchFn } = fakeFetch(() => emptyResponse(200));
+			const { calls, fetchFn } = fakeFetch((request) => {
+				return request.method === "PATCH"
+					? emptyResponse(200)
+					: okJson({ files: { "state.production.json": { content: "{}" } } });
+			});
 			const port = createGistStateAdapter({ fetch: fetchFn, gistId: GIST_ID, token: TOKEN });
 
 			const result = await port.write({
@@ -542,13 +546,14 @@ describe(createGistStateAdapter, () => {
 			});
 
 			expect(result.success).toBeTrue();
-			expect(calls).toHaveLength(1);
 
-			const request = calls[0]!;
+			const patchRequest = calls[0]!;
 
-			expect(request.method).toBe("PATCH");
+			expect(patchRequest.method).toBe("PATCH");
 
-			const body = (await request.json()) as { files: Record<string, { content: string }> };
+			const body = (await patchRequest.json()) as {
+				files: Record<string, { content: string }>;
+			};
 
 			expect(JSON.parse(body.files["state.production.json"]!.content)).toStrictEqual({
 				$bedrock: { version: 1 },
@@ -560,7 +565,11 @@ describe(createGistStateAdapter, () => {
 		it("should send a json content-type header on write", async () => {
 			expect.assertions(1);
 
-			const { calls, fetchFn } = fakeFetch(() => emptyResponse(200));
+			const { calls, fetchFn } = fakeFetch((request) => {
+				return request.method === "PATCH"
+					? emptyResponse(200)
+					: okJson({ files: { "state.production.json": { content: "{}" } } });
+			});
 			const port = createGistStateAdapter({ fetch: fetchFn, gistId: GIST_ID, token: TOKEN });
 
 			await port.write({ environment: "production", resources: [], version: 1 });
@@ -651,7 +660,11 @@ describe(createGistStateAdapter, () => {
 		it("should retry the PATCH on 409 and succeed on the second attempt", async () => {
 			expect.assertions(3);
 
-			const { calls, fetchFn } = fakeFetchSequence([emptyResponse(409), emptyResponse(200)]);
+			const { calls, fetchFn } = fakeFetchSequence([
+				emptyResponse(409),
+				emptyResponse(200),
+				okJson({ files: { "state.production.json": { content: "{}" } } }),
+			]);
 			const sleepFake = fakeSleep();
 			const port = createGistStateAdapter({
 				fetch: fetchFn,
@@ -667,7 +680,7 @@ describe(createGistStateAdapter, () => {
 			});
 
 			expect(result.success).toBeTrue();
-			expect(calls).toHaveLength(2);
+			expect(calls).toHaveLength(3);
 			expect(sleepFake.calls).toStrictEqual([1000]);
 		});
 
@@ -710,7 +723,11 @@ describe(createGistStateAdapter, () => {
 				vi.useRealTimers();
 			});
 
-			const { calls, fetchFn } = fakeFetchSequence([emptyResponse(409), emptyResponse(200)]);
+			const { calls, fetchFn } = fakeFetchSequence([
+				emptyResponse(409),
+				emptyResponse(200),
+				okJson({ files: { "state.production.json": { content: "{}" } } }),
+			]);
 			const port = createGistStateAdapter({
 				fetch: fetchFn,
 				gistId: GIST_ID,
@@ -732,7 +749,7 @@ describe(createGistStateAdapter, () => {
 			const result = await writePromise;
 
 			expect(result.success).toBeTrue();
-			expect(calls).toHaveLength(2);
+			expect(calls).toHaveLength(3);
 		});
 
 		it.for<[number, RegExp]>([
@@ -776,6 +793,64 @@ describe(createGistStateAdapter, () => {
 				const { calls, fetchFn } = fakeFetchSequence([
 					emptyResponse(status),
 					emptyResponse(200),
+					okJson({ files: { "state.production.json": { content: "{}" } } }),
+				]);
+				const sleepFake = fakeSleep();
+				const port = createGistStateAdapter({
+					fetch: fetchFn,
+					gistId: GIST_ID,
+					sleep: sleepFake.sleep,
+					token: TOKEN,
+				});
+
+				const result = await port.write({
+					environment: "production",
+					resources: [],
+					version: 1,
+				});
+
+				expect(result.success).toBeTrue();
+				expect(calls).toHaveLength(3);
+				expect(sleepFake.calls).toStrictEqual([1000]);
+			},
+		);
+
+		describe("read-after-write visibility", () => {
+			it("should not resolve write until the written file is visible on a subsequent GET", async () => {
+				expect.assertions(5);
+
+				const { calls, fetchFn } = fakeFetchSequence([
+					emptyResponse(200),
+					okJson({ files: {} }),
+					okJson({ files: { "state.production.json": { content: "{}" } } }),
+				]);
+				const sleepFake = fakeSleep();
+				const port = createGistStateAdapter({
+					fetch: fetchFn,
+					gistId: GIST_ID,
+					sleep: sleepFake.sleep,
+					token: TOKEN,
+				});
+
+				const result = await port.write({
+					environment: "production",
+					resources: [],
+					version: 1,
+				});
+
+				expect(result.success).toBeTrue();
+				expect(calls).toHaveLength(3);
+				expect(calls[0]!.method).toBe("PATCH");
+				expect(calls[1]!.method).toBe("GET");
+				expect(calls[2]!.method).toBe("GET");
+			});
+
+			it("should resolve write without polling further when the file is already visible on the first GET", async () => {
+				expect.assertions(3);
+
+				const { calls, fetchFn } = fakeFetchSequence([
+					emptyResponse(200),
+					okJson({ files: { "state.production.json": { content: "{}" } } }),
 				]);
 				const sleepFake = fakeSleep();
 				const port = createGistStateAdapter({
@@ -793,8 +868,97 @@ describe(createGistStateAdapter, () => {
 
 				expect(result.success).toBeTrue();
 				expect(calls).toHaveLength(2);
-				expect(sleepFake.calls).toStrictEqual([1000]);
-			},
-		);
+				expect(sleepFake.calls).toBeEmpty();
+			});
+
+			it("should resolve write success after exhausting the visibility budget", async () => {
+				expect.assertions(3);
+
+				const { calls, fetchFn } = fakeFetch((request) => {
+					if (request.method === "PATCH") {
+						return emptyResponse(200);
+					}
+
+					return okJson({ files: {} });
+				});
+				const sleepFake = fakeSleep();
+				const port = createGistStateAdapter({
+					fetch: fetchFn,
+					gistId: GIST_ID,
+					sleep: sleepFake.sleep,
+					token: TOKEN,
+				});
+
+				const result = await port.write({
+					environment: "production",
+					resources: [],
+					version: 1,
+				});
+
+				expect(result.success).toBeTrue();
+				expect(calls).toHaveLength(6);
+				expect(sleepFake.calls).toStrictEqual([250, 500, 1000, 2000]);
+			});
+
+			it("should treat a transient non-ok GET as 'not yet visible' and keep polling", async () => {
+				expect.assertions(2);
+
+				const { calls, fetchFn } = fakeFetchSequence([
+					emptyResponse(200),
+					emptyResponse(503),
+					okJson({ files: { "state.production.json": { content: "{}" } } }),
+				]);
+				const sleepFake = fakeSleep();
+				const port = createGistStateAdapter({
+					fetch: fetchFn,
+					gistId: GIST_ID,
+					sleep: sleepFake.sleep,
+					token: TOKEN,
+				});
+
+				const result = await port.write({
+					environment: "production",
+					resources: [],
+					version: 1,
+				});
+
+				expect(result.success).toBeTrue();
+				expect(calls).toHaveLength(3);
+			});
+
+			it("should treat a thrown visibility GET as 'not yet visible' and keep polling", async () => {
+				expect.assertions(2);
+
+				let getCount = 0;
+				const { calls, fetchFn } = fakeFetch((request) => {
+					if (request.method === "PATCH") {
+						return emptyResponse(200);
+					}
+
+					getCount += 1;
+					if (getCount === 1) {
+						throw new Error("transient connection reset");
+					}
+
+					return okJson({ files: { "state.production.json": { content: "{}" } } });
+				});
+				const sleepFake = fakeSleep();
+				const port = createGistStateAdapter({
+					fetch: fetchFn,
+					gistId: GIST_ID,
+					sleep: sleepFake.sleep,
+					token: TOKEN,
+				});
+
+				const result = await port.write({
+					environment: "production",
+					resources: [],
+					version: 1,
+				});
+
+				expect(result.success).toBeTrue();
+				expect(calls).toHaveLength(3);
+			});
+		});
 	});
 });

--- a/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
@@ -926,6 +926,33 @@ describe(createGistStateAdapter, () => {
 				expect(calls).toHaveLength(3);
 			});
 
+			it("should resolve write success when the injected sleep rejects during visibility polling", async () => {
+				expect.assertions(2);
+
+				const { calls, fetchFn } = fakeFetch((request) => {
+					return request.method === "PATCH" ? emptyResponse(200) : okJson({ files: {} });
+				});
+				async function rejectingSleep(): Promise<void> {
+					throw new Error("aborted");
+				}
+
+				const port = createGistStateAdapter({
+					fetch: fetchFn,
+					gistId: GIST_ID,
+					sleep: rejectingSleep,
+					token: TOKEN,
+				});
+
+				const result = await port.write({
+					environment: "production",
+					resources: [],
+					version: 1,
+				});
+
+				expect(result.success).toBeTrue();
+				expect(calls).toHaveLength(2);
+			});
+
 			it("should treat a thrown visibility GET as 'not yet visible' and keep polling", async () => {
 				expect.assertions(2);
 

--- a/packages/bedrock/src/adapters/gist-state-adapter.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.ts
@@ -357,7 +357,12 @@ async function writePath(
 	}
 
 	if (response.ok) {
-		await waitForFileVisibility(ctx, state.environment);
+		try {
+			await waitForFileVisibility(ctx, state.environment);
+		} catch {
+			/* visibility poll errors are non-fatal; the PATCH already committed. */
+		}
+
 		return { data: undefined, success: true };
 	}
 

--- a/packages/bedrock/src/adapters/gist-state-adapter.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.ts
@@ -303,7 +303,7 @@ async function sendPatch(ctx: AdapterContext, body: string): Promise<Response> {
 async function isFileVisible(ctx: AdapterContext, target: string): Promise<boolean> {
 	try {
 		const response = await sendGet(ctx);
-		const body: JSONValue = JSON.parse(await response.text());
+		const body = JSON.parse(await response.text());
 		const files = Reflect.get(body, "files");
 		return typeof files === "object" && files !== null && target in files;
 	} catch {

--- a/packages/bedrock/src/adapters/gist-state-adapter.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.ts
@@ -11,6 +11,8 @@ const USER_AGENT = "bedrock";
 const MAX_INLINE_BYTES = 10_000_000;
 const MAX_RETRIES = 3;
 const RETRYABLE_STATUSES: ReadonlySet<number> = new Set([409, 502, 503, 504]);
+const MAX_VISIBILITY_ATTEMPTS = 5;
+const VISIBILITY_BASE_DELAY_MS = 250;
 
 /**
  * Minimal `fetch`-compatible signature the adapter needs, narrower than
@@ -298,6 +300,46 @@ async function sendPatch(ctx: AdapterContext, body: string): Promise<Response> {
 	});
 }
 
+async function isFileVisible(ctx: AdapterContext, target: string): Promise<boolean> {
+	try {
+		const response = await sendGet(ctx);
+		const body: JSONValue = JSON.parse(await response.text());
+		const files = Reflect.get(body, "files");
+		return typeof files === "object" && files !== null && target in files;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Polls the gist until the just-written environment file is visible on a
+ * GET, with bounded retries. GitHub's gist API does not guarantee
+ * read-your-write across replicas: a GET issued immediately after a
+ * successful PATCH can return a body that omits the new file. The poll
+ * pre-warms the cache the consumer's next read will hit, so a successful
+ * write honours read-after-write at the port boundary.
+ *
+ * Best-effort: resolves after exhausting the visibility budget regardless
+ * of whether the file became visible. The PATCH already committed; the
+ * poll only narrows the window in which subsequent reads can lag.
+ *
+ * @param ctx - Adapter context carrying the injected fetch and sleep seams.
+ * @param environment - Environment name whose file is being verified.
+ */
+async function waitForFileVisibility(ctx: AdapterContext, environment: string): Promise<void> {
+	const target = fileName(environment);
+
+	for (let attempt = 0; attempt < MAX_VISIBILITY_ATTEMPTS; attempt += 1) {
+		if (await isFileVisible(ctx, target)) {
+			return;
+		}
+
+		if (attempt < MAX_VISIBILITY_ATTEMPTS - 1) {
+			await ctx.sleep(VISIBILITY_BASE_DELAY_MS * 2 ** attempt);
+		}
+	}
+}
+
 async function writePath(
 	ctx: AdapterContext,
 	state: BedrockState,
@@ -315,6 +357,7 @@ async function writePath(
 	}
 
 	if (response.ok) {
+		await waitForFileVisibility(ctx, state.environment);
 		return { data: undefined, success: true };
 	}
 


### PR DESCRIPTION
## Summary

Smoke tests have been failing on first attempt for ~5 PRs in the last 4 days (PRs #381, #384, #386 among them). All hidden first-attempt failures landed on the same two assertions: `state-gist.spec.ts:53` (read after write returns undefined) and `deploy-place.spec.ts:110` (verifying read after deploy). Re-running the failed job typically went green.

Root cause: GitHub Gist's REST API does not guarantee read-your-write across replicas. A 200 PATCH commits the write to the primary, but a GET issued seconds later can land on a replica that has not yet caught up, returning a stale `files` map without the just-written file. This was invisible to the existing retry layer because the GET returns HTTP 200 with valid JSON, just without the file.

This change makes `createGistStateAdapter`'s `write()` poll the gist after a successful PATCH until the written file is visible in the response, with bounded retries (5 attempts, 250ms → 500ms → 1s → 2s backoff, ~3.75s ceiling). Best-effort: write still resolves success if the budget exhausts, since the PATCH has already committed.

The poll pre-warms the cache the consumer's subsequent read will hit, so a successful write honours read-after-write at the port boundary.

## Diagnose notes

- Initial failure rate read from the workflow runs API was misleading: GitHub's "Re-run failed jobs" creates a new attempt on the same run ID and the run's top-level `conclusion` updates to the latest attempt. The first-attempt failures were invisible until I filtered on `run_attempt > 1`.
- The Apr 30 - May 1 Roblox 401 cluster (8 failures) and Apr 29 gist 409 contention cluster (2 failures) seen in the issue are real but separate failure modes; this PR does not address them.

## Test plan

- [x] Unit tests at the adapter level for the visibility poll (visible immediately, visible after lag, budget exhausted, non-ok GET keeps polling, thrown GET keeps polling).
- [x] All existing `write()` tests updated to include the verification GET response.
- [x] Mutation score on `gist-state-adapter.ts`: 100%.
- [x] Repo-wide `pnpm test` green (3171 passed).
- [x] Repo-wide `pnpm lint`, `pnpm typecheck`, `pnpm build` green.
- [ ] Watch the next ~10 PRs after merge to confirm the first-attempt smoke failure rate drops toward 0.

Closes #385.

🤖 Generated with [Claude Code](https://claude.com/claude-code)