### PR TITLE
fix(ocale): accept missing or null arrays in list-response parsers

### DIFF
--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.spec.ts
@@ -149,6 +149,35 @@ describe(parseListLogsResponse, () => {
 		expect(result.data.messages).toStrictEqual([]);
 	});
 
+	it("should treat a body whose luauExecutionSessionTaskLogs is explicitly null as an empty page", () => {
+		expect.assertions(1);
+
+		const body: Record<string, unknown> = {
+			luauExecutionSessionTaskLogs: JSON.parse("null"),
+		};
+
+		const result = parseListLogsResponse({ body, headers: {}, status: 200 });
+
+		assert(result.success);
+
+		expect(result.data.messages).toStrictEqual([]);
+	});
+
+	it("should normalize a JSON null nextPageToken to undefined", () => {
+		expect.assertions(1);
+
+		const body: Record<string, unknown> = {
+			luauExecutionSessionTaskLogs: [],
+			nextPageToken: JSON.parse("null"),
+		};
+
+		const result = parseListLogsResponse({ body, headers: {}, status: 200 });
+
+		assert(result.success);
+
+		expect(result.data.nextPageToken).toBeUndefined();
+	});
+
 	it("should skip a chunk whose structuredMessages field is omitted", () => {
 		expect.assertions(1);
 

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/parsers.ts
@@ -3,7 +3,7 @@ import { ApiError } from "../../../errors/api-error.ts";
 import { isRecord } from "../../../internal/utils/is-record.ts";
 import type { Result } from "../../../types.ts";
 import type { LogMessage, LogPage } from "./types.ts";
-import type { ListLogsResponseWire, LogChunkWire, LogMessageWire } from "./wire.ts";
+import type { LogChunkWire, LogMessageWire } from "./wire.ts";
 
 const MALFORMED_LOGS_MESSAGE = "Malformed list-luau-execution-task-logs response";
 
@@ -19,14 +19,22 @@ const MALFORMED_LOGS_MESSAGE = "Malformed list-luau-execution-task-logs response
  */
 export function parseListLogsResponse(response: HttpResponse): Result<LogPage, ApiError> {
 	const { body, status: statusCode } = response;
-	if (!isListLogsResponseWire(body)) {
+	if (!isRecord(body)) {
 		return malformed(statusCode);
 	}
 
-	const chunks = body.luauExecutionSessionTaskLogs ?? [];
-	const messages: Array<LogMessage> = [];
+	const rawChunks = body["luauExecutionSessionTaskLogs"] ?? undefined;
+	if (!isOptionalLogChunks(rawChunks)) {
+		return malformed(statusCode);
+	}
 
-	for (const chunk of chunks) {
+	const rawToken = body["nextPageToken"] ?? undefined;
+	if (rawToken !== undefined && typeof rawToken !== "string") {
+		return malformed(statusCode);
+	}
+
+	const messages: Array<LogMessage> = [];
+	for (const chunk of rawChunks ?? []) {
 		for (const wireMessage of chunk.structuredMessages ?? []) {
 			messages.push({
 				createTime: wireMessage.createTime,
@@ -37,7 +45,7 @@ export function parseListLogsResponse(response: HttpResponse): Result<LogPage, A
 	}
 
 	return {
-		data: { messages, nextPageToken: body.nextPageToken },
+		data: { messages, nextPageToken: rawToken },
 		success: true,
 	};
 }
@@ -72,14 +80,6 @@ function isOptionalLogChunks(value: unknown): value is ReadonlyArray<LogChunkWir
 	return (
 		value === undefined ||
 		(Array.isArray(value) && value.every((item: unknown) => isLogChunkWire(item)))
-	);
-}
-
-function isListLogsResponseWire(body: unknown): body is ListLogsResponseWire {
-	return (
-		isRecord(body) &&
-		isOptionalLogChunks(body["luauExecutionSessionTaskLogs"]) &&
-		(body["nextPageToken"] === undefined || typeof body["nextPageToken"] === "string")
 	);
 }
 

--- a/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/wire.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/luau-execution-task-logs/wire.ts
@@ -34,17 +34,22 @@ export interface LogChunkWire {
 }
 
 /**
- * Wire shape of the list-luau-execution-task-logs response body.
+ * Wire shape of the list-luau-execution-task-logs response body. Both
+ * fields are optional per the OpenAPI spec
+ * (`ListLuauExecutionSessionTaskLogsResponse` has no `required` array);
+ * the parser also accepts JSON `null` on either field at the wire
+ * boundary and normalizes it to `undefined` / `[]`.
  */
 export interface ListLogsResponseWire {
 	/**
-	 * Array of log chunks. Optional on the wire; absent on an empty
-	 * page.
+	 * Array of log chunks. Omitted or JSON `null` on an empty page; the
+	 * parser normalizes both to an empty array.
 	 */
 	readonly luauExecutionSessionTaskLogs?: ReadonlyArray<LogChunkWire> | undefined;
 	/**
-	 * Opaque continuation token for the next page. Absent when this
-	 * is the last page.
+	 * Opaque continuation token for the next page. Absent or JSON
+	 * `null` when this is the last page; the parser normalizes both to
+	 * `undefined`.
 	 */
 	readonly nextPageToken?: string | undefined;
 }

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-queues/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-queues/parsers.spec.ts
@@ -311,6 +311,37 @@ describe(parseDequeueResponse, () => {
 		expect(result.data.items).toStrictEqual([]);
 	});
 
+	it("should accept a response with queueItems omitted", () => {
+		expect.assertions(2);
+
+		const result = parseDequeueResponse({
+			body: { id: "read-1" },
+			headers: {},
+			status: 200,
+		});
+
+		assert(result.success);
+
+		expect(result.data.items).toStrictEqual([]);
+		expect(result.data.readId).toBe("read-1");
+	});
+
+	it("should accept a response with queueItems explicitly null", () => {
+		expect.assertions(2);
+
+		const body: Record<string, unknown> = {
+			id: "read-1",
+			queueItems: JSON.parse("null"),
+		};
+
+		const result = parseDequeueResponse({ body, headers: {}, status: 200 });
+
+		assert(result.success);
+
+		expect(result.data.items).toStrictEqual([]);
+		expect(result.data.readId).toBe("read-1");
+	});
+
 	it("should reject a non-record body", () => {
 		expect.assertions(2);
 

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-queues/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-queues/parsers.ts
@@ -46,11 +46,16 @@ export function parseDequeueResponse(response: HttpResponse): Result<DequeueResu
 	}
 
 	const { id, queueItems } = body;
-	if (typeof id !== "string" || !Array.isArray(queueItems)) {
+	if (typeof id !== "string") {
 		return malformedDequeue(statusCode);
 	}
 
-	const items = queueItems.map(wireBodyToQueueItem);
+	if (queueItems !== undefined && queueItems !== null && !Array.isArray(queueItems)) {
+		return malformedDequeue(statusCode);
+	}
+
+	const rawItems = queueItems ?? [];
+	const items = rawItems.map(wireBodyToQueueItem);
 	if (!items.every(isQueueItem)) {
 		return malformedDequeue(statusCode);
 	}

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-queues/wire.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-queues/wire.ts
@@ -27,10 +27,20 @@ export interface MemoryStoreQueueItemWire {
  * names it `items`) and the read identifier under `id` (schema names
  * it `readId`); both deviations are corrected by `apply-schema-patches`,
  * so the wire interface here matches the patched schema.
+ *
+ * `queueItems` is optional per the OpenAPI spec
+ * (`ReadMemoryStoreQueueItemsResponse` has no `required` array); empty
+ * queues come back with the field omitted or JSON `null`. `id` is also
+ * spec-optional but the server always returns it for a 200 dequeue (it
+ * is the `:discard` token), so the parser requires it.
  */
 export interface ReadQueueItemsResponseWire {
 	/** Identifier of the read operation, passed back to `:discard`. */
 	readonly id: string;
-	/** Items at the front of the queue, in dequeue order. */
-	readonly queueItems: ReadonlyArray<MemoryStoreQueueItemWire>;
+	/**
+	 * Items at the front of the queue, in dequeue order. Omitted or
+	 * JSON `null` on an empty queue; the parser normalizes both to an
+	 * empty array.
+	 */
+	readonly queueItems?: ReadonlyArray<MemoryStoreQueueItemWire>;
 }

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-queues/wire.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-queues/wire.ts
@@ -42,5 +42,5 @@ export interface ReadQueueItemsResponseWire {
 	 * JSON `null` on an empty queue; the parser normalizes both to an
 	 * empty array.
 	 */
-	readonly queueItems?: ReadonlyArray<MemoryStoreQueueItemWire>;
+	readonly queueItems?: ReadonlyArray<MemoryStoreQueueItemWire> | undefined;
 }

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.spec.ts
@@ -44,6 +44,21 @@ describe(parseListResponse, () => {
 		expect(result.data.nextPageToken).toBeUndefined();
 	});
 
+	it("should normalize a JSON null nextPageToken to undefined", () => {
+		expect.assertions(1);
+
+		const body: Record<string, unknown> = {
+			...validListSortedMapItemsBody(),
+			nextPageToken: JSON.parse("null"),
+		};
+
+		const result = parseListResponse({ body, headers: {}, status: 200 });
+
+		assert(result.success);
+
+		expect(result.data.nextPageToken).toBeUndefined();
+	});
+
 	it("should map every entry through the same parser as the single-item endpoints", () => {
 		expect.assertions(3);
 
@@ -83,6 +98,36 @@ describe(parseListResponse, () => {
 		assert(result.success);
 
 		expect(result.data.items).toStrictEqual([]);
+	});
+
+	it("should accept a response with memoryStoreSortedMapItems omitted", () => {
+		expect.assertions(2);
+
+		const result = parseListResponse({
+			body: { nextPageToken: "tok-1" },
+			headers: {},
+			status: 200,
+		});
+
+		assert(result.success);
+
+		expect(result.data.items).toStrictEqual([]);
+		expect(result.data.nextPageToken).toBe("tok-1");
+	});
+
+	it("should accept a response with memoryStoreSortedMapItems explicitly null", () => {
+		expect.assertions(2);
+
+		const body: Record<string, unknown> = {
+			memoryStoreSortedMapItems: JSON.parse("null"),
+		};
+
+		const result = parseListResponse({ body, headers: {}, status: 200 });
+
+		assert(result.success);
+
+		expect(result.data.items).toStrictEqual([]);
+		expect(result.data.nextPageToken).toBeUndefined();
 	});
 
 	it("should reject a non-record body", () => {

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.ts
@@ -53,20 +53,26 @@ export function parseListResponse(
 	}
 
 	const { memoryStoreSortedMapItems, nextPageToken } = body;
-	if (!Array.isArray(memoryStoreSortedMapItems)) {
+	if (
+		memoryStoreSortedMapItems !== undefined &&
+		memoryStoreSortedMapItems !== null &&
+		!Array.isArray(memoryStoreSortedMapItems)
+	) {
 		return malformedList(statusCode);
 	}
 
-	if (nextPageToken !== undefined && typeof nextPageToken !== "string") {
+	const normalizedToken = nextPageToken ?? undefined;
+	if (normalizedToken !== undefined && typeof normalizedToken !== "string") {
 		return malformedList(statusCode);
 	}
 
-	const items = memoryStoreSortedMapItems.map(wireBodyToSortedMapItem);
+	const rawItems = memoryStoreSortedMapItems ?? [];
+	const items = rawItems.map(wireBodyToSortedMapItem);
 	if (!items.every(isSortedMapItem)) {
 		return malformedList(statusCode);
 	}
 
-	return { data: { items, nextPageToken }, success: true };
+	return { data: { items, nextPageToken: normalizedToken }, success: true };
 }
 
 function isSortedMapItemWire(body: unknown): body is MemoryStoreSortedMapItemWire {

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/wire.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/wire.ts
@@ -48,7 +48,7 @@ export interface ListSortedMapItemsResponseWire {
 	 * Omitted or JSON `null` on an empty page; the parser normalizes
 	 * both to an empty array.
 	 */
-	readonly memoryStoreSortedMapItems?: ReadonlyArray<MemoryStoreSortedMapItemWire>;
+	readonly memoryStoreSortedMapItems?: ReadonlyArray<MemoryStoreSortedMapItemWire> | undefined;
 	/**
 	 * Page token for the next call, or `undefined` when no more pages
 	 * exist. JSON `null` is accepted on the wire and normalized to

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/wire.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/wire.ts
@@ -36,10 +36,23 @@ export interface MemoryStoreSortedMapItemWire {
  * Wire shape of the `Cloud_ListMemoryStoreSortedMapItems` response.
  * The server emits the items array under `memoryStoreSortedMapItems`
  * and an optional `nextPageToken` when more items are available.
+ *
+ * Both fields are optional per the OpenAPI spec
+ * (`ListMemoryStoreSortedMapItemsResponse` has no `required` array);
+ * empty maps come back with `memoryStoreSortedMapItems` omitted or
+ * JSON `null`. The parser normalizes both forms to `items: []`.
  */
 export interface ListSortedMapItemsResponseWire {
-	/** Items in the current page, ordered per the request's `orderBy`. */
-	readonly memoryStoreSortedMapItems: ReadonlyArray<MemoryStoreSortedMapItemWire>;
-	/** Page token for the next call, or `undefined` when no more pages exist. */
+	/**
+	 * Items in the current page, ordered per the request's `orderBy`.
+	 * Omitted or JSON `null` on an empty page; the parser normalizes
+	 * both to an empty array.
+	 */
+	readonly memoryStoreSortedMapItems?: ReadonlyArray<MemoryStoreSortedMapItemWire>;
+	/**
+	 * Page token for the next call, or `undefined` when no more pages
+	 * exist. JSON `null` is accepted on the wire and normalized to
+	 * `undefined` by the parser.
+	 */
 	readonly nextPageToken?: string | undefined;
 }

--- a/packages/open-cloud/tests/conformance/list-response-optionality.spec.ts
+++ b/packages/open-cloud/tests/conformance/list-response-optionality.spec.ts
@@ -1,0 +1,155 @@
+import { parseListLogsResponse } from "#src/domains/cloud-v2/luau-execution-task-logs/parsers";
+import { parseDequeueResponse } from "#src/domains/cloud-v2/memory-store-queues/parsers";
+import { parseListResponse as parseSortedMapListResponse } from "#src/domains/cloud-v2/memory-store-sorted-maps/parsers";
+import { parseGamePassesListResponse } from "#src/domains/game-passes/game-passes/parsers";
+import { validListGamePassesBody } from "#tests/helpers/game-passes";
+import { validLogPageBody } from "#tests/helpers/luau-execution-task-logs";
+import { validDequeueBody } from "#tests/helpers/memory-store-queues";
+import { validListSortedMapItemsBody } from "#tests/helpers/memory-store-sorted-maps";
+import { assert, describe, expect, it } from "vitest";
+
+import { getOpenApiDocument, isRecord } from "./_helpers.ts";
+
+/**
+ * One row per list-response parser. The pin keeps three things in sync:
+ *
+ * - the parser's runtime behaviour (does it accept missing/null on each
+ *   spec-optional field?);
+ * - the OpenAPI spec (`required` array on the response schema);
+ * - the wire type (whether the field is declared optional).
+ *
+ * Every spec-optional property must be classified into exactly one of
+ * `acceptsMissingOrNull` (parser tolerates absence and JSON `null`) or
+ * `stricterThanSpec` (parser keeps requiring it; rationale documents
+ * why — typically because the server is stricter than the spec).
+ */
+interface ListParserPin {
+	readonly name: string;
+	readonly acceptsMissingOrNull: ReadonlyArray<string>;
+	readonly parse: (body: unknown) => { readonly success: boolean };
+	readonly schemaName: string;
+	readonly stricterThanSpec: Readonly<Record<string, string>>;
+	readonly validBody: () => Record<string, unknown>;
+}
+
+const PINS: ReadonlyArray<ListParserPin> = [
+	{
+		name: "parseListResponse (memory-store sorted-maps)",
+		acceptsMissingOrNull: ["memoryStoreSortedMapItems", "nextPageToken"],
+		parse: (body) => parseSortedMapListResponse({ body, headers: {}, status: 200 }),
+		schemaName: "ListMemoryStoreSortedMapItemsResponse",
+		stricterThanSpec: {},
+		validBody: () => ({ ...validListSortedMapItemsBody() }),
+	},
+	{
+		name: "parseDequeueResponse (memory-store queues)",
+		acceptsMissingOrNull: ["queueItems"],
+		parse: (body) => parseDequeueResponse({ body, headers: {}, status: 200 }),
+		schemaName: "ReadMemoryStoreQueueItemsResponse",
+		stricterThanSpec: {
+			id: "Server always returns the dequeue identifier on a 200; it is the `:discard` token, so the parser keeps requiring it.",
+		},
+		validBody: () => ({ ...validDequeueBody() }),
+	},
+	{
+		name: "parseListLogsResponse (luau-task-logs)",
+		acceptsMissingOrNull: ["luauExecutionSessionTaskLogs", "nextPageToken"],
+		parse: (body) => parseListLogsResponse({ body, headers: {}, status: 200 }),
+		schemaName: "ListLuauExecutionSessionTaskLogsResponse",
+		stricterThanSpec: {},
+		validBody: () => ({ ...validLogPageBody() }),
+	},
+	{
+		name: "parseGamePassesListResponse (game-passes)",
+		acceptsMissingOrNull: [],
+		parse: (body) => parseGamePassesListResponse({ body, headers: {}, status: 200 }),
+		schemaName: "ListGamePassConfigsByUniverseResponse",
+		stricterThanSpec: {},
+		validBody: () => ({ ...validListGamePassesBody() }),
+	},
+];
+
+interface ResponseSchemaShape {
+	readonly properties: ReadonlyArray<string>;
+	readonly required: ReadonlyArray<string>;
+}
+
+function loadResponseSchema(schemaName: string): ResponseSchemaShape {
+	const document = getOpenApiDocument();
+	const { components } = document;
+	assert(isRecord(components), "OpenAPI document missing components");
+	const { schemas } = components;
+	assert(isRecord(schemas), "OpenAPI document missing components.schemas");
+	const schema = schemas[schemaName];
+	assert(isRecord(schema), `schema ${schemaName} not registered in vendor OpenAPI doc`);
+	const properties = isRecord(schema["properties"]) ? Object.keys(schema["properties"]) : [];
+	const required = Array.isArray(schema["required"])
+		? schema["required"].filter((field): field is string => typeof field === "string")
+		: [];
+	return { properties, required };
+}
+
+const FIELD_ROWS: ReadonlyArray<{
+	readonly field: string;
+	readonly pin: ListParserPin;
+	readonly pinName: string;
+}> = PINS.flatMap((pin) => {
+	return pin.acceptsMissingOrNull.map((field) => {
+		return { field, pin, pinName: pin.name };
+	});
+});
+
+describe("list-response parsers align with OpenAPI optionality", () => {
+	it.for(PINS)(
+		"should partition every spec-optional field of $name into acceptsMissingOrNull or stricterThanSpec",
+		(pin) => {
+			expect.assertions(1);
+
+			const schema = loadResponseSchema(pin.schemaName);
+			const required = new Set(schema.required);
+			const specOptional = schema.properties.filter((name) => !required.has(name));
+			const declared = [...pin.acceptsMissingOrNull, ...Object.keys(pin.stricterThanSpec)];
+
+			expect([...specOptional].sort()).toStrictEqual([...declared].sort());
+		},
+	);
+
+	it.for(PINS)(
+		"should restrict $name acceptsMissingOrNull and stricterThanSpec to spec-optional properties",
+		(pin) => {
+			expect.assertions(1);
+
+			const schema = loadResponseSchema(pin.schemaName);
+			const required = new Set(schema.required);
+			const properties = new Set(schema.properties);
+			const offenders = [
+				...pin.acceptsMissingOrNull,
+				...Object.keys(pin.stricterThanSpec),
+			].filter((field) => !properties.has(field) || required.has(field));
+
+			expect(offenders).toStrictEqual([]);
+		},
+	);
+
+	it.for(FIELD_ROWS)("should accept $field omitted in $pinName", ({ field, pin }) => {
+		expect.assertions(1);
+
+		const { [field]: _removed, ...rest } = pin.validBody();
+
+		expect(pin.parse(rest).success).toBeTrue();
+	});
+
+	it.for(FIELD_ROWS)(
+		"should accept $field as explicit JSON null in $pinName",
+		({ field, pin }) => {
+			expect.assertions(1);
+
+			const body: Record<string, unknown> = {
+				...pin.validBody(),
+				[field]: JSON.parse("null"),
+			};
+
+			expect(pin.parse(body).success).toBeTrue();
+		},
+	);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ catalogs:
       specifier: 5.0.0-beta.11
       version: 5.0.0-beta.11
     '@isentinel/hooks':
-      specifier: 1.4.0
-      version: 1.4.0
+      specifier: 1.4.1
+      version: 1.4.1
     '@vitest/eslint-plugin':
       specifier: 1.6.16
       version: 1.6.16
@@ -210,15 +210,9 @@ overrides:
   vitest: npm:@voidzero-dev/vite-plus-test@0.1.19
 
 patchedDependencies:
-  '@stryker-mutator/core@9.6.1':
-    hash: e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08
-    path: patches/@stryker-mutator__core@9.6.1.patch
-  '@stryker-mutator/vitest-runner@9.6.1':
-    hash: da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63
-    path: patches/@stryker-mutator__vitest-runner@9.6.1.patch
-  generate-jsdoc-example-tests:
-    hash: a8344a1c43e398b3146cd7ec6cd783c14a200e7987277a41dd6cefd6581f86b4
-    path: patches/generate-jsdoc-example-tests.patch
+  '@stryker-mutator/core@9.6.1': e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08
+  '@stryker-mutator/vitest-runner@9.6.1': da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63
+  generate-jsdoc-example-tests: a8344a1c43e398b3146cd7ec6cd783c14a200e7987277a41dd6cefd6581f86b4
 
 importers:
 
@@ -256,10 +250,10 @@ importers:
         version: 1.5.0(eslint@9.39.2(jiti@2.6.1))
       '@isentinel/eslint-config':
         specifier: catalog:lint
-        version: 5.0.0-beta.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/estree@1.0.8)(@typescript-eslint/utils@8.58.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(@voidzero-dev/vite-plus-test@0.1.19)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-eslint-plugin@7.0.0(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-jest-extended@3.0.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-n@17.24.0(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-react-naming-convention@2.3.9(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+        version: 5.0.0-beta.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/estree@1.0.8)(@typescript-eslint/utils@8.58.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(@voidzero-dev/vite-plus-test@0.1.19)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-jest-extended@3.0.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-n@17.24.0(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-react-naming-convention@2.3.9(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       '@isentinel/hooks':
         specifier: catalog:lint
-        version: 1.4.0(@typescript/native-preview@7.0.0-dev.20260428.1)(@typescript/typescript6@6.0.1)(jiti@2.6.1)
+        version: 1.4.1(@typescript/native-preview@7.0.0-dev.20260428.1)(@typescript/typescript6@6.0.1)(jiti@2.6.1)
       '@isentinel/tsconfig':
         specifier: catalog:tsc
         version: 1.2.0(@typescript/typescript6@6.0.1)
@@ -389,7 +383,7 @@ importers:
         version: '@typescript/typescript6@6.0.1'
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.19
-        version: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.4)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.5)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
 
   apps/website:
     devDependencies:
@@ -434,7 +428,7 @@ importers:
         version: 0.8.0(vitepress@2.0.0-alpha.17(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(change-case@5.4.4)(esbuild@0.27.7)(jiti@2.6.1)(oxc-minify@0.128.0)(postcss@8.5.9)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3))(vue@3.5.32(@typescript/typescript6@6.0.1))
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.19
-        version: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.5(@voidzero-dev/vite-plus-test@0.1.19))(@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3)'
 
   packages/bedrock:
     dependencies:
@@ -480,7 +474,7 @@ importers:
         version: 9.6.1(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@typescript/typescript6@6.0.1)
       '@stryker-mutator/vitest-runner':
         specifier: catalog:test
-        version: 9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19)
+        version: 9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.5(@voidzero-dev/vite-plus-test@0.1.19))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))
       '@types/bun':
         specifier: catalog:types
         version: 1.3.13
@@ -495,7 +489,7 @@ importers:
         version: '@typescript/typescript6@6.0.1'
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.19
-        version: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.4)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.5)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
 
   packages/open-cloud:
     devDependencies:
@@ -519,7 +513,7 @@ importers:
         version: 9.6.1(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@typescript/typescript6@6.0.1)
       '@stryker-mutator/vitest-runner':
         specifier: catalog:test
-        version: 9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19)
+        version: 9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.5(@voidzero-dev/vite-plus-test@0.1.19))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))
       '@types/bun':
         specifier: catalog:types
         version: 1.3.13
@@ -540,7 +534,7 @@ importers:
         version: '@typescript/typescript6@6.0.1'
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.19
-        version: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.4)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.5)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
 
   packages/testing:
     dependencies:
@@ -565,7 +559,7 @@ importers:
         version: 9.6.1(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@typescript/typescript6@6.0.1)
       '@stryker-mutator/vitest-runner':
         specifier: catalog:test
-        version: 9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19)
+        version: 9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.5(@voidzero-dev/vite-plus-test@0.1.19))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))
       '@types/bun':
         specifier: catalog:types
         version: 1.3.13
@@ -574,7 +568,7 @@ importers:
         version: '@typescript/typescript6@6.0.1'
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.19
-        version: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.4)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.5)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
 
   packages/typescript-config:
     devDependencies:
@@ -586,7 +580,7 @@ importers:
     dependencies:
       vite-plus:
         specifier: catalog:build
-        version: 0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.4)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
+        version: 0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.5)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
     devDependencies:
       '@bedrock-rbx/typescript-config':
         specifier: workspace:*
@@ -599,7 +593,7 @@ importers:
         version: '@typescript/typescript6@6.0.1'
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.19
-        version: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.4)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
+        version: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.5)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
 
 packages:
 
@@ -1994,8 +1988,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@isentinel/hooks@1.4.0':
-    resolution: {integrity: sha512-DKB5OHSFmIwr+rxtJKkv5FqSBiYN/4kRRNsyafRE4ME0PedBCy4MQUShaOLa0QfMqm1hI1VvSV0ssDVvveboeQ==}
+  '@isentinel/hooks@1.4.1':
+    resolution: {integrity: sha512-Pd4W0qbKWxBfyVRl3QtbQtmxGSFDWx/hxBu4YSwzghnpuPiw9PdYm/G+pm6S99TtvvaSSqMAAGJAY/qEERI+EQ==}
     engines: {node: '>=24.11.0'}
     peerDependencies:
       '@typescript/native-preview': '>=7'
@@ -3562,15 +3556,6 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
-  '@vitest/coverage-v8@4.1.4':
-    resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
-    peerDependencies:
-      '@vitest/browser': 4.1.4
-      vitest: 4.1.4
-    peerDependenciesMeta:
-      '@vitest/browser':
-        optional: true
-
   '@vitest/coverage-v8@4.1.5':
     resolution: {integrity: sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==}
     peerDependencies:
@@ -3596,14 +3581,8 @@ packages:
       vitest:
         optional: true
 
-  '@vitest/pretty-format@4.1.4':
-    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
-
   '@vitest/pretty-format@4.1.5':
     resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
-
-  '@vitest/utils@4.1.4':
-    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
@@ -4580,12 +4559,6 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=8'
-
-  eslint-plugin-eslint-plugin@7.0.0:
-    resolution: {integrity: sha512-EgiW9zf4PbqA+yN9T6Z8bHx46+fWtAIXFrYkL4nSTnI84LnTKmzjh+cIJaVAyFVZveKUSG8LcVe1suGG78qZPw==}
-    engines: {node: ^20.19.0 || ^22.13.1 || >=24.0.0}
-    peerDependencies:
-      eslint: '>=9.0.0'
 
   eslint-plugin-flawless@0.1.0:
     resolution: {integrity: sha512-Q8xelgVMfn8BGUj0qW0/+6Rm5DsPTlReExMnwymm4URaWQJbMtwtzgXdpykV3ptHjEY60SckwfP/BNuEgJ4QXQ==}
@@ -8258,7 +8231,7 @@ snapshots:
 
   '@isentinel/dict-roblox@1.0.3': {}
 
-  '@isentinel/eslint-config@5.0.0-beta.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/estree@1.0.8)(@typescript-eslint/utils@8.58.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(@voidzero-dev/vite-plus-test@0.1.19)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-eslint-plugin@7.0.0(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-jest-extended@3.0.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-n@17.24.0(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-react-naming-convention@2.3.9(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))':
+  '@isentinel/eslint-config@5.0.0-beta.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/estree@1.0.8)(@typescript-eslint/utils@8.58.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(@voidzero-dev/vite-plus-test@0.1.19)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-jest-extended@3.0.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-n@17.24.0(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-react-naming-convention@2.3.9(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 1.0.1
@@ -8312,7 +8285,6 @@ snapshots:
       yargs: 18.0.0
     optionalDependencies:
       '@vitest/eslint-plugin': 1.6.16(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(@voidzero-dev/vite-plus-test@0.1.19)(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-eslint-plugin: 7.0.0(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jest-extended: 3.0.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-n: 17.24.0(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
@@ -8332,7 +8304,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@isentinel/hooks@1.4.0(@typescript/native-preview@7.0.0-dev.20260428.1)(@typescript/typescript6@6.0.1)(jiti@2.6.1)':
+  '@isentinel/hooks@1.4.1(@typescript/native-preview@7.0.0-dev.20260428.1)(@typescript/typescript6@6.0.1)(jiti@2.6.1)':
     dependencies:
       eslint_d: 15.0.2(jiti@2.6.1)
       file-entry-cache: 11.1.2
@@ -9218,14 +9190,14 @@ snapshots:
 
   '@stryker-mutator/util@9.6.1': {}
 
-  '@stryker-mutator/vitest-runner@9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19)':
+  '@stryker-mutator/vitest-runner@9.6.1(patch_hash=da506df9115772af6e9fa45219f3fabe9ce165e134d76247f4ffde28bf5eae63)(@stryker-mutator/core@9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1))(@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.5(@voidzero-dev/vite-plus-test@0.1.19))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))':
     dependencies:
       '@stryker-mutator/api': 9.6.1
       '@stryker-mutator/core': 9.6.1(patch_hash=e91fc2011203722589e16b3dcfb4481127cb2dd5b94ce2d240971a1980f37c08)(@types/node@24.10.1)
       '@stryker-mutator/util': 9.6.1
       semver: 7.7.4
       tslib: 2.8.1
-      vitest: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.4)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
+      vitest: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.5)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
 
   '@stylistic/eslint-plugin@5.9.0(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
@@ -9479,21 +9451,6 @@ snapshots:
       vite: '@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3)'
       vue: 3.5.32(@typescript/typescript6@6.0.1)
 
-  '@vitest/coverage-v8@4.1.4(@voidzero-dev/vite-plus-test@0.1.19)':
-    dependencies:
-      '@bcoe/v8-coverage': 1.0.2
-      '@vitest/utils': 4.1.4
-      ast-v8-to-istanbul: 1.0.0
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-reports: 3.2.0
-      magicast: 0.5.2
-      obug: 2.1.1
-      std-env: 4.1.0
-      tinyrainbow: 3.1.0
-      vitest: '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.4)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)'
-    optional: true
-
   '@vitest/coverage-v8@4.1.5(@voidzero-dev/vite-plus-test@0.1.19)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
@@ -9520,21 +9477,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/pretty-format@4.1.4':
-    dependencies:
-      tinyrainbow: 3.1.0
-    optional: true
-
   '@vitest/pretty-format@4.1.5':
     dependencies:
       tinyrainbow: 3.1.0
-
-  '@vitest/utils@4.1.4':
-    dependencies:
-      '@vitest/pretty-format': 4.1.4
-      convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
-    optional: true
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -9577,7 +9522,7 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.19':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.4)(@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3)':
+  '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.5(@voidzero-dev/vite-plus-test@0.1.19))(@voidzero-dev/vite-plus-core@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3))(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3)':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
@@ -9595,47 +9540,7 @@ snapshots:
       ws: 8.20.0
     optionalDependencies:
       '@types/node': 24.10.1
-      '@vitest/coverage-v8': 4.1.4(@voidzero-dev/vite-plus-test@0.1.19)
-    transitivePeerDependencies:
-      - '@arethetypeswrong/core'
-      - '@tsdown/css'
-      - '@tsdown/exe'
-      - '@vitejs/devtools'
-      - bufferutil
-      - esbuild
-      - jiti
-      - less
-      - publint
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - typescript
-      - unplugin-unused
-      - utf-8-validate
-      - yaml
-
-  '@voidzero-dev/vite-plus-test@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.4)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3)
-      es-module-lexer: 1.7.0
-      obug: 2.1.1
-      pixelmatch: 7.1.0
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
-      vite: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
-      ws: 8.20.0
-    optionalDependencies:
-      '@types/node': 24.10.1
-      '@vitest/coverage-v8': 4.1.4(@voidzero-dev/vite-plus-test@0.1.19)
+      '@vitest/coverage-v8': 4.1.5(@voidzero-dev/vite-plus-test@0.1.19)
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@tsdown/css'
@@ -10568,13 +10473,6 @@ snapshots:
       '@eslint-community/regexpp': 4.12.2
       eslint: 9.39.2(jiti@2.6.1)
       eslint-compat-utils: 0.5.1(eslint@9.39.2(jiti@2.6.1))
-
-  eslint-plugin-eslint-plugin@7.0.0(eslint@9.39.2(jiti@2.6.1)):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
-      eslint: 9.39.2(jiti@2.6.1)
-      estraverse: 5.3.0
-    optional: true
 
   eslint-plugin-flawless@0.1.0(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
@@ -13138,53 +13036,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
-
-  vite-plus@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.4)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3):
-    dependencies:
-      '@oxc-project/types': 0.126.0
-      '@voidzero-dev/vite-plus-core': 0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(yaml@2.8.3)
-      '@voidzero-dev/vite-plus-test': 0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.4)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3)
-      oxfmt: 0.45.0
-      oxlint: 1.60.0(oxlint-tsgolint@0.21.1)
-      oxlint-tsgolint: 0.21.1
-    optionalDependencies:
-      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.19
-      '@voidzero-dev/vite-plus-darwin-x64': 0.1.19
-      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.19
-      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.19
-      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.19
-      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.19
-      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.19
-      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.19
-    transitivePeerDependencies:
-      - '@arethetypeswrong/core'
-      - '@edge-runtime/vm'
-      - '@opentelemetry/api'
-      - '@tsdown/css'
-      - '@tsdown/exe'
-      - '@types/node'
-      - '@vitejs/devtools'
-      - '@vitest/coverage-istanbul'
-      - '@vitest/coverage-v8'
-      - '@vitest/ui'
-      - bufferutil
-      - esbuild
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - publint
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - typescript
-      - unplugin-unused
-      - utf-8-validate
-      - vite
-      - yaml
 
   vite-plus@0.1.19(@types/node@24.10.1)(@typescript/typescript6@6.0.1)(@vitest/coverage-v8@4.1.5)(esbuild@0.27.7)(jiti@2.6.1)(publint@0.3.18)(tsx@4.21.0)(unplugin-unused@0.5.7)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ catalogs:
     "@commitlint/types": 20.5.0
     "@eslint/config-inspector": 1.5.0
     "@isentinel/eslint-config": 5.0.0-beta.11
-    "@isentinel/hooks": 1.4.0
+    "@isentinel/hooks": 1.4.1
     "@typescript-eslint/parser": 8.58.1
     "@vitest/eslint-plugin": 1.6.16
     eslint: 9.39.2


### PR DESCRIPTION
## References

- Downstream consumer (`jest-roblox-cli`) hit `Malformed memory-store sorted-map list response` from `@bedrock-rbx/ocale@0.1.0-beta.9` when polling a freshly-created SortedMap on a tight loop — the first poll's response body is the empty-map shape (`memoryStoreSortedMapItems` omitted) and the SDK threw.

## Summary

Roblox Open Cloud omits (or returns JSON `null` for) the items array on empty list responses. Per the vendored OpenAPI spec these fields are optional (no `required` array on the response schemas), but the parsers required `Array.isArray(...)` and rejected the legitimate empty shape.

- **sorted-maps** (`parseListResponse`): missing/null `memoryStoreSortedMapItems` → `items: []`; null `nextPageToken` → `undefined` to match the game-passes precedent.
- **memory-store queues** (`parseDequeueResponse`): missing/null `queueItems` → `items: []`. `id` stays strictly required because the server always returns the `:discard` token on a 200.
- **luau-execution-task-logs** (`parseListLogsResponse`): already accepted missing `luauExecutionSessionTaskLogs`; now also accepts explicit JSON `null` on it and on `nextPageToken`, normalising the latter to `undefined`.
- **conformance pin** (`tests/conformance/list-response-optionality.spec.ts`, new): symmetric to the writable-keys pins. For every list parser, every spec-optional response field is classified into `acceptsMissingOrNull` (parser tolerates absence and JSON null) or `stricterThanSpec` (parser keeps requiring it with documented rationale). Would have caught the sorted-map and queue regressions on day one.

`parseGamePassesListResponse` was also audited — already correct (spec marks `gamePasses` required and `nextPageToken` `nullable: true`; parser handles both).

## Test Plan

- [x] `pnpm test` in `@bedrock-rbx/ocale` — 1488 tests pass, including the new pin's 18 rows
- [x] `pnpm typecheck` clean across the monorepo
- [x] `pnpm lint` clean
- [x] `pnpm build` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Bedrock Code Review: List-Response Parser Optionality Fix

## Architecture Compliance ✅

- Changes are limited to pure parsing functions in Core: parseListResponse, parseDequeueResponse, parseListLogsResponse. No I/O or side effects introduced.
- Wire interfaces and JSDoc updated to reflect OpenAPI optionality; adapters/shells unaffected.
- No FCIS violations detected.

---

## Testing Compliance ✅

- Every parser change is accompanied by unit tests:
  - luau-execution-task-logs/parsers.spec.ts (adds null/omitted chunk & token cases)
  - memory-store-queues/parsers.spec.ts (omitted/null queueItems cases)
  - memory-store-sorted-maps/parsers.spec.ts (omitted/null items and token cases)
- New conformance meta-test: packages/open-cloud/tests/conformance/list-response-optionality.spec.ts validates each parser’s handling of spec-optional fields against the OpenAPI schema and enumerates per-field behavior (acceptsMissingOrNull vs stricterThanSpec).
- Tests follow TDD conventions and run in suite: pnpm test in @bedrock-rbx/ocale passed (1488 tests including new rows).

---

## Test Isolation ✅

- Tests are focused unit tests for parsers (Core).
- Conformance test uses OpenAPI document helper but exercises only parser inputs; no external network calls.
- Mocking or fakes are not used for parser logic (no I/O to isolate).

---

## Security & Standards ✅

- Changes are within Open Cloud domain packages only; no Roblox legacy auth or secrets introduced.
- All external response shapes validated at wire boundary with explicit guards.
- Required fields that server must provide (e.g., id in dequeue response) remain enforced.

---

## Code Quality & Type Safety ✅

- TypeScript strictness preserved; no any usage introduced.
- Parsers now tolerate wire fields that are omitted or JSON null where the vendored OpenAPI spec allows it:
  - memoryStoreSortedMapItems?: ... → normalized to []
  - ReadQueueItemsResponseWire.queueItems?: ... → normalized to []
  - ListLogsResponseWire.luauExecutionSessionTaskLogs?: ... → normalized to []
  - nextPageToken null → normalized to undefined
- Validators reject present-but-invalid shapes (non-array when array expected, non-string tokens).
- JSDoc on wire types updated to document parser normalization behavior.

---

## Pattern Consistency ✅

- Uses existing isOptional* / guard idioms consistent with other domain parsers.
- Per-item validation still routes through existing wire->public conversion functions; malformed entries continue to reject the entire response as before.
- parseGamePassesListResponse was audited (no changes required).

---

## Recommendations

1. Approve and merge: changes align with Bedrock architecture, testing, and security standards.
2. Consider running the conformance meta-test periodically (CI) to catch regressions across other list parsers.
3. The pnpm-workspace.yaml catalog bump (@isentinel/hooks 1.4.0 → 1.4.1) is unrelated to parser logic; validate separately if needed.

---

## Overall Summary

This PR correctly hardens list-response parsers to accept spec-allowed omitted or JSON null arrays/tokens, adds focused unit tests, and introduces a valuable conformance test that pins parser behavior to the OpenAPI spec. The changes are type-safe, pattern-consistent, and well-tested—ready to merge.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/393)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->