### PR TITLE
feat(website): add introduction page and unified nav

### DIFF
--- a/apps/website/.vitepress/config.ts
+++ b/apps/website/.vitepress/config.ts
@@ -47,13 +47,16 @@ export default defineConfig({
 		sidebar: {
 			"/bedrock/": [
 				{
-					items: [{ link: "/bedrock/guide/getting-started", text: "Getting Started" }],
+					items: [
+						{ link: "/bedrock/introduction", text: "Introduction" },
+						{ link: "/bedrock/guide/getting-started", text: "Getting Started" },
+					],
 					text: "Bedrock",
 				},
 				{
 					collapsed: false,
 					items: buildSidebarFromNavigation(navigationBedrock, "/bedrock/api/"),
-					text: "API",
+					text: "API Reference",
 				},
 			],
 			"/ocale/": [

--- a/apps/website/.vitepress/theme/components/bedrock-footer.vue
+++ b/apps/website/.vitepress/theme/components/bedrock-footer.vue
@@ -1,0 +1,201 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import { version as bedrockVersion } from "@bedrock-rbx/core/package.json";
+
+export interface BedrockFooterLink {
+	readonly external?: boolean;
+	readonly href: string;
+	readonly text: string;
+}
+
+export interface BedrockFooterColumn {
+	readonly links: ReadonlyArray<BedrockFooterLink>;
+	readonly title: string;
+}
+
+interface Props {
+	readonly columns: ReadonlyArray<BedrockFooterColumn>;
+	readonly homeHref?: string;
+	readonly tagline?: string;
+}
+
+const {
+	columns,
+	homeHref = "/",
+	tagline = "Infrastructure-as-Code for Roblox. Typed, Open Cloud only.",
+} = defineProps<Props>();
+
+const VERSION = `v${bedrockVersion}`;
+
+const gridTemplateColumns = computed(() => `1.4fr repeat(${columns.length}, 1fr)`);
+</script>
+
+<template>
+	<footer class="bedrock-foot">
+		<div class="wrap">
+			<div class="foot" :style="{ gridTemplateColumns }">
+				<div class="foot-brand">
+					<a class="brand" :href="homeHref">
+						<span class="brand-mark"> <span /><span /><span /><span /> </span>
+						Bedrock
+					</a>
+					<p>{{ tagline }}</p>
+				</div>
+				<div v-for="column in columns" :key="column.title">
+					<h5>{{ column.title }}</h5>
+					<ul>
+						<li v-for="link in column.links" :key="link.href">
+							<a
+								:href="link.href"
+								:rel="link.external ? 'noopener noreferrer' : undefined"
+								:target="link.external ? '_blank' : undefined"
+							>
+								{{ link.text }}
+							</a>
+						</li>
+					</ul>
+				</div>
+			</div>
+			<div class="foot-bottom">
+				<div>&copy; 2026 &middot; MIT Licensed &middot; {{ VERSION }}</div>
+				<div>built with vitepress</div>
+			</div>
+		</div>
+	</footer>
+</template>
+
+<style scoped>
+.bedrock-foot {
+	padding: 72px 0 48px;
+	background: var(--bg-soft);
+	border-top: 1px solid var(--line);
+	transition:
+		background-color 0.25s var(--ease),
+		border-color 0.25s var(--ease),
+		color 0.2s var(--ease);
+}
+
+.bedrock-foot a {
+	color: inherit;
+	text-decoration: none;
+}
+
+.wrap {
+	max-width: var(--bedrock-wrap, 1200px);
+	margin: 0 auto;
+	padding: 0 32px;
+}
+
+.foot {
+	display: grid;
+	gap: 48px;
+	margin-bottom: 56px;
+}
+
+.foot-brand .brand {
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	font-family: var(--f-serif);
+	font-size: 23px;
+	letter-spacing: -0.01em;
+}
+
+.brand-mark {
+	width: 22px;
+	height: 22px;
+	display: grid;
+	grid-template-rows: repeat(4, 1fr);
+	gap: 2px;
+}
+
+.brand-mark span {
+	background: var(--ink);
+	border-radius: 1px;
+}
+
+.brand-mark span:nth-child(1) {
+	opacity: 0.3;
+}
+
+.brand-mark span:nth-child(2) {
+	opacity: 0.55;
+}
+
+.brand-mark span:nth-child(3) {
+	opacity: 0.8;
+}
+
+.brand-mark span:nth-child(4) {
+	background: var(--accent);
+	opacity: 1;
+}
+
+.foot-brand p {
+	font-size: 14px;
+	color: var(--ink-3);
+	max-width: 34ch;
+	margin: 14px 0 0;
+	line-height: 1.55;
+}
+
+.foot h5 {
+	font-family: var(--f-mono);
+	font-size: 11px;
+	font-weight: 500;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+	color: var(--ink-3);
+	margin: 0 0 16px;
+}
+
+.foot ul {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.foot li {
+	margin-bottom: 10px;
+}
+
+.foot a {
+	font-size: 14px;
+	color: var(--ink-2);
+	transition: color 0.15s var(--ease);
+}
+
+.foot a:hover {
+	color: var(--ink);
+}
+
+.foot-bottom {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding-top: 28px;
+	border-top: 1px solid var(--line);
+	font-size: 12px;
+	color: var(--ink-4);
+	font-family: var(--f-mono);
+}
+
+@media (max-width: 960px) {
+	.foot {
+		grid-template-columns: 1fr !important;
+		gap: 40px;
+	}
+}
+
+@media (max-width: 760px) {
+	.wrap {
+		padding: 0 20px;
+	}
+
+	.foot {
+		grid-template-columns: 1fr 1fr !important;
+		gap: 24px;
+	}
+}
+</style>

--- a/apps/website/.vitepress/theme/components/bedrock-nav.vue
+++ b/apps/website/.vitepress/theme/components/bedrock-nav.vue
@@ -295,6 +295,7 @@ onBeforeUnmount(() => {
 						:ref="(element) => (linkRefs[index] = element as HTMLAnchorElement | null)"
 						:aria-current="ariaCurrentFor(link, index)"
 						:class="{ active: isActive(index), phantom: isPhantom(link) }"
+						:data-text="link.text"
 						:href="linkHref(link)"
 						:rel="link.external ? 'noopener noreferrer' : undefined"
 						:style="
@@ -494,12 +495,25 @@ onBeforeUnmount(() => {
 }
 
 .nav-links a {
+	/* `inline-grid` + a ghost `::before` at the active weight reserves the
+	   bold width so siblings don't reflow when the underline lands on a new
+	   item. The cell sizes to max(text-at-current-weight, ::before-at-500). */
+	display: inline-grid;
+	place-items: center;
 	font-size: 14px;
 	color: var(--ink-2);
 	position: relative;
 	padding: 20px 0;
 	transition: color 0.15s var(--ease);
 	border-radius: 2px;
+}
+
+.nav-links a::before {
+	content: attr(data-text);
+	grid-area: 1 / 1;
+	font-weight: 500;
+	visibility: hidden;
+	pointer-events: none;
 }
 
 .nav-links a:hover {

--- a/apps/website/.vitepress/theme/components/bedrock-nav.vue
+++ b/apps/website/.vitepress/theme/components/bedrock-nav.vue
@@ -295,7 +295,6 @@ onBeforeUnmount(() => {
 						:ref="(element) => (linkRefs[index] = element as HTMLAnchorElement | null)"
 						:aria-current="ariaCurrentFor(link, index)"
 						:class="{ active: isActive(index), phantom: isPhantom(link) }"
-						:data-text="link.text"
 						:href="linkHref(link)"
 						:rel="link.external ? 'noopener noreferrer' : undefined"
 						:style="
@@ -495,25 +494,12 @@ onBeforeUnmount(() => {
 }
 
 .nav-links a {
-	/* `inline-grid` + a ghost `::before` at the active weight reserves the
-	   bold width so siblings don't reflow when the underline lands on a new
-	   item. The cell sizes to max(text-at-current-weight, ::before-at-500). */
-	display: inline-grid;
-	place-items: center;
 	font-size: 14px;
 	color: var(--ink-2);
 	position: relative;
 	padding: 20px 0;
 	transition: color 0.15s var(--ease);
 	border-radius: 2px;
-}
-
-.nav-links a::before {
-	content: attr(data-text);
-	grid-area: 1 / 1;
-	font-weight: 500;
-	visibility: hidden;
-	pointer-events: none;
 }
 
 .nav-links a:hover {
@@ -540,7 +526,11 @@ onBeforeUnmount(() => {
 
 .nav-links a.active {
 	color: var(--ink);
-	font-weight: 500;
+	/* `text-shadow` paints a subpixel stroke around each glyph which reads as
+	   weight without actually changing the font weight; that keeps the
+	   text's advance-width fixed so siblings don't reflow when the underline
+	   crosses sections. */
+	text-shadow: 0 0 0.55px currentColor;
 }
 
 .nav-right {

--- a/apps/website/.vitepress/theme/components/bedrock-nav.vue
+++ b/apps/website/.vitepress/theme/components/bedrock-nav.vue
@@ -1,18 +1,19 @@
 <script setup lang="ts">
-import { useData } from "vitepress";
+import { useData, useRoute, withBase } from "vitepress";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
 import { version as bedrockVersion } from "@bedrock-rbx/core/package.json";
 
-export interface BedrockNavLink {
-	readonly active?: boolean;
+interface UnifiedNavLink {
+	readonly divider?: boolean;
 	readonly external?: boolean;
 	readonly href: string;
+	readonly section: "bridge" | "docs" | "landing";
 	readonly text: string;
 }
 
 interface Props {
 	readonly homeHref?: string;
-	readonly links: ReadonlyArray<BedrockNavLink>;
 	readonly showSearch?: boolean;
 }
 
@@ -20,11 +21,264 @@ const { homeHref = "/", showSearch = false } = defineProps<Props>();
 
 const VERSION = `v${bedrockVersion}`;
 
+// Single source of truth for the nav: a flat list with explicit divider
+// placement and section ownership. The landing-side items are page-anchors
+// on the homepage; the bridge (`Docs`) lights up the bedrock docs section;
+// the docs-side items are bedrock-specific. Ocale is a peer package and
+// lives outside this list as a separate affordance in the right cluster.
+const UNIFIED_LINKS: ReadonlyArray<UnifiedNavLink> = [
+	{ href: "/#features", section: "landing", text: "Features" },
+	{ href: "/#install", section: "landing", text: "Quickstart" },
+	{ divider: true, href: "/bedrock/introduction", section: "bridge", text: "Docs" },
+	{ href: "/bedrock/api/", section: "docs", text: "API" },
+	{ href: "#", section: "docs", text: "CLI" },
+	{
+		external: true,
+		href: "https://github.com/christopher-buss/bedrock/releases",
+		section: "docs",
+		text: "Changelog",
+	},
+];
+
+const OCALE_HREF = "/ocale/guide/getting-started";
+
+const BRIDGE_INDEX = UNIFIED_LINKS.findIndex((link) => link.section === "bridge");
+
 const { isDark } = useData();
+const route = useRoute();
+
+function normalizePath(value: string): string {
+	return value.toLowerCase().replace(/\/$/u, "");
+}
+
+const currentPath = computed(() => normalizePath(route.path));
+
+const currentSection = computed<"docs" | "landing">(() =>
+	currentPath.value.startsWith("/bedrock") ? "docs" : "landing",
+);
+
+function isRouteLink(link: UnifiedNavLink): boolean {
+	return !link.external && !link.href.startsWith("#") && !link.href.includes("/#");
+}
+
+// Longest-prefix match: /bedrock/api/functions/diff lights up "API" rather
+// than nothing. Equality alone would only match top-level pages.
+const activeIndex = computed<number>(() => {
+	let bestIndex = -1;
+	let bestLength = 0;
+	for (const [index, link] of UNIFIED_LINKS.entries()) {
+		if (!isRouteLink(link)) {
+			continue;
+		}
+
+		const linkPath = normalizePath(link.href);
+		if (linkPath.length === 0) {
+			continue;
+		}
+
+		const matches =
+			currentPath.value === linkPath || currentPath.value.startsWith(`${linkPath}/`);
+		if (matches && linkPath.length > bestLength) {
+			bestIndex = index;
+			bestLength = linkPath.length;
+		}
+	}
+
+	return bestIndex;
+});
+
+// Anchor sections on the landing that scroll-spy can light up. Order matches
+// the position of the link in UNIFIED_LINKS so the underline lands on the
+// correct item.
+const ANCHOR_SECTION_IDS: ReadonlyArray<string> = ["features", "install"];
+
+const intersectingSections = ref<ReadonlySet<string>>(new Set());
+
+// Pick the *last* intersecting section so when both briefly overlap the
+// scroll band, the lower (further-scrolled) one wins. Picking the first
+// would flicker back up as soon as the next section enters.
+const scrollSpyIndex = computed<number>(() => {
+	let last = -1;
+	for (const [index, id] of ANCHOR_SECTION_IDS.entries()) {
+		if (intersectingSections.value.has(id)) {
+			last = index;
+		}
+	}
+
+	return last;
+});
+
+// Scroll-spy takes precedence on the landing route; everywhere else the
+// route-based active index wins.
+const currentActiveIndex = computed<number>(() => {
+	if (currentSection.value === "landing" && scrollSpyIndex.value >= 0) {
+		return scrollSpyIndex.value;
+	}
+
+	return activeIndex.value;
+});
+
+function isActive(index: number): boolean {
+	return currentActiveIndex.value === index;
+}
+
+function ariaCurrentFor(link: UnifiedNavLink, index: number): "location" | "page" | undefined {
+	if (!isActive(index)) {
+		return undefined;
+	}
+
+	return isRouteLink(link) ? "page" : "location";
+}
+
+function isPhantom(link: UnifiedNavLink): boolean {
+	if (link.section === "bridge") {
+		return false;
+	}
+
+	return link.section !== currentSection.value;
+}
+
+// Opacity ladder by distance from the bridge. The 0.35 floor sits below
+// strict WCAG AA Normal text contrast, but :hover and :focus-visible both
+// restore to 1, so any user actively engaging with a phantom item sees it
+// at full strength. The fade is a peripheral-vision cue, not a contrast
+// statement.
+function phantomOpacity(link: UnifiedNavLink, index: number): number | undefined {
+	if (!isPhantom(link) || BRIDGE_INDEX === -1) {
+		return undefined;
+	}
+
+	const distance = Math.abs(index - BRIDGE_INDEX);
+	return Math.max(0.35, 0.85 - distance * 0.18);
+}
+
+function linkHref(link: UnifiedNavLink): string {
+	if (link.external || link.href.startsWith("#") || link.href.includes("/#")) {
+		return link.href;
+	}
+
+	return withBase(link.href);
+}
 
 function toggleTheme(): void {
 	isDark.value = !isDark.value;
 }
+
+// Template refs for the sliding underline. Each <a> registers itself so we
+// can read its layout box and position the underline beneath it. `linkRefs`
+// is populated by inline `:ref` bindings in the template.
+const navLinksElement = ref<HTMLDivElement | null>(null);
+const linkRefs = ref<Array<HTMLAnchorElement | null>>([]);
+
+const underlineStyle = ref<{
+	opacity: string;
+	transform: string;
+	width: string;
+}>({
+	opacity: "0",
+	transform: "translateX(0)",
+	width: "0px",
+});
+
+// Use `offsetLeft` / `offsetWidth` (layout-relative, not affected by scroll)
+// rather than `getBoundingClientRect` (viewport-relative). The underline
+// lives inside `.nav-links`, which is the scrolling container on narrow
+// viewports; using viewport coords would drift in the wrong direction as
+// the row scrolls.
+function updateUnderline(): void {
+	const index = currentActiveIndex.value;
+	const item = index >= 0 ? linkRefs.value[index] : null;
+	if (item === null || item === undefined || navLinksElement.value === null) {
+		underlineStyle.value = { ...underlineStyle.value, opacity: "0" };
+		return;
+	}
+
+	underlineStyle.value = {
+		opacity: "1",
+		transform: `translateX(${item.offsetLeft}px)`,
+		width: `${item.offsetWidth}px`,
+	};
+}
+
+let observer: IntersectionObserver | undefined;
+let resizeObserver: ResizeObserver | undefined;
+
+function teardownScrollSpy(): void {
+	observer?.disconnect();
+	observer = undefined;
+	intersectingSections.value = new Set();
+}
+
+function setupScrollSpy(): void {
+	teardownScrollSpy();
+	if (currentSection.value !== "landing") {
+		return;
+	}
+
+	const observed: Array<Element> = [];
+	for (const id of ANCHOR_SECTION_IDS) {
+		const element = document.getElementById(id);
+		if (element !== null) {
+			observed.push(element);
+		}
+	}
+
+	if (observed.length === 0) {
+		return;
+	}
+
+	observer = new IntersectionObserver(
+		(entries) => {
+			const next = new Set(intersectingSections.value);
+			for (const entry of entries) {
+				if (entry.isIntersecting) {
+					next.add(entry.target.id);
+				} else {
+					next.delete(entry.target.id);
+				}
+			}
+
+			intersectingSections.value = next;
+		},
+		{ rootMargin: "-40% 0px -50% 0px" },
+	);
+
+	for (const element of observed) {
+		observer.observe(element);
+	}
+}
+
+watch(
+	currentActiveIndex,
+	() => {
+		void nextTick(updateUnderline);
+	},
+	{ flush: "post" },
+);
+
+watch(currentSection, () => {
+	void nextTick(() => {
+		setupScrollSpy();
+		updateUnderline();
+	});
+});
+
+onMounted(() => {
+	setupScrollSpy();
+	updateUnderline();
+	if (navLinksElement.value !== null) {
+		resizeObserver = new ResizeObserver(() => {
+			updateUnderline();
+		});
+		resizeObserver.observe(navLinksElement.value);
+	}
+});
+
+onBeforeUnmount(() => {
+	teardownScrollSpy();
+	resizeObserver?.disconnect();
+	resizeObserver = undefined;
+});
 </script>
 
 <template>
@@ -34,26 +288,29 @@ function toggleTheme(): void {
 				<span class="brand-mark"> <span /><span /><span /><span /> </span>
 				Bedrock<span class="nav-v">{{ VERSION }}</span>
 			</a>
-			<div class="nav-links">
-				<a
-					v-for="link in links"
-					:key="link.href"
-					:class="{ active: link.active }"
-					:href="link.href"
-					:rel="link.external ? 'noopener noreferrer' : undefined"
-					:target="link.external ? '_blank' : undefined"
-				>
-					{{ link.text }}
-				</a>
+			<div ref="navLinksElement" class="nav-links">
+				<template v-for="(link, index) in UNIFIED_LINKS" :key="link.href">
+					<span v-if="link.divider" class="nav-divider" aria-hidden="true" />
+					<a
+						:ref="(element) => (linkRefs[index] = element as HTMLAnchorElement | null)"
+						:aria-current="ariaCurrentFor(link, index)"
+						:class="{ active: isActive(index), phantom: isPhantom(link) }"
+						:href="linkHref(link)"
+						:rel="link.external ? 'noopener noreferrer' : undefined"
+						:style="
+							phantomOpacity(link, index) !== undefined
+								? { '--phantom-opacity': phantomOpacity(link, index) }
+								: undefined
+						"
+						:target="link.external ? '_blank' : undefined"
+					>
+						{{ link.text }}
+					</a>
+				</template>
+				<span class="nav-underline" :style="underlineStyle" aria-hidden="true" />
 			</div>
 			<div class="nav-right">
-				<div
-					v-if="showSearch"
-					class="nav-search"
-					role="button"
-					tabindex="0"
-					aria-label="Search docs"
-				>
+				<button v-if="showSearch" class="nav-search" type="button" aria-label="Search docs">
 					<svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
 						<circle cx="7" cy="7" r="5" stroke="currentColor" stroke-width="1.4" />
 						<path
@@ -65,7 +322,7 @@ function toggleTheme(): void {
 					</svg>
 					Search docs&hellip;
 					<span class="kbd">&#8984;K</span>
-				</div>
+				</button>
 				<button class="theme-toggle" aria-label="Toggle theme" @click="toggleTheme">
 					<svg
 						v-if="!isDark"
@@ -91,6 +348,10 @@ function toggleTheme(): void {
 						/>
 					</svg>
 				</button>
+				<a class="nav-cta nav-cta-secondary" :href="withBase(OCALE_HREF)">
+					<span class="nav-cta-mark" aria-hidden="true"> <span /><span /><span /> </span>
+					Ocale
+				</a>
 				<a class="nav-cta" href="https://github.com/christopher-buss/bedrock">
 					GitHub
 					<svg width="11" height="11" viewBox="0 0 12 12" fill="none" aria-hidden="true">
@@ -199,26 +460,73 @@ function toggleTheme(): void {
 }
 
 .nav-links {
+	position: relative;
 	display: flex;
-	gap: 28px;
+	align-items: center;
+	gap: 20px;
+}
+
+.nav-underline {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	height: 2px;
+	background: var(--accent);
+	border-radius: 1px;
+	pointer-events: none;
+	transition:
+		transform 0.28s var(--ease),
+		width 0.28s var(--ease),
+		opacity 0.18s var(--ease);
+	will-change: transform, width;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.nav-underline {
+		transition: opacity 0.18s var(--ease);
+	}
+}
+
+.nav-divider {
+	width: 1px;
+	height: 18px;
+	background: var(--line);
 }
 
 .nav-links a {
 	font-size: 14px;
 	color: var(--ink-2);
+	position: relative;
+	padding: 20px 0;
 	transition: color 0.15s var(--ease);
+	border-radius: 2px;
 }
 
 .nav-links a:hover {
 	color: var(--ink);
 }
 
-.nav-links a.active {
-	color: var(--accent-deep);
+.nav-links a:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 4px;
 }
 
-html.dark .nav-links a.active {
-	color: var(--accent-soft);
+.nav-links a.phantom {
+	opacity: var(--phantom-opacity, 0.35);
+	transition:
+		color 0.15s var(--ease),
+		opacity 0.18s var(--ease);
+}
+
+.nav-links a.phantom:hover,
+.nav-links a.phantom:focus-visible {
+	opacity: 1;
+	color: var(--ink);
+}
+
+.nav-links a.active {
+	color: var(--ink);
+	font-weight: 500;
 }
 
 .nav-right {
@@ -245,6 +553,11 @@ html.dark .nav-links a.active {
 .nav-search:hover {
 	border-color: var(--line-strong);
 	color: var(--ink-2);
+}
+
+.nav-search:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
 }
 
 .nav-search svg {
@@ -282,6 +595,11 @@ html.dark .nav-links a.active {
 	background: var(--bg-soft);
 }
 
+.theme-toggle:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+}
+
 .theme-toggle svg {
 	width: 14px;
 	height: 14px;
@@ -304,12 +622,91 @@ html.dark .nav-links a.active {
 	color: var(--bg);
 }
 
+.nav-cta:focus-visible {
+	outline: 2px solid var(--accent);
+	outline-offset: 2px;
+}
+
+.nav-cta-secondary {
+	color: var(--ink-3);
+	padding-left: 10px;
+	gap: 8px;
+}
+
+.nav-cta-secondary:hover {
+	border-color: var(--accent-deep);
+	background: transparent;
+	color: var(--accent-deep);
+}
+
+html.dark .nav-cta-secondary:hover {
+	border-color: var(--accent-soft);
+	color: var(--accent-soft);
+}
+
+.nav-cta-mark {
+	width: 10px;
+	height: 10px;
+	display: grid;
+	grid-template-rows: repeat(3, 1fr);
+	gap: 1.5px;
+}
+
+.nav-cta-mark span {
+	background: currentColor;
+	border-radius: 1px;
+	opacity: 0.55;
+}
+
+.nav-cta-mark span:nth-child(3) {
+	background: var(--accent);
+	opacity: 1;
+}
+
+html.dark .nav-cta-mark span:nth-child(3) {
+	background: var(--accent-soft);
+}
+
+@media (max-width: 960px) {
+	.nav-links {
+		gap: 14px;
+	}
+
+	.nav-links a {
+		font-size: 13px;
+	}
+
+	.nav-search {
+		min-width: 160px;
+	}
+}
+
 @media (max-width: 760px) {
 	.wrap {
 		padding: 0 20px;
 	}
 
-	.nav-links,
+	.inner {
+		flex-wrap: wrap;
+		height: auto;
+		padding-top: 12px;
+		padding-bottom: 12px;
+		row-gap: 8px;
+	}
+
+	.nav-links {
+		order: 3;
+		width: 100%;
+		overflow-x: auto;
+		flex-wrap: nowrap;
+		scrollbar-width: none;
+		padding-bottom: 4px;
+	}
+
+	.nav-links::-webkit-scrollbar {
+		display: none;
+	}
+
 	.nav-search {
 		display: none;
 	}

--- a/apps/website/.vitepress/theme/components/bedrock-nav.vue
+++ b/apps/website/.vitepress/theme/components/bedrock-nav.vue
@@ -1,0 +1,317 @@
+<script setup lang="ts">
+import { useData } from "vitepress";
+
+import { version as bedrockVersion } from "@bedrock-rbx/core/package.json";
+
+export interface BedrockNavLink {
+	readonly active?: boolean;
+	readonly external?: boolean;
+	readonly href: string;
+	readonly text: string;
+}
+
+interface Props {
+	readonly homeHref?: string;
+	readonly links: ReadonlyArray<BedrockNavLink>;
+	readonly showSearch?: boolean;
+}
+
+const { homeHref = "/", showSearch = false } = defineProps<Props>();
+
+const VERSION = `v${bedrockVersion}`;
+
+const { isDark } = useData();
+
+function toggleTheme(): void {
+	isDark.value = !isDark.value;
+}
+</script>
+
+<template>
+	<nav class="bedrock-nav">
+		<div class="wrap inner">
+			<a class="brand" :href="homeHref">
+				<span class="brand-mark"> <span /><span /><span /><span /> </span>
+				Bedrock<span class="nav-v">{{ VERSION }}</span>
+			</a>
+			<div class="nav-links">
+				<a
+					v-for="link in links"
+					:key="link.href"
+					:class="{ active: link.active }"
+					:href="link.href"
+					:rel="link.external ? 'noopener noreferrer' : undefined"
+					:target="link.external ? '_blank' : undefined"
+				>
+					{{ link.text }}
+				</a>
+			</div>
+			<div class="nav-right">
+				<div
+					v-if="showSearch"
+					class="nav-search"
+					role="button"
+					tabindex="0"
+					aria-label="Search docs"
+				>
+					<svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+						<circle cx="7" cy="7" r="5" stroke="currentColor" stroke-width="1.4" />
+						<path
+							d="m11 11 3 3"
+							stroke="currentColor"
+							stroke-width="1.4"
+							stroke-linecap="round"
+						/>
+					</svg>
+					Search docs&hellip;
+					<span class="kbd">&#8984;K</span>
+				</div>
+				<button class="theme-toggle" aria-label="Toggle theme" @click="toggleTheme">
+					<svg
+						v-if="!isDark"
+						class="icon-moon"
+						viewBox="0 0 16 16"
+						fill="none"
+						aria-hidden="true"
+					>
+						<path
+							d="M13.5 9.5A5.5 5.5 0 0 1 6.5 2.5a5.5 5.5 0 1 0 7 7Z"
+							stroke="currentColor"
+							stroke-width="1.4"
+							stroke-linejoin="round"
+						/>
+					</svg>
+					<svg v-else class="icon-sun" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+						<circle cx="8" cy="8" r="3" stroke="currentColor" stroke-width="1.4" />
+						<path
+							d="M8 1.5v1.5M8 13v1.5M14.5 8H13M3 8H1.5M12.6 3.4l-1.1 1.1M4.5 11.5l-1.1 1.1M12.6 12.6l-1.1-1.1M4.5 4.5 3.4 3.4"
+							stroke="currentColor"
+							stroke-width="1.4"
+							stroke-linecap="round"
+						/>
+					</svg>
+				</button>
+				<a class="nav-cta" href="https://github.com/christopher-buss/bedrock">
+					GitHub
+					<svg width="11" height="11" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+						<path
+							d="M3 9L9 3M9 3H4M9 3V8"
+							stroke="currentColor"
+							stroke-width="1.5"
+							stroke-linecap="round"
+						/>
+					</svg>
+				</a>
+			</div>
+		</div>
+	</nav>
+</template>
+
+<style scoped>
+.bedrock-nav {
+	position: sticky;
+	top: 0;
+	z-index: 40;
+	backdrop-filter: blur(14px);
+	background: var(--bg-nav);
+	border-bottom: 1px solid var(--line);
+	transition:
+		background-color 0.25s var(--ease),
+		border-color 0.25s var(--ease),
+		color 0.2s var(--ease);
+}
+
+.bedrock-nav a {
+	color: inherit;
+	text-decoration: none;
+}
+
+.bedrock-nav button {
+	font: inherit;
+	cursor: pointer;
+	border: 0;
+	background: none;
+	color: inherit;
+	padding: 0;
+}
+
+.wrap {
+	max-width: var(--bedrock-wrap, 1200px);
+	margin: 0 auto;
+	padding: 0 32px;
+}
+
+.inner {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	height: 60px;
+	gap: 24px;
+}
+
+.brand {
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	font-family: var(--f-serif);
+	font-size: 23px;
+	letter-spacing: -0.01em;
+}
+
+.brand-mark {
+	width: 22px;
+	height: 22px;
+	display: grid;
+	grid-template-rows: repeat(4, 1fr);
+	gap: 2px;
+}
+
+.brand-mark span {
+	background: var(--ink);
+	border-radius: 1px;
+}
+
+.brand-mark span:nth-child(1) {
+	opacity: 0.3;
+}
+
+.brand-mark span:nth-child(2) {
+	opacity: 0.55;
+}
+
+.brand-mark span:nth-child(3) {
+	opacity: 0.8;
+}
+
+.brand-mark span:nth-child(4) {
+	background: var(--accent);
+	opacity: 1;
+}
+
+.nav-v {
+	font-family: var(--f-mono);
+	font-size: 11px;
+	color: var(--ink-4);
+	padding: 2px 6px;
+	background: var(--bg-soft);
+	border-radius: 3px;
+	margin-left: 8px;
+}
+
+.nav-links {
+	display: flex;
+	gap: 28px;
+}
+
+.nav-links a {
+	font-size: 14px;
+	color: var(--ink-2);
+	transition: color 0.15s var(--ease);
+}
+
+.nav-links a:hover {
+	color: var(--ink);
+}
+
+.nav-links a.active {
+	color: var(--accent-deep);
+}
+
+html.dark .nav-links a.active {
+	color: var(--accent-soft);
+}
+
+.nav-right {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.nav-search {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 10px 6px 12px;
+	background: var(--bg-soft);
+	border: 1px solid var(--line);
+	border-radius: 8px;
+	font-size: 13px;
+	color: var(--ink-3);
+	min-width: 220px;
+	transition: all 0.15s var(--ease);
+	cursor: pointer;
+}
+
+.nav-search:hover {
+	border-color: var(--line-strong);
+	color: var(--ink-2);
+}
+
+.nav-search svg {
+	width: 13px;
+	height: 13px;
+	opacity: 0.7;
+}
+
+.nav-search .kbd {
+	margin-left: auto;
+	font-family: var(--f-mono);
+	font-size: 10.5px;
+	padding: 1px 5px;
+	border: 1px solid var(--line-strong);
+	border-radius: 3px;
+	color: var(--ink-4);
+	background: var(--bg);
+}
+
+.theme-toggle {
+	width: 32px;
+	height: 32px;
+	border: 1px solid var(--line);
+	border-radius: 999px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--ink-2);
+	transition: all 0.15s var(--ease);
+}
+
+.theme-toggle:hover {
+	border-color: var(--ink-3);
+	color: var(--ink);
+	background: var(--bg-soft);
+}
+
+.theme-toggle svg {
+	width: 14px;
+	height: 14px;
+}
+
+.nav-cta {
+	font-size: 13px;
+	padding: 6px 12px 6px 14px;
+	border: 1px solid var(--line-strong);
+	border-radius: 999px;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	transition: all 0.15s var(--ease);
+}
+
+.nav-cta:hover {
+	border-color: var(--ink);
+	background: var(--ink);
+	color: var(--bg);
+}
+
+@media (max-width: 760px) {
+	.wrap {
+		padding: 0 20px;
+	}
+
+	.nav-links,
+	.nav-search {
+		display: none;
+	}
+}
+</style>

--- a/apps/website/.vitepress/theme/home-introduction.vue
+++ b/apps/website/.vitepress/theme/home-introduction.vue
@@ -573,6 +573,65 @@ html.dark .article :deep(a) {
 	font-family: var(--f-sans);
 }
 
+/* Resource list — supported resource kinds */
+.article :deep(.resource-list) {
+	list-style: none;
+	padding: 0;
+	margin: 0 0 18px;
+	max-width: 62ch;
+}
+
+.article :deep(.resource-list li) {
+	display: grid;
+	grid-template-columns: 160px 1fr;
+	gap: 18px;
+	padding: 12px 0;
+	border-top: 1px dashed var(--line);
+	align-items: baseline;
+	font-size: 15.5px;
+	margin-bottom: 0;
+}
+
+.article :deep(.resource-list li:last-child) {
+	border-bottom: 1px dashed var(--line);
+}
+
+.article :deep(.resource-list .kind) {
+	font-family: var(--f-mono);
+	font-size: 12.5px;
+	color: var(--ink);
+}
+
+.article :deep(.resource-list .kind code) {
+	background: none;
+	border: none;
+	padding: 0;
+	font-size: inherit;
+	color: inherit;
+}
+
+.article :deep(.resource-list .kind.soon) {
+	color: var(--ink-4);
+}
+
+.article :deep(.resource-list .desc) {
+	color: var(--ink-3);
+	font-family: var(--f-sans);
+}
+
+.article :deep(.resource-list .desc .badge) {
+	font-family: var(--f-mono);
+	font-size: 10px;
+	letter-spacing: 0.1em;
+	text-transform: uppercase;
+	color: var(--ink-4);
+	border: 1px solid var(--line);
+	border-radius: 3px;
+	padding: 1px 5px;
+	margin-left: 8px;
+	vertical-align: 1px;
+}
+
 /* Next-steps card grid */
 .article :deep(.next-steps) {
 	display: grid;

--- a/apps/website/.vitepress/theme/home-introduction.vue
+++ b/apps/website/.vitepress/theme/home-introduction.vue
@@ -4,7 +4,6 @@ import { Content, useData, useRoute, withBase } from "vitepress";
 import { computed } from "vue";
 
 import BedrockFooter, { type BedrockFooterColumn } from "./components/bedrock-footer.vue";
-import BedrockNav from "./components/bedrock-nav.vue";
 
 type SidebarGroup = DefaultTheme.SidebarItem;
 type SidebarLink = DefaultTheme.SidebarItem;
@@ -128,8 +127,6 @@ const footerColumns = computed<ReadonlyArray<BedrockFooterColumn>>(() => [
 
 <template>
 	<div class="bedrock-intro">
-		<BedrockNav :home-href="withBase('/')" show-search />
-
 		<div class="wrap shell">
 			<aside class="side" aria-label="Documentation navigation">
 				<div v-for="(group, gi) in sidebar" :key="gi" class="side-group">
@@ -191,48 +188,6 @@ const footerColumns = computed<ReadonlyArray<BedrockFooterColumn>>(() => [
 
 <style scoped>
 .bedrock-intro {
-	--bg: #f4f6fa;
-	--bg-soft: #e9edf3;
-	--bg-card: #ffffff;
-	--bg-nav: rgba(244, 246, 250, 0.78);
-	--ink: #0e131a;
-	--ink-2: #2a3240;
-	--ink-3: #5a6472;
-	--ink-4: #8b95a4;
-	--line: #dde2eb;
-	--line-strong: #c4cbd6;
-
-	--dark-bg: #0c1018;
-	--dark-bg-2: #131826;
-	--dark-line: #232a3a;
-	--dark-ink: #eef1f7;
-	--dark-ink-2: #b9c1d0;
-	--dark-ink-3: #6f7889;
-
-	--accent: #5944a2;
-	--accent-soft: #a8bdd8;
-	--accent-deep: #324a6e;
-	--accent-bg: #e4ebf5;
-
-	--ok: #4a8a64;
-	--warn: #c89a3a;
-	--del: #b5523a;
-
-	--kind-fn: oklch(62% 0.115 235);
-	--kind-type: oklch(68% 0.105 75);
-	--kind-cls: oklch(58% 0.095 145);
-	--kind-const: oklch(60% 0.115 305);
-
-	--f-sans: "Geist", "Inter", system-ui, -apple-system, sans-serif;
-	--f-serif: "Source Serif 4", "Source Serif Pro", "Times New Roman", serif;
-	--f-mono: "JetBrains Mono", ui-monospace, Menlo, monospace;
-
-	--r-sm: 4px;
-	--r: 8px;
-	--r-lg: 14px;
-
-	--ease: cubic-bezier(0.2, 0.7, 0.2, 1);
-
 	min-height: 100vh;
 	background: var(--bg);
 	color: var(--ink);
@@ -241,22 +196,6 @@ const footerColumns = computed<ReadonlyArray<BedrockFooterColumn>>(() => [
 	line-height: 1.6;
 	-webkit-font-smoothing: antialiased;
 	text-rendering: optimizeLegibility;
-}
-
-html.dark .bedrock-intro {
-	--bg: #0d1119;
-	--bg-soft: #141a26;
-	--bg-card: #1a2030;
-	--bg-nav: rgba(13, 17, 25, 0.78);
-	--ink: #eef1f7;
-	--ink-2: #c1c8d4;
-	--ink-3: #828b9c;
-	--ink-4: #565e6e;
-	--line: #232a39;
-	--line-strong: #2f3849;
-	--accent-soft: #b8c9e0;
-	--accent-deep: #4e6c92;
-	--accent-bg: #1e2840;
 }
 
 .bedrock-intro,

--- a/apps/website/.vitepress/theme/home-introduction.vue
+++ b/apps/website/.vitepress/theme/home-introduction.vue
@@ -3,14 +3,13 @@ import type { DefaultTheme } from "vitepress";
 import { Content, useData, useRoute, withBase } from "vitepress";
 import { computed } from "vue";
 
-import { version as bedrockVersion } from "@bedrock-rbx/core/package.json";
+import BedrockFooter, { type BedrockFooterColumn } from "./components/bedrock-footer.vue";
+import BedrockNav, { type BedrockNavLink } from "./components/bedrock-nav.vue";
 
 type SidebarGroup = DefaultTheme.SidebarItem;
 type SidebarLink = DefaultTheme.SidebarItem;
 
-const VERSION = `v${bedrockVersion}`;
-
-const { isDark, theme } = useData();
+const { theme } = useData();
 const route = useRoute();
 
 const sidebar = computed<ReadonlyArray<SidebarGroup>>(() => {
@@ -87,90 +86,64 @@ function kindDot(link: string | undefined): "cls" | "const" | "fn" | "type" | un
 	return undefined;
 }
 
-function toggleTheme(): void {
-	isDark.value = !isDark.value;
-}
+const navLinks = computed<ReadonlyArray<BedrockNavLink>>(() => [
+	{
+		active: currentPath.value.startsWith("/bedrock"),
+		href: withBase("/bedrock/introduction"),
+		text: "Docs",
+	},
+	{ href: withBase("/bedrock/api/"), text: "API" },
+	{ href: "#", text: "CLI" },
+	{
+		external: true,
+		href: "https://github.com/christopher-buss/bedrock/releases",
+		text: "Changelog",
+	},
+]);
+
+const footerColumns = computed<ReadonlyArray<BedrockFooterColumn>>(() => [
+	{
+		links: [
+			{ href: withBase("/bedrock/introduction"), text: "Introduction" },
+			{ href: withBase("/bedrock/guide/getting-started"), text: "Getting started" },
+			{ href: withBase("/bedrock/api/"), text: "API reference" },
+		],
+		title: "Docs",
+	},
+	{
+		links: [
+			{ href: withBase("/ocale/guide/getting-started"), text: "Getting started" },
+			{ href: withBase("/ocale/api/"), text: "Resource clients" },
+			{ href: withBase("/ocale/guide/errors"), text: "Error hierarchy" },
+		],
+		title: "Ocale",
+	},
+	{
+		links: [
+			{
+				external: true,
+				href: "https://github.com/christopher-buss/bedrock",
+				text: "GitHub",
+			},
+			{
+				external: true,
+				href: "https://github.com/christopher-buss/bedrock/tree/main/docs/adr",
+				text: "ADRs",
+			},
+			{
+				external: true,
+				href: "https://github.com/christopher-buss/bedrock/releases",
+				text: "Changelog",
+			},
+		],
+		title: "Project",
+	},
+]);
 </script>
 
 <template>
 	<div class="bedrock-intro">
-		<nav class="bedrock-nav">
-			<div class="wrap inner">
-				<a class="brand" :href="withBase('/')">
-					<span class="brand-mark"> <span /><span /><span /><span /> </span>
-					Bedrock<span class="nav-v">{{ VERSION }}</span>
-				</a>
-				<div class="nav-links">
-					<a class="active" :href="withBase('/bedrock/introduction')">Docs</a>
-					<a :href="withBase('/bedrock/api/')">API</a>
-					<a href="#">CLI</a>
-					<a href="https://github.com/christopher-buss/bedrock/releases">Changelog</a>
-				</div>
-				<div class="nav-right">
-					<div class="nav-search" role="button" tabindex="0" aria-label="Search docs">
-						<svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
-							<circle cx="7" cy="7" r="5" stroke="currentColor" stroke-width="1.4" />
-							<path
-								d="m11 11 3 3"
-								stroke="currentColor"
-								stroke-width="1.4"
-								stroke-linecap="round"
-							/>
-						</svg>
-						Search docs&hellip;
-						<span class="kbd">&#8984;K</span>
-					</div>
-					<button class="theme-toggle" aria-label="Toggle theme" @click="toggleTheme">
-						<svg
-							v-if="!isDark"
-							class="icon-moon"
-							viewBox="0 0 16 16"
-							fill="none"
-							aria-hidden="true"
-						>
-							<path
-								d="M13.5 9.5A5.5 5.5 0 0 1 6.5 2.5a5.5 5.5 0 1 0 7 7Z"
-								stroke="currentColor"
-								stroke-width="1.4"
-								stroke-linejoin="round"
-							/>
-						</svg>
-						<svg
-							v-else
-							class="icon-sun"
-							viewBox="0 0 16 16"
-							fill="none"
-							aria-hidden="true"
-						>
-							<circle cx="8" cy="8" r="3" stroke="currentColor" stroke-width="1.4" />
-							<path
-								d="M8 1.5v1.5M8 13v1.5M14.5 8H13M3 8H1.5M12.6 3.4l-1.1 1.1M4.5 11.5l-1.1 1.1M12.6 12.6l-1.1-1.1M4.5 4.5 3.4 3.4"
-								stroke="currentColor"
-								stroke-width="1.4"
-								stroke-linecap="round"
-							/>
-						</svg>
-					</button>
-					<a class="nav-cta" href="https://github.com/christopher-buss/bedrock">
-						GitHub
-						<svg
-							width="11"
-							height="11"
-							viewBox="0 0 12 12"
-							fill="none"
-							aria-hidden="true"
-						>
-							<path
-								d="M3 9L9 3M9 3H4M9 3V8"
-								stroke="currentColor"
-								stroke-width="1.5"
-								stroke-linecap="round"
-							/>
-						</svg>
-					</a>
-				</div>
-			</div>
-		</nav>
+		<BedrockNav :home-href="withBase('/')" :links="navLinks" show-search />
 
 		<div class="wrap shell">
 			<aside class="side" aria-label="Documentation navigation">
@@ -227,69 +200,7 @@ function toggleTheme(): void {
 			</article>
 		</div>
 
-		<footer class="bedrock-foot">
-			<div class="wrap">
-				<div class="foot">
-					<div class="foot-brand">
-						<a class="brand" :href="withBase('/')">
-							<span class="brand-mark"> <span /><span /><span /><span /> </span>
-							Bedrock
-						</a>
-						<p>Infrastructure-as-Code for Roblox. Typed, Open Cloud only.</p>
-					</div>
-					<div>
-						<h5>Docs</h5>
-						<ul>
-							<li>
-								<a :href="withBase('/bedrock/introduction')">Introduction</a>
-							</li>
-							<li>
-								<a :href="withBase('/bedrock/guide/getting-started')"
-									>Getting started</a
-								>
-							</li>
-							<li><a :href="withBase('/bedrock/api/')">API reference</a></li>
-						</ul>
-					</div>
-					<div>
-						<h5>Ocale</h5>
-						<ul>
-							<li>
-								<a :href="withBase('/ocale/guide/getting-started')"
-									>Getting started</a
-								>
-							</li>
-							<li><a :href="withBase('/ocale/api/')">Resource clients</a></li>
-							<li><a :href="withBase('/ocale/guide/errors')">Error hierarchy</a></li>
-						</ul>
-					</div>
-					<div>
-						<h5>Project</h5>
-						<ul>
-							<li>
-								<a href="https://github.com/christopher-buss/bedrock">GitHub</a>
-							</li>
-							<li>
-								<a
-									href="https://github.com/christopher-buss/bedrock/tree/main/docs/adr"
-								>
-									ADRs
-								</a>
-							</li>
-							<li>
-								<a href="https://github.com/christopher-buss/bedrock/releases">
-									Changelog
-								</a>
-							</li>
-						</ul>
-					</div>
-				</div>
-				<div class="foot-bottom">
-					<div>&copy; 2026 &middot; MIT Licensed &middot; {{ VERSION }}</div>
-					<div>built with vitepress</div>
-				</div>
-			</div>
-		</footer>
+		<BedrockFooter :columns="footerColumns" :home-href="withBase('/')" />
 	</div>
 </template>
 
@@ -364,7 +275,6 @@ html.dark .bedrock-intro {
 }
 
 .bedrock-intro,
-.bedrock-intro .bedrock-nav,
 .bedrock-intro .side,
 .bedrock-intro .article {
 	transition:
@@ -378,197 +288,15 @@ html.dark .bedrock-intro {
 	text-decoration: none;
 }
 
-.bedrock-intro button {
-	font: inherit;
-	cursor: pointer;
-	border: 0;
-	background: none;
-	color: inherit;
-	padding: 0;
-}
-
 .bedrock-intro ::selection {
 	background: var(--accent);
 	color: #fff;
 }
 
 .wrap {
-	max-width: 1280px;
+	max-width: 1200px;
 	margin: 0 auto;
 	padding: 0 32px;
-}
-
-/* Nav (mirrors the landing's shape so navigating between feels seamless) */
-.bedrock-nav {
-	position: sticky;
-	top: 0;
-	z-index: 40;
-	backdrop-filter: blur(14px);
-	background: var(--bg-nav);
-	border-bottom: 1px solid var(--line);
-}
-
-.bedrock-nav .inner {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	height: 60px;
-	gap: 24px;
-}
-
-.nav-links {
-	display: flex;
-	gap: 28px;
-}
-
-.nav-links a {
-	font-size: 14px;
-	color: var(--ink-2);
-	transition: color 0.15s var(--ease);
-}
-
-.nav-links a:hover {
-	color: var(--ink);
-}
-
-.nav-links a.active {
-	color: var(--accent-deep);
-}
-
-html.dark .nav-links a.active {
-	color: var(--accent-soft);
-}
-
-.nav-right {
-	display: flex;
-	align-items: center;
-	gap: 8px;
-}
-
-.nav-search {
-	display: inline-flex;
-	align-items: center;
-	gap: 8px;
-	padding: 6px 10px 6px 12px;
-	background: var(--bg-soft);
-	border: 1px solid var(--line);
-	border-radius: 8px;
-	font-size: 13px;
-	color: var(--ink-3);
-	min-width: 220px;
-	transition: all 0.15s var(--ease);
-	cursor: pointer;
-}
-
-.nav-search:hover {
-	border-color: var(--line-strong);
-	color: var(--ink-2);
-}
-
-.nav-search svg {
-	width: 13px;
-	height: 13px;
-	opacity: 0.7;
-}
-
-.nav-search .kbd {
-	margin-left: auto;
-	font-family: var(--f-mono);
-	font-size: 10.5px;
-	padding: 1px 5px;
-	border: 1px solid var(--line-strong);
-	border-radius: 3px;
-	color: var(--ink-4);
-	background: var(--bg);
-}
-
-.nav-cta {
-	font-size: 13px;
-	padding: 6px 12px 6px 14px;
-	border: 1px solid var(--line-strong);
-	border-radius: 999px;
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	transition: all 0.15s var(--ease);
-}
-
-.nav-cta:hover {
-	border-color: var(--ink);
-	background: var(--ink);
-	color: var(--bg);
-}
-
-.nav-v {
-	font-family: var(--f-mono);
-	font-size: 11px;
-	color: var(--ink-4);
-	padding: 2px 6px;
-	background: var(--bg-soft);
-	border-radius: 3px;
-	margin-left: 8px;
-}
-
-.theme-toggle {
-	width: 32px;
-	height: 32px;
-	border: 1px solid var(--line);
-	border-radius: 999px;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	color: var(--ink-2);
-	transition: all 0.15s var(--ease);
-}
-
-.theme-toggle:hover {
-	border-color: var(--ink-3);
-	color: var(--ink);
-	background: var(--bg-soft);
-}
-
-.theme-toggle svg {
-	width: 14px;
-	height: 14px;
-}
-
-.brand {
-	display: inline-flex;
-	align-items: center;
-	gap: 10px;
-	font-family: var(--f-serif);
-	font-size: 23px;
-	letter-spacing: -0.01em;
-}
-
-.brand-mark {
-	width: 22px;
-	height: 22px;
-	display: grid;
-	grid-template-rows: repeat(4, 1fr);
-	gap: 2px;
-}
-
-.brand-mark span {
-	background: var(--ink);
-	border-radius: 1px;
-}
-
-.brand-mark span:nth-child(1) {
-	opacity: 0.3;
-}
-
-.brand-mark span:nth-child(2) {
-	opacity: 0.55;
-}
-
-.brand-mark span:nth-child(3) {
-	opacity: 0.8;
-}
-
-.brand-mark span:nth-child(4) {
-	background: var(--accent);
-	opacity: 1;
 }
 
 /* Two-column shell */
@@ -1053,69 +781,6 @@ html.dark .article :deep(.next-step .arrow) {
 	text-align: right;
 }
 
-/* Footer (mirrors landing's footer shape) */
-.bedrock-foot {
-	padding: 72px 0 48px;
-	background: var(--bg-soft);
-	border-top: 1px solid var(--line);
-}
-
-.foot {
-	display: grid;
-	grid-template-columns: 1.4fr 1fr 1fr 1fr;
-	gap: 48px;
-	margin-bottom: 56px;
-}
-
-.foot h5 {
-	font-family: var(--f-mono);
-	font-size: 11px;
-	font-weight: 500;
-	letter-spacing: 0.14em;
-	text-transform: uppercase;
-	color: var(--ink-3);
-	margin: 0 0 16px;
-}
-
-.foot ul {
-	list-style: none;
-	padding: 0;
-	margin: 0;
-}
-
-.foot li {
-	margin-bottom: 10px;
-}
-
-.foot a {
-	font-size: 14px;
-	color: var(--ink-2);
-	transition: color 0.15s var(--ease);
-}
-
-.foot a:hover {
-	color: var(--ink);
-}
-
-.foot-brand p {
-	font-size: 14px;
-	color: var(--ink-3);
-	max-width: 34ch;
-	margin: 14px 0 0;
-	line-height: 1.55;
-}
-
-.foot-bottom {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	padding-top: 28px;
-	border-top: 1px solid var(--line);
-	font-size: 12px;
-	color: var(--ink-4);
-	font-family: var(--f-mono);
-}
-
 /* Responsive */
 @media (max-width: 1100px) {
 	.shell {
@@ -1142,11 +807,6 @@ html.dark .article :deep(.next-step .arrow) {
 		border-bottom: 1px solid var(--line);
 	}
 
-	.nav-links,
-	.nav-search {
-		display: none;
-	}
-
 	.article :deep(h1) {
 		font-size: 52px;
 	}
@@ -1157,11 +817,6 @@ html.dark .article :deep(.next-step .arrow) {
 
 	.article :deep(.next-steps) {
 		grid-template-columns: 1fr;
-	}
-
-	.foot {
-		grid-template-columns: 1fr 1fr;
-		gap: 24px;
 	}
 }
 </style>

--- a/apps/website/.vitepress/theme/home-introduction.vue
+++ b/apps/website/.vitepress/theme/home-introduction.vue
@@ -1,0 +1,1167 @@
+<script setup lang="ts">
+import type { DefaultTheme } from "vitepress";
+import { Content, useData, useRoute, withBase } from "vitepress";
+import { computed } from "vue";
+
+import { version as bedrockVersion } from "@bedrock-rbx/core/package.json";
+
+type SidebarGroup = DefaultTheme.SidebarItem;
+type SidebarLink = DefaultTheme.SidebarItem;
+
+const VERSION = `v${bedrockVersion}`;
+
+const { isDark, theme } = useData();
+const route = useRoute();
+
+const sidebar = computed<ReadonlyArray<SidebarGroup>>(() => {
+	const config = theme.value.sidebar;
+	if (config === undefined) {
+		return [];
+	}
+
+	if (Array.isArray(config)) {
+		return config;
+	}
+
+	const path = route.path;
+	let best: ReadonlyArray<SidebarGroup> = [];
+	let bestLength = 0;
+	for (const [prefix, items] of Object.entries(config)) {
+		if (!path.startsWith(prefix) || prefix.length <= bestLength) {
+			continue;
+		}
+
+		if (Array.isArray(items)) {
+			best = items;
+			bestLength = prefix.length;
+		}
+	}
+
+	return best;
+});
+
+function normalizePath(path: string): string {
+	return path.replace(/\/$/u, "").toLowerCase();
+}
+
+const currentPath = computed(() => normalizePath(route.path));
+
+function isLinkActive(link: string | undefined): boolean {
+	if (link === undefined) {
+		return false;
+	}
+
+	return normalizePath(link) === currentPath.value;
+}
+
+function isSectionCurrent(item: SidebarLink): boolean {
+	if (isLinkActive(item.link)) {
+		return true;
+	}
+
+	const children = item.items ?? [];
+	return children.some((child) => isLinkActive(child.link));
+}
+
+function kindDot(link: string | undefined): "cls" | "const" | "fn" | "type" | undefined {
+	if (link === undefined) {
+		return undefined;
+	}
+
+	if (link.includes("/functions/")) {
+		return "fn";
+	}
+
+	if (link.includes("/classes/")) {
+		return "cls";
+	}
+
+	if (link.includes("/interfaces/") || link.includes("/type-aliases/")) {
+		return "type";
+	}
+
+	if (link.includes("/variables/")) {
+		return "const";
+	}
+
+	return undefined;
+}
+
+function toggleTheme(): void {
+	isDark.value = !isDark.value;
+}
+</script>
+
+<template>
+	<div class="bedrock-intro">
+		<nav class="bedrock-nav">
+			<div class="wrap inner">
+				<a class="brand" :href="withBase('/')">
+					<span class="brand-mark"> <span /><span /><span /><span /> </span>
+					Bedrock<span class="nav-v">{{ VERSION }}</span>
+				</a>
+				<div class="nav-links">
+					<a class="active" :href="withBase('/bedrock/introduction')">Docs</a>
+					<a :href="withBase('/bedrock/api/')">API</a>
+					<a href="#">CLI</a>
+					<a href="https://github.com/christopher-buss/bedrock/releases">Changelog</a>
+				</div>
+				<div class="nav-right">
+					<div class="nav-search" role="button" tabindex="0" aria-label="Search docs">
+						<svg viewBox="0 0 16 16" fill="none" aria-hidden="true">
+							<circle cx="7" cy="7" r="5" stroke="currentColor" stroke-width="1.4" />
+							<path
+								d="m11 11 3 3"
+								stroke="currentColor"
+								stroke-width="1.4"
+								stroke-linecap="round"
+							/>
+						</svg>
+						Search docs&hellip;
+						<span class="kbd">&#8984;K</span>
+					</div>
+					<button class="theme-toggle" aria-label="Toggle theme" @click="toggleTheme">
+						<svg
+							v-if="!isDark"
+							class="icon-moon"
+							viewBox="0 0 16 16"
+							fill="none"
+							aria-hidden="true"
+						>
+							<path
+								d="M13.5 9.5A5.5 5.5 0 0 1 6.5 2.5a5.5 5.5 0 1 0 7 7Z"
+								stroke="currentColor"
+								stroke-width="1.4"
+								stroke-linejoin="round"
+							/>
+						</svg>
+						<svg
+							v-else
+							class="icon-sun"
+							viewBox="0 0 16 16"
+							fill="none"
+							aria-hidden="true"
+						>
+							<circle cx="8" cy="8" r="3" stroke="currentColor" stroke-width="1.4" />
+							<path
+								d="M8 1.5v1.5M8 13v1.5M14.5 8H13M3 8H1.5M12.6 3.4l-1.1 1.1M4.5 11.5l-1.1 1.1M12.6 12.6l-1.1-1.1M4.5 4.5 3.4 3.4"
+								stroke="currentColor"
+								stroke-width="1.4"
+								stroke-linecap="round"
+							/>
+						</svg>
+					</button>
+					<a class="nav-cta" href="https://github.com/christopher-buss/bedrock">
+						GitHub
+						<svg
+							width="11"
+							height="11"
+							viewBox="0 0 12 12"
+							fill="none"
+							aria-hidden="true"
+						>
+							<path
+								d="M3 9L9 3M9 3H4M9 3V8"
+								stroke="currentColor"
+								stroke-width="1.5"
+								stroke-linecap="round"
+							/>
+						</svg>
+					</a>
+				</div>
+			</div>
+		</nav>
+
+		<div class="wrap shell">
+			<aside class="side" aria-label="Documentation navigation">
+				<div v-for="(group, gi) in sidebar" :key="gi" class="side-group">
+					<div v-if="group.text" class="side-title">{{ group.text }}</div>
+					<template v-for="(item, ii) in group.items ?? []" :key="ii">
+						<template v-if="(item.items ?? []).length > 0">
+							<a
+								v-if="item.link"
+								class="side-link side-section-current"
+								:class="{ active: isLinkActive(item.link) }"
+								:href="withBase(item.link)"
+							>
+								{{ item.text }}
+							</a>
+							<div v-else class="side-link side-section-current">
+								{{ item.text }}
+							</div>
+							<div class="side-sub">
+								<a
+									v-for="(child, ci) in item.items ?? []"
+									:key="ci"
+									class="side-link"
+									:class="{ active: isLinkActive(child.link) }"
+									:href="child.link ? withBase(child.link) : '#'"
+								>
+									<span
+										v-if="kindDot(child.link)"
+										class="dot"
+										:class="kindDot(child.link)"
+									/>
+									<span class="name-mono">{{ child.text }}</span>
+								</a>
+							</div>
+						</template>
+						<a
+							v-else
+							class="side-link"
+							:class="{
+								'active': isLinkActive(item.link),
+								'side-section-current':
+									!isLinkActive(item.link) && isSectionCurrent(item),
+							}"
+							:href="item.link ? withBase(item.link) : '#'"
+						>
+							{{ item.text }}
+						</a>
+					</template>
+				</div>
+			</aside>
+
+			<article class="article">
+				<Content />
+			</article>
+		</div>
+
+		<footer class="bedrock-foot">
+			<div class="wrap">
+				<div class="foot">
+					<div class="foot-brand">
+						<a class="brand" :href="withBase('/')">
+							<span class="brand-mark"> <span /><span /><span /><span /> </span>
+							Bedrock
+						</a>
+						<p>Infrastructure-as-Code for Roblox. Typed, Open Cloud only.</p>
+					</div>
+					<div>
+						<h5>Docs</h5>
+						<ul>
+							<li>
+								<a :href="withBase('/bedrock/introduction')">Introduction</a>
+							</li>
+							<li>
+								<a :href="withBase('/bedrock/guide/getting-started')"
+									>Getting started</a
+								>
+							</li>
+							<li><a :href="withBase('/bedrock/api/')">API reference</a></li>
+						</ul>
+					</div>
+					<div>
+						<h5>Ocale</h5>
+						<ul>
+							<li>
+								<a :href="withBase('/ocale/guide/getting-started')"
+									>Getting started</a
+								>
+							</li>
+							<li><a :href="withBase('/ocale/api/')">Resource clients</a></li>
+							<li><a :href="withBase('/ocale/guide/errors')">Error hierarchy</a></li>
+						</ul>
+					</div>
+					<div>
+						<h5>Project</h5>
+						<ul>
+							<li>
+								<a href="https://github.com/christopher-buss/bedrock">GitHub</a>
+							</li>
+							<li>
+								<a
+									href="https://github.com/christopher-buss/bedrock/tree/main/docs/adr"
+								>
+									ADRs
+								</a>
+							</li>
+							<li>
+								<a href="https://github.com/christopher-buss/bedrock/releases">
+									Changelog
+								</a>
+							</li>
+						</ul>
+					</div>
+				</div>
+				<div class="foot-bottom">
+					<div>&copy; 2026 &middot; MIT Licensed &middot; {{ VERSION }}</div>
+					<div>built with vitepress</div>
+				</div>
+			</div>
+		</footer>
+	</div>
+</template>
+
+<style scoped>
+.bedrock-intro {
+	--bg: #f4f6fa;
+	--bg-soft: #e9edf3;
+	--bg-card: #ffffff;
+	--bg-nav: rgba(244, 246, 250, 0.78);
+	--ink: #0e131a;
+	--ink-2: #2a3240;
+	--ink-3: #5a6472;
+	--ink-4: #8b95a4;
+	--line: #dde2eb;
+	--line-strong: #c4cbd6;
+
+	--dark-bg: #0c1018;
+	--dark-bg-2: #131826;
+	--dark-line: #232a3a;
+	--dark-ink: #eef1f7;
+	--dark-ink-2: #b9c1d0;
+	--dark-ink-3: #6f7889;
+
+	--accent: #5944a2;
+	--accent-soft: #a8bdd8;
+	--accent-deep: #324a6e;
+	--accent-bg: #e4ebf5;
+
+	--ok: #4a8a64;
+	--warn: #c89a3a;
+	--del: #b5523a;
+
+	--kind-fn: oklch(62% 0.115 235);
+	--kind-type: oklch(68% 0.105 75);
+	--kind-cls: oklch(58% 0.095 145);
+	--kind-const: oklch(60% 0.115 305);
+
+	--f-sans: "Geist", "Inter", system-ui, -apple-system, sans-serif;
+	--f-serif: "Source Serif 4", "Source Serif Pro", "Times New Roman", serif;
+	--f-mono: "JetBrains Mono", ui-monospace, Menlo, monospace;
+
+	--r-sm: 4px;
+	--r: 8px;
+	--r-lg: 14px;
+
+	--ease: cubic-bezier(0.2, 0.7, 0.2, 1);
+
+	min-height: 100vh;
+	background: var(--bg);
+	color: var(--ink);
+	font-family: var(--f-sans);
+	font-size: 15px;
+	line-height: 1.6;
+	-webkit-font-smoothing: antialiased;
+	text-rendering: optimizeLegibility;
+}
+
+html.dark .bedrock-intro {
+	--bg: #0d1119;
+	--bg-soft: #141a26;
+	--bg-card: #1a2030;
+	--bg-nav: rgba(13, 17, 25, 0.78);
+	--ink: #eef1f7;
+	--ink-2: #c1c8d4;
+	--ink-3: #828b9c;
+	--ink-4: #565e6e;
+	--line: #232a39;
+	--line-strong: #2f3849;
+	--accent-soft: #b8c9e0;
+	--accent-deep: #4e6c92;
+	--accent-bg: #1e2840;
+}
+
+.bedrock-intro,
+.bedrock-intro .bedrock-nav,
+.bedrock-intro .side,
+.bedrock-intro .article {
+	transition:
+		background-color 0.25s var(--ease),
+		border-color 0.25s var(--ease),
+		color 0.2s var(--ease);
+}
+
+.bedrock-intro a {
+	color: inherit;
+	text-decoration: none;
+}
+
+.bedrock-intro button {
+	font: inherit;
+	cursor: pointer;
+	border: 0;
+	background: none;
+	color: inherit;
+	padding: 0;
+}
+
+.bedrock-intro ::selection {
+	background: var(--accent);
+	color: #fff;
+}
+
+.wrap {
+	max-width: 1280px;
+	margin: 0 auto;
+	padding: 0 32px;
+}
+
+/* Nav (mirrors the landing's shape so navigating between feels seamless) */
+.bedrock-nav {
+	position: sticky;
+	top: 0;
+	z-index: 40;
+	backdrop-filter: blur(14px);
+	background: var(--bg-nav);
+	border-bottom: 1px solid var(--line);
+}
+
+.bedrock-nav .inner {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	height: 60px;
+	gap: 24px;
+}
+
+.nav-links {
+	display: flex;
+	gap: 28px;
+}
+
+.nav-links a {
+	font-size: 14px;
+	color: var(--ink-2);
+	transition: color 0.15s var(--ease);
+}
+
+.nav-links a:hover {
+	color: var(--ink);
+}
+
+.nav-links a.active {
+	color: var(--accent-deep);
+}
+
+html.dark .nav-links a.active {
+	color: var(--accent-soft);
+}
+
+.nav-right {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.nav-search {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 10px 6px 12px;
+	background: var(--bg-soft);
+	border: 1px solid var(--line);
+	border-radius: 8px;
+	font-size: 13px;
+	color: var(--ink-3);
+	min-width: 220px;
+	transition: all 0.15s var(--ease);
+	cursor: pointer;
+}
+
+.nav-search:hover {
+	border-color: var(--line-strong);
+	color: var(--ink-2);
+}
+
+.nav-search svg {
+	width: 13px;
+	height: 13px;
+	opacity: 0.7;
+}
+
+.nav-search .kbd {
+	margin-left: auto;
+	font-family: var(--f-mono);
+	font-size: 10.5px;
+	padding: 1px 5px;
+	border: 1px solid var(--line-strong);
+	border-radius: 3px;
+	color: var(--ink-4);
+	background: var(--bg);
+}
+
+.nav-cta {
+	font-size: 13px;
+	padding: 6px 12px 6px 14px;
+	border: 1px solid var(--line-strong);
+	border-radius: 999px;
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	transition: all 0.15s var(--ease);
+}
+
+.nav-cta:hover {
+	border-color: var(--ink);
+	background: var(--ink);
+	color: var(--bg);
+}
+
+.nav-v {
+	font-family: var(--f-mono);
+	font-size: 11px;
+	color: var(--ink-4);
+	padding: 2px 6px;
+	background: var(--bg-soft);
+	border-radius: 3px;
+	margin-left: 8px;
+}
+
+.theme-toggle {
+	width: 32px;
+	height: 32px;
+	border: 1px solid var(--line);
+	border-radius: 999px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--ink-2);
+	transition: all 0.15s var(--ease);
+}
+
+.theme-toggle:hover {
+	border-color: var(--ink-3);
+	color: var(--ink);
+	background: var(--bg-soft);
+}
+
+.theme-toggle svg {
+	width: 14px;
+	height: 14px;
+}
+
+.brand {
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	font-family: var(--f-serif);
+	font-size: 23px;
+	letter-spacing: -0.01em;
+}
+
+.brand-mark {
+	width: 22px;
+	height: 22px;
+	display: grid;
+	grid-template-rows: repeat(4, 1fr);
+	gap: 2px;
+}
+
+.brand-mark span {
+	background: var(--ink);
+	border-radius: 1px;
+}
+
+.brand-mark span:nth-child(1) {
+	opacity: 0.3;
+}
+
+.brand-mark span:nth-child(2) {
+	opacity: 0.55;
+}
+
+.brand-mark span:nth-child(3) {
+	opacity: 0.8;
+}
+
+.brand-mark span:nth-child(4) {
+	background: var(--accent);
+	opacity: 1;
+}
+
+/* Two-column shell */
+.shell {
+	display: grid;
+	grid-template-columns: 240px 1fr;
+	gap: 64px;
+	padding: 40px 32px 80px;
+}
+
+/* Sidebar */
+.side {
+	position: sticky;
+	top: 84px;
+	align-self: start;
+	max-height: calc(100vh - 100px);
+	overflow-y: auto;
+	padding-right: 8px;
+	padding-bottom: 32px;
+	font-size: 13.5px;
+}
+
+.side::-webkit-scrollbar {
+	width: 6px;
+}
+
+.side::-webkit-scrollbar-thumb {
+	background: var(--line);
+	border-radius: 3px;
+}
+
+.side-group {
+	margin-bottom: 22px;
+}
+
+.side-group:first-child {
+	margin-top: 4px;
+}
+
+.side-title {
+	font-family: var(--f-mono);
+	font-size: 10.5px;
+	font-weight: 500;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+	color: var(--ink-4);
+	margin-bottom: 8px;
+	padding-left: 10px;
+}
+
+.side-link {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 5px 10px;
+	border-radius: 5px;
+	color: var(--ink-2);
+	font-weight: 400;
+	line-height: 1.4;
+	transition: all 0.12s var(--ease);
+}
+
+.side-link:hover {
+	color: var(--ink);
+	background: var(--bg-soft);
+}
+
+.side-link.active {
+	color: var(--accent-deep);
+	background: var(--accent-bg);
+	font-weight: 500;
+}
+
+html.dark .side-link.active {
+	color: var(--accent-soft);
+}
+
+.side-section-current {
+	color: var(--ink);
+	font-weight: 500;
+}
+
+.side-sub {
+	padding-left: 10px;
+	margin-top: 2px;
+	border-left: 1px solid var(--line);
+	margin-left: 14px;
+}
+
+.side-sub .side-link {
+	font-size: 13px;
+	padding: 4px 12px;
+}
+
+.side-sub .name-mono {
+	font-family: var(--f-mono);
+	font-size: 12.5px;
+}
+
+.dot {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	flex-shrink: 0;
+}
+
+.dot.fn {
+	background: var(--kind-fn);
+}
+
+.dot.type {
+	background: var(--kind-type);
+}
+
+.dot.cls {
+	background: var(--kind-cls);
+}
+
+.dot.const {
+	background: var(--kind-const);
+}
+
+/* Article — base (shared with concept template) */
+.article {
+	min-width: 0;
+	max-width: 760px;
+	padding-bottom: 80px;
+}
+
+/* Editorial styles target markdown rendered by <Content /> — needs :deep */
+.article :deep(.intro-kicker) {
+	font-family: var(--f-mono);
+	font-size: 11px;
+	letter-spacing: 0.16em;
+	text-transform: uppercase;
+	color: var(--ink-4);
+	margin: 0 0 18px;
+	display: inline-flex;
+	align-items: center;
+	gap: 12px;
+}
+
+.article :deep(.intro-kicker::before) {
+	content: "";
+	width: 24px;
+	height: 1px;
+	background: currentColor;
+}
+
+.article :deep(.intro-kicker .v) {
+	padding: 2px 7px;
+	background: var(--bg-soft);
+	border: 1px solid var(--line);
+	border-radius: 3px;
+	color: var(--ink-3);
+	letter-spacing: 0.06em;
+}
+
+.article :deep(h1) {
+	font-family: var(--f-serif);
+	font-weight: 400;
+	font-size: 78px;
+	line-height: 0.95;
+	letter-spacing: -0.03em;
+	color: var(--ink);
+	max-width: 14ch;
+	margin: 0 0 16px;
+}
+
+.article :deep(h1 em) {
+	font-style: italic;
+	color: var(--accent-deep);
+}
+
+html.dark .article :deep(h1 em) {
+	color: var(--accent-soft);
+}
+
+.article :deep(.lede) {
+	font-family: var(--f-serif);
+	font-weight: 400;
+	font-size: 22px;
+	line-height: 1.45;
+	color: var(--ink-2);
+	max-width: 56ch;
+	margin: 0 0 56px;
+}
+
+.article :deep(h2) {
+	font-family: var(--f-serif);
+	font-weight: 400;
+	font-style: italic;
+	font-size: 38px;
+	line-height: 1.05;
+	letter-spacing: -0.015em;
+	color: var(--accent-deep);
+	margin: 64px 0 18px;
+	scroll-margin-top: 90px;
+}
+
+html.dark .article :deep(h2) {
+	color: var(--accent-soft);
+}
+
+.article :deep(h2 .num) {
+	font-family: var(--f-mono);
+	font-style: normal;
+	font-size: 12px;
+	color: var(--ink-4);
+	margin-right: 14px;
+	letter-spacing: 0.1em;
+	vertical-align: 8px;
+}
+
+.article :deep(h3) {
+	font-family: var(--f-sans);
+	font-weight: 600;
+	font-size: 16px;
+	letter-spacing: -0.005em;
+	margin: 28px 0 8px;
+	color: var(--ink);
+}
+
+.article :deep(p) {
+	font-size: 16.5px;
+	color: var(--ink-2);
+	line-height: 1.65;
+	max-width: 62ch;
+	margin: 0 0 14px;
+}
+
+.article :deep(p.dropcap::first-letter) {
+	font-family: var(--f-serif);
+	font-size: 64px;
+	line-height: 0.85;
+	float: left;
+	padding: 6px 12px 0 0;
+	color: var(--accent-deep);
+	font-style: italic;
+}
+
+html.dark .article :deep(p.dropcap::first-letter) {
+	color: var(--accent-soft);
+}
+
+.article :deep(p code),
+.article :deep(li code) {
+	font-size: 0.92em;
+	background: var(--bg-soft);
+	padding: 1px 6px;
+	border-radius: 4px;
+	color: var(--ink);
+	border: 1px solid var(--line);
+	font-family: var(--f-mono);
+}
+
+.article :deep(ul),
+.article :deep(ol) {
+	margin: 0 0 18px;
+	padding-left: 20px;
+	color: var(--ink-2);
+	max-width: 62ch;
+}
+
+.article :deep(li) {
+	margin-bottom: 6px;
+}
+
+.article :deep(a) {
+	color: var(--accent-deep);
+	border-bottom: 1px solid color-mix(in oklch, var(--accent) 40%, transparent);
+	transition: border-color 0.15s var(--ease);
+}
+
+.article :deep(a:hover) {
+	border-bottom-color: var(--accent);
+}
+
+html.dark .article :deep(a) {
+	color: var(--accent-soft);
+}
+
+/* Pull quote */
+.article :deep(.pull-quote) {
+	margin: 36px 0;
+	padding: 0 0 0 28px;
+	border-left: 2px solid var(--accent);
+	font-family: var(--f-serif);
+	font-style: italic;
+	font-size: 24px;
+	line-height: 1.35;
+	color: var(--ink-2);
+	max-width: 56ch;
+}
+
+.article :deep(.pull-quote cite) {
+	display: block;
+	margin-top: 12px;
+	font-family: var(--f-mono);
+	font-style: normal;
+	font-size: 11px;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	color: var(--ink-4);
+}
+
+/* Not-list — "what Bedrock isn't" */
+.article :deep(.not-list) {
+	list-style: none;
+	padding: 0;
+	margin: 0 0 18px;
+	max-width: 62ch;
+}
+
+.article :deep(.not-list li) {
+	display: grid;
+	grid-template-columns: 92px 1fr;
+	gap: 18px;
+	padding: 12px 0;
+	border-top: 1px dashed var(--line);
+	align-items: baseline;
+	font-size: 15.5px;
+	margin-bottom: 0;
+}
+
+.article :deep(.not-list li:last-child) {
+	border-bottom: 1px dashed var(--line);
+}
+
+.article :deep(.not-list li .x) {
+	font-family: var(--f-mono);
+	font-size: 11px;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	color: var(--del);
+	opacity: 0.9;
+}
+
+.article :deep(.not-list li .x::before) {
+	content: "\00d7 ";
+}
+
+.article :deep(.not-list li b) {
+	color: var(--ink);
+	font-weight: 500;
+}
+
+.article :deep(.not-list li .why) {
+	color: var(--ink-3);
+	font-family: var(--f-sans);
+}
+
+/* Next-steps card grid */
+.article :deep(.next-steps) {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 14px;
+	margin: 32px 0 0;
+}
+
+.article :deep(.next-step) {
+	display: block;
+	padding: 22px;
+	border: 1px solid var(--line);
+	border-radius: var(--r-lg);
+	background: var(--bg-card);
+	transition:
+		border-color 0.15s,
+		transform 0.15s var(--ease),
+		background 0.15s;
+}
+
+.article :deep(.next-step:hover) {
+	border-color: var(--line-strong);
+	transform: translateY(-2px);
+}
+
+.article :deep(.next-step .kicker) {
+	font-family: var(--f-mono);
+	font-size: 10.5px;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+	color: var(--ink-4);
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.article :deep(.next-step .kicker .num) {
+	width: 18px;
+	height: 18px;
+	border: 1px solid var(--line-strong);
+	border-radius: 50%;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 10px;
+	color: var(--ink-3);
+}
+
+.article :deep(.next-step h4) {
+	font-family: var(--f-serif);
+	font-weight: 400;
+	font-size: 26px;
+	margin: 12px 0 8px;
+	color: var(--ink);
+	line-height: 1.1;
+	letter-spacing: -0.01em;
+}
+
+.article :deep(.next-step p) {
+	margin: 0;
+	font-size: 13.5px;
+	color: var(--ink-3);
+	line-height: 1.5;
+	max-width: none;
+}
+
+.article :deep(.next-step .arrow) {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	margin-top: 16px;
+	font-family: var(--f-mono);
+	font-size: 11.5px;
+	color: var(--accent-deep);
+	letter-spacing: 0.06em;
+	transition: transform 0.15s var(--ease);
+	border-bottom: 0;
+}
+
+html.dark .article :deep(.next-step .arrow) {
+	color: var(--accent-soft);
+}
+
+.article :deep(.next-step:hover .arrow) {
+	transform: translateX(3px);
+}
+
+/* Doc footer (prev / next) */
+.article :deep(.doc-foot) {
+	margin-top: 56px;
+	padding-top: 24px;
+	border-top: 1px solid var(--line);
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	gap: 16px;
+}
+
+.article :deep(.doc-foot a) {
+	display: block;
+	padding: 16px 18px;
+	border: 1px solid var(--line);
+	border-radius: var(--r);
+	border-bottom: 1px solid var(--line);
+	transition:
+		border-color 0.15s,
+		transform 0.15s var(--ease);
+}
+
+.article :deep(.doc-foot a:hover) {
+	border-color: var(--line-strong);
+	transform: translateY(-1px);
+}
+
+.article :deep(.doc-foot a .dir) {
+	font-family: var(--f-mono);
+	font-size: 10.5px;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+	color: var(--ink-4);
+	margin-bottom: 6px;
+}
+
+.article :deep(.doc-foot a .label) {
+	font-size: 15px;
+	color: var(--ink);
+	font-weight: 500;
+}
+
+.article :deep(.doc-foot a.next) {
+	text-align: right;
+}
+
+/* Footer (mirrors landing's footer shape) */
+.bedrock-foot {
+	padding: 72px 0 48px;
+	background: var(--bg-soft);
+	border-top: 1px solid var(--line);
+}
+
+.foot {
+	display: grid;
+	grid-template-columns: 1.4fr 1fr 1fr 1fr;
+	gap: 48px;
+	margin-bottom: 56px;
+}
+
+.foot h5 {
+	font-family: var(--f-mono);
+	font-size: 11px;
+	font-weight: 500;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+	color: var(--ink-3);
+	margin: 0 0 16px;
+}
+
+.foot ul {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+}
+
+.foot li {
+	margin-bottom: 10px;
+}
+
+.foot a {
+	font-size: 14px;
+	color: var(--ink-2);
+	transition: color 0.15s var(--ease);
+}
+
+.foot a:hover {
+	color: var(--ink);
+}
+
+.foot-brand p {
+	font-size: 14px;
+	color: var(--ink-3);
+	max-width: 34ch;
+	margin: 14px 0 0;
+	line-height: 1.55;
+}
+
+.foot-bottom {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	padding-top: 28px;
+	border-top: 1px solid var(--line);
+	font-size: 12px;
+	color: var(--ink-4);
+	font-family: var(--f-mono);
+}
+
+/* Responsive */
+@media (max-width: 1100px) {
+	.shell {
+		grid-template-columns: 220px 1fr;
+		gap: 40px;
+	}
+}
+
+@media (max-width: 760px) {
+	.wrap {
+		padding: 0 20px;
+	}
+
+	.shell {
+		grid-template-columns: 1fr;
+		gap: 32px;
+		padding: 32px 20px 64px;
+	}
+
+	.side {
+		position: static;
+		max-height: none;
+		padding: 0 0 24px;
+		border-bottom: 1px solid var(--line);
+	}
+
+	.nav-links,
+	.nav-search {
+		display: none;
+	}
+
+	.article :deep(h1) {
+		font-size: 52px;
+	}
+
+	.article :deep(h2) {
+		font-size: 28px;
+	}
+
+	.article :deep(.next-steps) {
+		grid-template-columns: 1fr;
+	}
+
+	.foot {
+		grid-template-columns: 1fr 1fr;
+		gap: 24px;
+	}
+}
+</style>

--- a/apps/website/.vitepress/theme/home-introduction.vue
+++ b/apps/website/.vitepress/theme/home-introduction.vue
@@ -4,7 +4,7 @@ import { Content, useData, useRoute, withBase } from "vitepress";
 import { computed } from "vue";
 
 import BedrockFooter, { type BedrockFooterColumn } from "./components/bedrock-footer.vue";
-import BedrockNav, { type BedrockNavLink } from "./components/bedrock-nav.vue";
+import BedrockNav from "./components/bedrock-nav.vue";
 
 type SidebarGroup = DefaultTheme.SidebarItem;
 type SidebarLink = DefaultTheme.SidebarItem;
@@ -86,21 +86,6 @@ function kindDot(link: string | undefined): "cls" | "const" | "fn" | "type" | un
 	return undefined;
 }
 
-const navLinks = computed<ReadonlyArray<BedrockNavLink>>(() => [
-	{
-		active: currentPath.value.startsWith("/bedrock"),
-		href: withBase("/bedrock/introduction"),
-		text: "Docs",
-	},
-	{ href: withBase("/bedrock/api/"), text: "API" },
-	{ href: "#", text: "CLI" },
-	{
-		external: true,
-		href: "https://github.com/christopher-buss/bedrock/releases",
-		text: "Changelog",
-	},
-]);
-
 const footerColumns = computed<ReadonlyArray<BedrockFooterColumn>>(() => [
 	{
 		links: [
@@ -143,7 +128,7 @@ const footerColumns = computed<ReadonlyArray<BedrockFooterColumn>>(() => [
 
 <template>
 	<div class="bedrock-intro">
-		<BedrockNav :home-href="withBase('/')" :links="navLinks" show-search />
+		<BedrockNav :home-href="withBase('/')" show-search />
 
 		<div class="wrap shell">
 			<aside class="side" aria-label="Documentation navigation">

--- a/apps/website/.vitepress/theme/home-landing.vue
+++ b/apps/website/.vitepress/theme/home-landing.vue
@@ -4,7 +4,7 @@ import { onBeforeUnmount, ref } from "vue";
 import { version as bedrockVersion } from "@bedrock-rbx/core/package.json";
 
 import BedrockFooter, { type BedrockFooterColumn } from "./components/bedrock-footer.vue";
-import BedrockNav, { type BedrockNavLink } from "./components/bedrock-nav.vue";
+import BedrockNav from "./components/bedrock-nav.vue";
 
 import configHtml from "../../landing/examples/config.ts?highlighted";
 import deployHtml from "../../landing/examples/deploy.ts?highlighted";
@@ -22,13 +22,6 @@ const activeTab = ref<TabId>("config");
 const activeTerm = ref<TermId>("diff");
 const copyState = ref<"idle" | "copied">("idle");
 let copyResetTimer: ReturnType<typeof setTimeout> | undefined;
-
-const navLinks: ReadonlyArray<BedrockNavLink> = [
-	{ href: "#features", text: "Features" },
-	{ href: "#install", text: "Quickstart" },
-	{ href: "#ecosystem", text: "Ocale" },
-	{ href: "/bedrock/introduction", text: "Docs" },
-];
 
 const footerColumns: ReadonlyArray<BedrockFooterColumn> = [
 	{
@@ -155,7 +148,7 @@ function navigateTerminalTab(event: KeyboardEvent, fromId: TermId): void {
 
 <template>
 	<div class="bedrock-landing">
-		<BedrockNav :links="navLinks" />
+		<BedrockNav />
 
 		<div class="wrap hero-wrap">
 			<section class="hero">

--- a/apps/website/.vitepress/theme/home-landing.vue
+++ b/apps/website/.vitepress/theme/home-landing.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { onBeforeUnmount, ref } from "vue";
-import { useData } from "vitepress";
 
 import { version as bedrockVersion } from "@bedrock-rbx/core/package.json";
+
+import BedrockFooter, { type BedrockFooterColumn } from "./components/bedrock-footer.vue";
+import BedrockNav, { type BedrockNavLink } from "./components/bedrock-nav.vue";
 
 import configHtml from "../../landing/examples/config.ts?highlighted";
 import deployHtml from "../../landing/examples/deploy.ts?highlighted";
@@ -16,11 +18,62 @@ type TermId = "diff" | "deploy" | "migrate";
 const INSTALL_COMMAND = "pnpm add @bedrock-rbx/core";
 const COPIED_RESET_MS = 1200;
 
-const { isDark } = useData();
 const activeTab = ref<TabId>("config");
 const activeTerm = ref<TermId>("diff");
 const copyState = ref<"idle" | "copied">("idle");
 let copyResetTimer: ReturnType<typeof setTimeout> | undefined;
+
+const navLinks: ReadonlyArray<BedrockNavLink> = [
+	{ href: "#features", text: "Features" },
+	{ href: "#install", text: "Quickstart" },
+	{ href: "#ecosystem", text: "Ocale" },
+	{ href: "/bedrock/introduction", text: "Docs" },
+];
+
+const footerColumns: ReadonlyArray<BedrockFooterColumn> = [
+	{
+		links: [
+			{ href: "/bedrock/guide/getting-started", text: "Getting started" },
+			{ href: "#", text: "Configuration" },
+			{ href: "#", text: "CLI reference" },
+			{ href: "#", text: "Migration from Mantle" },
+		],
+		title: "Bedrock",
+	},
+	{
+		links: [
+			{ href: "/ocale/guide/getting-started", text: "Getting started" },
+			{ href: "/ocale/api/", text: "Resource clients" },
+			{ href: "/ocale/guide/errors", text: "Error hierarchy" },
+		],
+		title: "Ocale",
+	},
+	{
+		links: [
+			{
+				external: true,
+				href: "https://github.com/christopher-buss/bedrock",
+				text: "GitHub",
+			},
+			{
+				external: true,
+				href: "https://github.com/christopher-buss/bedrock/projects?query=is%3Aopen",
+				text: "Roadmap",
+			},
+			{
+				external: true,
+				href: "https://github.com/christopher-buss/bedrock/tree/main/docs/adr",
+				text: "ADRs",
+			},
+			{
+				external: true,
+				href: "https://github.com/christopher-buss/bedrock/releases",
+				text: "Changelog",
+			},
+		],
+		title: "Project",
+	},
+];
 
 async function copyInstall(): Promise<void> {
 	try {
@@ -98,58 +151,11 @@ function navigateTerminalTab(event: KeyboardEvent, fromId: TermId): void {
 	activeTerm.value = nextId;
 	focusTabButton("term", nextId);
 }
-
-function toggleTheme(): void {
-	isDark.value = !isDark.value;
-}
 </script>
 
 <template>
 	<div class="bedrock-landing">
-		<nav class="bedrock-nav">
-			<div class="wrap inner">
-				<a class="brand" href="#">
-					<span class="brand-mark"> <span /><span /><span /><span /> </span>
-					Bedrock<span class="nav-v">{{ VERSION }}</span>
-				</a>
-				<div class="nav-links">
-					<a href="#features">Features</a>
-					<a href="#install">Quickstart</a>
-					<a href="#ecosystem">Ocale</a>
-					<a href="/bedrock/guide/getting-started">Docs</a>
-				</div>
-				<button class="theme-toggle" aria-label="Toggle theme" @click="toggleTheme">
-					<svg v-if="!isDark" class="icon-moon" viewBox="0 0 16 16" fill="none">
-						<path
-							d="M13.5 9.5A5.5 5.5 0 0 1 6.5 2.5a5.5 5.5 0 1 0 7 7Z"
-							stroke="currentColor"
-							stroke-width="1.4"
-							stroke-linejoin="round"
-						/>
-					</svg>
-					<svg v-else class="icon-sun" viewBox="0 0 16 16" fill="none">
-						<circle cx="8" cy="8" r="3" stroke="currentColor" stroke-width="1.4" />
-						<path
-							d="M8 1.5v1.5M8 13v1.5M14.5 8H13M3 8H1.5M12.6 3.4l-1.1 1.1M4.5 11.5l-1.1 1.1M12.6 12.6l-1.1-1.1M4.5 4.5 3.4 3.4"
-							stroke="currentColor"
-							stroke-width="1.4"
-							stroke-linecap="round"
-						/>
-					</svg>
-				</button>
-				<a class="nav-cta" href="https://github.com/christopher-buss/bedrock">
-					GitHub
-					<svg width="11" height="11" viewBox="0 0 12 12" fill="none">
-						<path
-							d="M3 9L9 3M9 3H4M9 3V8"
-							stroke="currentColor"
-							stroke-width="1.5"
-							stroke-linecap="round"
-						/>
-					</svg>
-				</a>
-			</div>
-		</nav>
+		<BedrockNav :links="navLinks" />
 
 		<div class="wrap hero-wrap">
 			<section class="hero">
@@ -185,7 +191,7 @@ function toggleTheme(): void {
 									/>
 								</svg>
 							</a>
-							<a class="btn btn-ghost-dark" href="/bedrock/guide/getting-started">
+							<a class="btn btn-ghost-dark" href="/bedrock/introduction">
 								Read the docs
 							</a>
 						</div>
@@ -668,65 +674,7 @@ function toggleTheme(): void {
 			</div>
 		</section>
 
-		<footer class="bedrock-foot">
-			<div class="wrap">
-				<div class="foot">
-					<div class="foot-brand">
-						<a class="brand" href="/">
-							<span class="brand-mark"> <span /><span /><span /><span /> </span>
-							Bedrock
-						</a>
-						<p>Infrastructure-as-Code for Roblox. Typed, Open Cloud only.</p>
-					</div>
-					<div>
-						<h5>Bedrock</h5>
-						<ul>
-							<li><a href="/bedrock/guide/getting-started">Getting started</a></li>
-							<li><a href="#">Configuration</a></li>
-							<li><a href="#">CLI reference</a></li>
-							<li><a href="#">Migration from Mantle</a></li>
-						</ul>
-					</div>
-					<div>
-						<h5>Ocale</h5>
-						<ul>
-							<li><a href="/ocale/guide/getting-started">Getting started</a></li>
-							<li><a href="/ocale/api/">Resource clients</a></li>
-							<li><a href="/ocale/guide/errors">Error hierarchy</a></li>
-						</ul>
-					</div>
-					<div>
-						<h5>Project</h5>
-						<ul>
-							<li>
-								<a href="https://github.com/christopher-buss/bedrock">GitHub</a>
-							</li>
-							<li>
-								<a
-									href="https://github.com/christopher-buss/bedrock/projects?query=is%3Aopen"
-									>Roadmap</a
-								>
-							</li>
-							<li>
-								<a
-									href="https://github.com/christopher-buss/bedrock/tree/main/docs/adr"
-									>ADRs</a
-								>
-							</li>
-							<li>
-								<a href="https://github.com/christopher-buss/bedrock/releases"
-									>Changelog</a
-								>
-							</li>
-						</ul>
-					</div>
-				</div>
-				<div class="foot-bottom">
-					<div>&copy; 2026 &middot; MIT Licensed &middot; {{ VERSION }}</div>
-					<div>built with vitepress</div>
-				</div>
-			</div>
-		</footer>
+		<BedrockFooter :columns="footerColumns" />
 	</div>
 </template>
 
@@ -804,7 +752,6 @@ html.dark .bedrock-landing {
 }
 
 .bedrock-landing,
-.bedrock-landing .bedrock-nav,
 .bedrock-landing .hero {
 	transition:
 		background-color 0.25s var(--ease),
@@ -839,127 +786,6 @@ html.dark .bedrock-landing {
 	max-width: 1200px;
 	margin: 0 auto;
 	padding: 0 32px;
-}
-
-.bedrock-nav {
-	position: sticky;
-	top: 0;
-	z-index: 40;
-	backdrop-filter: blur(14px);
-	background: var(--bg-nav);
-	border-bottom: 1px solid var(--line);
-}
-
-.bedrock-nav .inner {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	height: 60px;
-}
-
-.nav-links {
-	display: flex;
-	gap: 28px;
-}
-
-.nav-links a {
-	font-size: 14px;
-	color: var(--ink-2);
-	transition: color 0.15s var(--ease);
-}
-
-.nav-links a:hover {
-	color: var(--ink);
-}
-
-.nav-cta {
-	font-size: 13px;
-	padding: 6px 12px 6px 14px;
-	border: 1px solid var(--line-strong);
-	border-radius: 999px;
-	display: inline-flex;
-	align-items: center;
-	gap: 6px;
-	transition: all 0.15s var(--ease);
-}
-
-.nav-cta:hover {
-	border-color: var(--ink);
-	background: var(--ink);
-	color: var(--bg);
-}
-
-.nav-v {
-	font-family: var(--f-mono);
-	font-size: 11px;
-	color: var(--ink-4);
-	padding: 2px 6px;
-	background: var(--bg-soft);
-	border-radius: 3px;
-	margin-left: 8px;
-}
-
-.theme-toggle {
-	width: 32px;
-	height: 32px;
-	border: 1px solid var(--line);
-	border-radius: 999px;
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	color: var(--ink-2);
-	transition: all 0.15s var(--ease);
-	margin-right: 6px;
-}
-
-.theme-toggle:hover {
-	border-color: var(--ink-3);
-	color: var(--ink);
-	background: var(--bg-soft);
-}
-
-.theme-toggle svg {
-	width: 14px;
-	height: 14px;
-}
-
-.brand {
-	display: inline-flex;
-	align-items: center;
-	gap: 10px;
-	font-family: var(--f-serif);
-	font-size: 23px;
-	letter-spacing: -0.01em;
-}
-
-.brand-mark {
-	width: 22px;
-	height: 22px;
-	display: grid;
-	grid-template-rows: repeat(4, 1fr);
-	gap: 2px;
-}
-
-.brand-mark span {
-	background: var(--ink);
-	border-radius: 1px;
-}
-
-.brand-mark span:nth-child(1) {
-	opacity: 0.3;
-}
-
-.brand-mark span:nth-child(2) {
-	opacity: 0.55;
-}
-
-.brand-mark span:nth-child(3) {
-	opacity: 0.8;
-}
-
-.brand-mark span:nth-child(4) {
-	background: var(--accent);
-	opacity: 1;
 }
 
 /* Eyebrow */
@@ -2126,77 +1952,13 @@ html.dark .bedrock-landing {
 	cursor: default;
 }
 
-/* Footer */
-.bedrock-foot {
-	padding: 72px 0 48px;
-	background: var(--bg-soft);
-	border-top: 1px solid var(--line);
-}
-
-.foot {
-	display: grid;
-	grid-template-columns: 1.4fr 1fr 1fr 1fr;
-	gap: 48px;
-	margin-bottom: 56px;
-}
-
-.foot h5 {
-	font-family: var(--f-mono);
-	font-size: 11px;
-	font-weight: 500;
-	letter-spacing: 0.14em;
-	text-transform: uppercase;
-	color: var(--ink-3);
-	margin: 0 0 16px;
-}
-
-.foot ul {
-	list-style: none;
-	padding: 0;
-	margin: 0;
-}
-
-.foot li {
-	margin-bottom: 10px;
-}
-
-.foot a {
-	font-size: 14px;
-	color: var(--ink-2);
-	transition: color 0.15s var(--ease);
-}
-
-.foot a:hover {
-	color: var(--ink);
-}
-
-.foot-brand p {
-	font-size: 14px;
-	color: var(--ink-3);
-	max-width: 34ch;
-	margin: 14px 0 0;
-	line-height: 1.55;
-}
-
-.foot-bottom {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	padding-top: 28px;
-	border-top: 1px solid var(--line);
-	font-size: 12px;
-	color: var(--ink-4);
-	font-family: var(--f-mono);
-}
-
 /* Responsive */
 @media (max-width: 960px) {
 	.hero-inner,
 	.tracks-head,
 	.tracks-grid,
 	.eco-head,
-	.install-grid,
-	.foot {
+	.install-grid {
 		grid-template-columns: 1fr;
 		gap: 40px;
 	}
@@ -2208,10 +1970,6 @@ html.dark .bedrock-landing {
 
 	.feature-grid {
 		grid-template-columns: 1fr 1fr;
-	}
-
-	.nav-links {
-		display: none;
 	}
 
 	.eco-layer {

--- a/apps/website/.vitepress/theme/home-landing.vue
+++ b/apps/website/.vitepress/theme/home-landing.vue
@@ -4,7 +4,6 @@ import { onBeforeUnmount, ref } from "vue";
 import { version as bedrockVersion } from "@bedrock-rbx/core/package.json";
 
 import BedrockFooter, { type BedrockFooterColumn } from "./components/bedrock-footer.vue";
-import BedrockNav from "./components/bedrock-nav.vue";
 
 import configHtml from "../../landing/examples/config.ts?highlighted";
 import deployHtml from "../../landing/examples/deploy.ts?highlighted";
@@ -148,8 +147,6 @@ function navigateTerminalTab(event: KeyboardEvent, fromId: TermId): void {
 
 <template>
 	<div class="bedrock-landing">
-		<BedrockNav />
-
 		<div class="wrap hero-wrap">
 			<section class="hero">
 				<div class="strata" aria-hidden="true">
@@ -673,43 +670,6 @@ function navigateTerminalTab(event: KeyboardEvent, fromId: TermId): void {
 
 <style scoped>
 .bedrock-landing {
-	--bg: #f4f6fa;
-	--bg-soft: #e9edf3;
-	--bg-card: #ffffff;
-	--bg-nav: rgba(244, 246, 250, 0.78);
-	--ink: #0e131a;
-	--ink-2: #2a3240;
-	--ink-3: #5a6472;
-	--ink-4: #8b95a4;
-	--line: #dde2eb;
-	--line-strong: #c4cbd6;
-
-	--dark-bg: #0c1018;
-	--dark-bg-2: #131826;
-	--dark-bg-3: #1c2235;
-	--dark-line: #232a3a;
-	--dark-ink: #eef1f7;
-	--dark-ink-2: #b9c1d0;
-	--dark-ink-3: #6f7889;
-
-	--accent: #5944a2;
-	--accent-soft: #a8bdd8;
-	--accent-deep: #324a6e;
-	--accent-bg: #e4ebf5;
-	--accent-em: var(--accent-deep);
-
-	--ok: #4a8a64;
-
-	--f-sans: "Geist", "Inter", system-ui, -apple-system, sans-serif;
-	--f-serif: "Source Serif 4", "Times New Roman", serif;
-	--f-mono: "JetBrains Mono", ui-monospace, Menlo, monospace;
-
-	--r-sm: 4px;
-	--r: 8px;
-	--r-lg: 14px;
-
-	--ease: cubic-bezier(0.2, 0.7, 0.2, 1);
-
 	min-height: 100vh;
 	background: var(--bg);
 	color: var(--ink);
@@ -718,30 +678,6 @@ function navigateTerminalTab(event: KeyboardEvent, fromId: TermId): void {
 	line-height: 1.55;
 	-webkit-font-smoothing: antialiased;
 	text-rendering: optimizeLegibility;
-}
-
-html.dark .bedrock-landing {
-	--bg: #0d1119;
-	--bg-soft: #141a26;
-	--bg-card: #1a2030;
-	--bg-nav: rgba(13, 17, 25, 0.78);
-	--ink: #eef1f7;
-	--ink-2: #c1c8d4;
-	--ink-3: #828b9c;
-	--ink-4: #565e6e;
-	--line: #232a39;
-	--line-strong: #2f3849;
-
-	--dark-bg: #080b12;
-	--dark-bg-2: #0f1320;
-	--dark-bg-3: #161c2c;
-	--dark-line: #1e2434;
-
-	--accent: #5944a2;
-	--accent-soft: #b8c9e0;
-	--accent-deep: #4e6c92;
-	--accent-bg: #1e2840;
-	--accent-em: var(--accent-soft);
 }
 
 .bedrock-landing,

--- a/apps/website/.vitepress/theme/layout.vue
+++ b/apps/website/.vitepress/theme/layout.vue
@@ -1,16 +1,101 @@
 <script setup lang="ts">
 import DefaultTheme from "vitepress/theme";
-import { useData } from "vitepress";
+import { useData, withBase } from "vitepress";
+import { computed } from "vue";
 
+import BedrockNav from "./components/bedrock-nav.vue";
 import HomeIntroduction from "./home-introduction.vue";
 import HomeLanding from "./home-landing.vue";
 
 const { Layout: DefaultLayout } = DefaultTheme;
 const { frontmatter } = useData();
+
+const useBedrockShell = computed(
+	() => frontmatter.value.layout === "landing" || frontmatter.value.layout === "introduction",
+);
+
+const showSearch = computed(() => frontmatter.value.layout === "introduction");
 </script>
 
 <template>
-	<HomeLanding v-if="frontmatter.layout === 'landing'" />
-	<HomeIntroduction v-else-if="frontmatter.layout === 'introduction'" />
+	<div v-if="useBedrockShell" class="bedrock-shell">
+		<BedrockNav :home-href="withBase('/')" :show-search="showSearch" />
+		<HomeLanding v-if="frontmatter.layout === 'landing'" />
+		<HomeIntroduction v-else-if="frontmatter.layout === 'introduction'" />
+	</div>
 	<DefaultLayout v-else />
 </template>
+
+<style scoped>
+/* Design tokens for the shared Bedrock chrome. Lifted up from the per-layout
+   components so that the persistent BedrockNav can read them too, and so
+   tokens don't drift between the landing and introduction containers. */
+.bedrock-shell {
+	--bg: #f4f6fa;
+	--bg-soft: #e9edf3;
+	--bg-card: #ffffff;
+	--bg-nav: rgba(244, 246, 250, 0.78);
+	--ink: #0e131a;
+	--ink-2: #2a3240;
+	--ink-3: #5a6472;
+	--ink-4: #8b95a4;
+	--line: #dde2eb;
+	--line-strong: #c4cbd6;
+
+	--dark-bg: #0c1018;
+	--dark-bg-2: #131826;
+	--dark-bg-3: #1c2235;
+	--dark-line: #232a3a;
+	--dark-ink: #eef1f7;
+	--dark-ink-2: #b9c1d0;
+	--dark-ink-3: #6f7889;
+
+	--accent: #5944a2;
+	--accent-soft: #a8bdd8;
+	--accent-deep: #324a6e;
+	--accent-bg: #e4ebf5;
+	--accent-em: var(--accent-deep);
+
+	--ok: #4a8a64;
+	--warn: #c89a3a;
+	--del: #b5523a;
+
+	--kind-fn: oklch(62% 0.115 235);
+	--kind-type: oklch(68% 0.105 75);
+	--kind-cls: oklch(58% 0.095 145);
+	--kind-const: oklch(60% 0.115 305);
+
+	--f-sans: "Geist", "Inter", system-ui, -apple-system, sans-serif;
+	--f-serif: "Source Serif 4", "Source Serif Pro", "Times New Roman", serif;
+	--f-mono: "JetBrains Mono", ui-monospace, Menlo, monospace;
+
+	--r-sm: 4px;
+	--r: 8px;
+	--r-lg: 14px;
+
+	--ease: cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+html.dark .bedrock-shell {
+	--bg: #0d1119;
+	--bg-soft: #141a26;
+	--bg-card: #1a2030;
+	--bg-nav: rgba(13, 17, 25, 0.78);
+	--ink: #eef1f7;
+	--ink-2: #c1c8d4;
+	--ink-3: #828b9c;
+	--ink-4: #565e6e;
+	--line: #232a39;
+	--line-strong: #2f3849;
+
+	--dark-bg: #080b12;
+	--dark-bg-2: #0f1320;
+	--dark-bg-3: #161c2c;
+	--dark-line: #1e2434;
+
+	--accent-soft: #b8c9e0;
+	--accent-deep: #4e6c92;
+	--accent-bg: #1e2840;
+	--accent-em: var(--accent-soft);
+}
+</style>

--- a/apps/website/.vitepress/theme/layout.vue
+++ b/apps/website/.vitepress/theme/layout.vue
@@ -2,6 +2,7 @@
 import DefaultTheme from "vitepress/theme";
 import { useData } from "vitepress";
 
+import HomeIntroduction from "./home-introduction.vue";
 import HomeLanding from "./home-landing.vue";
 
 const { Layout: DefaultLayout } = DefaultTheme;
@@ -10,5 +11,6 @@ const { frontmatter } = useData();
 
 <template>
 	<HomeLanding v-if="frontmatter.layout === 'landing'" />
+	<HomeIntroduction v-else-if="frontmatter.layout === 'introduction'" />
 	<DefaultLayout v-else />
 </template>

--- a/apps/website/docs/bedrock/introduction.md
+++ b/apps/website/docs/bedrock/introduction.md
@@ -1,0 +1,117 @@
+---
+layout: introduction
+description: Bedrock turns the Roblox commerce surface into a single typed file in your repo.
+---
+
+<div class="intro-kicker">
+  Introduction
+  <span class="v">v0.1 · alpha</span>
+</div>
+
+# Your catalog,<br/>as _code_.
+
+<p class="lede">
+Bedrock turns the Roblox commerce surface (game passes, products, places, subscriptions) into a single typed file in your repo. Edit it, open a pull request, and let CI reconcile through Open Cloud. The next price change is a one-line diff, not a tab in Creator Hub.
+</p>
+
+## <span class="num">§ 01</span>The status quo
+
+<p class="dropcap">Today, the canonical place to manage a Roblox catalog is Creator Hub: click into the dashboard, edit a price, save, hope you remember to update the team. There's no diff, no review, no rollback. Pricing experiments mean three people coordinating in Slack; multi-place experiences mean five browser tabs open just to verify a launch.</p>
+
+This works fine for a solo developer with two passes. It does not survive contact with a team shipping live ops.
+
+<blockquote class="pull-quote">
+Your game's commerce surface should live in your repo, reviewed, diffed, deployed, not in a browser tab.
+<cite>Design goal</cite>
+</blockquote>
+
+## <span class="num">§ 02</span>What changes
+
+Bedrock turns the catalog into data. You write one TypeScript file that lists what you want to exist. Bedrock reads it, reads what's actually live on Roblox, and figures out the Open Cloud calls needed to make reality match. Change the file, run `apply`, and the changes ship. Roll back by reverting the commit.
+
+There is nothing Bedrock can do that you couldn't do by hand. The point is that doing it by hand doesn't compose with the rest of your engineering practice. This does.
+
+## <span class="num">§ 03</span>A 30-second taste
+
+Here is the whole interface, end to end. One file declares a single game pass; one CLI command reconciles it.
+
+```ts
+import { asResourceKey, defineConfig } from "@bedrock-rbx/core";
+
+export default defineConfig({
+	resources: [
+		{
+			key: asResourceKey("vip-pass"),
+			name: "VIP Pass",
+			kind: "gamePass",
+			price: 500,
+		},
+	],
+	state: { backend: "gist" },
+	universeId: "5182930447",
+});
+```
+
+```bash
+$ npx bedrock apply
+  ✓ created gamePass.vip-pass (id 184219204)
+```
+
+Resources are typed. Keys are branded so duplicates fail at compile time. Everything else is a thin layer over Open Cloud.
+
+## <span class="num">§ 04</span>What Bedrock is _not_
+
+<ul class="not-list">
+  <li>
+    <span class="x">not a plugin</span>
+    <span class="why"><b>It never touches your <code>.rbxl</code> file.</b> Bedrock manages metadata around your experience, not the experience itself.</span>
+  </li>
+  <li>
+    <span class="x">not a runtime SDK</span>
+    <span class="why"><b>It does not ship to your game server.</b> Bedrock runs in CI; your players never see it.</span>
+  </li>
+  <li>
+    <span class="x">not a billing platform</span>
+    <span class="why"><b>Roblox still owns the transaction.</b> Bedrock declares what you sell, Roblox handles the money.</span>
+  </li>
+  <li>
+    <span class="x">not a Luau library</span>
+    <span class="why"><b>Your config is TypeScript, in your tooling repo,</b> alongside CI scripts, lint rules, and the rest of your build chain.</span>
+  </li>
+</ul>
+
+## <span class="num">§ 05</span>Where to next
+
+Three doors, depending on what you want to do in the next ten minutes:
+
+<div class="next-steps">
+  <a class="next-step" href="/bedrock/guide/getting-started">
+    <div class="kicker"><span class="num">01</span>install</div>
+    <h4>Get the CLI</h4>
+    <p>One <code>npm install</code>, then <code>bedrock --version</code>. Five lines, no config.</p>
+    <span class="arrow">Installation →</span>
+  </a>
+  <a class="next-step" href="/bedrock/guide/getting-started">
+    <div class="kicker"><span class="num">02</span>do</div>
+    <h4>Ship a game pass</h4>
+    <p>A five-step recipe from zero to a live pass. Roughly four minutes if you've got a universe ID.</p>
+    <span class="arrow">Quickstart →</span>
+  </a>
+  <a class="next-step" href="/bedrock/api/">
+    <div class="kicker"><span class="num">03</span>understand</div>
+    <h4>Read the loop</h4>
+    <p>How <code>apply</code> reconciles desired, actual, and last-known state without erasing your colleague's hotfix.</p>
+    <span class="arrow">Concepts →</span>
+  </a>
+</div>
+
+<div class="doc-foot">
+  <a class="prev" href="#" style="opacity:0.45;pointer-events:none">
+    <div class="dir">— Start</div>
+    <div class="label">You are here</div>
+  </a>
+  <a class="next" href="/bedrock/guide/getting-started">
+    <div class="dir">Next →</div>
+    <div class="label">Getting Started</div>
+  </a>
+</div>

--- a/apps/website/docs/bedrock/introduction.md
+++ b/apps/website/docs/bedrock/introduction.md
@@ -8,81 +8,82 @@ description: Bedrock turns the Roblox commerce surface into a single typed file 
   <span class="v">v0.1 · alpha</span>
 </div>
 
-# Your catalog,<br/>as _code_.
+# What is<br/>as _Bedrock?_
 
 <p class="lede">
-Bedrock turns the Roblox commerce surface (game passes, products, places, subscriptions) into a single typed file in your repo. Edit it, open a pull request, and let CI reconcile through Open Cloud. The next price change is a one-line diff, not a tab in Creator Hub.
+Bedrock is an open-source CLI and programmatic tool for managing your game's resources, such as game passes, developer products, and places. It turns Roblox's commerce surface into a single file in your repo. Manage infrastructure and configuration with a unified workflow, alongside your code.
 </p>
 
-## <span class="num">§ 01</span>The status quo
+## <span class="num">§ 01</span>How it works
 
-<p class="dropcap">Today, the canonical place to manage a Roblox catalog is Creator Hub: click into the dashboard, edit a price, save, hope you remember to update the team. There's no diff, no review, no rollback. Pricing experiments mean three people coordinating in Slack; multi-place experiences mean five browser tabs open just to verify a launch.</p>
+<p class="dropcap">You can think of Bedrock as a single source of truth for your game's metadata. Rather than manually updating your game's description, passes, and other resources in the Creator Hub, you declare what you want in a config file. Then, when you run `bedrock deploy`, that declaration is automatically applied to your game on Roblox. This means that your game's metadata is version-controlled, reviewable, and deployable through your existing CI/CD pipelines, just like the rest of your code.
+</p>
 
-This works fine for a solo developer with two passes. It does not survive contact with a team shipping live ops.
+## <span class="num">§ 02</span>Supported resources
 
-<blockquote class="pull-quote">
-Your game's commerce surface should live in your repo, reviewed, diffed, deployed, not in a browser tab.
-<cite>Design goal</cite>
-</blockquote>
-
-## <span class="num">§ 02</span>What changes
-
-Bedrock turns the catalog into data. You write one TypeScript file that lists what you want to exist. Bedrock reads it, reads what's actually live on Roblox, and figures out the Open Cloud calls needed to make reality match. Change the file, run `apply`, and the changes ship. Roll back by reverting the commit.
-
-There is nothing Bedrock can do that you couldn't do by hand. The point is that doing it by hand doesn't compose with the rest of your engineering practice. This does.
-
-## <span class="num">§ 03</span>A 30-second taste
-
-Here is the whole interface, end to end. One file declares a single game pass; one CLI command reconciles it.
-
-```ts
-import { asResourceKey, defineConfig } from "@bedrock-rbx/core";
-
-export default defineConfig({
-	resources: [
-		{
-			key: asResourceKey("vip-pass"),
-			name: "VIP Pass",
-			kind: "gamePass",
-			price: 500,
-		},
-	],
-	state: { backend: "gist" },
-	universeId: "5182930447",
-});
-```
-
-```bash
-$ npx bedrock apply
-  ✓ created gamePass.vip-pass (id 184219204)
-```
-
-Resources are typed. Keys are branded so duplicates fail at compile time. Everything else is a thin layer over Open Cloud.
-
-## <span class="num">§ 04</span>What Bedrock is _not_
-
-<ul class="not-list">
+<ul class="resource-list">
   <li>
-    <span class="x">not a plugin</span>
-    <span class="why"><b>It never touches your <code>.rbxl</code> file.</b> Bedrock manages metadata around your experience, not the experience itself.</span>
+    <span class="kind"><code>gamePass</code></span>
+    <span class="desc">Name, price, description, icon</span>
   </li>
   <li>
-    <span class="x">not a runtime SDK</span>
-    <span class="why"><b>It does not ship to your game server.</b> Bedrock runs in CI; your players never see it.</span>
+    <span class="kind"><code>developerProduct</code></span>
+    <span class="desc">Name, price, description, icon, regional pricing</span>
   </li>
   <li>
-    <span class="x">not a billing platform</span>
-    <span class="why"><b>Roblox still owns the transaction.</b> Bedrock declares what you sell, Roblox handles the money.</span>
+    <span class="kind"><code>place</code></span>
+    <span class="desc">Place file (<code>.rbxl</code> / <code>.rbxlx</code>), display name, description</span>
   </li>
   <li>
-    <span class="x">not a Luau library</span>
-    <span class="why"><b>Your config is TypeScript, in your tooling repo,</b> alongside CI scripts, lint rules, and the rest of your build chain.</span>
+    <span class="kind"><code>universe</code></span>
+    <span class="desc">Display name, social links, platform flags, voice chat</span>
+  </li>
+  <li>
+    <span class="kind soon">assets</span>
+    <span class="desc">Textures, audio, models <span class="badge">coming soon</span></span>
   </li>
 </ul>
 
-## <span class="num">§ 05</span>Where to next
+## <span class="num">§ 03</span>The deploy pipeline
 
-Three doors, depending on what you want to do in the next ten minutes:
+The model becomes most useful when used as part of your CI/CD pipeline. 
+Assets and code are already in source control, so why not your game metadata? 
+
+Consider a seasonal event. A week before launch you commit the new game
+description and two new game passes to your config. The change goes through a
+normal pull request. On release day, all you have to do is merge a PR into your
+main branch, and bedrock will update any changed resources, as well as your
+place file. Never forget to manually update a description again, or accidentally
+leave a pass hidden because you forgot to flip it live.
+
+<blockquote class="pull-quote">
+Declare what should exist. Let CI make it true.
+<cite>Core idea</cite>
+</blockquote>
+
+This workflow allows you to keep your game's metadata in sync with your code and
+assets, and ensures that all changes are tracked and reviewable. It also makes
+it easier to roll back changes if something goes wrong, since you can simply
+revert the commit that introduced the change.
+
+## <span class="num">§ 04</span>What it works with
+
+Bedrock works best alongside a fully-managed [Rojo](https://rojo.space) project,
+where scripts, assets, and configuration all live on the filesystem. When you
+run `bedrock deploy`, Bedrock handles publishing your place file and reconciling
+your config in a single step - your game and its metadata always ship together.
+
+You can also use Bedrock without managing a place at all. Version-controlled
+game passes and products are useful on their own, and the reconcile loop works
+the same either way. This still gives you the benefits of a review process and
+version history for your metadata, even if you prefer to manage your place
+directly through Roblox.
+
+> **Coming soon:** a system for turning your state file into usable Luau
+> constants so that asset IDs, image IDs, and product IDs declared in config can
+> be referenced directly in your game code without hardcoding.
+
+## <span class="num">§ 05</span>Where to next
 
 <div class="next-steps">
   <a class="next-step" href="/bedrock/guide/getting-started">


### PR DESCRIPTION
## Summary

- Adds `/bedrock/introduction` rendered by a new editorial Vue layout (`home-introduction.vue`) selected via `layout: introduction` frontmatter. Consumes the existing `themeConfig.sidebar` so it sits alongside the auto-generated TypeDoc API tree.
- Replaces the per-page top nav with a single sticky row shared between landing and docs (`bedrock-nav.vue`). Items in the section you're not in fade by distance from a `Docs` bridge; an accent underline slides between active items via scroll-spy on the landing and longest-prefix route match on the docs.
- Moves Ocale into a separate right-cluster pill leading with a mini Bedrock brand mark (signals "sibling destination" rather than the `↗` external-link arrow used by the GitHub pill).
- Extracts shared `bedrock-nav.vue` + `bedrock-footer.vue` components so landing and docs share chrome without duplicating ~700 lines of CSS.

A11y / responsiveness baked in: `aria-current` on active links (`page` for route matches, `location` for scroll-spy matches), real `<button>` for the search trigger, visible `:focus-visible` outlines across every interactive control, `prefers-reduced-motion` fallback for the sliding underline, mobile (<760px) wraps the link row beneath the brand with horizontal scrolling.

Content for the introduction page is placeholder lifted from the design handoff and not finalised; I'll follow up with real copy.

## Test plan

- [ ] Landing renders with `Features Quickstart | Docs API CLI Changelog` and `Ocale` / `GitHub` pills on the right
- [ ] Scrolling the landing slides the active underline from `Features` to `Quickstart`
- [ ] Clicking `Docs` from the landing navigates to `/bedrock/introduction` and the underline locks onto `Docs`
- [ ] Introduction page renders the editorial layout (intro kicker, big serif H1 with italic em, § NN h2s, dropcap, pull-quote, not-list, next-steps cards)
- [ ] Sidebar on the docs page lists Bedrock + API REFERENCE groups pulled from VitePress config
- [ ] Dark mode renders correctly on both pages (toggle via theme button)
- [ ] Mobile <760px wraps the nav under the brand with horizontal-scrollable link row; underline still tracks the active item under row scroll
- [ ] Keyboard tab cycles nav items with a visible focus outline; phantom items get full opacity on focus
- [ ] `aria-current` present on the active link

🤖 Generated with [Claude Code](https://claude.com/claude-code)