### PR TITLE
fix(ocale): parse luau-execution submit response without timestamps

### DIFF
--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.spec.ts
@@ -16,7 +16,9 @@ function validInProgressBody(
 	};
 }
 
-const REQUIRED_STRING_FIELDS = ["path", "createTime", "updateTime", "state", "user"] as const;
+const REQUIRED_STRING_FIELDS = ["path", "state", "user"] as const;
+const OPTIONAL_STRING_FIELDS = ["createTime", "updateTime"] as const;
+const ALL_STRING_FIELDS = [...REQUIRED_STRING_FIELDS, ...OPTIONAL_STRING_FIELDS] as const;
 
 describe(parseLuauExecutionTaskResponse, () => {
 	it.for(["QUEUED", "PROCESSING", "CANCELLED"] as const)(
@@ -248,6 +250,80 @@ describe(parseLuauExecutionTaskResponse, () => {
 		});
 	});
 
+	describe("optional timestamps", () => {
+		it.for(OPTIONAL_STRING_FIELDS)(
+			"should accept a body without %s and parse it without failing",
+			(field) => {
+				expect.assertions(1);
+
+				const { [field]: _omitted, ...body } = validInProgressBody();
+				const result = parseLuauExecutionTaskResponse({ body, headers: {}, status: 200 });
+
+				expect(result.success).toBeTrue();
+			},
+		);
+
+		it("should surface createdAt as undefined when wire createTime is absent on an in-progress body", () => {
+			expect.assertions(1);
+
+			const { createTime: _omitted, ...body } = validInProgressBody();
+			const result = parseLuauExecutionTaskResponse({ body, headers: {}, status: 200 });
+
+			assert(result.success);
+
+			expect(result.data.createdAt).toBeUndefined();
+		});
+
+		it("should surface updatedAt as undefined when wire updateTime is absent on an in-progress body", () => {
+			expect.assertions(1);
+
+			const { updateTime: _omitted, ...body } = validInProgressBody();
+			const result = parseLuauExecutionTaskResponse({ body, headers: {}, status: 200 });
+
+			assert(result.success);
+
+			expect(result.data.updatedAt).toBeUndefined();
+		});
+
+		it("should surface both timestamps as undefined on a COMPLETE body whose wire omits them", () => {
+			expect.assertions(2);
+
+			const {
+				createTime: _ct,
+				updateTime: _ut,
+				...body
+			} = validInProgressBody({
+				output: { results: [] },
+				state: "COMPLETE",
+			});
+			const result = parseLuauExecutionTaskResponse({ body, headers: {}, status: 200 });
+
+			assert(result.success);
+
+			expect(result.data.createdAt).toBeUndefined();
+			expect(result.data.updatedAt).toBeUndefined();
+		});
+
+		it("should surface both timestamps as undefined on a FAILED body whose wire omits them", () => {
+			expect.assertions(2);
+
+			const {
+				createTime: _ct,
+				updateTime: _ut,
+				...body
+			} = validInProgressBody({
+				error: { code: "SCRIPT_ERROR", message: "boom" },
+				state: "FAILED",
+			});
+			const result = parseLuauExecutionTaskResponse({ body, headers: {}, status: 200 });
+
+			assert(result.success);
+
+			expect(result.data.createdAt).toBeUndefined();
+			expect(result.data.updatedAt).toBeUndefined();
+		});
+	});
+
 	it("should return ApiError when the wire state is STATE_UNSPECIFIED", () => {
 		expect.assertions(2);
 
@@ -372,8 +448,8 @@ describe(parseLuauExecutionTaskResponse, () => {
 			},
 		);
 
-		it.for(REQUIRED_STRING_FIELDS)(
-			"should reject a body whose required %s field is not a string",
+		it.for(ALL_STRING_FIELDS)(
+			"should reject a body whose %s field is not a string",
 			(field) => {
 				expect.assertions(1);
 

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.spec.ts
@@ -465,6 +465,23 @@ describe(parseLuauExecutionTaskResponse, () => {
 			},
 		);
 
+		it.for(OPTIONAL_STRING_FIELDS)(
+			"should reject a body whose %s is a string that does not parse to a Date",
+			(field) => {
+				expect.assertions(1);
+
+				const result = parseLuauExecutionTaskResponse({
+					body: validInProgressBody({ [field]: "not-a-date" }),
+					headers: {},
+					status: 200,
+				});
+
+				assert(!result.success);
+
+				expect(result.err).toBeInstanceOf(ApiError);
+			},
+		);
+
 		it("should reject a body whose path is a non-string with a matching toString", () => {
 			expect.assertions(1);
 

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.ts
@@ -122,8 +122,8 @@ function isLuauExecutionTaskWire(body: unknown): body is LuauExecutionTaskWire {
 	return (
 		isRecord(body) &&
 		typeof body["path"] === "string" &&
-		typeof body["createTime"] === "string" &&
-		typeof body["updateTime"] === "string" &&
+		isOptionalString(body["createTime"]) &&
+		isOptionalString(body["updateTime"]) &&
 		isAcceptedWireState(body["state"]) &&
 		typeof body["user"] === "string" &&
 		isOptionalOutputWire(body["output"]) &&
@@ -133,6 +133,10 @@ function isLuauExecutionTaskWire(body: unknown): body is LuauExecutionTaskWire {
 		isOptionalBoolean(body["enableBinaryOutput"]) &&
 		isOptionalString(body["binaryOutputUri"])
 	);
+}
+
+function parseOptionalDate(value: string | undefined): Date | undefined {
+	return value === undefined ? undefined : new Date(value);
 }
 
 const DURATION_PATTERN = /^(\d+)s$/;
@@ -167,12 +171,12 @@ function parseInProgressTask(
 		data: {
 			binaryInput: body.binaryInput,
 			binaryOutputUri: body.binaryOutputUri,
-			createdAt: new Date(body.createTime),
+			createdAt: parseOptionalDate(body.createTime),
 			enableBinaryOutput: body.enableBinaryOutput,
 			ref,
 			state,
 			timeoutSeconds,
-			updatedAt: new Date(body.updateTime),
+			updatedAt: parseOptionalDate(body.updateTime),
 			user: body.user,
 		},
 		success: true,
@@ -189,13 +193,13 @@ function parseCompleteTask(args: ParseVariantArgs): Result<LuauExecutionTask, Ap
 		data: {
 			binaryInput: body.binaryInput,
 			binaryOutputUri: body.binaryOutputUri,
-			createdAt: new Date(body.createTime),
+			createdAt: parseOptionalDate(body.createTime),
 			enableBinaryOutput: body.enableBinaryOutput,
 			output: { results: body.output.results },
 			ref,
 			state: "COMPLETE",
 			timeoutSeconds,
-			updatedAt: new Date(body.updateTime),
+			updatedAt: parseOptionalDate(body.updateTime),
 			user: body.user,
 		},
 		success: true,
@@ -212,13 +216,13 @@ function parseFailedTask(args: ParseVariantArgs): Result<LuauExecutionTask, ApiE
 		data: {
 			binaryInput: body.binaryInput,
 			binaryOutputUri: body.binaryOutputUri,
-			createdAt: new Date(body.createTime),
+			createdAt: parseOptionalDate(body.createTime),
 			enableBinaryOutput: body.enableBinaryOutput,
 			error: { code: body.error.code, message: body.error.message },
 			ref,
 			state: "FAILED",
 			timeoutSeconds,
-			updatedAt: new Date(body.updateTime),
+			updatedAt: parseOptionalDate(body.updateTime),
 			user: body.user,
 		},
 		success: true,

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/parsers.ts
@@ -1,5 +1,6 @@
 import type { HttpResponse } from "../../../client/types.ts";
 import { ApiError } from "../../../errors/api-error.ts";
+import { isDateTimeString } from "../../../internal/utils/is-date-time-string.ts";
 import { isRecord } from "../../../internal/utils/is-record.ts";
 import type { Result } from "../../../types.ts";
 import type { LuauExecutionTask, LuauExecutionTaskRef } from "./types.ts";
@@ -28,9 +29,11 @@ type InProgressWireState = Exclude<LuauExecutionTaskWire["state"], "COMPLETE" | 
 
 interface ParseVariantArgs {
 	readonly body: LuauExecutionTaskWire;
+	readonly createdAt: Date | undefined;
 	readonly ref: LuauExecutionTaskRef;
 	readonly statusCode: number;
 	readonly timeoutSeconds: number | undefined;
+	readonly updatedAt: Date | undefined;
 }
 
 /**
@@ -59,16 +62,26 @@ export function parseLuauExecutionTaskResponse(
 	}
 
 	const timeoutSeconds = parseTimeoutSeconds(body.timeout);
+	const createdAt = parseOptionalDate(body.createTime);
+	const updatedAt = parseOptionalDate(body.updateTime);
 
 	if (body.state === "COMPLETE") {
-		return parseCompleteTask({ body, ref, statusCode, timeoutSeconds });
+		return parseCompleteTask({ body, createdAt, ref, statusCode, timeoutSeconds, updatedAt });
 	}
 
 	if (body.state === "FAILED") {
-		return parseFailedTask({ body, ref, statusCode, timeoutSeconds });
+		return parseFailedTask({ body, createdAt, ref, statusCode, timeoutSeconds, updatedAt });
 	}
 
-	return parseInProgressTask({ body, ref, state: body.state, statusCode, timeoutSeconds });
+	return parseInProgressTask({
+		body,
+		createdAt,
+		ref,
+		state: body.state,
+		statusCode,
+		timeoutSeconds,
+		updatedAt,
+	});
 }
 
 function isAcceptedWireState(
@@ -118,12 +131,16 @@ function isOptionalBoolean(value: unknown): value is boolean | undefined {
 	return value === undefined || typeof value === "boolean";
 }
 
+function isOptionalDateTimeString(value: unknown): value is string | undefined {
+	return value === undefined || isDateTimeString(value);
+}
+
 function isLuauExecutionTaskWire(body: unknown): body is LuauExecutionTaskWire {
 	return (
 		isRecord(body) &&
 		typeof body["path"] === "string" &&
-		isOptionalString(body["createTime"]) &&
-		isOptionalString(body["updateTime"]) &&
+		isOptionalDateTimeString(body["createTime"]) &&
+		isOptionalDateTimeString(body["updateTime"]) &&
 		isAcceptedWireState(body["state"]) &&
 		typeof body["user"] === "string" &&
 		isOptionalOutputWire(body["output"]) &&
@@ -166,17 +183,17 @@ function malformed(statusCode: number): Result<LuauExecutionTask, ApiError> {
 function parseInProgressTask(
 	args: ParseVariantArgs & { readonly state: InProgressWireState },
 ): Result<LuauExecutionTask, ApiError> {
-	const { body, ref, state, timeoutSeconds } = args;
+	const { body, createdAt, ref, state, timeoutSeconds, updatedAt } = args;
 	return {
 		data: {
 			binaryInput: body.binaryInput,
 			binaryOutputUri: body.binaryOutputUri,
-			createdAt: parseOptionalDate(body.createTime),
+			createdAt,
 			enableBinaryOutput: body.enableBinaryOutput,
 			ref,
 			state,
 			timeoutSeconds,
-			updatedAt: parseOptionalDate(body.updateTime),
+			updatedAt,
 			user: body.user,
 		},
 		success: true,
@@ -184,7 +201,7 @@ function parseInProgressTask(
 }
 
 function parseCompleteTask(args: ParseVariantArgs): Result<LuauExecutionTask, ApiError> {
-	const { body, ref, statusCode, timeoutSeconds } = args;
+	const { body, createdAt, ref, statusCode, timeoutSeconds, updatedAt } = args;
 	if (body.output === undefined) {
 		return malformed(statusCode);
 	}
@@ -193,13 +210,13 @@ function parseCompleteTask(args: ParseVariantArgs): Result<LuauExecutionTask, Ap
 		data: {
 			binaryInput: body.binaryInput,
 			binaryOutputUri: body.binaryOutputUri,
-			createdAt: parseOptionalDate(body.createTime),
+			createdAt,
 			enableBinaryOutput: body.enableBinaryOutput,
 			output: { results: body.output.results },
 			ref,
 			state: "COMPLETE",
 			timeoutSeconds,
-			updatedAt: parseOptionalDate(body.updateTime),
+			updatedAt,
 			user: body.user,
 		},
 		success: true,
@@ -207,7 +224,7 @@ function parseCompleteTask(args: ParseVariantArgs): Result<LuauExecutionTask, Ap
 }
 
 function parseFailedTask(args: ParseVariantArgs): Result<LuauExecutionTask, ApiError> {
-	const { body, ref, statusCode, timeoutSeconds } = args;
+	const { body, createdAt, ref, statusCode, timeoutSeconds, updatedAt } = args;
 	if (body.error === undefined) {
 		return malformed(statusCode);
 	}
@@ -216,13 +233,13 @@ function parseFailedTask(args: ParseVariantArgs): Result<LuauExecutionTask, ApiE
 		data: {
 			binaryInput: body.binaryInput,
 			binaryOutputUri: body.binaryOutputUri,
-			createdAt: parseOptionalDate(body.createTime),
+			createdAt,
 			enableBinaryOutput: body.enableBinaryOutput,
 			error: { code: body.error.code, message: body.error.message },
 			ref,
 			state: "FAILED",
 			timeoutSeconds,
-			updatedAt: parseOptionalDate(body.updateTime),
+			updatedAt,
 			user: body.user,
 		},
 		success: true,

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/types.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/types.ts
@@ -164,8 +164,12 @@ interface LuauExecutionTaskBase {
 	 * `true`.
 	 */
 	readonly binaryOutputUri?: string | undefined;
-	/** Timestamp when the task was created. */
-	readonly createdAt: Date;
+	/**
+	 * Timestamp when the task was created. Surfaces `undefined` on the
+	 * task returned by `submit`, since the server omits the timestamp
+	 * from the create-task response; polled tasks carry it.
+	 */
+	readonly createdAt?: Date | undefined;
 	/** When `true`, the server writes output to a binary blob. */
 	readonly enableBinaryOutput?: boolean | undefined;
 	/** Round-trip-safe reference to this task. */
@@ -176,8 +180,12 @@ interface LuauExecutionTaskBase {
 	 * server applies its 5-minute default in that case).
 	 */
 	readonly timeoutSeconds?: number | undefined;
-	/** Timestamp of the most recent state change. */
-	readonly updatedAt: Date;
+	/**
+	 * Timestamp of the most recent state change. Surfaces `undefined`
+	 * on the task returned by `submit`, since the server omits the
+	 * timestamp from the create-task response; polled tasks carry it.
+	 */
+	readonly updatedAt?: Date | undefined;
 	/** Identifier of the user that owns the API key used to create this task. */
 	readonly user: string;
 }

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/types.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/types.ts
@@ -164,11 +164,7 @@ interface LuauExecutionTaskBase {
 	 * `true`.
 	 */
 	readonly binaryOutputUri?: string | undefined;
-	/**
-	 * Timestamp when the task was created. Surfaces `undefined` on the
-	 * task returned by `submit`, since the server omits the timestamp
-	 * from the create-task response; polled tasks carry it.
-	 */
+	/** Timestamp when the task was created; `undefined` on tasks returned by `submit`. */
 	readonly createdAt?: Date | undefined;
 	/** When `true`, the server writes output to a binary blob. */
 	readonly enableBinaryOutput?: boolean | undefined;
@@ -180,11 +176,7 @@ interface LuauExecutionTaskBase {
 	 * server applies its 5-minute default in that case).
 	 */
 	readonly timeoutSeconds?: number | undefined;
-	/**
-	 * Timestamp of the most recent state change. Surfaces `undefined`
-	 * on the task returned by `submit`, since the server omits the
-	 * timestamp from the create-task response; polled tasks carry it.
-	 */
+	/** Timestamp of the most recent state change; `undefined` on tasks returned by `submit`. */
 	readonly updatedAt?: Date | undefined;
 	/** Identifier of the user that owns the API key used to create this task. */
 	readonly user: string;

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/wire.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/wire.ts
@@ -47,11 +47,7 @@ export interface LuauExecutionTaskWire {
 	 * `enableBinaryOutput` was `true`.
 	 */
 	readonly binaryOutputUri?: string | undefined;
-	/**
-	 * ISO timestamp when the task was created. Present on polled GET
-	 * responses; omitted by the server from the create-task POST
-	 * response.
-	 */
+	/** ISO timestamp when the task was created; omitted from the create-task POST response. */
 	readonly createTime?: string | undefined;
 	/** When `true`, the server writes output to a binary blob. */
 	readonly enableBinaryOutput?: boolean | undefined;
@@ -78,11 +74,7 @@ export interface LuauExecutionTaskWire {
 	 * absent, the server applies its 5-minute default.
 	 */
 	readonly timeout?: string | undefined;
-	/**
-	 * ISO timestamp of the most recent state change. Present on polled
-	 * GET responses; omitted by the server from the create-task POST
-	 * response.
-	 */
+	/** ISO timestamp of the most recent state change; omitted from the create-task POST response. */
 	readonly updateTime?: string | undefined;
 	/** Identifier of the user that owns the API key used to create this task. */
 	readonly user: string;

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/wire.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-tasks/wire.ts
@@ -47,8 +47,12 @@ export interface LuauExecutionTaskWire {
 	 * `enableBinaryOutput` was `true`.
 	 */
 	readonly binaryOutputUri?: string | undefined;
-	/** ISO timestamp when the task was created. */
-	readonly createTime: string;
+	/**
+	 * ISO timestamp when the task was created. Present on polled GET
+	 * responses; omitted by the server from the create-task POST
+	 * response.
+	 */
+	readonly createTime?: string | undefined;
 	/** When `true`, the server writes output to a binary blob. */
 	readonly enableBinaryOutput?: boolean | undefined;
 	/**
@@ -74,8 +78,12 @@ export interface LuauExecutionTaskWire {
 	 * absent, the server applies its 5-minute default.
 	 */
 	readonly timeout?: string | undefined;
-	/** ISO timestamp of the most recent state change. */
-	readonly updateTime: string;
+	/**
+	 * ISO timestamp of the most recent state change. Present on polled
+	 * GET responses; omitted by the server from the create-task POST
+	 * response.
+	 */
+	readonly updateTime?: string | undefined;
 	/** Identifier of the user that owns the API key used to create this task. */
 	readonly user: string;
 }

--- a/packages/open-cloud/tests/conformance/luau-execution-tasks.spec.ts
+++ b/packages/open-cloud/tests/conformance/luau-execution-tasks.spec.ts
@@ -3,6 +3,14 @@ import { assert, describe, expect, it } from "vitest";
 
 import { loadFixture } from "./_helpers.ts";
 
+// The vendored `LuauExecutionSessionTask` schema declares `timeout` as
+// `format: "duration"` (ISO 8601 e.g. `"PT3S"`), but the upstream
+// example and the live server both emit `"<n>s"` (e.g. `"3s"`). Ajv
+// rejects the live shape against the declared format, so unlike the
+// other resource specs this file does not run the schema validator
+// against the recorded fixtures; the parser round-trip below covers
+// the divergence between hand-built test bodies and the live wire.
+
 describe("luau-execution-tasks fixtures", () => {
 	describe(parseLuauExecutionTaskResponse, () => {
 		it("should round-trip submit-response-processing.json into an in-progress task whose timestamps are undefined", () => {

--- a/packages/open-cloud/tests/conformance/luau-execution-tasks.spec.ts
+++ b/packages/open-cloud/tests/conformance/luau-execution-tasks.spec.ts
@@ -1,0 +1,40 @@
+import { parseLuauExecutionTaskResponse } from "#src/domains/cloud-v2/luau-execution-tasks/parsers";
+import { assert, describe, expect, it } from "vitest";
+
+import { loadFixture } from "./_helpers.ts";
+
+describe("luau-execution-tasks fixtures", () => {
+	describe(parseLuauExecutionTaskResponse, () => {
+		it("should round-trip submit-response-processing.json into an in-progress task whose timestamps are undefined", () => {
+			expect.assertions(5);
+
+			const body = loadFixture("luau-execution-tasks", "submit-response-processing.json");
+
+			const result = parseLuauExecutionTaskResponse({ body, headers: {}, status: 200 });
+
+			assert(result.success);
+
+			expect(result.data.state).toBe("PROCESSING");
+			expect(result.data.user).toBe("1910140");
+			expect(result.data.timeoutSeconds).toBe(60);
+			expect(result.data.createdAt).toBeUndefined();
+			expect(result.data.updatedAt).toBeUndefined();
+		});
+
+		it("should round-trip get-response-complete.json into a COMPLETE task whose timestamps and output are surfaced", () => {
+			expect.assertions(4);
+
+			const body = loadFixture("luau-execution-tasks", "get-response-complete.json");
+
+			const result = parseLuauExecutionTaskResponse({ body, headers: {}, status: 200 });
+
+			assert(result.success);
+			assert(result.data.state === "COMPLETE");
+
+			expect(result.data.output.results).toStrictEqual([1]);
+			expect(result.data.createdAt).toStrictEqual(new Date("2026-05-12T01:42:25.171Z"));
+			expect(result.data.updatedAt).toStrictEqual(new Date("2026-05-12T01:42:26.443Z"));
+			expect(result.data.timeoutSeconds).toBe(60);
+		});
+	});
+});

--- a/packages/open-cloud/tests/fixtures/luau-execution-tasks/get-response-complete.json
+++ b/packages/open-cloud/tests/fixtures/luau-execution-tasks/get-response-complete.json
@@ -1,0 +1,13 @@
+{
+	"path": "universes/123/places/456/versions/789/luau-execution-sessions/01HXYZ-session/tasks/01HXYZ-task",
+	"createTime": "2026-05-12T01:42:25.171Z",
+	"updateTime": "2026-05-12T01:42:26.443Z",
+	"user": "1910140",
+	"state": "COMPLETE",
+	"script": "return 1",
+	"timeout": "60s",
+	"binaryInput": "",
+	"enableBinaryOutput": false,
+	"binaryOutputUri": "",
+	"output": { "results": [1] }
+}

--- a/packages/open-cloud/tests/fixtures/luau-execution-tasks/submit-response-processing.json
+++ b/packages/open-cloud/tests/fixtures/luau-execution-tasks/submit-response-processing.json
@@ -1,0 +1,10 @@
+{
+	"path": "universes/123/places/456/versions/789/luau-execution-sessions/01HXYZ-session/tasks/01HXYZ-task",
+	"user": "1910140",
+	"state": "PROCESSING",
+	"script": "return 1",
+	"timeout": "60s",
+	"binaryInput": "",
+	"enableBinaryOutput": false,
+	"binaryOutputUri": ""
+}


### PR DESCRIPTION
## Summary

The Open Cloud create-task POST returns a `LuauExecutionSessionTask` body that omits `createTime` and `updateTime` even though the schema lists no `required` array. `isLuauExecutionTaskWire` required both unconditionally, so every `LuauExecutionClient.tasks.submit` / `runUntilDone` call against the live API surfaced a malformed-response `ApiError` and the polling helpers never started.

The wire type now treats both timestamps as optional; the parser surfaces `createdAt` / `updatedAt` as `undefined` when the wire body omits them. Polled GET responses still carry both fields, so `COMPLETE` and `FAILED` variants continue to expose the timestamps.

## Why the existing tests missed this

- `parsers.spec.ts` built every body from a `validInProgressBody` helper that hard-coded `createTime` / `updateTime` and explicitly asserted in `REQUIRED_STRING_FIELDS` that omitting them must reject — so the unit suite certified the buggy contract as correct.
- The integration suite at `tests/integration/resources/places/luau-execution.spec.ts` feeds the same synthetic helper to `createFakeHttpClient`, so the fake transport never returns shapes the live API actually returns.
- The OpenAPI schema has no `required` array on `LuauExecutionSessionTask`, so even Ajv conformance against the vendored spec would have accepted a body without timestamps; the rejection was a parser-side assumption with nothing checking it against reality.

## Structural change

- `tests/fixtures/luau-execution-tasks/submit-response-processing.json` and `get-response-complete.json` mirror the observed live responses (path IDs substituted; `user` and `state` left verbatim).
- `tests/conformance/luau-execution-tasks.spec.ts` round-trips both through `parseLuauExecutionTaskResponse`, asserting the public-shape result. A future divergence between hand-built test bodies and the live wire is now caught at parse time on every test run.
- Ajv-validating these fixtures against `LuauExecutionSessionTask` is skipped for now: the upstream spec marks `timeout` as `format: "duration"` (RFC 3339, e.g. `PT60S`) but the live API returns `"60s"`, so the validator would reject every real recording on a separate spec/reality divergence. Worth a follow-up to either custom-format or strip-format that one field, but it's orthogonal to this fix.

## Test plan

- [x] `pnpm test` — 1364 ocale tests pass (new conformance round-trip exercises both fixtures; `parsers.spec.ts` covers the optional-timestamp branches across in-progress / COMPLETE / FAILED).
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm build` clean.
- [x] `pnpm mutate:changed` — 100% mutation score on `parsers.ts`, 0 surviving mutants.

Fixes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# PR #391 Code Review Summary

## Architecture Compliance ✅

- FCIS pattern preserved: parseLuauExecutionTaskResponse and validators are pure, side-effect-free functions. No I/O or state mutation found in Core logic.

## Testing (TDD Compliance) ✅

- Tests added alongside the parsing changes.
  - packages/.../parsers.spec.ts: covers optional timestamp absence/presence, invalid timestamp rejection, required-field enforcement, and variants for PROCESSING/COMPLETE/FAILED.
  - tests/conformance/luau-execution-tasks.spec.ts: round-trip parsing of two real-world fixtures (submit-response-processing.json and get-response-complete.json).
- Test isolation is appropriate for parser logic (unit/conformance fixtures used; no external HTTP calls).
- Naming follows the repository's existing test conventions.

## Type Safety & Error Handling ✅

- Wire type updated: createTime/updateTime are optional on the wire.
- Public type updated: createdAt/updatedAt now Date | undefined.
- Parser validates optional timestamps with a date-time predicate and converts to Date | undefined; invalid timestamps raise typed ApiError.
- No new any types; changes maintain TypeScript strictness.

## Notable Items

- Fixtures include empty string fields (binaryInput, binaryOutputUri). Validators accept empty strings; this matches prior behavior but is a semantic note (low risk).
- Conformance tests intentionally skip Ajv schema validation due to an upstream duration format mismatch (spec uses RFC3339 duration; live API uses "<n>s"). This is documented in-code; parser round-trip provides practical verification.
- The PR claims mutation testing success for parsers.ts; reviewers cannot verify mutation report output here — recommend CI confirmation post-merge.

## Alignment with Bedrock Standards

- TDD: satisfied (tests accompany changes).
- Pure Core and shell separation: satisfied (parsers remain pure).
- Test coverage: parser paths (with/without timestamps, invalid inputs) are tested.
- Security: Open Cloud-only domain; no secrets introduced.
- Code quality: TypeScript strictness and typed error handling maintained.

## Recommendation

APPROVE — changes are correct, well-tested, and align with Bedrock architecture and standards.

Minor follow-up: verify the reported mutation-testing artifacts in CI logs after merge.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/391)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->