### PR TITLE
fix(ocale): correct sorted-map parser against real-api drift

### DIFF
--- a/packages/open-cloud/scripts/apply-schema-patches.spec.ts
+++ b/packages/open-cloud/scripts/apply-schema-patches.spec.ts
@@ -16,6 +16,7 @@ describe(findObsoletePatchDescriptions, () => {
 			"ReadMemoryStoreQueueItemsResponse renames items→queueItems and readId→id",
 			"MemoryStoreQueueItem.ttl drops invalid format: duration",
 			"Cloud_ReadMemoryStoreQueueItems.invisibilityWindow drops invalid format: duration",
+			"ListMemoryStoreSortedMapItemsResponse renames memoryStoreSortedMapItems→items",
 		]);
 	});
 
@@ -29,7 +30,7 @@ describe(findObsoletePatchDescriptions, () => {
 
 		const text = readFileSync(VENDOR_SPEC_PATH, "utf8");
 
-		expect(findObsoletePatchDescriptions(text)).toHaveLength(5);
+		expect(findObsoletePatchDescriptions(text)).toHaveLength(6);
 	});
 
 	it("should not flag a patch when its pre-patch shape is present in the input", () => {

--- a/packages/open-cloud/scripts/apply-schema-patches.ts
+++ b/packages/open-cloud/scripts/apply-schema-patches.ts
@@ -59,6 +59,19 @@ const PATCHES: ReadonlyArray<Patch> = [
 		find: /("name": "invisibilityWindow",[\s\S]*?"example": "3s",\n {14}"type": "string")(,\n {14}"format": "duration")/,
 		replace: "$1",
 	},
+	{
+		// Real-API probe (2026-05) shows the list endpoint returns the items
+		// array under `items`, not `memoryStoreSortedMapItems` as the spec
+		// claims. Same class of drift as the queue rename above. Without
+		// this patch the parser reads the wrong key and silently drops
+		// every real item on a non-empty page.
+		appliedMarker:
+			'"ListMemoryStoreSortedMapItemsResponse": {\n        "type": "object",\n        "properties": {\n          "items":',
+		description:
+			"ListMemoryStoreSortedMapItemsResponse renames memoryStoreSortedMapItems→items",
+		find: /("ListMemoryStoreSortedMapItemsResponse": \{\n {8}"type": "object",\n {8}"properties": \{\n {10})"memoryStoreSortedMapItems":/,
+		replace: '$1"items":',
+	},
 ];
 
 /**

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.fixtures.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.fixtures.spec.ts
@@ -15,8 +15,8 @@ import { parseListResponse, parseSortedMapItemResponse } from "./parsers.ts";
 //  - Item ids with URL-reserved characters round-trip URL-encoded
 //    in `path`; the parser reads the decoded form from body.id.
 
-describe("memory-store sorted-map parsers against captured live-API responses", () => {
-	it("should parse a CREATE 200 with a URL-encoded item path", () => {
+describe(parseSortedMapItemResponse, () => {
+	it("should parse a captured CREATE 200 with a URL-encoded item path", () => {
 		expect.assertions(4);
 
 		const body = loadFixture("memory-store-sorted-maps", "create-response.json");
@@ -31,7 +31,7 @@ describe("memory-store sorted-map parsers against captured live-API responses", 
 		expect(result.data.value).toStrictEqual({ hello: "world" });
 	});
 
-	it("should parse a GET 200 whose path uses the plural memory-stores prefix", () => {
+	it("should parse a captured GET 200 whose path uses the plural memory-stores prefix", () => {
 		expect.assertions(4);
 
 		const body = loadFixture("memory-store-sorted-maps", "get-response.json");
@@ -45,8 +45,10 @@ describe("memory-store sorted-map parsers against captured live-API responses", 
 		expect(result.data.universeId).toBe("123");
 		expect(result.data.value).toStrictEqual({ hello: "world" });
 	});
+});
 
-	it("should parse a LIST 200 that uses the items field and a null nextPageToken", () => {
+describe(parseListResponse, () => {
+	it("should parse a captured LIST 200 that uses the items field and a null nextPageToken", () => {
 		expect.assertions(4);
 
 		const body = loadFixture("memory-store-sorted-maps", "list-response.json");

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.fixtures.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.fixtures.spec.ts
@@ -1,0 +1,63 @@
+import { loadFixture } from "#tests/conformance/_helpers";
+import { assert, describe, expect, it } from "vitest";
+
+import { parseListResponse, parseSortedMapItemResponse } from "./parsers.ts";
+
+// Captured against the live Open Cloud API at apis.roblox.com in
+// 2026-05; universeId scrubbed to 123 and itemId/mapId replaced with
+// neutral placeholders, otherwise the shape is verbatim. These
+// fixtures exercise three real-server quirks the SDK absorbs:
+//
+//  - CREATE/LIST emit singular `memory-store` paths; GET emits plural
+//    `memory-stores` (parser regex accepts both).
+//  - LIST returns the array under `items`, not `memoryStoreSortedMapItems`
+//    (apply-schema-patches renames the spec field).
+//  - Item ids with URL-reserved characters round-trip URL-encoded
+//    in `path`; the parser reads the decoded form from body.id.
+
+describe("memory-store sorted-map parsers against captured live-API responses", () => {
+	it("should parse a CREATE 200 with a URL-encoded item path", () => {
+		expect.assertions(4);
+
+		const body = loadFixture("memory-store-sorted-maps", "create-response.json");
+
+		const result = parseSortedMapItemResponse({ body, headers: {}, status: 200 });
+
+		assert(result.success);
+
+		expect(result.data.id).toBe("name::id");
+		expect(result.data.mapId).toBe("test-map");
+		expect(result.data.universeId).toBe("123");
+		expect(result.data.value).toStrictEqual({ hello: "world" });
+	});
+
+	it("should parse a GET 200 whose path uses the plural memory-stores prefix", () => {
+		expect.assertions(4);
+
+		const body = loadFixture("memory-store-sorted-maps", "get-response.json");
+
+		const result = parseSortedMapItemResponse({ body, headers: {}, status: 200 });
+
+		assert(result.success);
+
+		expect(result.data.id).toBe("name::id");
+		expect(result.data.mapId).toBe("test-map");
+		expect(result.data.universeId).toBe("123");
+		expect(result.data.value).toStrictEqual({ hello: "world" });
+	});
+
+	it("should parse a LIST 200 that uses the items field and a null nextPageToken", () => {
+		expect.assertions(4);
+
+		const body = loadFixture("memory-store-sorted-maps", "list-response.json");
+
+		const result = parseListResponse({ body, headers: {}, status: 200 });
+
+		assert(result.success);
+
+		expect(result.data.items).toHaveLength(1);
+		expect(result.data.items[0]?.id).toBe("name::id");
+		expect(result.data.items[0]?.value).toStrictEqual({ hello: "world" });
+		expect(result.data.nextPageToken).toBeUndefined();
+	});
+});

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.spec.ts
@@ -66,9 +66,11 @@ describe(parseListResponse, () => {
 			body: validListSortedMapItemsBody({
 				items: [
 					validSortedMapItemBody({
+						id: "first",
 						path: "cloud/v2/universes/1/memory-store/sorted-maps/m/items/first",
 					}),
 					validSortedMapItemBody({
+						id: "second",
 						numericSortKey: 7,
 						path: "cloud/v2/universes/1/memory-store/sorted-maps/m/items/second",
 						stringSortKey: undefined,
@@ -355,12 +357,13 @@ describe(parseSortedMapItemResponse, () => {
 	});
 
 	describe("id extraction", () => {
-		it("should extract universeId, mapId, and id from the resource path", () => {
+		it("should extract universeId and mapId from the resource path and id from the body", () => {
 			expect.assertions(3);
 
 			const result = parseSortedMapItemResponse(
 				okSortedMapItemResponse(
 					validSortedMapItemBody({
+						id: "400ffff0001",
 						path: "cloud/v2/universes/99999/memory-store/sorted-maps/some-map/items/400ffff0001",
 					}),
 				),
@@ -373,12 +376,30 @@ describe(parseSortedMapItemResponse, () => {
 			expect(result.data.id).toBe("400ffff0001");
 		});
 
+		it("should surface the body's id field decoded even when the path contains URL-encoded characters", () => {
+			expect.assertions(1);
+
+			const result = parseSortedMapItemResponse(
+				okSortedMapItemResponse(
+					validSortedMapItemBody({
+						id: "name::id",
+						path: "cloud/v2/universes/99999/memory-store/sorted-maps/m/items/name%3A%3Aid",
+					}),
+				),
+			);
+
+			assert(result.success);
+
+			expect(result.data.id).toBe("name::id");
+		});
+
 		it("should accept a path that uses the plural memory-stores prefix the GET endpoint emits", () => {
 			expect.assertions(3);
 
 			const result = parseSortedMapItemResponse(
 				okSortedMapItemResponse(
 					validSortedMapItemBody({
+						id: "400ffff0001",
 						path: "cloud/v2/universes/99999/memory-stores/sorted-maps/some-map/items/400ffff0001",
 					}),
 				),

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.spec.ts
@@ -373,6 +373,24 @@ describe(parseSortedMapItemResponse, () => {
 			expect(result.data.id).toBe("400ffff0001");
 		});
 
+		it("should accept a path that uses the plural memory-stores prefix the GET endpoint emits", () => {
+			expect.assertions(3);
+
+			const result = parseSortedMapItemResponse(
+				okSortedMapItemResponse(
+					validSortedMapItemBody({
+						path: "cloud/v2/universes/99999/memory-stores/sorted-maps/some-map/items/400ffff0001",
+					}),
+				),
+			);
+
+			assert(result.success);
+
+			expect(result.data.universeId).toBe("99999");
+			expect(result.data.mapId).toBe("some-map");
+			expect(result.data.id).toBe("400ffff0001");
+		});
+
 		it("should reject a path that does not match the sorted-map item pattern", () => {
 			expect.assertions(2);
 

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.spec.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.spec.ts
@@ -64,7 +64,7 @@ describe(parseListResponse, () => {
 
 		const result = parseListResponse({
 			body: validListSortedMapItemsBody({
-				memoryStoreSortedMapItems: [
+				items: [
 					validSortedMapItemBody({
 						path: "cloud/v2/universes/1/memory-store/sorted-maps/m/items/first",
 					}),
@@ -86,11 +86,11 @@ describe(parseListResponse, () => {
 		expect(result.data.items[1]?.sortKey).toStrictEqual({ kind: "numeric", value: 7 });
 	});
 
-	it("should accept an empty memoryStoreSortedMapItems array", () => {
+	it("should accept an empty items array", () => {
 		expect.assertions(1);
 
 		const result = parseListResponse({
-			body: validListSortedMapItemsBody({ memoryStoreSortedMapItems: [] }),
+			body: validListSortedMapItemsBody({ items: [] }),
 			headers: {},
 			status: 200,
 		});
@@ -100,7 +100,7 @@ describe(parseListResponse, () => {
 		expect(result.data.items).toStrictEqual([]);
 	});
 
-	it("should accept a response with memoryStoreSortedMapItems omitted", () => {
+	it("should accept a response with items omitted", () => {
 		expect.assertions(2);
 
 		const result = parseListResponse({
@@ -115,11 +115,11 @@ describe(parseListResponse, () => {
 		expect(result.data.nextPageToken).toBe("tok-1");
 	});
 
-	it("should accept a response with memoryStoreSortedMapItems explicitly null", () => {
+	it("should accept a response with items explicitly null", () => {
 		expect.assertions(2);
 
 		const body: Record<string, unknown> = {
-			memoryStoreSortedMapItems: JSON.parse("null"),
+			items: JSON.parse("null"),
 		};
 
 		const result = parseListResponse({ body, headers: {}, status: 200 });
@@ -145,11 +145,11 @@ describe(parseListResponse, () => {
 		expect(result.err.message).toBe("Malformed memory-store sorted-map list response");
 	});
 
-	it("should reject a body whose memoryStoreSortedMapItems is not an array", () => {
+	it("should reject a body whose items is not an array", () => {
 		expect.assertions(1);
 
 		const result = parseListResponse({
-			body: { ...validListSortedMapItemsBody(), memoryStoreSortedMapItems: "nope" },
+			body: { ...validListSortedMapItemsBody(), items: "nope" },
 			headers: {},
 			status: 200,
 		});
@@ -173,7 +173,7 @@ describe(parseListResponse, () => {
 		expect(result.err).toBeInstanceOf(ApiError);
 	});
 
-	it("should reject a body whose memoryStoreSortedMapItems contains a malformed entry", () => {
+	it("should reject a body whose items contains a malformed entry", () => {
 		expect.assertions(1);
 
 		const malformedItem: Record<string, unknown> = {
@@ -183,7 +183,7 @@ describe(parseListResponse, () => {
 		const result = parseListResponse({
 			body: {
 				...validListSortedMapItemsBody(),
-				memoryStoreSortedMapItems: [malformedItem],
+				items: [malformedItem],
 			},
 			headers: {},
 			status: 200,

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.ts
@@ -6,9 +6,6 @@ import type { Result } from "../../../types.ts";
 import type { ListSortedMapItemsResult, SortedMapItem, SortKey } from "./types.ts";
 import type { MemoryStoreSortedMapItemWire } from "./wire.ts";
 
-// The CREATE and LIST endpoints emit paths under singular `memory-store`,
-// while GET emits plural `memory-stores`. The regex tolerates both to
-// absorb that upstream inconsistency at the wire boundary.
 const PATH_PATTERN =
 	/^cloud\/v2\/universes\/(\d+)\/memory-stores?\/sorted-maps\/([^/]+)\/items\/([^/]+)$/;
 const MALFORMED_MESSAGE = "Malformed memory-store sorted-map item response";
@@ -117,17 +114,12 @@ function wireBodyToSortedMapItem(body: unknown): SortedMapItem | undefined {
 		return undefined;
 	}
 
-	// Validate path shape and extract the universe + map ids from it,
-	// but read the item id from `body.id` directly: item ids may contain
-	// characters that arrive URL-encoded inside `path` (e.g. `::` shows
-	// up as `%3A%3A`), and the body's top-level `id` field carries the
-	// decoded form the caller supplied.
+	// Item ids round-trip URL-encoded in `path` (e.g. `name::id` arrives
+	// as `name%3A%3Aid`), so the decoded id is read from `body.id` rather
+	// than the regex group.
 	const match = PATH_PATTERN.exec(body.path);
-	if (match === null) {
-		return undefined;
-	}
-
-	const [, universeId, mapId] = match;
+	const universeId = match?.[1];
+	const mapId = match?.[2];
 	if (universeId === undefined || mapId === undefined) {
 		return undefined;
 	}

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.ts
@@ -6,8 +6,11 @@ import type { Result } from "../../../types.ts";
 import type { ListSortedMapItemsResult, SortedMapItem, SortKey } from "./types.ts";
 import type { MemoryStoreSortedMapItemWire } from "./wire.ts";
 
+// The CREATE and LIST endpoints emit paths under singular `memory-store`,
+// while GET emits plural `memory-stores`. The regex tolerates both to
+// absorb that upstream inconsistency at the wire boundary.
 const PATH_PATTERN =
-	/^cloud\/v2\/universes\/(\d+)\/memory-store\/sorted-maps\/([^/]+)\/items\/([^/]+)$/;
+	/^cloud\/v2\/universes\/(\d+)\/memory-stores?\/sorted-maps\/([^/]+)\/items\/([^/]+)$/;
 const MALFORMED_MESSAGE = "Malformed memory-store sorted-map item response";
 const MALFORMED_LIST_MESSAGE = "Malformed memory-store sorted-map list response";
 

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.ts
@@ -117,11 +117,18 @@ function wireBodyToSortedMapItem(body: unknown): SortedMapItem | undefined {
 		return undefined;
 	}
 
+	// Validate path shape and extract the universe + map ids from it,
+	// but read the item id from `body.id` directly: item ids may contain
+	// characters that arrive URL-encoded inside `path` (e.g. `::` shows
+	// up as `%3A%3A`), and the body's top-level `id` field carries the
+	// decoded form the caller supplied.
 	const match = PATH_PATTERN.exec(body.path);
-	const universeId = match?.[1];
-	const mapId = match?.[2];
-	const id = match?.[3];
-	if (universeId === undefined || mapId === undefined || id === undefined) {
+	if (match === null) {
+		return undefined;
+	}
+
+	const [, universeId, mapId] = match;
+	if (universeId === undefined || mapId === undefined) {
 		return undefined;
 	}
 
@@ -131,7 +138,7 @@ function wireBodyToSortedMapItem(body: unknown): SortedMapItem | undefined {
 	}
 
 	return {
-		id,
+		id: body.id,
 		etag: body.etag,
 		expiresAt: new Date(body.expireTime),
 		mapId,

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/parsers.ts
@@ -34,10 +34,9 @@ export function parseSortedMapItemResponse(
 /**
  * Parses a successful `Cloud_ListMemoryStoreSortedMapItems` response
  * body into the public {@link ListSortedMapItemsResult} shape. Each
- * item in the `memoryStoreSortedMapItems` array is validated through
- * the same path-and-shape checks as
- * {@link parseSortedMapItemResponse}; a malformed entry rejects the
- * whole response.
+ * item in the `items` array is validated through the same
+ * path-and-shape checks as {@link parseSortedMapItemResponse}; a
+ * malformed entry rejects the whole response.
  *
  * @param response - The full {@link HttpResponse} from the Open Cloud API.
  * @returns A success result wrapping the parsed
@@ -52,12 +51,8 @@ export function parseListResponse(
 		return malformedList(statusCode);
 	}
 
-	const { memoryStoreSortedMapItems, nextPageToken } = body;
-	if (
-		memoryStoreSortedMapItems !== undefined &&
-		memoryStoreSortedMapItems !== null &&
-		!Array.isArray(memoryStoreSortedMapItems)
-	) {
+	const { items: rawItemsField, nextPageToken } = body;
+	if (rawItemsField !== undefined && rawItemsField !== null && !Array.isArray(rawItemsField)) {
 		return malformedList(statusCode);
 	}
 
@@ -66,7 +61,7 @@ export function parseListResponse(
 		return malformedList(statusCode);
 	}
 
-	const rawItems = memoryStoreSortedMapItems ?? [];
+	const rawItems = rawItemsField ?? [];
 	const items = rawItems.map(wireBodyToSortedMapItem);
 	if (!items.every(isSortedMapItem)) {
 		return malformedList(statusCode);

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/wire.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/wire.ts
@@ -22,8 +22,11 @@ export interface MemoryStoreSortedMapItemWire {
 	/** Numeric sort key. Mutually exclusive with `stringSortKey`. */
 	readonly numericSortKey?: number | undefined;
 	/**
-	 * Resource path:
-	 * `cloud/v2/universes/{u}/memory-store/sorted-maps/{m}/items/{i}`.
+	 * Resource path. CREATE and LIST emit the singular form
+	 * (`cloud/v2/universes/{u}/memory-store/sorted-maps/{m}/items/{i}`);
+	 * GET emits the plural form (`.../memory-stores/sorted-maps/...`).
+	 * The parser accepts both. Item ids with URL-reserved characters
+	 * arrive URL-encoded here; the decoded form is on `id`.
 	 */
 	readonly path: string;
 	/** Lexicographic sort key. Mutually exclusive with `numericSortKey`. */

--- a/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/wire.ts
+++ b/packages/open-cloud/src/domains/cloud-v2/memory-store-sorted-maps/wire.ts
@@ -34,13 +34,18 @@ export interface MemoryStoreSortedMapItemWire {
 
 /**
  * Wire shape of the `Cloud_ListMemoryStoreSortedMapItems` response.
- * The server emits the items array under `memoryStoreSortedMapItems`
- * and an optional `nextPageToken` when more items are available.
+ * The server emits the items array under `items` and an optional
+ * `nextPageToken` when more items are available.
  *
  * Both fields are optional per the OpenAPI spec
  * (`ListMemoryStoreSortedMapItemsResponse` has no `required` array);
- * empty maps come back with `memoryStoreSortedMapItems` omitted or
- * JSON `null`. The parser normalizes both forms to `items: []`.
+ * empty maps come back with `items` omitted or JSON `null`. The
+ * parser normalizes both forms to `items: []`.
+ *
+ * The upstream schema names this field `memoryStoreSortedMapItems`
+ * (see `scripts/apply-schema-patches.ts`), but a real-API probe in
+ * 2026-05 confirmed the wire shape is `items`. The vendored spec is
+ * patched to match the server.
  */
 export interface ListSortedMapItemsResponseWire {
 	/**
@@ -48,7 +53,7 @@ export interface ListSortedMapItemsResponseWire {
 	 * Omitted or JSON `null` on an empty page; the parser normalizes
 	 * both to an empty array.
 	 */
-	readonly memoryStoreSortedMapItems?: ReadonlyArray<MemoryStoreSortedMapItemWire> | undefined;
+	readonly items?: ReadonlyArray<MemoryStoreSortedMapItemWire> | undefined;
 	/**
 	 * Page token for the next call, or `undefined` when no more pages
 	 * exist. JSON `null` is accepted on the wire and normalized to

--- a/packages/open-cloud/tests/conformance/list-response-optionality.spec.ts
+++ b/packages/open-cloud/tests/conformance/list-response-optionality.spec.ts
@@ -35,7 +35,7 @@ interface ListParserPin {
 const PINS: ReadonlyArray<ListParserPin> = [
 	{
 		name: "parseListResponse (memory-store sorted-maps)",
-		acceptsMissingOrNull: ["memoryStoreSortedMapItems", "nextPageToken"],
+		acceptsMissingOrNull: ["items", "nextPageToken"],
 		parse: (body) => parseSortedMapListResponse({ body, headers: {}, status: 200 }),
 		schemaName: "ListMemoryStoreSortedMapItemsResponse",
 		stricterThanSpec: {},

--- a/packages/open-cloud/tests/fixtures/memory-store-sorted-maps/create-response.json
+++ b/packages/open-cloud/tests/fixtures/memory-store-sorted-maps/create-response.json
@@ -1,0 +1,8 @@
+{
+	"path": "cloud/v2/universes/123/memory-store/sorted-maps/test-map/items/name%3A%3Aid",
+	"value": { "hello": "world" },
+	"etag": "1",
+	"expireTime": "2026-05-13T02:48:08Z",
+	"id": "name::id",
+	"numericSortKey": null
+}

--- a/packages/open-cloud/tests/fixtures/memory-store-sorted-maps/get-response.json
+++ b/packages/open-cloud/tests/fixtures/memory-store-sorted-maps/get-response.json
@@ -1,0 +1,8 @@
+{
+	"path": "cloud/v2/universes/123/memory-stores/sorted-maps/test-map/items/name%3A%3Aid",
+	"value": { "hello": "world" },
+	"etag": "1",
+	"expireTime": "2026-05-13T02:48:08Z",
+	"id": "name::id",
+	"numericSortKey": null
+}

--- a/packages/open-cloud/tests/fixtures/memory-store-sorted-maps/list-response.json
+++ b/packages/open-cloud/tests/fixtures/memory-store-sorted-maps/list-response.json
@@ -1,0 +1,13 @@
+{
+	"items": [
+		{
+			"path": "cloud/v2/universes/123/memory-store/sorted-maps/test-map/items/name%3A%3Aid",
+			"value": { "hello": "world" },
+			"etag": "1",
+			"expireTime": "2026-05-13T02:48:08Z",
+			"id": "name::id",
+			"numericSortKey": null
+		}
+	],
+	"nextPageToken": null
+}

--- a/packages/open-cloud/tests/helpers/memory-store-sorted-maps.ts
+++ b/packages/open-cloud/tests/helpers/memory-store-sorted-maps.ts
@@ -39,7 +39,7 @@ export function validListSortedMapItemsBody(
 	overrides: Partial<ListSortedMapItemsResponseWire> = {},
 ): ListSortedMapItemsResponseWire {
 	return {
-		memoryStoreSortedMapItems: [validSortedMapItemBody()],
+		items: [validSortedMapItemBody()],
 		nextPageToken: undefined,
 		...overrides,
 	};

--- a/packages/open-cloud/tests/integration/resources/storage/sorted-maps.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/storage/sorted-maps.spec.ts
@@ -16,6 +16,7 @@ describe(StorageClient, () => {
 
 			const httpClient = createFakeHttpClient().mockResponse({
 				body: validSortedMapItemBody({
+					id: "abc",
 					path: "cloud/v2/universes/123/memory-store/sorted-maps/my-map/items/abc",
 				}),
 				status: 200,
@@ -346,6 +347,7 @@ describe(StorageClient, () => {
 
 			const httpClient = createFakeHttpClient().mockResponse({
 				body: validSortedMapItemBody({
+					id: "abc",
 					path: "cloud/v2/universes/123/memory-store/sorted-maps/my-map/items/abc",
 				}),
 				status: 200,
@@ -461,6 +463,7 @@ describe(StorageClient, () => {
 
 			const httpClient = createFakeHttpClient().mockResponse({
 				body: validSortedMapItemBody({
+					id: "abc",
 					path: "cloud/v2/universes/123/memory-store/sorted-maps/my-map/items/abc",
 				}),
 				status: 200,

--- a/packages/open-cloud/vendor/roblox-openapi.json
+++ b/packages/open-cloud/vendor/roblox-openapi.json
@@ -74392,7 +74392,7 @@
       "ListMemoryStoreSortedMapItemsResponse": {
         "type": "object",
         "properties": {
-          "memoryStoreSortedMapItems": {
+          "items": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/MemoryStoreSortedMapItem"


### PR DESCRIPTION
## References

- Downstream agent ran a raw-HTTP probe against the live Open Cloud API at `apis.roblox.com` and surfaced three drifts the SDK's `0.1.0-beta.10` parser cannot handle. Captured probe payloads are committed under `tests/fixtures/memory-store-sorted-maps/` (with `universeId` and `itemId`/`mapId` sanitised).

## Summary

Three correlated bugs in the sorted-map parsers, plus a fixture-based regression net:

### Bug A — list-response field name (`items`, not `memoryStoreSortedMapItems`)

`Cloud_ListMemoryStoreSortedMapItems` returns the array under `items`. The upstream spec names the field `memoryStoreSortedMapItems`; the parser destructured the spec's name and never saw the real items. PR #393's "empty list → `[]`" fix actively made the bug worse — the wrong key always resolved to `undefined`, so the fallback returned `[]` and silently dropped every real item on a non-empty page.

Fix: add an `apply-schema-patches.ts` entry renaming the spec field to match the server (same pattern as the existing queue rename `items → queueItems`), then update wire type, parser, helper, tests, and the conformance pin to match.

### Bug B — GET emits plural `memory-stores/sorted-maps/…` paths

CREATE and LIST emit `…/memory-store/sorted-maps/…` (singular); GET emits `…/memory-stores/sorted-maps/…` (plural). The path regex required singular, so every successful `client.sortedMaps.get(...)` round-tripped as `Malformed memory-store sorted-map item response`.

Fix: relax `PATH_PATTERN` to `memory-stores?` so the parser absorbs the upstream inconsistency. (Will report separately to Roblox creator-docs.)

### Bug C — item id read from URL-encoded path

Item ids containing characters like `::` round-trip URL-encoded in the wire `path` field (`name%3A%3Aid`) while the body's top-level `id` carries the decoded form (`name::id`). The parser extracted the id from the regex match, surfacing the encoded form to callers.

Fix: use `body.id` directly; the regex still validates path shape and extracts `universeId` + `mapId`.

### Fixture regression pin

Three captured-payload tests (`parsers.fixtures.spec.ts`) drive the parser against the actual CREATE/GET/LIST wire shapes. The schema-driven conformance pin catches parser-vs-spec drift but not parser-vs-server drift — this fixture pin closes that gap.

## Out of scope

- `parseGamePassesListResponse` and `parseListLogsResponse` may carry similar server-vs-spec drift; no probe data yet. Worth a follow-up probe before publishing further betas.

## Test Plan

- [x] `pnpm test` in `@bedrock-rbx/ocale` — 1493 tests pass (incl. 3 new fixture rows, 1 new sorted-map regex test, 1 new url-encoded-id test)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` clean (no publint issues)
- [x] `bun scripts/apply-schema-patches.ts` confirmed idempotent (rerun is a no-op once applied)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Bedrock Code Review — Sorted-Map Parser Drift Fixes

## ✅ Recommendation: Approve (ready to merge)

This PR correctly fixes three correlated parser drifts between the SDK spec and real API responses for memory-store sorted-maps, adds fixture-based tests that pin parser behavior to real payloads, and includes an idempotent schema-patch to keep the vendored OpenAPI aligned. Changes are narrowly scoped, well-documented, and tests run locally (test/typecheck/lint/build passed per author).

---

## Key Changes & Rationale

- Bug A — List field rename: server uses items but spec used memoryStoreSortedMapItems.
  - Added an idempotent apply-schema-patches entry to rename the field on the vendored spec.
  - Updated wire types, parser, helpers, tests, and conformance pin to accept/normalize `items`.
  - Parser normalizes missing/null to [] and validates array elements.

- Bug B — Path pluralization: GET uses /memory-stores while CREATE/LIST use /memory-store.
  - PATH_PATTERN relaxed to accept both (`memory-stores?`) and documented in JSDoc.
  - Tests added to exercise both singular and plural forms.

- Bug C — Item ID encoding mismatch:
  - Parser now validates/unpacks universeId and mapId from the path but sources item id from body.id (decoded).
  - Tests and fixtures include a captured CREATE response with URL-encoded path to assert correct decoding behavior.

- Tests: Added three fixture-based tests (CREATE/GET/LIST captured responses) plus unit-spec updates. Fixtures are sanitized and committed under tests/fixtures/memory-store-sorted-maps/.

- Schema patch: Idempotent string-surgery style patch added to apply-schema-patches.ts; apply-schema-patches spec updated to recognize the new patch.

---

## Bedrock Architecture & Standards Checklist

- Architecture (FCIS): Compliant
  - Parsers are pure, operate on wire models, and return typed Result/ApiError values (no I/O or side effects within core parsing logic).
  - Schema patching and vendor file touches are infra-level scripts/adapters (not core parsing logic).

- Testing (TDD & Coverage): Appears compliant
  - Tests accompany the implementation: unit tests updated/added and three fixture-based parsing tests added to pin real-server shapes.
  - Tests are colocated with implementation and integration mocks use fake adapters where applicable.
  - Author reports local test/typecheck/lint/build success. (Repository-wide 100% coverage claim cannot be independently verified here.)

- Test Isolation: Compliant
  - Parser unit tests exercise pure functions.
  - Fixture tests use static JSON captures (no network).
  - Integration tests mock HTTP adapters.

- Security & Constraints: Compliant
  - Changes confined to Open Cloud domain; fixtures are sanitized and contain no secrets.
  - Parsers validate external input at the boundary.

- Code Quality: Compliant
  - TypeScript strictness preserved; no surface-level any usage in the diffs.
  - Error paths return typed ApiError/Result values.
  - JSDoc and inline comments document server oddities and design rationale.

---

## Minor Notes / Suggestions

- The schema-patch operates on vendored JSON via text replacement; that's the established pattern here and is idempotent, but reviewers may want to confirm CI’s vendoring refresh step runs the patch during spec updates to avoid drift surprises.
- The PR message and JSDoc clearly document why item `id` is taken from body.id; the tests cover the encoded-path case—good to keep this rationale in comments near the regex for future maintainers.

---

## Summary

This PR properly addresses the three parser drifts, adds deterministic fixtures and tests that pin behavior to real API responses, and follows Bedrock's architectural, testing, and security expectations. Approve and merge.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/395)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->