### PR TITLE
chore: bump packages to v0.1.0-beta.11

### DIFF
--- a/packages/bedrock/package.json
+++ b/packages/bedrock/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bedrock-rbx/core",
-	"version": "0.1.0-beta.7",
+	"version": "0.1.0-beta.8",
 	"description": "Infrastructure-as-Code deployment tool for Roblox",
 	"keywords": [
 		"infrastructure",

--- a/packages/bedrock/package.json
+++ b/packages/bedrock/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bedrock-rbx/core",
-	"version": "0.1.0-beta.9",
+	"version": "0.1.0-beta.10",
 	"description": "Infrastructure-as-Code deployment tool for Roblox",
 	"keywords": [
 		"infrastructure",

--- a/packages/bedrock/package.json
+++ b/packages/bedrock/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bedrock-rbx/core",
-	"version": "0.1.0-beta.10",
+	"version": "0.1.0-beta.11",
 	"description": "Infrastructure-as-Code deployment tool for Roblox",
 	"keywords": [
 		"infrastructure",

--- a/packages/bedrock/package.json
+++ b/packages/bedrock/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bedrock-rbx/core",
-	"version": "0.1.0-beta.8",
+	"version": "0.1.0-beta.9",
 	"description": "Infrastructure-as-Code deployment tool for Roblox",
 	"keywords": [
 		"infrastructure",

--- a/packages/bedrock/package.json
+++ b/packages/bedrock/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bedrock-rbx/core",
-	"version": "0.1.0-beta.5",
+	"version": "0.1.0-beta.6",
 	"description": "Infrastructure-as-Code deployment tool for Roblox",
 	"keywords": [
 		"infrastructure",

--- a/packages/bedrock/package.json
+++ b/packages/bedrock/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bedrock-rbx/core",
-	"version": "0.1.0-beta.6",
+	"version": "0.1.0-beta.7",
 	"description": "Infrastructure-as-Code deployment tool for Roblox",
 	"keywords": [
 		"infrastructure",

--- a/packages/open-cloud/package.json
+++ b/packages/open-cloud/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bedrock-rbx/ocale",
-	"version": "0.1.0-beta.5",
+	"version": "0.1.0-beta.6",
 	"description": "Roblox Open Cloud API client",
 	"keywords": [
 		"api",

--- a/packages/open-cloud/package.json
+++ b/packages/open-cloud/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bedrock-rbx/ocale",
-	"version": "0.1.0-beta.8",
+	"version": "0.1.0-beta.9",
 	"description": "Roblox Open Cloud API client",
 	"keywords": [
 		"api",

--- a/packages/open-cloud/package.json
+++ b/packages/open-cloud/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bedrock-rbx/ocale",
-	"version": "0.1.0-beta.10",
+	"version": "0.1.0-beta.11",
 	"description": "Roblox Open Cloud API client",
 	"keywords": [
 		"api",

--- a/packages/open-cloud/package.json
+++ b/packages/open-cloud/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bedrock-rbx/ocale",
-	"version": "0.1.0-beta.6",
+	"version": "0.1.0-beta.7",
 	"description": "Roblox Open Cloud API client",
 	"keywords": [
 		"api",

--- a/packages/open-cloud/package.json
+++ b/packages/open-cloud/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bedrock-rbx/ocale",
-	"version": "0.1.0-beta.9",
+	"version": "0.1.0-beta.10",
 	"description": "Roblox Open Cloud API client",
 	"keywords": [
 		"api",

--- a/packages/open-cloud/package.json
+++ b/packages/open-cloud/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bedrock-rbx/ocale",
-	"version": "0.1.0-beta.7",
+	"version": "0.1.0-beta.8",
 	"description": "Roblox Open Cloud API client",
 	"keywords": [
 		"api",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Bedrock Code Review: Version Bump PR

### Summary
This is a pure version bump PR that updates the published packages from `0.1.0-beta.5` to `0.1.0-beta.11` with no code changes.

### Files Modified
- `packages/bedrock/package.json` (`@bedrock-rbx/core`): version updated from `0.1.0-beta.5` → `0.1.0-beta.11`
- `packages/open-cloud/package.json` (`@bedrock-rbx/ocale`): version updated from `0.1.0-beta.5` → `0.1.0-beta.11`

### Architectural & Testing Compliance
**Not applicable** — version bumps do not alter source code, architecture, business logic, or test coverage. The FCIS pattern, public API discipline, and 100% coverage requirements are not impacted.

### Observations

1. **Consistency**: Both published packages (`@bedrock-rbx/core` and `@bedrock-rbx/ocale`) are bumped in tandem to the same version, which is appropriate for coordinated releases in a monorepo.

2. **Scope verification**: The non-published packages (`@bedrock-rbx/testing`, `@bedrock-rbx/typescript-config`, `@bedrock-rbx/vite-config`) and apps (`e2e`, `website`) correctly remain at their distinct versions (0.0.x) and are not affected by this bump. This is correct — only the two public packages should version together.

3. **Workspace dependencies**: The bedrock package declares `@bedrock-rbx/ocale` as a workspace dependency with `"workspace:*"` (not pinned to a specific version), so no dependency declaration changes are needed.

4. **No missing updates**: No CHANGELOG entries, version references in documentation, or additional metadata files require updates for this scope-limited bump.

### Verdict
✅ **Ready to merge.** Pure version maintenance with no code review required.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/397)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->