### PR TITLE
chore(deps): move vite into build catalog

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -29,7 +29,7 @@
 		"typedoc-plugin-markdown": "catalog:build",
 		"typedoc-plugin-replace-text": "catalog:build",
 		"typescript": "catalog:tsc",
-		"vite": "catalog:",
+		"vite": "catalog:build",
 		"vitepress": "catalog:docs",
 		"vitepress-plugin-tabs": "catalog:docs",
 		"vitest": "catalog:test"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,15 +32,13 @@ patchedDependencies:
   "@stryker-mutator/vitest-runner@9.6.1": patches/@stryker-mutator__vitest-runner@9.6.1.patch
   generate-jsdoc-example-tests: patches/generate-jsdoc-example-tests.patch
 
-catalog:
-  vite: npm:@voidzero-dev/vite-plus-core@0.1.19
-
 catalogs:
   build:
     typedoc: 0.28.19
     typedoc-plugin-markdown: 4.11.0
     typedoc-plugin-replace-text: 4.2.0
     unplugin-unused: 0.5.7
+    vite: npm:@voidzero-dev/vite-plus-core@0.1.19
     vite-plus: 0.1.19
   dev:
     "@ai-hero/sandcastle": 0.5.10


### PR DESCRIPTION
## Summary

- `vite` was the lone entry in the unnamed default catalog in `pnpm-workspace.yaml`.
- Moved it into `catalogs.build` next to `vite-plus`. Both pin to `@voidzero-dev/vite-plus-core@0.1.19`, so they sit naturally together.
- `apps/website/package.json` switches `"vite": "catalog:"` to `"vite": "catalog:build"` (sole consumer).

## Test plan

- [x] `pnpm install` (lockfile already up to date — pure catalog rename)
- [x] Pre-commit hook (lint, typecheck, test, build, knip) passed on commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Code Review: Vite Catalog Migration

### Summary
This is a pure dependency catalog reorganization with no functional or architectural changes. The PR consolidates `vite` from an unnamed default catalog into the `catalogs.build` section in `pnpm-workspace.yaml`, with a corresponding reference update in `apps/website/package.json`.

### Changes Reviewed
- **pnpm-workspace.yaml**: Moved `vite: npm:@voidzero-dev/vite-plus-core@0.1.19` into `catalogs.build` alongside `vite-plus` and build-related dependencies
- **apps/website/package.json**: Updated `vite` dependency reference from `catalog:` to `catalog:build`

### Architecture Compliance
✅ **FCIS Pattern**: No impact - this is configuration, not logic
✅ **No I/O in Core**: N/A - no code changes
✅ **Proper Separation**: N/A - no code changes

### Testing
✅ **TDD Compliance**: Not applicable - dependency catalog changes do not require test coverage
✅ **Test Plan**: Adequate - `pnpm install` validates lockfile consistency; pre-commit hooks (lint, typecheck, test, build, knip) all passed

### Code Quality
✅ **TypeScript Strict Mode**: N/A
✅ **Error Handling**: N/A
✅ **No Undocumented `any` Types**: N/A

### Semantics & Best Practices
✅ **Logical Organization**: Correctly places `vite` (a build tool) in `catalogs.build` alongside other build tools (`vite-plus`, `typedoc`, `unplugin-unused`)
✅ **Consistency**: Only consumer (`apps/website`) updated to reference the new catalog location
✅ **Lockfile**: No changes to actual dependencies, purely a catalog namespace reorganization

### Verdict
**Approved for merge.** This is a safe, low-risk chore that improves catalog organization by eliminating the unnamed default catalog and grouping related build tools together. All validation checks passed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/398)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->