### PR TITLE
feat(ocale): add memory-store-sorted-maps to storage-client

### DIFF
--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildCreateRequest } from "./builders.ts";
+import { buildCreateRequest, buildGetRequest } from "./builders.ts";
 
 describe(buildCreateRequest, () => {
 	it("should produce a POST request targeting /cloud/v2/universes/{uid}/memory-store/sorted-maps/{mid}/items", () => {
@@ -140,6 +140,46 @@ describe(buildCreateRequest, () => {
 
 		expect(request.url).toBe(
 			"/cloud/v2/universes/1/memory-store/sorted-maps/m/items?id=Hello+world%21%3F",
+		);
+	});
+});
+
+describe(buildGetRequest, () => {
+	it("should produce a GET request targeting /cloud/v2/universes/{uid}/memory-store/sorted-maps/{mid}/items/{iid}", () => {
+		expect.assertions(2);
+
+		const request = buildGetRequest({
+			itemId: "item-1",
+			mapId: "my-map",
+			universeId: "123",
+		});
+
+		expect(request.method).toBe("GET");
+		expect(request.url).toBe(
+			"/cloud/v2/universes/123/memory-store/sorted-maps/my-map/items/item-1",
+		);
+	});
+
+	it("should not carry a body or content-type", () => {
+		expect.assertions(2);
+
+		const request = buildGetRequest({ itemId: "i", mapId: "m", universeId: "1" });
+
+		expect(request.body).toBeUndefined();
+		expect(request.headers).toBeUndefined();
+	});
+
+	it("should URL-encode an itemId carrying reserved characters in the path", () => {
+		expect.assertions(1);
+
+		const request = buildGetRequest({
+			itemId: "Hello world!?",
+			mapId: "m",
+			universeId: "1",
+		});
+
+		expect(request.url).toBe(
+			"/cloud/v2/universes/1/memory-store/sorted-maps/m/items/Hello%20world!%3F",
 		);
 	});
 });

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { buildCreateRequest, buildGetRequest } from "./builders.ts";
+import { buildCreateRequest, buildDeleteRequest, buildGetRequest } from "./builders.ts";
 
 describe(buildCreateRequest, () => {
 	it("should produce a POST request targeting /cloud/v2/universes/{uid}/memory-store/sorted-maps/{mid}/items", () => {
@@ -140,6 +140,46 @@ describe(buildCreateRequest, () => {
 
 		expect(request.url).toBe(
 			"/cloud/v2/universes/1/memory-store/sorted-maps/m/items?id=Hello+world%21%3F",
+		);
+	});
+});
+
+describe(buildDeleteRequest, () => {
+	it("should produce a DELETE request targeting /cloud/v2/universes/{uid}/memory-store/sorted-maps/{mid}/items/{iid}", () => {
+		expect.assertions(2);
+
+		const request = buildDeleteRequest({
+			itemId: "item-1",
+			mapId: "my-map",
+			universeId: "123",
+		});
+
+		expect(request.method).toBe("DELETE");
+		expect(request.url).toBe(
+			"/cloud/v2/universes/123/memory-store/sorted-maps/my-map/items/item-1",
+		);
+	});
+
+	it("should not carry a body or content-type", () => {
+		expect.assertions(2);
+
+		const request = buildDeleteRequest({ itemId: "i", mapId: "m", universeId: "1" });
+
+		expect(request.body).toBeUndefined();
+		expect(request.headers).toBeUndefined();
+	});
+
+	it("should URL-encode an itemId carrying reserved characters in the path", () => {
+		expect.assertions(1);
+
+		const request = buildDeleteRequest({
+			itemId: "Hello world!?",
+			mapId: "m",
+			universeId: "1",
+		});
+
+		expect(request.url).toBe(
+			"/cloud/v2/universes/1/memory-store/sorted-maps/m/items/Hello%20world!%3F",
 		);
 	});
 });

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.spec.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCreateRequest } from "./builders.ts";
+
+describe(buildCreateRequest, () => {
+	it("should produce a POST request targeting /cloud/v2/universes/{uid}/memory-store/sorted-maps/{mid}/items", () => {
+		expect.assertions(2);
+
+		const request = buildCreateRequest({
+			itemId: "item-1",
+			mapId: "my-map",
+			universeId: "123",
+			value: "hello",
+		});
+
+		expect(request.method).toBe("POST");
+		expect(request.url).toBe(
+			"/cloud/v2/universes/123/memory-store/sorted-maps/my-map/items?id=item-1",
+		);
+	});
+
+	it("should send application/json as the content-type header", () => {
+		expect.assertions(1);
+
+		const request = buildCreateRequest({
+			itemId: "i",
+			mapId: "m",
+			universeId: "1",
+			value: "x",
+		});
+
+		expect(request.headers).toStrictEqual({ "content-type": "application/json" });
+	});
+
+	it("should serialize value verbatim into the JSON body", () => {
+		expect.assertions(1);
+
+		const value = JSON.parse('{"foo":1,"nested":[true,null]}');
+
+		const request = buildCreateRequest({
+			itemId: "i",
+			mapId: "m",
+			universeId: "1",
+			value,
+		});
+
+		expect(request.body).toStrictEqual({ value });
+	});
+
+	it("should allow value to be JSON null at the top level", () => {
+		expect.assertions(1);
+
+		const request = buildCreateRequest({
+			itemId: "i",
+			mapId: "m",
+			universeId: "1",
+			value: JSON.parse("null"),
+		});
+
+		expect(request.body).toStrictEqual({ value: JSON.parse("null") });
+	});
+
+	it("should preserve a falsy value (zero) in the body", () => {
+		expect.assertions(1);
+
+		const request = buildCreateRequest({
+			itemId: "i",
+			mapId: "m",
+			universeId: "1",
+			value: 0,
+		});
+
+		expect(request.body).toStrictEqual({ value: 0 });
+	});
+
+	it("should serialize ttl as a duration string in seconds when supplied", () => {
+		expect.assertions(1);
+
+		const request = buildCreateRequest({
+			itemId: "i",
+			mapId: "m",
+			ttl: 30,
+			universeId: "1",
+			value: "x",
+		});
+
+		expect(request.body).toStrictEqual({ ttl: "30s", value: "x" });
+	});
+
+	it("should project a string sort key into stringSortKey on the body", () => {
+		expect.assertions(1);
+
+		const request = buildCreateRequest({
+			itemId: "i",
+			mapId: "m",
+			sortKey: { kind: "string", value: "alpha" },
+			universeId: "1",
+			value: "x",
+		});
+
+		expect(request.body).toStrictEqual({ stringSortKey: "alpha", value: "x" });
+	});
+
+	it("should project a numeric sort key into numericSortKey on the body", () => {
+		expect.assertions(1);
+
+		const request = buildCreateRequest({
+			itemId: "i",
+			mapId: "m",
+			sortKey: { kind: "numeric", value: 42 },
+			universeId: "1",
+			value: "x",
+		});
+
+		expect(request.body).toStrictEqual({ numericSortKey: 42, value: "x" });
+	});
+
+	it("should omit ttl and sort-key fields when not supplied", () => {
+		expect.assertions(1);
+
+		const request = buildCreateRequest({
+			itemId: "i",
+			mapId: "m",
+			universeId: "1",
+			value: "x",
+		});
+
+		expect(request.body).toStrictEqual({ value: "x" });
+	});
+
+	it("should URL-encode an itemId carrying reserved characters", () => {
+		expect.assertions(1);
+
+		const request = buildCreateRequest({
+			itemId: "Hello world!?",
+			mapId: "m",
+			universeId: "1",
+			value: "x",
+		});
+
+		expect(request.url).toBe(
+			"/cloud/v2/universes/1/memory-store/sorted-maps/m/items?id=Hello+world%21%3F",
+		);
+	});
+});

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.spec.ts
@@ -148,6 +148,21 @@ describe(buildCreateRequest, () => {
 			"/cloud/v2/universes/1/memory-store/sorted-maps/m/items?id=Hello+world%21%3F",
 		);
 	});
+
+	it("should URL-encode universeId and mapId carrying reserved characters in the path", () => {
+		expect.assertions(1);
+
+		const request = buildCreateRequest({
+			itemId: "i",
+			mapId: "team/red",
+			universeId: "1/2",
+			value: "x",
+		});
+
+		expect(request.url).toBe(
+			"/cloud/v2/universes/1%2F2/memory-store/sorted-maps/team%2Fred/items?id=i",
+		);
+	});
 });
 
 describe(buildDeleteRequest, () => {
@@ -186,6 +201,20 @@ describe(buildDeleteRequest, () => {
 
 		expect(request.url).toBe(
 			"/cloud/v2/universes/1/memory-store/sorted-maps/m/items/Hello%20world!%3F",
+		);
+	});
+
+	it("should URL-encode universeId and mapId carrying reserved characters in the path", () => {
+		expect.assertions(1);
+
+		const request = buildDeleteRequest({
+			itemId: "i",
+			mapId: "team/red",
+			universeId: "1/2",
+		});
+
+		expect(request.url).toBe(
+			"/cloud/v2/universes/1%2F2/memory-store/sorted-maps/team%2Fred/items/i",
 		);
 	});
 });
@@ -237,6 +266,16 @@ describe(buildListRequest, () => {
 
 		expect(request.url).toContain("?maxPageSize=10");
 		expect(request.url).not.toContain("pageToken");
+	});
+
+	it("should URL-encode universeId and mapId carrying reserved characters in the path", () => {
+		expect.assertions(1);
+
+		const request = buildListRequest({ mapId: "team/red", universeId: "1/2" });
+
+		expect(request.url).toBe(
+			"/cloud/v2/universes/1%2F2/memory-store/sorted-maps/team%2Fred/items",
+		);
 	});
 });
 
@@ -367,6 +406,20 @@ describe(buildUpdateRequest, () => {
 			"/cloud/v2/universes/1/memory-store/sorted-maps/m/items/Hello%20world!%3F",
 		);
 	});
+
+	it("should URL-encode universeId and mapId carrying reserved characters in the path", () => {
+		expect.assertions(1);
+
+		const request = buildUpdateRequest({
+			itemId: "i",
+			mapId: "team/red",
+			universeId: "1/2",
+		});
+
+		expect(request.url).toBe(
+			"/cloud/v2/universes/1%2F2/memory-store/sorted-maps/team%2Fred/items/i",
+		);
+	});
 });
 
 describe(buildGetRequest, () => {
@@ -405,6 +458,20 @@ describe(buildGetRequest, () => {
 
 		expect(request.url).toBe(
 			"/cloud/v2/universes/1/memory-store/sorted-maps/m/items/Hello%20world!%3F",
+		);
+	});
+
+	it("should URL-encode universeId and mapId carrying reserved characters in the path", () => {
+		expect.assertions(1);
+
+		const request = buildGetRequest({
+			itemId: "i",
+			mapId: "team/red",
+			universeId: "1/2",
+		});
+
+		expect(request.url).toBe(
+			"/cloud/v2/universes/1%2F2/memory-store/sorted-maps/team%2Fred/items/i",
 		);
 	});
 });

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import { buildCreateRequest, buildDeleteRequest, buildGetRequest } from "./builders.ts";
+import {
+	buildCreateRequest,
+	buildDeleteRequest,
+	buildGetRequest,
+	buildUpdateRequest,
+} from "./builders.ts";
 
 describe(buildCreateRequest, () => {
 	it("should produce a POST request targeting /cloud/v2/universes/{uid}/memory-store/sorted-maps/{mid}/items", () => {
@@ -173,6 +178,135 @@ describe(buildDeleteRequest, () => {
 		expect.assertions(1);
 
 		const request = buildDeleteRequest({
+			itemId: "Hello world!?",
+			mapId: "m",
+			universeId: "1",
+		});
+
+		expect(request.url).toBe(
+			"/cloud/v2/universes/1/memory-store/sorted-maps/m/items/Hello%20world!%3F",
+		);
+	});
+});
+
+describe(buildUpdateRequest, () => {
+	it("should produce a PATCH request targeting /cloud/v2/universes/{uid}/memory-store/sorted-maps/{mid}/items/{iid}", () => {
+		expect.assertions(2);
+
+		const request = buildUpdateRequest({
+			itemId: "item-1",
+			mapId: "my-map",
+			universeId: "123",
+		});
+
+		expect(request.method).toBe("PATCH");
+		expect(request.url).toBe(
+			"/cloud/v2/universes/123/memory-store/sorted-maps/my-map/items/item-1",
+		);
+	});
+
+	it("should send application/json as the content-type header", () => {
+		expect.assertions(1);
+
+		const request = buildUpdateRequest({ itemId: "i", mapId: "m", universeId: "1" });
+
+		expect(request.headers).toStrictEqual({ "content-type": "application/json" });
+	});
+
+	it("should send an empty body when no body fields are supplied", () => {
+		expect.assertions(1);
+
+		const request = buildUpdateRequest({ itemId: "i", mapId: "m", universeId: "1" });
+
+		expect(request.body).toStrictEqual({});
+	});
+
+	it("should include value in the body when supplied", () => {
+		expect.assertions(1);
+
+		const request = buildUpdateRequest({
+			itemId: "i",
+			mapId: "m",
+			universeId: "1",
+			value: { score: 5 },
+		});
+
+		expect(request.body).toStrictEqual({ value: { score: 5 } });
+	});
+
+	it("should serialize ttl as a duration string in seconds when supplied", () => {
+		expect.assertions(1);
+
+		const request = buildUpdateRequest({
+			itemId: "i",
+			mapId: "m",
+			ttl: 30,
+			universeId: "1",
+		});
+
+		expect(request.body).toStrictEqual({ ttl: "30s" });
+	});
+
+	it("should project a string sort key into stringSortKey on the body", () => {
+		expect.assertions(1);
+
+		const request = buildUpdateRequest({
+			itemId: "i",
+			mapId: "m",
+			sortKey: { kind: "string", value: "alpha" },
+			universeId: "1",
+		});
+
+		expect(request.body).toStrictEqual({ stringSortKey: "alpha" });
+	});
+
+	it("should project a numeric sort key into numericSortKey on the body", () => {
+		expect.assertions(1);
+
+		const request = buildUpdateRequest({
+			itemId: "i",
+			mapId: "m",
+			sortKey: { kind: "numeric", value: 7 },
+			universeId: "1",
+		});
+
+		expect(request.body).toStrictEqual({ numericSortKey: 7 });
+	});
+
+	it("should append allowMissing as a boolean query string when supplied", () => {
+		expect.assertions(1);
+
+		const request = buildUpdateRequest({
+			allowMissing: true,
+			itemId: "i",
+			mapId: "m",
+			universeId: "1",
+		});
+
+		expect(request.url).toBe(
+			"/cloud/v2/universes/1/memory-store/sorted-maps/m/items/i?allowMissing=true",
+		);
+	});
+
+	it("should send allowMissing=false explicitly when supplied as false", () => {
+		expect.assertions(1);
+
+		const request = buildUpdateRequest({
+			allowMissing: false,
+			itemId: "i",
+			mapId: "m",
+			universeId: "1",
+		});
+
+		expect(request.url).toBe(
+			"/cloud/v2/universes/1/memory-store/sorted-maps/m/items/i?allowMissing=false",
+		);
+	});
+
+	it("should URL-encode an itemId carrying reserved characters in the path", () => {
+		expect.assertions(1);
+
+		const request = buildUpdateRequest({
 			itemId: "Hello world!?",
 			mapId: "m",
 			universeId: "1",

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.spec.ts
@@ -4,6 +4,7 @@ import {
 	buildCreateRequest,
 	buildDeleteRequest,
 	buildGetRequest,
+	buildListRequest,
 	buildUpdateRequest,
 } from "./builders.ts";
 
@@ -186,6 +187,56 @@ describe(buildDeleteRequest, () => {
 		expect(request.url).toBe(
 			"/cloud/v2/universes/1/memory-store/sorted-maps/m/items/Hello%20world!%3F",
 		);
+	});
+});
+
+describe(buildListRequest, () => {
+	it("should produce a GET request targeting /cloud/v2/universes/{uid}/memory-store/sorted-maps/{mid}/items", () => {
+		expect.assertions(2);
+
+		const request = buildListRequest({ mapId: "my-map", universeId: "123" });
+
+		expect(request.method).toBe("GET");
+		expect(request.url).toBe("/cloud/v2/universes/123/memory-store/sorted-maps/my-map/items");
+	});
+
+	it("should not carry a body or content-type", () => {
+		expect.assertions(2);
+
+		const request = buildListRequest({ mapId: "m", universeId: "1" });
+
+		expect(request.body).toBeUndefined();
+		expect(request.headers).toBeUndefined();
+	});
+
+	it("should serialize maxPageSize, pageToken, orderBy, and filter into the query string", () => {
+		expect.assertions(1);
+
+		const request = buildListRequest({
+			filter: 'id > "key-001"',
+			mapId: "m",
+			maxPageSize: 50,
+			orderBy: "id desc",
+			pageToken: "tok-123",
+			universeId: "1",
+		});
+
+		expect(request.url).toBe(
+			"/cloud/v2/universes/1/memory-store/sorted-maps/m/items?maxPageSize=50&pageToken=tok-123&orderBy=id+desc&filter=id+%3E+%22key-001%22",
+		);
+	});
+
+	it("should omit query keys for parameters not supplied", () => {
+		expect.assertions(2);
+
+		const request = buildListRequest({
+			mapId: "m",
+			maxPageSize: 10,
+			universeId: "1",
+		});
+
+		expect(request.url).toContain("?maxPageSize=10");
+		expect(request.url).not.toContain("pageToken");
 	});
 });
 

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.ts
@@ -1,0 +1,46 @@
+import type { HttpRequest } from "../../../client/types.ts";
+import type { CreateSortedMapItemParameters, SortKey } from "./types.ts";
+
+/**
+ * Builds a `POST` request for the Open Cloud
+ * `Cloud_CreateMemoryStoreSortedMapItem` endpoint. The caller-supplied
+ * `itemId` travels as the `id` query parameter (URL-encoded by
+ * `URLSearchParams`); the body carries `value`, the optional `ttl`
+ * (serialized as a Google protobuf `Duration` string in seconds), and
+ * one of `stringSortKey`/`numericSortKey` projected from the
+ * {@link SortKey} discriminated union.
+ *
+ * @param parameters - Universe, sorted-map, item identifiers, the
+ *   value to store, and optional `sortKey` and `ttl`.
+ * @returns A pure {@link HttpRequest} describing the create call.
+ */
+export function buildCreateRequest(parameters: CreateSortedMapItemParameters): HttpRequest {
+	const { itemId, mapId, sortKey, ttl, universeId, value } = parameters;
+	const body: Record<string, unknown> = { value };
+	if (ttl !== undefined) {
+		body["ttl"] = `${ttl}s`;
+	}
+
+	applySortKeyToBody(body, sortKey);
+
+	const query = new URLSearchParams({ id: itemId });
+	return {
+		body,
+		headers: { "content-type": "application/json" },
+		method: "POST",
+		url: `/cloud/v2/universes/${universeId}/memory-store/sorted-maps/${mapId}/items?${query.toString()}`,
+	};
+}
+
+function applySortKeyToBody(body: Record<string, unknown>, sortKey: SortKey | undefined): void {
+	if (sortKey === undefined) {
+		return;
+	}
+
+	if (sortKey.kind === "string") {
+		body["stringSortKey"] = sortKey.value;
+		return;
+	}
+
+	body["numericSortKey"] = sortKey.value;
+}

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.ts
@@ -35,15 +35,16 @@ export function buildCreateRequest(parameters: CreateSortedMapItemParameters): H
 		body,
 		headers: { "content-type": "application/json" },
 		method: "POST",
-		url: `/cloud/v2/universes/${universeId}/memory-store/sorted-maps/${mapId}/items?${query.toString()}`,
+		url: `/cloud/v2/universes/${encodeURIComponent(universeId)}/memory-store/sorted-maps/${encodeURIComponent(mapId)}/items?${query.toString()}`,
 	};
 }
 
 /**
  * Builds a `DELETE` request for the Open Cloud
- * `Cloud_DeleteMemoryStoreSortedMapItem` endpoint. The `itemId` is
- * URL-encoded into the path segment, matching the `get` and `update`
- * builders.
+ * `Cloud_DeleteMemoryStoreSortedMapItem` endpoint. Every path segment
+ * (universe, sorted-map, item identifiers) is URL-encoded so callers
+ * can pass values containing reserved characters without manual
+ * escaping.
  *
  * @param parameters - Universe, sorted-map, and item identifiers.
  * @returns A pure {@link HttpRequest} describing the delete call.
@@ -52,15 +53,16 @@ export function buildDeleteRequest(parameters: DeleteSortedMapItemParameters): H
 	const { itemId, mapId, universeId } = parameters;
 	return {
 		method: "DELETE",
-		url: `/cloud/v2/universes/${universeId}/memory-store/sorted-maps/${mapId}/items/${encodeURIComponent(itemId)}`,
+		url: `/cloud/v2/universes/${encodeURIComponent(universeId)}/memory-store/sorted-maps/${encodeURIComponent(mapId)}/items/${encodeURIComponent(itemId)}`,
 	};
 }
 
 /**
  * Builds a `GET` request for the Open Cloud
- * `Cloud_GetMemoryStoreSortedMapItem` endpoint. The `itemId` is
- * URL-encoded into the path segment so callers can pass values
- * containing reserved characters without manual escaping.
+ * `Cloud_GetMemoryStoreSortedMapItem` endpoint. Every path segment
+ * (universe, sorted-map, item identifiers) is URL-encoded so callers
+ * can pass values containing reserved characters without manual
+ * escaping.
  *
  * @param parameters - Universe, sorted-map, and item identifiers.
  * @returns A pure {@link HttpRequest} describing the get call.
@@ -69,7 +71,7 @@ export function buildGetRequest(parameters: GetSortedMapItemParameters): HttpReq
 	const { itemId, mapId, universeId } = parameters;
 	return {
 		method: "GET",
-		url: `/cloud/v2/universes/${universeId}/memory-store/sorted-maps/${mapId}/items/${encodeURIComponent(itemId)}`,
+		url: `/cloud/v2/universes/${encodeURIComponent(universeId)}/memory-store/sorted-maps/${encodeURIComponent(mapId)}/items/${encodeURIComponent(itemId)}`,
 	};
 }
 
@@ -102,7 +104,7 @@ export function buildListRequest(parameters: ListSortedMapItemsParameters): Http
 		query.append("filter", filter);
 	}
 
-	const base = `/cloud/v2/universes/${universeId}/memory-store/sorted-maps/${mapId}/items`;
+	const base = `/cloud/v2/universes/${encodeURIComponent(universeId)}/memory-store/sorted-maps/${encodeURIComponent(mapId)}/items`;
 	const queryString = query.toString();
 	return { method: "GET", url: queryString === "" ? base : `${base}?${queryString}` };
 }
@@ -120,7 +122,7 @@ export function buildListRequest(parameters: ListSortedMapItemsParameters): Http
  */
 export function buildUpdateRequest(parameters: UpdateSortedMapItemParameters): HttpRequest {
 	const { allowMissing: shouldAllowMissing, itemId, mapId, universeId } = parameters;
-	const base = `/cloud/v2/universes/${universeId}/memory-store/sorted-maps/${mapId}/items/${encodeURIComponent(itemId)}`;
+	const base = `/cloud/v2/universes/${encodeURIComponent(universeId)}/memory-store/sorted-maps/${encodeURIComponent(mapId)}/items/${encodeURIComponent(itemId)}`;
 	const query = new URLSearchParams();
 	if (shouldAllowMissing !== undefined) {
 		query.append("allowMissing", String(shouldAllowMissing));

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.ts
@@ -4,6 +4,7 @@ import type {
 	DeleteSortedMapItemParameters,
 	GetSortedMapItemParameters,
 	SortKey,
+	UpdateSortedMapItemParameters,
 } from "./types.ts";
 
 /**
@@ -71,6 +72,34 @@ export function buildGetRequest(parameters: GetSortedMapItemParameters): HttpReq
 	};
 }
 
+/**
+ * Builds a `PATCH` request for the Open Cloud
+ * `Cloud_UpdateMemoryStoreSortedMapItem` endpoint. Body fields are
+ * conditionally included so a partial update sends only the changed
+ * fields; the optional `allowMissing` query string drives
+ * upsert-on-missing behaviour server-side.
+ *
+ * @param parameters - Universe, sorted-map, and item identifiers,
+ *   plus any subset of `value`, `ttl`, `sortKey`, and `allowMissing`.
+ * @returns A pure {@link HttpRequest} describing the update call.
+ */
+export function buildUpdateRequest(parameters: UpdateSortedMapItemParameters): HttpRequest {
+	const { allowMissing: shouldAllowMissing, itemId, mapId, universeId } = parameters;
+	const base = `/cloud/v2/universes/${universeId}/memory-store/sorted-maps/${mapId}/items/${encodeURIComponent(itemId)}`;
+	const query = new URLSearchParams();
+	if (shouldAllowMissing !== undefined) {
+		query.append("allowMissing", String(shouldAllowMissing));
+	}
+
+	const queryString = query.toString();
+	return {
+		body: buildUpdateBody(parameters),
+		headers: { "content-type": "application/json" },
+		method: "PATCH",
+		url: queryString === "" ? base : `${base}?${queryString}`,
+	};
+}
+
 function applySortKeyToBody(body: Record<string, unknown>, sortKey: SortKey | undefined): void {
 	if (sortKey === undefined) {
 		return;
@@ -82,4 +111,19 @@ function applySortKeyToBody(body: Record<string, unknown>, sortKey: SortKey | un
 	}
 
 	body["numericSortKey"] = sortKey.value;
+}
+
+function buildUpdateBody(parameters: UpdateSortedMapItemParameters): Record<string, unknown> {
+	const { sortKey, ttl, value } = parameters;
+	const body: Record<string, unknown> = {};
+	if (value !== undefined) {
+		body["value"] = value;
+	}
+
+	if (ttl !== undefined) {
+		body["ttl"] = `${ttl}s`;
+	}
+
+	applySortKeyToBody(body, sortKey);
+	return body;
 }

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.ts
@@ -3,6 +3,7 @@ import type {
 	CreateSortedMapItemParameters,
 	DeleteSortedMapItemParameters,
 	GetSortedMapItemParameters,
+	ListSortedMapItemsParameters,
 	SortKey,
 	UpdateSortedMapItemParameters,
 } from "./types.ts";
@@ -70,6 +71,40 @@ export function buildGetRequest(parameters: GetSortedMapItemParameters): HttpReq
 		method: "GET",
 		url: `/cloud/v2/universes/${universeId}/memory-store/sorted-maps/${mapId}/items/${encodeURIComponent(itemId)}`,
 	};
+}
+
+/**
+ * Builds a `GET` request for the Open Cloud
+ * `Cloud_ListMemoryStoreSortedMapItems` endpoint. Optional `filter`,
+ * `maxPageSize`, `orderBy`, and `pageToken` parameters travel as query
+ * string parameters and are omitted when unset.
+ *
+ * @param parameters - Universe and sorted-map identifiers, plus
+ *   optional pagination and filter parameters.
+ * @returns A pure {@link HttpRequest} describing the list call.
+ */
+export function buildListRequest(parameters: ListSortedMapItemsParameters): HttpRequest {
+	const { filter, mapId, maxPageSize, orderBy, pageToken, universeId } = parameters;
+	const query = new URLSearchParams();
+	if (maxPageSize !== undefined) {
+		query.append("maxPageSize", String(maxPageSize));
+	}
+
+	if (pageToken !== undefined) {
+		query.append("pageToken", pageToken);
+	}
+
+	if (orderBy !== undefined) {
+		query.append("orderBy", orderBy);
+	}
+
+	if (filter !== undefined) {
+		query.append("filter", filter);
+	}
+
+	const base = `/cloud/v2/universes/${universeId}/memory-store/sorted-maps/${mapId}/items`;
+	const queryString = query.toString();
+	return { method: "GET", url: queryString === "" ? base : `${base}?${queryString}` };
 }
 
 /**

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.ts
@@ -1,5 +1,9 @@
 import type { HttpRequest } from "../../../client/types.ts";
-import type { CreateSortedMapItemParameters, SortKey } from "./types.ts";
+import type {
+	CreateSortedMapItemParameters,
+	GetSortedMapItemParameters,
+	SortKey,
+} from "./types.ts";
 
 /**
  * Builds a `POST` request for the Open Cloud
@@ -29,6 +33,23 @@ export function buildCreateRequest(parameters: CreateSortedMapItemParameters): H
 		headers: { "content-type": "application/json" },
 		method: "POST",
 		url: `/cloud/v2/universes/${universeId}/memory-store/sorted-maps/${mapId}/items?${query.toString()}`,
+	};
+}
+
+/**
+ * Builds a `GET` request for the Open Cloud
+ * `Cloud_GetMemoryStoreSortedMapItem` endpoint. The `itemId` is
+ * URL-encoded into the path segment so callers can pass values
+ * containing reserved characters without manual escaping.
+ *
+ * @param parameters - Universe, sorted-map, and item identifiers.
+ * @returns A pure {@link HttpRequest} describing the get call.
+ */
+export function buildGetRequest(parameters: GetSortedMapItemParameters): HttpRequest {
+	const { itemId, mapId, universeId } = parameters;
+	return {
+		method: "GET",
+		url: `/cloud/v2/universes/${universeId}/memory-store/sorted-maps/${mapId}/items/${encodeURIComponent(itemId)}`,
 	};
 }
 

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/builders.ts
@@ -1,6 +1,7 @@
 import type { HttpRequest } from "../../../client/types.ts";
 import type {
 	CreateSortedMapItemParameters,
+	DeleteSortedMapItemParameters,
 	GetSortedMapItemParameters,
 	SortKey,
 } from "./types.ts";
@@ -33,6 +34,23 @@ export function buildCreateRequest(parameters: CreateSortedMapItemParameters): H
 		headers: { "content-type": "application/json" },
 		method: "POST",
 		url: `/cloud/v2/universes/${universeId}/memory-store/sorted-maps/${mapId}/items?${query.toString()}`,
+	};
+}
+
+/**
+ * Builds a `DELETE` request for the Open Cloud
+ * `Cloud_DeleteMemoryStoreSortedMapItem` endpoint. The `itemId` is
+ * URL-encoded into the path segment, matching the `get` and `update`
+ * builders.
+ *
+ * @param parameters - Universe, sorted-map, and item identifiers.
+ * @returns A pure {@link HttpRequest} describing the delete call.
+ */
+export function buildDeleteRequest(parameters: DeleteSortedMapItemParameters): HttpRequest {
+	const { itemId, mapId, universeId } = parameters;
+	return {
+		method: "DELETE",
+		url: `/cloud/v2/universes/${universeId}/memory-store/sorted-maps/${mapId}/items/${encodeURIComponent(itemId)}`,
 	};
 }
 

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/operations.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/operations.ts
@@ -1,0 +1,24 @@
+import type { OperationLimit } from "../../../internal/http/rate-limit-queue.ts";
+
+const CREATE_PER_MINUTE = 1_000_000;
+const SECONDS_PER_MINUTE = 60;
+
+/**
+ * Per-second request ceiling for creating a memory-store sorted-map
+ * item, from the Open Cloud OpenAPI schema (1,000,000 requests per
+ * minute per API key owner). Keyed independently from the get, update,
+ * delete, and list operations so the five do not share a queue.
+ */
+export const CREATE_OPERATION_LIMIT: OperationLimit = Object.freeze({
+	maxPerSecond: CREATE_PER_MINUTE / SECONDS_PER_MINUTE,
+	operationKey: "memory-store-sorted-maps.create",
+});
+
+/**
+ * Scopes required to create a memory-store sorted-map item, sourced
+ * from `x-roblox-scopes` on the `Cloud_CreateMemoryStoreSortedMapItem`
+ * operation in the vendored OpenAPI schema.
+ */
+export const CREATE_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([
+	"memory-store.sorted-map:write",
+]);

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/operations.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/operations.ts
@@ -63,6 +63,27 @@ export const GET_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([
 	"memory-store.sorted-map:read",
 ]);
 
+const LIST_PER_MINUTE = 1_000_000;
+
+/**
+ * Per-second request ceiling for listing memory-store sorted-map
+ * items, from the Open Cloud OpenAPI schema (1,000,000 requests per
+ * minute per API key owner).
+ */
+export const LIST_OPERATION_LIMIT: OperationLimit = Object.freeze({
+	maxPerSecond: LIST_PER_MINUTE / SECONDS_PER_MINUTE,
+	operationKey: "memory-store-sorted-maps.list",
+});
+
+/**
+ * Scopes required to list memory-store sorted-map items, sourced from
+ * `x-roblox-scopes` on the `Cloud_ListMemoryStoreSortedMapItems`
+ * operation in the vendored OpenAPI schema.
+ */
+export const LIST_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([
+	"memory-store.sorted-map:read",
+]);
+
 const UPDATE_PER_MINUTE = 1_000_000;
 
 /**

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/operations.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/operations.ts
@@ -22,3 +22,24 @@ export const CREATE_OPERATION_LIMIT: OperationLimit = Object.freeze({
 export const CREATE_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([
 	"memory-store.sorted-map:write",
 ]);
+
+const GET_PER_MINUTE = 1_000_000;
+
+/**
+ * Per-second request ceiling for reading a memory-store sorted-map
+ * item, from the Open Cloud OpenAPI schema (1,000,000 requests per
+ * minute per API key owner).
+ */
+export const GET_OPERATION_LIMIT: OperationLimit = Object.freeze({
+	maxPerSecond: GET_PER_MINUTE / SECONDS_PER_MINUTE,
+	operationKey: "memory-store-sorted-maps.get",
+});
+
+/**
+ * Scopes required to read a memory-store sorted-map item, sourced from
+ * `x-roblox-scopes` on the `Cloud_GetMemoryStoreSortedMapItem`
+ * operation in the vendored OpenAPI schema.
+ */
+export const GET_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([
+	"memory-store.sorted-map:read",
+]);

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/operations.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/operations.ts
@@ -23,6 +23,27 @@ export const CREATE_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([
 	"memory-store.sorted-map:write",
 ]);
 
+const DELETE_PER_MINUTE = 1_000_000;
+
+/**
+ * Per-second request ceiling for deleting a memory-store sorted-map
+ * item, from the Open Cloud OpenAPI schema (1,000,000 requests per
+ * minute per API key owner).
+ */
+export const DELETE_OPERATION_LIMIT: OperationLimit = Object.freeze({
+	maxPerSecond: DELETE_PER_MINUTE / SECONDS_PER_MINUTE,
+	operationKey: "memory-store-sorted-maps.delete",
+});
+
+/**
+ * Scopes required to delete a memory-store sorted-map item, sourced
+ * from `x-roblox-scopes` on the `Cloud_DeleteMemoryStoreSortedMapItem`
+ * operation in the vendored OpenAPI schema.
+ */
+export const DELETE_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([
+	"memory-store.sorted-map:write",
+]);
+
 const GET_PER_MINUTE = 1_000_000;
 
 /**

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/operations.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/operations.ts
@@ -3,6 +3,8 @@ import type { OperationLimit } from "../../../internal/http/rate-limit-queue.ts"
 const CREATE_PER_MINUTE = 1_000_000;
 const SECONDS_PER_MINUTE = 60;
 
+const WRITE_SCOPE = "memory-store.sorted-map:write";
+
 /**
  * Per-second request ceiling for creating a memory-store sorted-map
  * item, from the Open Cloud OpenAPI schema (1,000,000 requests per
@@ -19,9 +21,7 @@ export const CREATE_OPERATION_LIMIT: OperationLimit = Object.freeze({
  * from `x-roblox-scopes` on the `Cloud_CreateMemoryStoreSortedMapItem`
  * operation in the vendored OpenAPI schema.
  */
-export const CREATE_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([
-	"memory-store.sorted-map:write",
-]);
+export const CREATE_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([WRITE_SCOPE]);
 
 const DELETE_PER_MINUTE = 1_000_000;
 
@@ -40,9 +40,7 @@ export const DELETE_OPERATION_LIMIT: OperationLimit = Object.freeze({
  * from `x-roblox-scopes` on the `Cloud_DeleteMemoryStoreSortedMapItem`
  * operation in the vendored OpenAPI schema.
  */
-export const DELETE_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([
-	"memory-store.sorted-map:write",
-]);
+export const DELETE_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([WRITE_SCOPE]);
 
 const GET_PER_MINUTE = 1_000_000;
 
@@ -64,3 +62,22 @@ export const GET_OPERATION_LIMIT: OperationLimit = Object.freeze({
 export const GET_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([
 	"memory-store.sorted-map:read",
 ]);
+
+const UPDATE_PER_MINUTE = 1_000_000;
+
+/**
+ * Per-second request ceiling for updating a memory-store sorted-map
+ * item, from the Open Cloud OpenAPI schema (1,000,000 requests per
+ * minute per API key owner).
+ */
+export const UPDATE_OPERATION_LIMIT: OperationLimit = Object.freeze({
+	maxPerSecond: UPDATE_PER_MINUTE / SECONDS_PER_MINUTE,
+	operationKey: "memory-store-sorted-maps.update",
+});
+
+/**
+ * Scopes required to update a memory-store sorted-map item, sourced
+ * from `x-roblox-scopes` on the `Cloud_UpdateMemoryStoreSortedMapItem`
+ * operation in the vendored OpenAPI schema.
+ */
+export const UPDATE_REQUIRED_SCOPES: ReadonlyArray<string> = Object.freeze([WRITE_SCOPE]);

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.spec.ts
@@ -1,0 +1,328 @@
+import { validSortedMapItemBody } from "#tests/helpers/memory-store-sorted-maps";
+import { assert, describe, expect, it } from "vitest";
+
+import { ApiError } from "../../../errors/api-error.ts";
+import { parseSortedMapItemResponse } from "./parsers.ts";
+import type { MemoryStoreSortedMapItemWire } from "./wire.ts";
+
+function okSortedMapItemResponse(
+	body: MemoryStoreSortedMapItemWire,
+): Parameters<typeof parseSortedMapItemResponse>[0] {
+	return { body, headers: {}, status: 200 };
+}
+
+describe(parseSortedMapItemResponse, () => {
+	it("should parse a full valid body into the public SortedMapItem shape", () => {
+		expect.assertions(1);
+
+		const result = parseSortedMapItemResponse(
+			okSortedMapItemResponse(validSortedMapItemBody()),
+		);
+
+		assert(result.success);
+
+		expect(result.data).toStrictEqual({
+			id: "abc123",
+			etag: 'W/"v1"',
+			expiresAt: new Date("2026-06-21T15:08:58.4806559Z"),
+			mapId: "test-map",
+			sortKey: { kind: "string", value: "score-100" },
+			universeId: "123",
+			value: "hello",
+		});
+	});
+
+	describe("sort-key normalization", () => {
+		it("should surface a numeric sort key as a numeric SortKey", () => {
+			expect.assertions(1);
+
+			const result = parseSortedMapItemResponse(
+				okSortedMapItemResponse(
+					validSortedMapItemBody({
+						numericSortKey: 7.5,
+						stringSortKey: undefined,
+					}),
+				),
+			);
+
+			assert(result.success);
+
+			expect(result.data.sortKey).toStrictEqual({ kind: "numeric", value: 7.5 });
+		});
+
+		it("should surface no sort key as undefined when both wire fields are absent", () => {
+			expect.assertions(1);
+
+			const result = parseSortedMapItemResponse(
+				okSortedMapItemResponse(
+					validSortedMapItemBody({
+						numericSortKey: undefined,
+						stringSortKey: undefined,
+					}),
+				),
+			);
+
+			assert(result.success);
+
+			expect(result.data.sortKey).toBeUndefined();
+		});
+
+		it("should normalize a JSON null stringSortKey to undefined", () => {
+			expect.assertions(1);
+
+			const body: Record<string, unknown> = {
+				...validSortedMapItemBody({ stringSortKey: undefined }),
+				stringSortKey: JSON.parse("null"),
+			};
+
+			const result = parseSortedMapItemResponse({ body, headers: {}, status: 200 });
+
+			assert(result.success);
+
+			expect(result.data.sortKey).toBeUndefined();
+		});
+
+		it("should normalize a JSON null numericSortKey to undefined", () => {
+			expect.assertions(1);
+
+			const body: Record<string, unknown> = {
+				...validSortedMapItemBody({ stringSortKey: undefined }),
+				numericSortKey: JSON.parse("null"),
+			};
+
+			const result = parseSortedMapItemResponse({ body, headers: {}, status: 200 });
+
+			assert(result.success);
+
+			expect(result.data.sortKey).toBeUndefined();
+		});
+
+		it("should reject a response carrying both stringSortKey and numericSortKey", () => {
+			expect.assertions(2);
+
+			const result = parseSortedMapItemResponse(
+				okSortedMapItemResponse(
+					validSortedMapItemBody({
+						numericSortKey: 1,
+						stringSortKey: "a",
+					}),
+				),
+			);
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+			expect(result.err.message).toBe("Malformed memory-store sorted-map item response");
+		});
+	});
+
+	describe("value preservation", () => {
+		it("should preserve nested null values inside an object payload", () => {
+			expect.assertions(1);
+
+			const result = parseSortedMapItemResponse(
+				okSortedMapItemResponse(
+					validSortedMapItemBody({ value: { a: "x", b: JSON.parse("null") } }),
+				),
+			);
+
+			assert(result.success);
+
+			expect(result.data.value).toStrictEqual({ a: "x", b: JSON.parse("null") });
+		});
+
+		it("should preserve a falsy primitive payload (zero) verbatim", () => {
+			expect.assertions(1);
+
+			const result = parseSortedMapItemResponse(
+				okSortedMapItemResponse(validSortedMapItemBody({ value: 0 })),
+			);
+
+			assert(result.success);
+
+			expect(result.data.value).toBe(0);
+		});
+
+		it("should accept a JSON null value at the top level", () => {
+			expect.assertions(1);
+
+			const result = parseSortedMapItemResponse(
+				okSortedMapItemResponse(validSortedMapItemBody({ value: JSON.parse("null") })),
+			);
+
+			assert(result.success);
+
+			expect(result.data.value).toBeNull();
+		});
+	});
+
+	describe("id extraction", () => {
+		it("should extract universeId, mapId, and id from the resource path", () => {
+			expect.assertions(3);
+
+			const result = parseSortedMapItemResponse(
+				okSortedMapItemResponse(
+					validSortedMapItemBody({
+						path: "cloud/v2/universes/99999/memory-store/sorted-maps/some-map/items/400ffff0001",
+					}),
+				),
+			);
+
+			assert(result.success);
+
+			expect(result.data.universeId).toBe("99999");
+			expect(result.data.mapId).toBe("some-map");
+			expect(result.data.id).toBe("400ffff0001");
+		});
+
+		it("should reject a path that does not match the sorted-map item pattern", () => {
+			expect.assertions(2);
+
+			const result = parseSortedMapItemResponse(
+				okSortedMapItemResponse(
+					validSortedMapItemBody({ path: "universes/123/places/456" }),
+				),
+			);
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+			expect(result.err.message).toBe("Malformed memory-store sorted-map item response");
+		});
+	});
+
+	describe("malformed bodies", () => {
+		it("should reject a non-record body", () => {
+			expect.assertions(2);
+
+			const result = parseSortedMapItemResponse({
+				body: "not an object",
+				headers: {},
+				status: 200,
+			});
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+			expect(result.err.statusCode).toBe(200);
+		});
+
+		it.for(["etag", "expireTime", "id", "path", "value"] as const)(
+			"should reject a body missing the required %s field",
+			(field) => {
+				expect.assertions(1);
+
+				const { [field]: _removed, ...rest } = validSortedMapItemBody();
+				const result = parseSortedMapItemResponse({
+					body: rest,
+					headers: {},
+					status: 200,
+				});
+
+				assert(!result.success);
+
+				expect(result.err).toBeInstanceOf(ApiError);
+			},
+		);
+
+		it("should reject a body whose path is a non-string with a matching toString", () => {
+			expect.assertions(1);
+
+			const body = {
+				...validSortedMapItemBody(),
+				path: {
+					toString: (): string =>
+						"cloud/v2/universes/1/memory-store/sorted-maps/m/items/i",
+				},
+			};
+			const result = parseSortedMapItemResponse({ body, headers: {}, status: 200 });
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should reject a body whose etag is not a string", () => {
+			expect.assertions(1);
+
+			const body = { ...validSortedMapItemBody(), etag: 123 };
+			const result = parseSortedMapItemResponse({ body, headers: {}, status: 200 });
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should reject a body whose expireTime is not a string", () => {
+			expect.assertions(1);
+
+			const body = { ...validSortedMapItemBody(), expireTime: 0 };
+			const result = parseSortedMapItemResponse({ body, headers: {}, status: 200 });
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should reject a body whose expireTime is a string that does not parse to a Date", () => {
+			expect.assertions(1);
+
+			const body = { ...validSortedMapItemBody(), expireTime: "not-a-date" };
+			const result = parseSortedMapItemResponse({ body, headers: {}, status: 200 });
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should reject a body whose stringSortKey is not a string", () => {
+			expect.assertions(1);
+
+			const body = { ...validSortedMapItemBody(), stringSortKey: 0 };
+			const result = parseSortedMapItemResponse({ body, headers: {}, status: 200 });
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should reject a body whose numericSortKey is not a number", () => {
+			expect.assertions(1);
+
+			const body = {
+				...validSortedMapItemBody({ stringSortKey: undefined }),
+				numericSortKey: "high",
+			};
+			const result = parseSortedMapItemResponse({ body, headers: {}, status: 200 });
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should reject an array body even when it carries a valid sorted-map item shape", () => {
+			expect.assertions(1);
+
+			const arrayWithShape = Object.assign([0], validSortedMapItemBody());
+			const result = parseSortedMapItemResponse({
+				body: arrayWithShape,
+				headers: {},
+				status: 200,
+			});
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+		});
+
+		it("should propagate the response status code on the returned ApiError", () => {
+			expect.assertions(1);
+
+			const result = parseSortedMapItemResponse({ body: "nope", headers: {}, status: 502 });
+
+			assert(!result.success);
+
+			expect(result.err.statusCode).toBe(502);
+		});
+	});
+});

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.spec.ts
@@ -1,8 +1,11 @@
-import { validSortedMapItemBody } from "#tests/helpers/memory-store-sorted-maps";
+import {
+	validListSortedMapItemsBody,
+	validSortedMapItemBody,
+} from "#tests/helpers/memory-store-sorted-maps";
 import { assert, describe, expect, it } from "vitest";
 
 import { ApiError } from "../../../errors/api-error.ts";
-import { parseSortedMapItemResponse } from "./parsers.ts";
+import { parseListResponse, parseSortedMapItemResponse } from "./parsers.ts";
 import type { MemoryStoreSortedMapItemWire } from "./wire.ts";
 
 function okSortedMapItemResponse(
@@ -10,6 +13,156 @@ function okSortedMapItemResponse(
 ): Parameters<typeof parseSortedMapItemResponse>[0] {
 	return { body, headers: {}, status: 200 };
 }
+
+describe(parseListResponse, () => {
+	it("should parse a valid list response into items and a nextPageToken", () => {
+		expect.assertions(2);
+
+		const result = parseListResponse({
+			body: validListSortedMapItemsBody({ nextPageToken: "tok-42" }),
+			headers: {},
+			status: 200,
+		});
+
+		assert(result.success);
+
+		expect(result.data.items).toHaveLength(1);
+		expect(result.data.nextPageToken).toBe("tok-42");
+	});
+
+	it("should surface a missing nextPageToken as undefined", () => {
+		expect.assertions(1);
+
+		const result = parseListResponse({
+			body: validListSortedMapItemsBody(),
+			headers: {},
+			status: 200,
+		});
+
+		assert(result.success);
+
+		expect(result.data.nextPageToken).toBeUndefined();
+	});
+
+	it("should map every entry through the same parser as the single-item endpoints", () => {
+		expect.assertions(3);
+
+		const result = parseListResponse({
+			body: validListSortedMapItemsBody({
+				memoryStoreSortedMapItems: [
+					validSortedMapItemBody({
+						path: "cloud/v2/universes/1/memory-store/sorted-maps/m/items/first",
+					}),
+					validSortedMapItemBody({
+						numericSortKey: 7,
+						path: "cloud/v2/universes/1/memory-store/sorted-maps/m/items/second",
+						stringSortKey: undefined,
+					}),
+				],
+			}),
+			headers: {},
+			status: 200,
+		});
+
+		assert(result.success);
+
+		expect(result.data.items).toHaveLength(2);
+		expect(result.data.items[0]?.id).toBe("first");
+		expect(result.data.items[1]?.sortKey).toStrictEqual({ kind: "numeric", value: 7 });
+	});
+
+	it("should accept an empty memoryStoreSortedMapItems array", () => {
+		expect.assertions(1);
+
+		const result = parseListResponse({
+			body: validListSortedMapItemsBody({ memoryStoreSortedMapItems: [] }),
+			headers: {},
+			status: 200,
+		});
+
+		assert(result.success);
+
+		expect(result.data.items).toStrictEqual([]);
+	});
+
+	it("should reject a non-record body", () => {
+		expect.assertions(2);
+
+		const result = parseListResponse({
+			body: "nope",
+			headers: {},
+			status: 200,
+		});
+
+		assert(!result.success);
+
+		expect(result.err).toBeInstanceOf(ApiError);
+		expect(result.err.message).toBe("Malformed memory-store sorted-map list response");
+	});
+
+	it("should reject a body whose memoryStoreSortedMapItems is not an array", () => {
+		expect.assertions(1);
+
+		const result = parseListResponse({
+			body: { ...validListSortedMapItemsBody(), memoryStoreSortedMapItems: "nope" },
+			headers: {},
+			status: 200,
+		});
+
+		assert(!result.success);
+
+		expect(result.err).toBeInstanceOf(ApiError);
+	});
+
+	it("should reject a body whose nextPageToken is a non-string non-undefined value", () => {
+		expect.assertions(1);
+
+		const result = parseListResponse({
+			body: { ...validListSortedMapItemsBody(), nextPageToken: 42 },
+			headers: {},
+			status: 200,
+		});
+
+		assert(!result.success);
+
+		expect(result.err).toBeInstanceOf(ApiError);
+	});
+
+	it("should reject a body whose memoryStoreSortedMapItems contains a malformed entry", () => {
+		expect.assertions(1);
+
+		const malformedItem: Record<string, unknown> = {
+			...validSortedMapItemBody(),
+			path: 12_345,
+		};
+		const result = parseListResponse({
+			body: {
+				...validListSortedMapItemsBody(),
+				memoryStoreSortedMapItems: [malformedItem],
+			},
+			headers: {},
+			status: 200,
+		});
+
+		assert(!result.success);
+
+		expect(result.err).toBeInstanceOf(ApiError);
+	});
+
+	it("should propagate the response status code on the returned ApiError", () => {
+		expect.assertions(1);
+
+		const result = parseListResponse({
+			body: "nope",
+			headers: {},
+			status: 503,
+		});
+
+		assert(!result.success);
+
+		expect(result.err.statusCode).toBe(503);
+	});
+});
 
 describe(parseSortedMapItemResponse, () => {
 	it("should parse a full valid body into the public SortedMapItem shape", () => {

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.ts
@@ -3,12 +3,13 @@ import { ApiError } from "../../../errors/api-error.ts";
 import { isDateTimeString } from "../../../internal/utils/is-date-time-string.ts";
 import { isRecord } from "../../../internal/utils/is-record.ts";
 import type { Result } from "../../../types.ts";
-import type { SortedMapItem, SortKey } from "./types.ts";
+import type { ListSortedMapItemsResult, SortedMapItem, SortKey } from "./types.ts";
 import type { MemoryStoreSortedMapItemWire } from "./wire.ts";
 
 const PATH_PATTERN =
 	/^cloud\/v2\/universes\/(\d+)\/memory-store\/sorted-maps\/([^/]+)\/items\/([^/]+)$/;
 const MALFORMED_MESSAGE = "Malformed memory-store sorted-map item response";
+const MALFORMED_LIST_MESSAGE = "Malformed memory-store sorted-map list response";
 
 /**
  * Parses a successful memory-store sorted-map item response body (the
@@ -28,6 +29,44 @@ export function parseSortedMapItemResponse(
 	}
 
 	return { data: item, success: true };
+}
+
+/**
+ * Parses a successful `Cloud_ListMemoryStoreSortedMapItems` response
+ * body into the public {@link ListSortedMapItemsResult} shape. Each
+ * item in the `memoryStoreSortedMapItems` array is validated through
+ * the same path-and-shape checks as
+ * {@link parseSortedMapItemResponse}; a malformed entry rejects the
+ * whole response.
+ *
+ * @param response - The full {@link HttpResponse} from the Open Cloud API.
+ * @returns A success result wrapping the parsed
+ *   {@link ListSortedMapItemsResult}, or an {@link ApiError} when the
+ *   response shape is wrong.
+ */
+export function parseListResponse(
+	response: HttpResponse,
+): Result<ListSortedMapItemsResult, ApiError> {
+	const { body, status: statusCode } = response;
+	if (!isRecord(body)) {
+		return malformedList(statusCode);
+	}
+
+	const { memoryStoreSortedMapItems, nextPageToken } = body;
+	if (!Array.isArray(memoryStoreSortedMapItems)) {
+		return malformedList(statusCode);
+	}
+
+	if (nextPageToken !== undefined && typeof nextPageToken !== "string") {
+		return malformedList(statusCode);
+	}
+
+	const items = memoryStoreSortedMapItems.map(wireBodyToSortedMapItem);
+	if (!items.every(isSortedMapItem)) {
+		return malformedList(statusCode);
+	}
+
+	return { data: { items, nextPageToken }, success: true };
 }
 
 function isSortedMapItemWire(body: unknown): body is MemoryStoreSortedMapItemWire {
@@ -101,6 +140,17 @@ function wireBodyToSortedMapItem(body: unknown): SortedMapItem | undefined {
 function malformedSortedMapItem(statusCode: number): Result<SortedMapItem, ApiError> {
 	return {
 		err: new ApiError(MALFORMED_MESSAGE, { statusCode }),
+		success: false,
+	};
+}
+
+function isSortedMapItem(item: SortedMapItem | undefined): item is SortedMapItem {
+	return item !== undefined;
+}
+
+function malformedList(statusCode: number): Result<ListSortedMapItemsResult, ApiError> {
+	return {
+		err: new ApiError(MALFORMED_LIST_MESSAGE, { statusCode }),
 		success: false,
 	};
 }

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.ts
@@ -1,0 +1,106 @@
+import type { HttpResponse } from "../../../client/types.ts";
+import { ApiError } from "../../../errors/api-error.ts";
+import { isDateTimeString } from "../../../internal/utils/is-date-time-string.ts";
+import { isRecord } from "../../../internal/utils/is-record.ts";
+import type { Result } from "../../../types.ts";
+import type { SortedMapItem, SortKey } from "./types.ts";
+import type { MemoryStoreSortedMapItemWire } from "./wire.ts";
+
+const PATH_PATTERN =
+	/^cloud\/v2\/universes\/(\d+)\/memory-store\/sorted-maps\/([^/]+)\/items\/([^/]+)$/;
+const MALFORMED_MESSAGE = "Malformed memory-store sorted-map item response";
+
+/**
+ * Parses a successful memory-store sorted-map item response body (the
+ * happy path for create, get, and update) into the public
+ * {@link SortedMapItem} shape.
+ *
+ * @param response - The full {@link HttpResponse} from the Open Cloud API.
+ * @returns A success result wrapping the parsed {@link SortedMapItem},
+ *   or an {@link ApiError} when the body does not match the wire schema.
+ */
+export function parseSortedMapItemResponse(
+	response: HttpResponse,
+): Result<SortedMapItem, ApiError> {
+	const item = wireBodyToSortedMapItem(response.body);
+	if (item === undefined) {
+		return malformedSortedMapItem(response.status);
+	}
+
+	return { data: item, success: true };
+}
+
+function isSortedMapItemWire(body: unknown): body is MemoryStoreSortedMapItemWire {
+	if (!isRecord(body)) {
+		return false;
+	}
+
+	const { id, etag, expireTime, numericSortKey, path, stringSortKey, value } = body;
+	return (
+		typeof path === "string" &&
+		typeof etag === "string" &&
+		typeof id === "string" &&
+		isDateTimeString(expireTime) &&
+		value !== undefined &&
+		(stringSortKey === undefined ||
+			stringSortKey === null ||
+			typeof stringSortKey === "string") &&
+		(numericSortKey === undefined ||
+			numericSortKey === null ||
+			typeof numericSortKey === "number")
+	);
+}
+
+function extractSortKey(body: MemoryStoreSortedMapItemWire): "conflict" | SortKey | undefined {
+	const hasStringKey = typeof body.stringSortKey === "string";
+	const hasNumericKey = typeof body.numericSortKey === "number";
+	if (hasStringKey && hasNumericKey) {
+		return "conflict";
+	}
+
+	if (hasStringKey) {
+		return { kind: "string", value: body.stringSortKey };
+	}
+
+	if (hasNumericKey) {
+		return { kind: "numeric", value: body.numericSortKey };
+	}
+
+	return undefined;
+}
+
+function wireBodyToSortedMapItem(body: unknown): SortedMapItem | undefined {
+	if (!isSortedMapItemWire(body)) {
+		return undefined;
+	}
+
+	const match = PATH_PATTERN.exec(body.path);
+	const universeId = match?.[1];
+	const mapId = match?.[2];
+	const id = match?.[3];
+	if (universeId === undefined || mapId === undefined || id === undefined) {
+		return undefined;
+	}
+
+	const sortKey = extractSortKey(body);
+	if (sortKey === "conflict") {
+		return undefined;
+	}
+
+	return {
+		id,
+		etag: body.etag,
+		expiresAt: new Date(body.expireTime),
+		mapId,
+		sortKey,
+		universeId,
+		value: body.value,
+	};
+}
+
+function malformedSortedMapItem(statusCode: number): Result<SortedMapItem, ApiError> {
+	return {
+		err: new ApiError(MALFORMED_MESSAGE, { statusCode }),
+		success: false,
+	};
+}

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/types.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/types.ts
@@ -67,6 +67,41 @@ export interface GetSortedMapItemParameters {
 }
 
 /**
+ * Caller-supplied input for the `update` method on
+ * `StorageClient.sortedMaps`. Mirrors
+ * `Cloud_UpdateMemoryStoreSortedMapItem` on the Open Cloud API. Body
+ * fields (`value`, `ttl`, `sortKey`) are optional under PATCH
+ * semantics; omitted fields are left unchanged on the server.
+ */
+export interface UpdateSortedMapItemParameters {
+	/**
+	 * When `true`, the server creates the item if it does not exist
+	 * instead of returning 404. Travels as the `allowMissing` query
+	 * string parameter.
+	 */
+	readonly allowMissing?: boolean;
+	/** Caller-supplied item identifier. URL-encoded by the builder. */
+	readonly itemId: string;
+	/** Stringified sorted-map identifier. */
+	readonly mapId: string;
+	/**
+	 * Replacement sort key. Either kind of {@link SortKey} resets the
+	 * field on the wire; omit the field to leave the existing sort key
+	 * untouched.
+	 */
+	readonly sortKey?: SortKey;
+	/**
+	 * Replacement time-to-live in seconds. Omitted entries leave the
+	 * existing TTL unchanged.
+	 */
+	readonly ttl?: number;
+	/** Stringified ID of the universe that owns the sorted map. */
+	readonly universeId: string;
+	/** Replacement value. Omitted entries leave the existing value unchanged. */
+	readonly value?: JSONValue;
+}
+
+/**
  * Parsed representation of a sorted-map item, as returned by every
  * sorted-map operation that yields a single item.
  */

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/types.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Discriminated union describing a sorted-map item's sort key. The
+ * server contract requires at most one of `stringSortKey` or
+ * `numericSortKey`; the union surfaces that constraint at the type
+ * level so callers cannot accidentally set both.
+ */
+export type SortKey =
+	| { readonly kind: "numeric"; readonly value: number }
+	| { readonly kind: "string"; readonly value: string };
+
+/**
+ * Caller-supplied input for the `create` method on
+ * `StorageClient.sortedMaps`. Mirrors
+ * `Cloud_CreateMemoryStoreSortedMapItem` on the Open Cloud API.
+ */
+export interface CreateSortedMapItemParameters {
+	/**
+	 * Caller-supplied item identifier. The server stores items
+	 * case-sensitively; the value is URL-encoded by the builder.
+	 */
+	readonly itemId: string;
+	/** Stringified sorted-map identifier. */
+	readonly mapId: string;
+	/** Optional sort key driving the item's position in the map. */
+	readonly sortKey?: SortKey;
+	/**
+	 * Optional time-to-live in seconds. After this many seconds the
+	 * item is automatically removed. Omitted entries inherit the
+	 * server-default TTL.
+	 */
+	readonly ttl?: number;
+	/** Stringified ID of the universe that owns the sorted map. */
+	readonly universeId: string;
+	/**
+	 * Opaque item payload. May be any JSON value, including `null`,
+	 * matching the protobuf `Value` contract on the wire.
+	 */
+	readonly value: JSONValue;
+}
+
+/**
+ * Parsed representation of a sorted-map item, as returned by every
+ * sorted-map operation that yields a single item.
+ */
+export interface SortedMapItem {
+	/** Item identifier, parsed from the wire `path`. */
+	readonly id: string;
+	/**
+	 * Server-generated etag for optimistic concurrency. Surfaced for
+	 * caller inspection; the SDK does not yet emit an `If-Match` header
+	 * for conditional update or delete.
+	 */
+	readonly etag: string;
+	/** Timestamp at which the server removes the item from the map. */
+	readonly expiresAt: Date;
+	/** Stringified sorted-map identifier, parsed from the wire `path`. */
+	readonly mapId: string;
+	/**
+	 * Parsed sort key, or `undefined` when the item has none. The server
+	 * contract is one-of: a response carrying both `stringSortKey` and
+	 * `numericSortKey` is rejected as malformed.
+	 */
+	readonly sortKey: SortKey | undefined;
+	/** Stringified universe identifier, parsed from the wire `path`. */
+	readonly universeId: string;
+	/**
+	 * Opaque item payload. Round-trips as JSON, including nested `null`
+	 * values inside objects and arrays, and `null` at the top level.
+	 */
+	readonly value: JSONValue;
+}

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/types.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/types.ts
@@ -39,6 +39,20 @@ export interface CreateSortedMapItemParameters {
 }
 
 /**
+ * Caller-supplied input for the `delete` method on
+ * `StorageClient.sortedMaps`. Mirrors
+ * `Cloud_DeleteMemoryStoreSortedMapItem` on the Open Cloud API.
+ */
+export interface DeleteSortedMapItemParameters {
+	/** Caller-supplied item identifier. URL-encoded by the builder. */
+	readonly itemId: string;
+	/** Stringified sorted-map identifier. */
+	readonly mapId: string;
+	/** Stringified ID of the universe that owns the sorted map. */
+	readonly universeId: string;
+}
+
+/**
  * Caller-supplied input for the `get` method on
  * `StorageClient.sortedMaps`. Mirrors
  * `Cloud_GetMemoryStoreSortedMapItem` on the Open Cloud API.

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/types.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/types.ts
@@ -39,6 +39,20 @@ export interface CreateSortedMapItemParameters {
 }
 
 /**
+ * Caller-supplied input for the `get` method on
+ * `StorageClient.sortedMaps`. Mirrors
+ * `Cloud_GetMemoryStoreSortedMapItem` on the Open Cloud API.
+ */
+export interface GetSortedMapItemParameters {
+	/** Caller-supplied item identifier. URL-encoded by the builder. */
+	readonly itemId: string;
+	/** Stringified sorted-map identifier. */
+	readonly mapId: string;
+	/** Stringified ID of the universe that owns the sorted map. */
+	readonly universeId: string;
+}
+
+/**
  * Parsed representation of a sorted-map item, as returned by every
  * sorted-map operation that yields a single item.
  */

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/types.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/types.ts
@@ -39,6 +39,87 @@ export interface CreateSortedMapItemParameters {
 }
 
 /**
+ * Caller-supplied input for the `list` method on
+ * `StorageClient.sortedMaps`. Mirrors
+ * `Cloud_ListMemoryStoreSortedMapItems` on the Open Cloud API. All
+ * paging and filtering parameters are optional; omitting them returns
+ * up to one item server-side (`maxPageSize` defaults to `1`).
+ */
+export interface ListSortedMapItemsParameters {
+	/**
+	 * Optional CEL filter on `id` and `sortKey`. The server supports
+	 * `<`, `>`, and `&&` operators only; other operators are rejected
+	 * server-side with a validation error.
+	 */
+	readonly filter?: string;
+	/** Stringified sorted-map identifier. */
+	readonly mapId: string;
+	/**
+	 * Maximum items per page. Capped at `100` server-side; values above
+	 * the cap are clamped. Defaults to `1` when omitted.
+	 */
+	readonly maxPageSize?: number;
+	/**
+	 * Sort order. The server supports the `id` field only, with an
+	 * optional ` desc` suffix.
+	 */
+	readonly orderBy?: string;
+	/**
+	 * Page token returned by a previous call. When supplied, all other
+	 * parameters must match the previous call exactly.
+	 */
+	readonly pageToken?: string;
+	/** Stringified ID of the universe that owns the sorted map. */
+	readonly universeId: string;
+}
+
+/**
+ * Parsed representation of a sorted-map item, as returned by every
+ * sorted-map operation that yields a single item.
+ */
+export interface SortedMapItem {
+	/** Item identifier, parsed from the wire `path`. */
+	readonly id: string;
+	/**
+	 * Server-generated etag for optimistic concurrency. Surfaced for
+	 * caller inspection; the SDK does not yet emit an `If-Match` header
+	 * for conditional update or delete.
+	 */
+	readonly etag: string;
+	/** Timestamp at which the server removes the item from the map. */
+	readonly expiresAt: Date;
+	/** Stringified sorted-map identifier, parsed from the wire `path`. */
+	readonly mapId: string;
+	/**
+	 * Parsed sort key, or `undefined` when the item has none. The server
+	 * contract is one-of: a response carrying both `stringSortKey` and
+	 * `numericSortKey` is rejected as malformed.
+	 */
+	readonly sortKey: SortKey | undefined;
+	/** Stringified universe identifier, parsed from the wire `path`. */
+	readonly universeId: string;
+	/**
+	 * Opaque item payload. Round-trips as JSON, including nested `null`
+	 * values inside objects and arrays, and `null` at the top level.
+	 */
+	readonly value: JSONValue;
+}
+
+/**
+ * Parsed result of a successful `Cloud_ListMemoryStoreSortedMapItems`
+ * response.
+ */
+export interface ListSortedMapItemsResult {
+	/** Items returned in the current page, ordered per `orderBy`. */
+	readonly items: ReadonlyArray<SortedMapItem>;
+	/**
+	 * Page token for the next call, or `undefined` when no more pages
+	 * exist. Pass back through `pageToken` to retrieve the next page.
+	 */
+	readonly nextPageToken: string | undefined;
+}
+
+/**
  * Caller-supplied input for the `delete` method on
  * `StorageClient.sortedMaps`. Mirrors
  * `Cloud_DeleteMemoryStoreSortedMapItem` on the Open Cloud API.
@@ -99,36 +180,4 @@ export interface UpdateSortedMapItemParameters {
 	readonly universeId: string;
 	/** Replacement value. Omitted entries leave the existing value unchanged. */
 	readonly value?: JSONValue;
-}
-
-/**
- * Parsed representation of a sorted-map item, as returned by every
- * sorted-map operation that yields a single item.
- */
-export interface SortedMapItem {
-	/** Item identifier, parsed from the wire `path`. */
-	readonly id: string;
-	/**
-	 * Server-generated etag for optimistic concurrency. Surfaced for
-	 * caller inspection; the SDK does not yet emit an `If-Match` header
-	 * for conditional update or delete.
-	 */
-	readonly etag: string;
-	/** Timestamp at which the server removes the item from the map. */
-	readonly expiresAt: Date;
-	/** Stringified sorted-map identifier, parsed from the wire `path`. */
-	readonly mapId: string;
-	/**
-	 * Parsed sort key, or `undefined` when the item has none. The server
-	 * contract is one-of: a response carrying both `stringSortKey` and
-	 * `numericSortKey` is rejected as malformed.
-	 */
-	readonly sortKey: SortKey | undefined;
-	/** Stringified universe identifier, parsed from the wire `path`. */
-	readonly universeId: string;
-	/**
-	 * Opaque item payload. Round-trips as JSON, including nested `null`
-	 * values inside objects and arrays, and `null` at the top level.
-	 */
-	readonly value: JSONValue;
 }

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/wire.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/wire.ts
@@ -1,0 +1,45 @@
+// Wire-level shapes for responses returned by the Open Cloud memory-store
+// sorted-map endpoints under `cloud/v2`. Internal to the sub-tree; not
+// re-exported.
+
+/**
+ * Wire shape of a `MemoryStoreSortedMapItem` resource: the response body
+ * returned by `Cloud_CreateMemoryStoreSortedMapItem`,
+ * `Cloud_GetMemoryStoreSortedMapItem`, and
+ * `Cloud_UpdateMemoryStoreSortedMapItem`, and the array entry inside
+ * `Cloud_ListMemoryStoreSortedMapItems`. Either `stringSortKey` or
+ * `numericSortKey` may be set on a single item, never both: the server
+ * contract is one-of and a response carrying both is rejected by the
+ * parser as malformed.
+ */
+export interface MemoryStoreSortedMapItemWire {
+	/** Item identifier (also the final path component). */
+	readonly id: string;
+	/** Server-generated etag for optimistic concurrency. */
+	readonly etag: string;
+	/** ISO 8601 timestamp at which the item is removed from the map. */
+	readonly expireTime: string;
+	/** Numeric sort key. Mutually exclusive with `stringSortKey`. */
+	readonly numericSortKey?: number | undefined;
+	/**
+	 * Resource path:
+	 * `cloud/v2/universes/{u}/memory-store/sorted-maps/{m}/items/{i}`.
+	 */
+	readonly path: string;
+	/** Lexicographic sort key. Mutually exclusive with `numericSortKey`. */
+	readonly stringSortKey?: string | undefined;
+	/** The opaque item payload. May be any JSON value including `null`. */
+	readonly value: JSONValue;
+}
+
+/**
+ * Wire shape of the `Cloud_ListMemoryStoreSortedMapItems` response.
+ * The server emits the items array under `memoryStoreSortedMapItems`
+ * and an optional `nextPageToken` when more items are available.
+ */
+export interface ListSortedMapItemsResponseWire {
+	/** Items in the current page, ordered per the request's `orderBy`. */
+	readonly memoryStoreSortedMapItems: ReadonlyArray<MemoryStoreSortedMapItemWire>;
+	/** Page token for the next call, or `undefined` when no more pages exist. */
+	readonly nextPageToken?: string | undefined;
+}

--- a/packages/open-cloud/src/resources/storage/client.ts
+++ b/packages/open-cloud/src/resources/storage/client.ts
@@ -1,13 +1,15 @@
 import type { OpenCloudClientOptions } from "../../client/types.ts";
 import { ResourceClient } from "../../internal/resource-client.ts";
 import { MemoryStoreQueuesGroup } from "./queues-group.ts";
+import { MemoryStoreSortedMapsGroup } from "./sorted-maps-group.ts";
 
 /**
  * Public client for the Roblox Open Cloud `Data and memory stores`
  * Feature. Today it covers memory-store queues via the
- * {@link StorageClient.queues} Operation Group; future Operation
- * Groups for sorted maps and data stores slot in as siblings on the
- * same client.
+ * {@link StorageClient.queues} Operation Group and memory-store sorted
+ * maps via the {@link StorageClient.sortedMaps} Operation Group; a
+ * future data-stores Operation Group slots in as a sibling on the same
+ * client.
  *
  * Every method returns a `Result` so callers handle failure
  * explicitly; no thrown error ever escapes the client.
@@ -24,6 +26,8 @@ import { MemoryStoreQueuesGroup } from "./queues-group.ts";
 export class StorageClient {
 	/** Memory-store queue Operation Group. */
 	public readonly queues: MemoryStoreQueuesGroup;
+	/** Memory-store sorted-map Operation Group. */
+	public readonly sortedMaps: MemoryStoreSortedMapsGroup;
 
 	/**
 	 * Creates a new {@link StorageClient}. Configuration is frozen on
@@ -34,5 +38,6 @@ export class StorageClient {
 	constructor(options: OpenCloudClientOptions) {
 		const inner = new ResourceClient(options);
 		this.queues = new MemoryStoreQueuesGroup(inner);
+		this.sortedMaps = new MemoryStoreSortedMapsGroup(inner);
 	}
 }

--- a/packages/open-cloud/src/resources/storage/index.ts
+++ b/packages/open-cloud/src/resources/storage/index.ts
@@ -7,6 +7,7 @@ export type {
 } from "../../domains/cloud-v2/memory-store-queues/types.ts";
 export type {
 	CreateSortedMapItemParameters,
+	GetSortedMapItemParameters,
 	SortedMapItem,
 	SortKey,
 } from "../../domains/cloud-v2/memory-store-sorted-maps/types.ts";

--- a/packages/open-cloud/src/resources/storage/index.ts
+++ b/packages/open-cloud/src/resources/storage/index.ts
@@ -5,4 +5,9 @@ export type {
 	EnqueueQueueItemParameters,
 	QueueItem,
 } from "../../domains/cloud-v2/memory-store-queues/types.ts";
+export type {
+	CreateSortedMapItemParameters,
+	SortedMapItem,
+	SortKey,
+} from "../../domains/cloud-v2/memory-store-sorted-maps/types.ts";
 export { StorageClient } from "./client.ts";

--- a/packages/open-cloud/src/resources/storage/index.ts
+++ b/packages/open-cloud/src/resources/storage/index.ts
@@ -11,5 +11,6 @@ export type {
 	GetSortedMapItemParameters,
 	SortedMapItem,
 	SortKey,
+	UpdateSortedMapItemParameters,
 } from "../../domains/cloud-v2/memory-store-sorted-maps/types.ts";
 export { StorageClient } from "./client.ts";

--- a/packages/open-cloud/src/resources/storage/index.ts
+++ b/packages/open-cloud/src/resources/storage/index.ts
@@ -9,6 +9,8 @@ export type {
 	CreateSortedMapItemParameters,
 	DeleteSortedMapItemParameters,
 	GetSortedMapItemParameters,
+	ListSortedMapItemsParameters,
+	ListSortedMapItemsResult,
 	SortedMapItem,
 	SortKey,
 	UpdateSortedMapItemParameters,

--- a/packages/open-cloud/src/resources/storage/index.ts
+++ b/packages/open-cloud/src/resources/storage/index.ts
@@ -7,6 +7,7 @@ export type {
 } from "../../domains/cloud-v2/memory-store-queues/types.ts";
 export type {
 	CreateSortedMapItemParameters,
+	DeleteSortedMapItemParameters,
 	GetSortedMapItemParameters,
 	SortedMapItem,
 	SortKey,

--- a/packages/open-cloud/src/resources/storage/sorted-maps-group.ts
+++ b/packages/open-cloud/src/resources/storage/sorted-maps-group.ts
@@ -1,16 +1,22 @@
 import type { OpenCloudClientOptions, RequestOptions } from "../../client/types.ts";
-import { buildCreateRequest } from "../../domains/cloud-v2/memory-store-sorted-maps/builders.ts";
+import {
+	buildCreateRequest,
+	buildGetRequest,
+} from "../../domains/cloud-v2/memory-store-sorted-maps/builders.ts";
 import {
 	CREATE_OPERATION_LIMIT,
 	CREATE_REQUIRED_SCOPES,
+	GET_OPERATION_LIMIT,
+	GET_REQUIRED_SCOPES,
 } from "../../domains/cloud-v2/memory-store-sorted-maps/operations.ts";
 import { parseSortedMapItemResponse } from "../../domains/cloud-v2/memory-store-sorted-maps/parsers.ts";
 import type {
 	CreateSortedMapItemParameters,
+	GetSortedMapItemParameters,
 	SortedMapItem,
 } from "../../domains/cloud-v2/memory-store-sorted-maps/types.ts";
 import type { OpenCloudError } from "../../errors/base.ts";
-import { CREATE_METHOD_DEFAULTS } from "../../internal/http/retry.ts";
+import { CREATE_METHOD_DEFAULTS, IDEMPOTENT_METHOD_DEFAULTS } from "../../internal/http/retry.ts";
 import {
 	okRequest,
 	type ResourceClient,
@@ -29,6 +35,15 @@ const CREATE_SPEC = makeSpec<CreateSortedMapItemParameters, SortedMapItem>({
 	operationLimit: CREATE_OPERATION_LIMIT,
 	parse: parseSortedMapItemResponse,
 	requiredScopes: CREATE_REQUIRED_SCOPES,
+});
+
+const GET_SPEC = makeSpec<GetSortedMapItemParameters, SortedMapItem>({
+	buildRequest: (parameters) => okRequest(buildGetRequest(parameters)),
+	methodDefaults: IDEMPOTENT_METHOD_DEFAULTS,
+	methodKind: "idempotent",
+	operationLimit: GET_OPERATION_LIMIT,
+	parse: parseSortedMapItemResponse,
+	requiredScopes: GET_REQUIRED_SCOPES,
 });
 
 /**
@@ -77,5 +92,23 @@ export class MemoryStoreSortedMapsGroup {
 		options?: RequestOptions,
 	): Promise<Result<SortedMapItem, OpenCloudError>> {
 		return this.#inner.execute({ options, parameters, spec: CREATE_SPEC });
+	}
+
+	/**
+	 * Reads a single item from a sorted map. Returns the parsed
+	 * {@link SortedMapItem} with the server-recorded `etag` for use in
+	 * subsequent conditional updates (once the SDK begins emitting
+	 * `If-Match`; see the package README).
+	 *
+	 * @param parameters - Universe, sorted-map, and item identifiers.
+	 * @param options - Optional per-request overrides.
+	 * @returns A {@link Result} wrapping the parsed {@link SortedMapItem}
+	 *   or the {@link OpenCloudError} that caused the request to fail.
+	 */
+	public async get(
+		parameters: GetSortedMapItemParameters,
+		options?: RequestOptions,
+	): Promise<Result<SortedMapItem, OpenCloudError>> {
+		return this.#inner.execute({ options, parameters, spec: GET_SPEC });
 	}
 }

--- a/packages/open-cloud/src/resources/storage/sorted-maps-group.ts
+++ b/packages/open-cloud/src/resources/storage/sorted-maps-group.ts
@@ -3,6 +3,7 @@ import {
 	buildCreateRequest,
 	buildDeleteRequest,
 	buildGetRequest,
+	buildUpdateRequest,
 } from "../../domains/cloud-v2/memory-store-sorted-maps/builders.ts";
 import {
 	CREATE_OPERATION_LIMIT,
@@ -11,6 +12,8 @@ import {
 	DELETE_REQUIRED_SCOPES,
 	GET_OPERATION_LIMIT,
 	GET_REQUIRED_SCOPES,
+	UPDATE_OPERATION_LIMIT,
+	UPDATE_REQUIRED_SCOPES,
 } from "../../domains/cloud-v2/memory-store-sorted-maps/operations.ts";
 import { parseSortedMapItemResponse } from "../../domains/cloud-v2/memory-store-sorted-maps/parsers.ts";
 import type {
@@ -18,6 +21,7 @@ import type {
 	DeleteSortedMapItemParameters,
 	GetSortedMapItemParameters,
 	SortedMapItem,
+	UpdateSortedMapItemParameters,
 } from "../../domains/cloud-v2/memory-store-sorted-maps/types.ts";
 import type { OpenCloudError } from "../../errors/base.ts";
 import { CREATE_METHOD_DEFAULTS, IDEMPOTENT_METHOD_DEFAULTS } from "../../internal/http/retry.ts";
@@ -58,6 +62,15 @@ const GET_SPEC = makeSpec<GetSortedMapItemParameters, SortedMapItem>({
 	operationLimit: GET_OPERATION_LIMIT,
 	parse: parseSortedMapItemResponse,
 	requiredScopes: GET_REQUIRED_SCOPES,
+});
+
+const UPDATE_SPEC = makeSpec<UpdateSortedMapItemParameters, SortedMapItem>({
+	buildRequest: (parameters) => okRequest(buildUpdateRequest(parameters)),
+	methodDefaults: IDEMPOTENT_METHOD_DEFAULTS,
+	methodKind: "idempotent",
+	operationLimit: UPDATE_OPERATION_LIMIT,
+	parse: parseSortedMapItemResponse,
+	requiredScopes: UPDATE_REQUIRED_SCOPES,
 });
 
 /**
@@ -142,5 +155,28 @@ export class MemoryStoreSortedMapsGroup {
 		options?: RequestOptions,
 	): Promise<Result<SortedMapItem, OpenCloudError>> {
 		return this.#inner.execute({ options, parameters, spec: GET_SPEC });
+	}
+
+	/**
+	 * Updates a sorted-map item under PATCH semantics: omitted body
+	 * fields are left unchanged on the server, supplied fields replace
+	 * their existing values. Passing `allowMissing: true` creates the
+	 * item when no row exists instead of returning 404.
+	 *
+	 * Retries 5xx because PATCH with the same body produces the same
+	 * server state.
+	 *
+	 * @param parameters - Universe, sorted-map, and item identifiers,
+	 *   plus any subset of `value`, `ttl`, `sortKey`, and
+	 *   `allowMissing`.
+	 * @param options - Optional per-request overrides.
+	 * @returns A {@link Result} wrapping the parsed {@link SortedMapItem}
+	 *   or the {@link OpenCloudError} that caused the request to fail.
+	 */
+	public async update(
+		parameters: UpdateSortedMapItemParameters,
+		options?: RequestOptions,
+	): Promise<Result<SortedMapItem, OpenCloudError>> {
+		return this.#inner.execute({ options, parameters, spec: UPDATE_SPEC });
 	}
 }

--- a/packages/open-cloud/src/resources/storage/sorted-maps-group.ts
+++ b/packages/open-cloud/src/resources/storage/sorted-maps-group.ts
@@ -1,0 +1,81 @@
+import type { OpenCloudClientOptions, RequestOptions } from "../../client/types.ts";
+import { buildCreateRequest } from "../../domains/cloud-v2/memory-store-sorted-maps/builders.ts";
+import {
+	CREATE_OPERATION_LIMIT,
+	CREATE_REQUIRED_SCOPES,
+} from "../../domains/cloud-v2/memory-store-sorted-maps/operations.ts";
+import { parseSortedMapItemResponse } from "../../domains/cloud-v2/memory-store-sorted-maps/parsers.ts";
+import type {
+	CreateSortedMapItemParameters,
+	SortedMapItem,
+} from "../../domains/cloud-v2/memory-store-sorted-maps/types.ts";
+import type { OpenCloudError } from "../../errors/base.ts";
+import { CREATE_METHOD_DEFAULTS } from "../../internal/http/retry.ts";
+import {
+	okRequest,
+	type ResourceClient,
+	type ResourceMethodSpec,
+} from "../../internal/resource-client.ts";
+import type { Result } from "../../types.ts";
+
+function makeSpec<P, R>(spec: ResourceMethodSpec<P, R>): ResourceMethodSpec<P, R> {
+	return Object.freeze(spec);
+}
+
+const CREATE_SPEC = makeSpec<CreateSortedMapItemParameters, SortedMapItem>({
+	buildRequest: (parameters) => okRequest(buildCreateRequest(parameters)),
+	methodDefaults: CREATE_METHOD_DEFAULTS,
+	methodKind: "create",
+	operationLimit: CREATE_OPERATION_LIMIT,
+	parse: parseSortedMapItemResponse,
+	requiredScopes: CREATE_REQUIRED_SCOPES,
+});
+
+/**
+ * Operation Group on `StorageClient` that exposes the memory-store
+ * sorted-map endpoints. Sorted maps are ordered collections of
+ * (id, value, sortKey) triples; consumers create, read, update, list,
+ * and delete items keyed by a caller-supplied identifier and ordered
+ * by an optional string or numeric sort key.
+ */
+export class MemoryStoreSortedMapsGroup {
+	readonly #inner: ResourceClient;
+
+	/**
+	 * Wraps the shared {@link ResourceClient} so the Operation Group
+	 * routes calls through the same retry, hooks, and rate-limit queues
+	 * as the rest of the parent client.
+	 *
+	 * @param inner - The shared {@link ResourceClient} owned by the
+	 *   parent client.
+	 */
+	constructor(inner: ResourceClient) {
+		this.#inner = inner;
+	}
+
+	/**
+	 * Creates a single item in a sorted map. The sorted map is
+	 * auto-created on first use; the map identifier is any string the
+	 * caller picks. Items are keyed by `itemId` (case-sensitive) and
+	 * ordered by an optional `sortKey`. Items expire and are removed
+	 * automatically after `ttl` seconds, or after a server-default
+	 * lifetime when omitted.
+	 *
+	 * On 5xx, create does not retry: Roblox Open Cloud has no
+	 * idempotency-key support, so a retry of a transient failure risks
+	 * producing a duplicate item.
+	 *
+	 * @param parameters - Universe, sorted-map, item identifiers, the
+	 *   value to store, and optional `sortKey` and `ttl`.
+	 * @param options - Optional per-request overrides (e.g. A different
+	 *   {@link OpenCloudClientOptions.apiKey} for this call only).
+	 * @returns A {@link Result} wrapping the parsed {@link SortedMapItem}
+	 *   or the {@link OpenCloudError} that caused the request to fail.
+	 */
+	public async create(
+		parameters: CreateSortedMapItemParameters,
+		options?: RequestOptions,
+	): Promise<Result<SortedMapItem, OpenCloudError>> {
+		return this.#inner.execute({ options, parameters, spec: CREATE_SPEC });
+	}
+}

--- a/packages/open-cloud/src/resources/storage/sorted-maps-group.ts
+++ b/packages/open-cloud/src/resources/storage/sorted-maps-group.ts
@@ -3,6 +3,7 @@ import {
 	buildCreateRequest,
 	buildDeleteRequest,
 	buildGetRequest,
+	buildListRequest,
 	buildUpdateRequest,
 } from "../../domains/cloud-v2/memory-store-sorted-maps/builders.ts";
 import {
@@ -12,14 +13,21 @@ import {
 	DELETE_REQUIRED_SCOPES,
 	GET_OPERATION_LIMIT,
 	GET_REQUIRED_SCOPES,
+	LIST_OPERATION_LIMIT,
+	LIST_REQUIRED_SCOPES,
 	UPDATE_OPERATION_LIMIT,
 	UPDATE_REQUIRED_SCOPES,
 } from "../../domains/cloud-v2/memory-store-sorted-maps/operations.ts";
-import { parseSortedMapItemResponse } from "../../domains/cloud-v2/memory-store-sorted-maps/parsers.ts";
+import {
+	parseListResponse,
+	parseSortedMapItemResponse,
+} from "../../domains/cloud-v2/memory-store-sorted-maps/parsers.ts";
 import type {
 	CreateSortedMapItemParameters,
 	DeleteSortedMapItemParameters,
 	GetSortedMapItemParameters,
+	ListSortedMapItemsParameters,
+	ListSortedMapItemsResult,
 	SortedMapItem,
 	UpdateSortedMapItemParameters,
 } from "../../domains/cloud-v2/memory-store-sorted-maps/types.ts";
@@ -62,6 +70,15 @@ const GET_SPEC = makeSpec<GetSortedMapItemParameters, SortedMapItem>({
 	operationLimit: GET_OPERATION_LIMIT,
 	parse: parseSortedMapItemResponse,
 	requiredScopes: GET_REQUIRED_SCOPES,
+});
+
+const LIST_SPEC = makeSpec<ListSortedMapItemsParameters, ListSortedMapItemsResult>({
+	buildRequest: (parameters) => okRequest(buildListRequest(parameters)),
+	methodDefaults: IDEMPOTENT_METHOD_DEFAULTS,
+	methodKind: "idempotent",
+	operationLimit: LIST_OPERATION_LIMIT,
+	parse: parseListResponse,
+	requiredScopes: LIST_REQUIRED_SCOPES,
 });
 
 const UPDATE_SPEC = makeSpec<UpdateSortedMapItemParameters, SortedMapItem>({
@@ -155,6 +172,27 @@ export class MemoryStoreSortedMapsGroup {
 		options?: RequestOptions,
 	): Promise<Result<SortedMapItem, OpenCloudError>> {
 		return this.#inner.execute({ options, parameters, spec: GET_SPEC });
+	}
+
+	/**
+	 * Lists items in a sorted map. The server caps `maxPageSize` at
+	 * `100` and defaults it to `1` when omitted, so callers explicitly
+	 * pass `maxPageSize` to retrieve more than a single item per page.
+	 * The `filter` parameter accepts a CEL expression on `id` and
+	 * `sortKey` (operators `<`, `>`, `&&` only).
+	 *
+	 * @param parameters - Universe and sorted-map identifiers, plus
+	 *   optional pagination and filter parameters.
+	 * @param options - Optional per-request overrides.
+	 * @returns A {@link Result} wrapping the parsed
+	 *   {@link ListSortedMapItemsResult} or the {@link OpenCloudError}
+	 *   that caused the request to fail.
+	 */
+	public async list(
+		parameters: ListSortedMapItemsParameters,
+		options?: RequestOptions,
+	): Promise<Result<ListSortedMapItemsResult, OpenCloudError>> {
+		return this.#inner.execute({ options, parameters, spec: LIST_SPEC });
 	}
 
 	/**

--- a/packages/open-cloud/src/resources/storage/sorted-maps-group.ts
+++ b/packages/open-cloud/src/resources/storage/sorted-maps-group.ts
@@ -1,17 +1,21 @@
 import type { OpenCloudClientOptions, RequestOptions } from "../../client/types.ts";
 import {
 	buildCreateRequest,
+	buildDeleteRequest,
 	buildGetRequest,
 } from "../../domains/cloud-v2/memory-store-sorted-maps/builders.ts";
 import {
 	CREATE_OPERATION_LIMIT,
 	CREATE_REQUIRED_SCOPES,
+	DELETE_OPERATION_LIMIT,
+	DELETE_REQUIRED_SCOPES,
 	GET_OPERATION_LIMIT,
 	GET_REQUIRED_SCOPES,
 } from "../../domains/cloud-v2/memory-store-sorted-maps/operations.ts";
 import { parseSortedMapItemResponse } from "../../domains/cloud-v2/memory-store-sorted-maps/parsers.ts";
 import type {
 	CreateSortedMapItemParameters,
+	DeleteSortedMapItemParameters,
 	GetSortedMapItemParameters,
 	SortedMapItem,
 } from "../../domains/cloud-v2/memory-store-sorted-maps/types.ts";
@@ -19,6 +23,7 @@ import type { OpenCloudError } from "../../errors/base.ts";
 import { CREATE_METHOD_DEFAULTS, IDEMPOTENT_METHOD_DEFAULTS } from "../../internal/http/retry.ts";
 import {
 	okRequest,
+	parseEmptyResponse,
 	type ResourceClient,
 	type ResourceMethodSpec,
 } from "../../internal/resource-client.ts";
@@ -35,6 +40,15 @@ const CREATE_SPEC = makeSpec<CreateSortedMapItemParameters, SortedMapItem>({
 	operationLimit: CREATE_OPERATION_LIMIT,
 	parse: parseSortedMapItemResponse,
 	requiredScopes: CREATE_REQUIRED_SCOPES,
+});
+
+const DELETE_SPEC = makeSpec<DeleteSortedMapItemParameters, undefined>({
+	buildRequest: (parameters) => okRequest(buildDeleteRequest(parameters)),
+	methodDefaults: IDEMPOTENT_METHOD_DEFAULTS,
+	methodKind: "idempotent",
+	operationLimit: DELETE_OPERATION_LIMIT,
+	parse: parseEmptyResponse,
+	requiredScopes: DELETE_REQUIRED_SCOPES,
 });
 
 const GET_SPEC = makeSpec<GetSortedMapItemParameters, SortedMapItem>({
@@ -92,6 +106,24 @@ export class MemoryStoreSortedMapsGroup {
 		options?: RequestOptions,
 	): Promise<Result<SortedMapItem, OpenCloudError>> {
 		return this.#inner.execute({ options, parameters, spec: CREATE_SPEC });
+	}
+
+	/**
+	 * Removes a single item from a sorted map. The call is idempotent:
+	 * a second `delete` against the same item is a no-op once the
+	 * server has dropped the row. The retry policy retries both 429
+	 * and 5xx.
+	 *
+	 * @param parameters - Universe, sorted-map, and item identifiers.
+	 * @param options - Optional per-request overrides.
+	 * @returns A {@link Result} wrapping `undefined` on success or the
+	 *   {@link OpenCloudError} that caused the request to fail.
+	 */
+	public async delete(
+		parameters: DeleteSortedMapItemParameters,
+		options?: RequestOptions,
+	): Promise<Result<undefined, OpenCloudError>> {
+		return this.#inner.execute({ options, parameters, spec: DELETE_SPEC });
 	}
 
 	/**

--- a/packages/open-cloud/tests/conformance/memory-store-sorted-map-create-writable-keys.spec.ts
+++ b/packages/open-cloud/tests/conformance/memory-store-sorted-map-create-writable-keys.spec.ts
@@ -1,0 +1,33 @@
+import type { CreateSortedMapItemParameters } from "#src/domains/cloud-v2/memory-store-sorted-maps/types";
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import { listWritablePropertyNames } from "./_helpers.ts";
+
+// Type-level pin: every key in the parameter interface (minus the
+// universeId, mapId, and itemId URL fields) must appear in this union,
+// and the union must not name a key that is not in the interface. The
+// pin diverges from the wire-body-keys array below because `sortKey` is
+// a discriminated union that the builder projects into either
+// `stringSortKey` or `numericSortKey` on the wire.
+expectTypeOf<"sortKey" | "ttl" | "value">().toEqualTypeOf<
+	Exclude<keyof CreateSortedMapItemParameters, "itemId" | "mapId" | "universeId">
+>();
+
+/**
+ * Wire-level body keys the create builder may emit, after projecting
+ * the `sortKey` discriminated union onto its two underlying schema
+ * fields. The runtime drift check asserts every entry is non-`readOnly`
+ * on the `MemoryStoreSortedMapItem` schema, so an entry cannot name a
+ * server-side readOnly field.
+ */
+const CREATE_WIRE_BODY_KEYS = ["numericSortKey", "stringSortKey", "ttl", "value"] as const;
+
+describe("createSortedMapItemParameters writable-keys pin", () => {
+	it.for(CREATE_WIRE_BODY_KEYS)(
+		"should expose %s as a non-readOnly property on the MemoryStoreSortedMapItem schema",
+		(key) => {
+			expect.assertions(1);
+			expect(listWritablePropertyNames("MemoryStoreSortedMapItem")).toContain(key);
+		},
+	);
+});

--- a/packages/open-cloud/tests/conformance/memory-store-sorted-map-update-writable-keys.spec.ts
+++ b/packages/open-cloud/tests/conformance/memory-store-sorted-map-update-writable-keys.spec.ts
@@ -1,0 +1,34 @@
+import type { UpdateSortedMapItemParameters } from "#src/domains/cloud-v2/memory-store-sorted-maps/types";
+import { describe, expect, expectTypeOf, it } from "vitest";
+
+import { listWritablePropertyNames } from "./_helpers.ts";
+
+// Type-level pin: every key in the parameter interface (minus the
+// universeId, mapId, and itemId URL fields and the `allowMissing`
+// query parameter) must appear in this union, and the union must not
+// name a key that is not in the interface. Mirrors the create pin: the
+// `sortKey` discriminated union does not appear in
+// `UPDATE_WIRE_BODY_KEYS` because the builder projects it onto the
+// wire as either `stringSortKey` or `numericSortKey`.
+expectTypeOf<"sortKey" | "ttl" | "value">().toEqualTypeOf<
+	Exclude<keyof UpdateSortedMapItemParameters, "allowMissing" | "itemId" | "mapId" | "universeId">
+>();
+
+/**
+ * Wire-level body keys the update builder may emit, after projecting
+ * the `sortKey` discriminated union onto its two underlying schema
+ * fields. The runtime drift check asserts every entry is non-`readOnly`
+ * on the `MemoryStoreSortedMapItem` schema, so an entry cannot name a
+ * server-side readOnly field.
+ */
+const UPDATE_WIRE_BODY_KEYS = ["numericSortKey", "stringSortKey", "ttl", "value"] as const;
+
+describe("updateSortedMapItemParameters writable-keys pin", () => {
+	it.for(UPDATE_WIRE_BODY_KEYS)(
+		"should expose %s as a non-readOnly property on the MemoryStoreSortedMapItem schema",
+		(key) => {
+			expect.assertions(1);
+			expect(listWritablePropertyNames("MemoryStoreSortedMapItem")).toContain(key);
+		},
+	);
+});

--- a/packages/open-cloud/tests/helpers/index.ts
+++ b/packages/open-cloud/tests/helpers/index.ts
@@ -19,5 +19,6 @@ export { validBinaryInputBody } from "./luau-execution-task-binary-inputs.ts";
 export { validLogPageBody } from "./luau-execution-task-logs.ts";
 export { validInProgressTaskBody } from "./luau-execution-tasks.ts";
 export { validDequeueBody, validQueueItemBody } from "./memory-store-queues.ts";
+export { validListSortedMapItemsBody, validSortedMapItemBody } from "./memory-store-sorted-maps.ts";
 export { rbxlBody, rbxlxBody, validPlaceBody, validPublishResponseBody } from "./places.ts";
 export { validUniverseBody } from "./universes.ts";

--- a/packages/open-cloud/tests/helpers/memory-store-sorted-maps.ts
+++ b/packages/open-cloud/tests/helpers/memory-store-sorted-maps.ts
@@ -1,0 +1,46 @@
+import type {
+	ListSortedMapItemsResponseWire,
+	MemoryStoreSortedMapItemWire,
+} from "#src/domains/cloud-v2/memory-store-sorted-maps/wire";
+
+/**
+ * Builds a minimally-valid {@link MemoryStoreSortedMapItemWire} body.
+ * Pass an `overrides` object to tweak fields without re-stating the
+ * defaults. The default carries a `stringSortKey`; pass
+ * `{ stringSortKey: undefined, numericSortKey: 12 }` to test the
+ * numeric branch.
+ *
+ * @param overrides - Fields to override on the default body.
+ * @returns A valid wire body with the overrides applied.
+ */
+export function validSortedMapItemBody(
+	overrides: Partial<MemoryStoreSortedMapItemWire> = {},
+): MemoryStoreSortedMapItemWire {
+	return {
+		id: "abc123",
+		etag: 'W/"v1"',
+		expireTime: "2026-06-21T15:08:58.4806559Z",
+		path: "cloud/v2/universes/123/memory-store/sorted-maps/test-map/items/abc123",
+		stringSortKey: "score-100",
+		value: "hello",
+		...overrides,
+	};
+}
+
+/**
+ * Builds a minimally-valid {@link ListSortedMapItemsResponseWire} body
+ * carrying a single default sorted-map item. Pass an `overrides`
+ * object to change the page token or supply a different items array.
+ *
+ * @param overrides - Fields to override on the default body.
+ * @returns A valid list response body with the overrides applied.
+ */
+export function validListSortedMapItemsBody(
+	overrides: Partial<ListSortedMapItemsResponseWire> = {},
+): ListSortedMapItemsResponseWire {
+	return {
+		memoryStoreSortedMapItems: [validSortedMapItemBody()],
+		nextPageToken: undefined,
+		...overrides,
+	};
+}

--- a/packages/open-cloud/tests/integration/resources/storage/sorted-maps.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/storage/sorted-maps.spec.ts
@@ -233,6 +233,121 @@ describe(StorageClient, () => {
 		});
 	});
 
+	describe("sortedMaps.update", () => {
+		it("should return a parsed SortedMapItem on a happy path", async () => {
+			expect.assertions(2);
+
+			const httpClient = createFakeHttpClient().mockResponse({
+				body: validSortedMapItemBody({
+					path: "cloud/v2/universes/123/memory-store/sorted-maps/my-map/items/abc",
+				}),
+				status: 200,
+			});
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.sortedMaps.update({
+				itemId: "abc",
+				mapId: "my-map",
+				universeId: "123",
+				value: "updated",
+			});
+
+			assert(result.success);
+
+			expect(result.data).toMatchObject({ id: "abc", mapId: "my-map", universeId: "123" });
+			expect(httpClient.requests).toHaveLength(1);
+		});
+
+		it("should send a PATCH whose URL embeds allowMissing and whose body carries the partial update", async () => {
+			expect.assertions(3);
+
+			const httpClient = createFakeHttpClient().mockResponse({
+				body: validSortedMapItemBody(),
+				status: 200,
+			});
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			await client.sortedMaps.update({
+				allowMissing: true,
+				itemId: "abc123",
+				mapId: "test-map",
+				sortKey: { kind: "string", value: "beta" },
+				ttl: 60,
+				universeId: "123",
+			});
+
+			const captured = httpClient.requests[0];
+			assert(captured !== undefined);
+
+			expect(captured.request.method).toBe("PATCH");
+			expect(captured.request.url).toBe(
+				"/cloud/v2/universes/123/memory-store/sorted-maps/test-map/items/abc123?allowMissing=true",
+			);
+			expect(captured.request.body).toStrictEqual({
+				stringSortKey: "beta",
+				ttl: "60s",
+			});
+		});
+
+		it("should retry a 5xx since update is idempotent", async () => {
+			expect.assertions(2);
+
+			const httpClient = createFakeHttpClient()
+				.mockApiError({ statusCode: 502 })
+				.mockResponse({ body: validSortedMapItemBody(), status: 200 });
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.sortedMaps.update({
+				itemId: "i",
+				mapId: "m",
+				universeId: "1",
+				value: "x",
+			});
+
+			assert(result.success);
+
+			expect(httpClient.requests).toHaveLength(2);
+			expect(result.data.id).toBe("abc123");
+		});
+
+		it("should upgrade a 403 to a PermissionError carrying memory-store.sorted-map:write", async () => {
+			expect.assertions(3);
+
+			const httpClient = createFakeHttpClient().mockApiError({ statusCode: 403 });
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.sortedMaps.update({
+				itemId: "i",
+				mapId: "m",
+				universeId: "1",
+				value: "x",
+			});
+
+			assert(!result.success);
+			assert(result.err instanceof PermissionError);
+
+			expect(result.err.requiredScopes).toStrictEqual(["memory-store.sorted-map:write"]);
+			expect(result.err.operationKey).toBe("memory-store-sorted-maps.update");
+			expect(result.err.statusCode).toBe(403);
+		});
+	});
+
 	describe("sortedMaps.get", () => {
 		it("should return a parsed SortedMapItem on a happy path", async () => {
 			expect.assertions(2);

--- a/packages/open-cloud/tests/integration/resources/storage/sorted-maps.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/storage/sorted-maps.spec.ts
@@ -3,7 +3,10 @@ import { PermissionError } from "#src/errors/permission-error";
 import { StorageClient } from "#src/resources/storage/client";
 import { createFakeHttpClient } from "#tests/helpers/fake-http-client-validated";
 import { createFakeSleep } from "#tests/helpers/fake-sleep";
-import { validSortedMapItemBody } from "#tests/helpers/memory-store-sorted-maps";
+import {
+	validListSortedMapItemsBody,
+	validSortedMapItemBody,
+} from "#tests/helpers/memory-store-sorted-maps";
 import { assert, describe, expect, it } from "vitest";
 
 describe(StorageClient, () => {
@@ -229,6 +232,110 @@ describe(StorageClient, () => {
 
 			expect(result.err.requiredScopes).toStrictEqual(["memory-store.sorted-map:write"]);
 			expect(result.err.operationKey).toBe("memory-store-sorted-maps.delete");
+			expect(result.err.statusCode).toBe(403);
+		});
+	});
+
+	describe("sortedMaps.list", () => {
+		it("should return parsed items and a nextPageToken on a happy path", async () => {
+			expect.assertions(2);
+
+			const httpClient = createFakeHttpClient().mockResponse({
+				body: validListSortedMapItemsBody({ nextPageToken: "tok-2" }),
+				status: 200,
+			});
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.sortedMaps.list({
+				mapId: "test-map",
+				maxPageSize: 50,
+				universeId: "123",
+			});
+
+			assert(result.success);
+
+			expect(result.data.items).toHaveLength(1);
+			expect(result.data.nextPageToken).toBe("tok-2");
+		});
+
+		it("should send a GET whose URL embeds the pagination and filter parameters", async () => {
+			expect.assertions(2);
+
+			const httpClient = createFakeHttpClient().mockResponse({
+				body: validListSortedMapItemsBody(),
+				status: 200,
+			});
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			await client.sortedMaps.list({
+				filter: 'id > "key-001"',
+				mapId: "test-map",
+				maxPageSize: 25,
+				orderBy: "id desc",
+				pageToken: "tok-1",
+				universeId: "123",
+			});
+
+			const captured = httpClient.requests[0];
+			assert(captured !== undefined);
+
+			expect(captured.request.method).toBe("GET");
+			expect(captured.request.url).toBe(
+				"/cloud/v2/universes/123/memory-store/sorted-maps/test-map/items?maxPageSize=25&pageToken=tok-1&orderBy=id+desc&filter=id+%3E+%22key-001%22",
+			);
+		});
+
+		it("should retry a 5xx since list is idempotent", async () => {
+			expect.assertions(2);
+
+			const httpClient = createFakeHttpClient()
+				.mockApiError({ statusCode: 502 })
+				.mockResponse({ body: validListSortedMapItemsBody(), status: 200 });
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.sortedMaps.list({
+				mapId: "m",
+				universeId: "1",
+			});
+
+			assert(result.success);
+
+			expect(httpClient.requests).toHaveLength(2);
+			expect(result.data.items).toHaveLength(1);
+		});
+
+		it("should upgrade a 403 to a PermissionError carrying memory-store.sorted-map:read", async () => {
+			expect.assertions(3);
+
+			const httpClient = createFakeHttpClient().mockApiError({ statusCode: 403 });
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.sortedMaps.list({
+				mapId: "m",
+				universeId: "1",
+			});
+
+			assert(!result.success);
+			assert(result.err instanceof PermissionError);
+
+			expect(result.err.requiredScopes).toStrictEqual(["memory-store.sorted-map:read"]);
+			expect(result.err.operationKey).toBe("memory-store-sorted-maps.list");
 			expect(result.err.statusCode).toBe(403);
 		});
 	});

--- a/packages/open-cloud/tests/integration/resources/storage/sorted-maps.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/storage/sorted-maps.spec.ts
@@ -150,4 +150,109 @@ describe(StorageClient, () => {
 			expect(httpClient.requests[0]?.config.apiKey).toBe("override-key");
 		});
 	});
+
+	describe("sortedMaps.get", () => {
+		it("should return a parsed SortedMapItem on a happy path", async () => {
+			expect.assertions(2);
+
+			const httpClient = createFakeHttpClient().mockResponse({
+				body: validSortedMapItemBody({
+					path: "cloud/v2/universes/123/memory-store/sorted-maps/my-map/items/abc",
+				}),
+				status: 200,
+			});
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.sortedMaps.get({
+				itemId: "abc",
+				mapId: "my-map",
+				universeId: "123",
+			});
+
+			assert(result.success);
+
+			expect(result.data).toMatchObject({ id: "abc", mapId: "my-map", universeId: "123" });
+			expect(httpClient.requests).toHaveLength(1);
+		});
+
+		it("should send a GET whose URL embeds the path identifiers", async () => {
+			expect.assertions(2);
+
+			const httpClient = createFakeHttpClient().mockResponse({
+				body: validSortedMapItemBody(),
+				status: 200,
+			});
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			await client.sortedMaps.get({
+				itemId: "abc123",
+				mapId: "test-map",
+				universeId: "123",
+			});
+
+			const captured = httpClient.requests[0];
+			assert(captured !== undefined);
+
+			expect(captured.request.method).toBe("GET");
+			expect(captured.request.url).toBe(
+				"/cloud/v2/universes/123/memory-store/sorted-maps/test-map/items/abc123",
+			);
+		});
+
+		it("should retry a 5xx since get is idempotent", async () => {
+			expect.assertions(2);
+
+			const httpClient = createFakeHttpClient()
+				.mockApiError({ statusCode: 502 })
+				.mockResponse({ body: validSortedMapItemBody(), status: 200 });
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.sortedMaps.get({
+				itemId: "i",
+				mapId: "m",
+				universeId: "1",
+			});
+
+			assert(result.success);
+
+			expect(httpClient.requests).toHaveLength(2);
+			expect(result.data.id).toBe("abc123");
+		});
+
+		it("should upgrade a 403 to a PermissionError carrying memory-store.sorted-map:read", async () => {
+			expect.assertions(3);
+
+			const httpClient = createFakeHttpClient().mockApiError({ statusCode: 403 });
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.sortedMaps.get({
+				itemId: "i",
+				mapId: "m",
+				universeId: "1",
+			});
+
+			assert(!result.success);
+			assert(result.err instanceof PermissionError);
+
+			expect(result.err.requiredScopes).toStrictEqual(["memory-store.sorted-map:read"]);
+			expect(result.err.operationKey).toBe("memory-store-sorted-maps.get");
+			expect(result.err.statusCode).toBe(403);
+		});
+	});
 });

--- a/packages/open-cloud/tests/integration/resources/storage/sorted-maps.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/storage/sorted-maps.spec.ts
@@ -1,0 +1,153 @@
+import { ApiError } from "#src/errors/api-error";
+import { PermissionError } from "#src/errors/permission-error";
+import { StorageClient } from "#src/resources/storage/client";
+import { createFakeHttpClient } from "#tests/helpers/fake-http-client-validated";
+import { createFakeSleep } from "#tests/helpers/fake-sleep";
+import { validSortedMapItemBody } from "#tests/helpers/memory-store-sorted-maps";
+import { assert, describe, expect, it } from "vitest";
+
+describe(StorageClient, () => {
+	describe("sortedMaps.create", () => {
+		it("should return a parsed SortedMapItem on a happy path", async () => {
+			expect.assertions(2);
+
+			const httpClient = createFakeHttpClient().mockResponse({
+				body: validSortedMapItemBody({
+					path: "cloud/v2/universes/123/memory-store/sorted-maps/my-map/items/abc",
+				}),
+				status: 200,
+			});
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.sortedMaps.create({
+				itemId: "abc",
+				mapId: "my-map",
+				universeId: "123",
+				value: "hello",
+			});
+
+			assert(result.success);
+
+			expect(result.data).toMatchObject({
+				id: "abc",
+				mapId: "my-map",
+				universeId: "123",
+			});
+			expect(httpClient.requests).toHaveLength(1);
+		});
+
+		it("should send a POST whose URL and JSON body carry the parameters", async () => {
+			expect.assertions(3);
+
+			const httpClient = createFakeHttpClient().mockResponse({
+				body: validSortedMapItemBody(),
+				status: 200,
+			});
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			await client.sortedMaps.create({
+				itemId: "abc123",
+				mapId: "test-map",
+				sortKey: { kind: "numeric", value: 100 },
+				ttl: 30,
+				universeId: "123",
+				value: { foo: 1 },
+			});
+
+			const captured = httpClient.requests[0];
+			assert(captured !== undefined);
+
+			expect(captured.request.method).toBe("POST");
+			expect(captured.request.url).toBe(
+				"/cloud/v2/universes/123/memory-store/sorted-maps/test-map/items?id=abc123",
+			);
+			expect(captured.request.body).toStrictEqual({
+				numericSortKey: 100,
+				ttl: "30s",
+				value: { foo: 1 },
+			});
+		});
+
+		it("should not retry a 5xx so a transient create does not duplicate the item", async () => {
+			expect.assertions(2);
+
+			const httpClient = createFakeHttpClient().mockApiError({ statusCode: 503 });
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.sortedMaps.create({
+				itemId: "i",
+				mapId: "m",
+				universeId: "1",
+				value: "x",
+			});
+
+			assert(!result.success);
+
+			expect(result.err).toBeInstanceOf(ApiError);
+			expect(httpClient.requests).toHaveLength(1);
+		});
+
+		it("should upgrade a 403 to a PermissionError carrying memory-store.sorted-map:write", async () => {
+			expect.assertions(3);
+
+			const httpClient = createFakeHttpClient().mockApiError({ statusCode: 403 });
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.sortedMaps.create({
+				itemId: "i",
+				mapId: "m",
+				universeId: "1",
+				value: "x",
+			});
+
+			assert(!result.success);
+			assert(result.err instanceof PermissionError);
+
+			expect(result.err.requiredScopes).toStrictEqual(["memory-store.sorted-map:write"]);
+			expect(result.err.operationKey).toBe("memory-store-sorted-maps.create");
+			expect(result.err.statusCode).toBe(403);
+		});
+
+		it("should route a per-request apiKey override through the request config", async () => {
+			expect.assertions(1);
+
+			const httpClient = createFakeHttpClient().mockResponse({
+				body: validSortedMapItemBody(),
+				status: 200,
+			});
+			const client = new StorageClient({
+				apiKey: "default-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			await client.sortedMaps.create(
+				{
+					itemId: "i",
+					mapId: "m",
+					universeId: "1",
+					value: "x",
+				},
+				{ apiKey: "override-key" },
+			);
+
+			expect(httpClient.requests[0]?.config.apiKey).toBe("override-key");
+		});
+	});
+});

--- a/packages/open-cloud/tests/integration/resources/storage/sorted-maps.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/storage/sorted-maps.spec.ts
@@ -151,6 +151,88 @@ describe(StorageClient, () => {
 		});
 	});
 
+	describe("sortedMaps.delete", () => {
+		it("should send a DELETE whose URL embeds the path identifiers and return undefined on success", async () => {
+			expect.assertions(3);
+
+			const httpClient = createFakeHttpClient().mockResponse({
+				body: undefined,
+				status: 200,
+			});
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.sortedMaps.delete({
+				itemId: "abc123",
+				mapId: "test-map",
+				universeId: "123",
+			});
+
+			assert(result.success);
+
+			expect(result.data).toBeUndefined();
+
+			const captured = httpClient.requests[0];
+			assert(captured !== undefined);
+
+			expect(captured.request.method).toBe("DELETE");
+			expect(captured.request.url).toBe(
+				"/cloud/v2/universes/123/memory-store/sorted-maps/test-map/items/abc123",
+			);
+		});
+
+		it("should retry a 5xx since delete is idempotent", async () => {
+			expect.assertions(2);
+
+			const httpClient = createFakeHttpClient()
+				.mockApiError({ statusCode: 502 })
+				.mockResponse({ body: undefined, status: 200 });
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.sortedMaps.delete({
+				itemId: "i",
+				mapId: "m",
+				universeId: "1",
+			});
+
+			assert(result.success);
+
+			expect(httpClient.requests).toHaveLength(2);
+			expect(result.data).toBeUndefined();
+		});
+
+		it("should upgrade a 403 to a PermissionError carrying memory-store.sorted-map:write", async () => {
+			expect.assertions(3);
+
+			const httpClient = createFakeHttpClient().mockApiError({ statusCode: 403 });
+			const client = new StorageClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			const result = await client.sortedMaps.delete({
+				itemId: "i",
+				mapId: "m",
+				universeId: "1",
+			});
+
+			assert(!result.success);
+			assert(result.err instanceof PermissionError);
+
+			expect(result.err.requiredScopes).toStrictEqual(["memory-store.sorted-map:write"]);
+			expect(result.err.operationKey).toBe("memory-store-sorted-maps.delete");
+			expect(result.err.statusCode).toBe(403);
+		});
+	});
+
 	describe("sortedMaps.get", () => {
 		it("should return a parsed SortedMapItem on a happy path", async () => {
 			expect.assertions(2);


### PR DESCRIPTION
## Summary

Adds `StorageClient.sortedMaps` as a sibling Operation Group to `queues`, covering the five `Cloud_*MemoryStoreSortedMapItem*` REST endpoints on Roblox's "Data and memory stores" feature: `create`, `get`, `update`, `delete`, and `list`. The sort key is exposed as a discriminated union so callers cannot accidentally set both `stringSortKey` and `numericSortKey` at the type level; the builder projects it onto the wire and the parser rejects responses carrying both as malformed.

```ts
import { StorageClient } from "@bedrock-rbx/ocale/storage";

const client = new StorageClient({ apiKey: process.env.ROBLOX_API_KEY! });

const created = await client.sortedMaps.create({
    universeId: "123",
    mapId: "leaderboard",
    itemId: "alice",
    value: { score: 1200 },
    sortKey: { kind: "numeric", value: 1200 },
    ttl: 3600,
});

const page = await client.sortedMaps.list({
    universeId: "123",
    mapId: "leaderboard",
    maxPageSize: 50,
    orderBy: "id desc",
    filter: 'id > "key-001"',
});

if (page.success) {
    for (const item of page.data.items) { /* ... */ }
    // page.data.nextPageToken is the next-page cursor when present
}

await client.sortedMaps.update({
    universeId: "123",
    mapId: "leaderboard",
    itemId: "alice",
    value: { score: 1300 },
    allowMissing: true,
});

await client.sortedMaps.delete({ universeId: "123", mapId: "leaderboard", itemId: "alice" });
```

## Method semantics

| Method | HTTP | Retry policy | Why |
| - | - | - | - |
| `create` | POST | 429 only (`create`) | No idempotency keys; 5xx retry could duplicate items |
| `get` | GET | 429 + 5xx (`idempotent`) | Pure read |
| `update` | PATCH | 429 + 5xx (`idempotent`) | Same body produces same server state |
| `delete` | DELETE | 429 + 5xx (`idempotent`) | Re-deleting a missing item is a no-op |
| `list` | GET | 429 + 5xx (`idempotent`) | Pure read |

`PATCH` semantics: `value`, `ttl`, `sortKey` are all optional, and omitted entries leave the existing server-side value untouched. The optional `allowMissing` query parameter drives create-on-missing behaviour.

`list`: `maxPageSize` defaults to **1** server-side when omitted (intentional Roblox quirk, called out in the `ListSortedMapItemsParameters` doc). `filter` is a raw CEL string and accepts `<`, `>`, `&&` operators on `id` and `sortKey` only; `orderBy` accepts `"id"` or `"id desc"`.

## Sort-key shape

The OpenAPI `MemoryStoreSortedMapItem` schema marks `stringSortKey` and `numericSortKey` as `x-oneOf`: at most one per item. Rather than mirror the wire as a flat optional pair (caller responsible for the xor), the public surface uses a discriminated union:

```ts
type SortKey =
    | { readonly kind: "string"; readonly value: string }
    | { readonly kind: "numeric"; readonly value: number };
```

The builder projects this onto the wire as either `stringSortKey` or `numericSortKey`; the parser collapses the wire back into the union and rejects responses with both keys present as malformed.

## Conformance pins

Two `tests/conformance/*-writable-keys.spec.ts` pins, one for `create` and one for `update`, mirror the existing `enqueue` pin. Both diverge from the queues pattern slightly because the parameter interface has `sortKey` (the union) while the wire body carries `stringSortKey` / `numericSortKey`. The pins use a type-level `expectTypeOf` on the parameter union for exhaustiveness and a runtime `it.for` over the wire-body keys for schema-drift detection.

## Deferred from this PR

- **`If-Match` / etag optimistic concurrency on update/delete.** The OpenAPI does not formally document `If-Match` on these paths even though it follows the AIP convention. The `etag` field is parsed and exposed on `SortedMapItem` for caller inspection, but the builder does not yet emit `If-Match`. Adding it later is gated by a manual integration test against the live API.
- **Universe-wide flush** (`POST /universes/{uid}/memory-store:flush`). Spans queues and sorted maps; if implemented it belongs as `StorageClient.flush(...)` directly on the parent, not under either group.

No schema patches were needed: the sorted-map schemas in `vendor/roblox-openapi.json` are accurate as-is.

## Commits

Five behaviour slices, one commit each, following the same RED+GREEN cadence the queues feature shipped under:

1. `feat(ocale): add memory-store-sorted-maps create method` — wire types, builder, parser, Operation Group scaffolding on `StorageClient`, helper fixtures, create-writable-keys pin, integration tests.
2. `feat(ocale): add memory-store-sorted-maps get method`.
3. `feat(ocale): add memory-store-sorted-maps delete method`.
4. `feat(ocale): add memory-store-sorted-maps update method` — adds update-writable-keys pin.
5. `feat(ocale): add memory-store-sorted-maps list method` — adds pagination + filter parser.

## Test plan

- [ ] `pnpm install`
- [ ] `pnpm --filter @bedrock-rbx/ocale test` — 1458 tests, 49 new (was 1409)
- [ ] `pnpm --filter @bedrock-rbx/ocale typecheck` — no errors
- [ ] `pnpm lint` — clean
- [ ] `pnpm --filter @bedrock-rbx/ocale build` — `dist/storage.mjs` and `dist/storage.d.mts` produced, publint clean
- [ ] Optional smoke (requires `ROBLOX_API_KEY` with `memory-store.sorted-map:read` + `:write` scopes and a test universe): create -> get -> update -> list -> delete a single item; confirm parsed shape and `nextPageToken` pagination.

Each commit's pre-commit hook reported a 100.00 mutation score on the touched `src/**` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Overall summary
- Implements StorageClient.sortedMaps operation group with create/get/update/delete/list; adds builders, parsers, types, wire shapes, operation limits/scopes, operation-group glue, conformance pins, helpers, unit and integration tests, and an integration spec exercising retry/permission behavior. Commits include an important fix: path segments (universeId, mapId, itemId) are URL-encoded with encodeURIComponent to avoid misrouting.

Architecture (FCIS)
- Core: builders.ts and parsers.ts are pure functions that construct/validate wire shapes only (no I/O or side effects) — compliant.
- Shell: sorted-maps-group.ts acts as orchestration, delegating request construction/parsing to builders/parsers and routing through ResourceClient — compliant.
- Ports/Adapters: wire/types/operations define contracts and limits; ResourceClient is used for HTTP adapter concerns. No business logic mixed into shell or adapters observed.
- Conclusion: FCIS separation is respected.

Testing (TDD & coverage)
- Every new implementation file has corresponding tests:
  - Unit tests: builders.spec.ts and parsers.spec.ts cover builders and parsers.
  - Conformance/unit-level type pins: two conformance specs added.
  - Integration tests: tests/integration/resources/storage/sorted-maps.spec.ts exercises the operation group and retry/permission behavior using a fake HTTP client and fake sleep.
- Cannot verify TDD ordering (tests-first) or 100% coverage from repository snapshot; no coverage report was produced. Recommendation: enforce coverage thresholds in CI and include a short note in the PR that tests were added in the same change as implementation (if they were not created first).

Test isolation
- Unit tests exercise pure builders/parsers directly (no external I/O) — correct for Core.
- Integration tests use createFakeHttpClient and createFakeSleep to simulate HTTP and time — appropriate fake adapters for Shell tests.
- Adapter-level HTTP tests (nock or equivalent network-level mocks) were not added here; integration tests rely on the project's fake-http-client infrastructure. If adapters exist that directly perform HTTP, add adapter-focused tests using nock-like tooling or the project's adapter test helpers.

Security & constraints
- No ROBLOSECURITY or legacy Roblox secrets are present in changed files.
- No secrets stored in new types or tests.
- Parsers validate external inputs (isRecord, date string checks, discriminated sort-key validation, path regex) at the adapter boundary — good.
- API key override is threaded per-request; ensure the override cannot be misused by logging or persisting secrets.

Code quality & TypeScript
- All new modules are strongly typed (discriminated SortKey union, JSONValue usage, explicit interfaces).
- Parsers return typed Result<ApiError> and create ApiError with status codes — good typed error handling.
- No use of any seen in changed files; ensure repository-level tsconfig has "strict": true. If not already enabled, enable strict mode in packages/open-cloud to catch regressions.
- Suggest running lint/tsc with strict checks in CI (PR lists typecheck/lint/build/run steps in test plan — confirm CI enforces them).

Behavioral & API notes / actionable items
1) If-Match / ETag conditional requests
   - PR notes deferred support for If-Match/etag optimistic concurrency. Recommend adding an explicit follow-up issue and, if feasible, a small adapter that sets If-Match in ResourceClient when callers provide an etag to update/delete.

2) Universe-wide flush endpoint
   - PR defers universal flush; confirm this omission is intentional and add a TODO/issue linking expected OpenAPI mapping if needed.

3) Coverage & CI
   - Add/verify coverage thresholds for statements/branches/functions/lines in package CI to meet project policy. Provide a coverage artifact for reviewer confidence.

4) Adapter-level HTTP tests
   - If the repository contains concrete HTTP adapters that hit network libraries, add adapter-level tests (nock or equivalent) to ensure request wiring (headers, query strings, apiKey propagation) is preserved at the adapter boundary.

5) OpenAPI schema / maintainers note
   - PR claims "No OpenAPI schema patches required." Maintainers should confirm that OpenAPI generation consumers remain consistent; add a short CHANGELOG entry or comment in the domain README documenting the discriminated SortKey mapping (stringSortKey vs numericSortKey) and the parser rejection of responses containing both keys.

Inline code observations (small, actionable)
- builders.ts: good: encodeURIComponent applied to universeId/mapId/itemId; create uses URLSearchParams for id query param — correct.
- parsers.ts: PATH_PATTERN expects numeric universeId (\d+). If universeId may be non-numeric in future, consider loosening or documenting the numeric-only expectation.
- types.ts: UpdateSortedMapItemParameters docs correctly note PATCH semantics; consider documenting behavior when sortKey is explicitly set to undefined vs omitted (already described, but callers may need examples).

Acceptance checklist (for merge)
- Ensure packages/open-cloud tsconfig.json has "strict": true and CI runs tsc with that config.
- CI must run the test plan listed in PR (install, package tests, typecheck, lint, build, optional manual smoke).
- Add/confirm coverage thresholds in CI or document exception rationale.
- Open follow-ups for If-Match/etag and universe-wide flush (PR already lists these as deferred).

Overall recommendation
- Code aligns with Bedrock architecture and standards: clear FCIS separation, tests present and appropriately isolated, good input validation, and strong typing. Mergeable after CI verifies TypeScript strict mode and coverage policy (or maintainers approve documented exceptions) and after adding follow-up tasks for If-Match/etag and the flush endpoint if needed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/392)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->