### PR TITLE
fix(ocale): refresh openapi spec and patch sorted-map ttl drift

### DIFF
--- a/packages/open-cloud/scripts/apply-schema-patches.spec.ts
+++ b/packages/open-cloud/scripts/apply-schema-patches.spec.ts
@@ -17,6 +17,7 @@ describe(findObsoletePatchDescriptions, () => {
 			"MemoryStoreQueueItem.ttl drops invalid format: duration",
 			"Cloud_ReadMemoryStoreQueueItems.invisibilityWindow drops invalid format: duration",
 			"ListMemoryStoreSortedMapItemsResponse renames memoryStoreSortedMapItems→items",
+			"MemoryStoreSortedMapItem.ttl drops invalid format: duration",
 		]);
 	});
 
@@ -30,7 +31,7 @@ describe(findObsoletePatchDescriptions, () => {
 
 		const text = readFileSync(VENDOR_SPEC_PATH, "utf8");
 
-		expect(findObsoletePatchDescriptions(text)).toHaveLength(6);
+		expect(findObsoletePatchDescriptions(text)).toHaveLength(7);
 	});
 
 	it("should not flag a patch when its pre-patch shape is present in the input", () => {

--- a/packages/open-cloud/scripts/apply-schema-patches.spec.ts
+++ b/packages/open-cloud/scripts/apply-schema-patches.spec.ts
@@ -50,4 +50,35 @@ describe(findObsoletePatchDescriptions, () => {
 			"MemoryStoreQueueItem.ttl drops invalid format: duration",
 		);
 	});
+
+	it("should flag the queue ttl patch as obsolete when only the sorted-map ttl still has format: duration", () => {
+		// Simulates a partial upstream fix: Roblox removes `format:
+		// "duration"` from `MemoryStoreQueueItem.ttl` (committed
+		// vendor state already reflects this) but leaves it on
+		// `MemoryStoreSortedMapItem.ttl`. We re-introduce the sorted-
+		// map drift to recreate that scenario. Two invariants are
+		// checked:
+		//   - the queue ttl patch IS reported as obsolete (the
+		//     queue regex must not backtrack across the schema
+		//     boundary into the sorted-map ttl)
+		//   - the sorted-map ttl patch is NOT reported as obsolete
+		//     (the sorted-map regex still finds its pre-patch shape,
+		//     so it is still load-bearing)
+		// This pins both the cross-schema safety of patch #4's
+		// `(?!"MemoryStoreSortedMapItem":)` lookahead and the
+		// reverse-direction correctness of patch #7's find regex.
+		expect.assertions(2);
+
+		const text = readFileSync(VENDOR_SPEC_PATH, "utf8");
+		const sortedMapReverted = text.replace(
+			/("The server generated tag of an item\."[\s\S]*?"The TTL for the item\.")(\n {10}\})/,
+			'$1,\n            "format": "duration"$2',
+		);
+		const obsolete = findObsoletePatchDescriptions(sortedMapReverted);
+
+		expect(obsolete).toContain("MemoryStoreQueueItem.ttl drops invalid format: duration");
+		expect(obsolete).not.toContain(
+			"MemoryStoreSortedMapItem.ttl drops invalid format: duration",
+		);
+	});
 });

--- a/packages/open-cloud/scripts/apply-schema-patches.ts
+++ b/packages/open-cloud/scripts/apply-schema-patches.ts
@@ -41,14 +41,17 @@ const PATCHES: ReadonlyArray<Patch> = [
 		replace: '$1\n$2"id":$3\n          "queueItems":$4',
 	},
 	{
-		// Anchored on the priority field that immediately precedes ttl so
-		// the marker is unique to MemoryStoreQueueItem (MemoryStoreSortedMapItem
-		// also ends with `"The TTL for the item."` followed by `expireTime`,
-		// but has no priority field).
+		// Anchored on `"The priority of the queue item."`, which is
+		// the description of the queue's `priority` field. That string
+		// is unique to `MemoryStoreQueueItem` (the sibling
+		// `MemoryStoreSortedMapItem` has no priority field), so the
+		// non-greedy `[\s\S]*?` to the next `"The TTL for the item."`
+		// cannot cross into `MemoryStoreSortedMapItem.ttl` during
+		// backtracking.
 		appliedMarker:
 			'"description": "The priority of the queue item.",\n            "format": "double"\n          },\n          "ttl": {\n            "writeOnly": true,\n            "example": "3s",\n            "type": "string",\n            "description": "The TTL for the item."\n          },\n          "expireTime"',
 		description: "MemoryStoreQueueItem.ttl drops invalid format: duration",
-		find: /(\{memory_store_queue_item_id\}`",[\s\S]*?"description": "The TTL for the item\.")(,\n {12}"format": "duration")/,
+		find: /("description": "The priority of the queue item\."[\s\S]*?"description": "The TTL for the item\.")(,\n {12}"format": "duration")/,
 		replace: "$1",
 	},
 	{
@@ -71,6 +74,20 @@ const PATCHES: ReadonlyArray<Patch> = [
 			"ListMemoryStoreSortedMapItemsResponse renames memoryStoreSortedMapItems→items",
 		find: /("ListMemoryStoreSortedMapItemsResponse": \{\n {8}"type": "object",\n {8}"properties": \{\n {10})"memoryStoreSortedMapItems":/,
 		replace: '$1"items":',
+	},
+	{
+		// Anchored on `"The server generated tag of an item."`, which
+		// is the description of `MemoryStoreSortedMapItem.etag` and is
+		// unique to that schema. Same drift class as the queue ttl
+		// patch above: the schema's example shows `"3s"` while the
+		// `format: "duration"` annotation makes Ajv-formats demand
+		// ISO 8601 (`PT3S`). The sorted-map item gained this
+		// annotation upstream after the queue patch above was added.
+		appliedMarker:
+			'"description": "The server generated tag of an item."\n          },\n          "ttl": {\n            "writeOnly": true,\n            "example": "3s",\n            "type": "string",\n            "description": "The TTL for the item."\n          },\n          "expireTime"',
+		description: "MemoryStoreSortedMapItem.ttl drops invalid format: duration",
+		find: /("description": "The server generated tag of an item\."[\s\S]*?"description": "The TTL for the item\.")(,\n {12}"format": "duration")/,
+		replace: "$1",
 	},
 ];
 

--- a/packages/open-cloud/scripts/apply-schema-patches.ts
+++ b/packages/open-cloud/scripts/apply-schema-patches.ts
@@ -42,16 +42,21 @@ const PATCHES: ReadonlyArray<Patch> = [
 	},
 	{
 		// Anchored on `"The priority of the queue item."`, which is
-		// the description of the queue's `priority` field. That string
-		// is unique to `MemoryStoreQueueItem` (the sibling
-		// `MemoryStoreSortedMapItem` has no priority field), so the
-		// non-greedy `[\s\S]*?` to the next `"The TTL for the item."`
-		// cannot cross into `MemoryStoreSortedMapItem.ttl` during
-		// backtracking.
+		// the description of the queue's `priority` field and is unique
+		// to `MemoryStoreQueueItem` (the sibling `MemoryStoreSortedMapItem`
+		// has no priority field). The `(?!"MemoryStoreSortedMapItem":)`
+		// lookahead in the non-greedy gap forbids the regex from
+		// backtracking past the queue schema's closing brace into the
+		// next sibling schema. Without it, a future upstream that fixes
+		// the queue's ttl but not the sorted-map's would let the gap
+		// stretch into `MemoryStoreSortedMapItem.ttl` (same description
+		// string, still has `format: "duration"`), masking the
+		// upstream fix and silently corrupting the sorted-map patch's
+		// post-patch shape.
 		appliedMarker:
 			'"description": "The priority of the queue item.",\n            "format": "double"\n          },\n          "ttl": {\n            "writeOnly": true,\n            "example": "3s",\n            "type": "string",\n            "description": "The TTL for the item."\n          },\n          "expireTime"',
 		description: "MemoryStoreQueueItem.ttl drops invalid format: duration",
-		find: /("description": "The priority of the queue item\."[\s\S]*?"description": "The TTL for the item\.")(,\n {12}"format": "duration")/,
+		find: /("description": "The priority of the queue item\."(?:(?!"MemoryStoreSortedMapItem":)[\s\S])*?"description": "The TTL for the item\.")(,\n {12}"format": "duration")/,
 		replace: "$1",
 	},
 	{

--- a/packages/open-cloud/scripts/probe-memory-store-queues.ts
+++ b/packages/open-cloud/scripts/probe-memory-store-queues.ts
@@ -1,0 +1,187 @@
+// Captures the live Open Cloud wire shape for memory-store queue items
+// and the read/discard custom-method responses. Sister of
+// `probe-memory-store-sorted-maps.ts`; same conventions apply. Each
+// probe targets a specific entry in `vendor/README.md` -> "Local
+// drift patches":
+//
+//   - Probes A (create + ttl="5s") and B (create + ttl="PT5S") prove
+//     patch #4 (`MemoryStoreQueueItem.ttl` drops invalid
+//     `format: "duration"`).
+//   - Probe C (create with no `data`) proves patch #1
+//     (`MemoryStoreQueueItem.required` gains `"data"`).
+//   - Probe D (create with caller-supplied `path`) probes patch #2
+//     (`MemoryStoreQueueItem.path` becomes `readOnly`).
+//   - Probes E (read + invisibilityWindow="3s") and F (read +
+//     invisibilityWindow="PT3S") prove patch #5
+//     (`Cloud_ReadMemoryStoreQueueItems.invisibilityWindow` drops
+//     invalid `format: "duration"`). Probe E's response body also
+//     proves patch #3 (`ReadMemoryStoreQueueItemsResponse` renames
+//     `items→queueItems`, `readId→id`).
+//
+// Run with:
+// BEDROCK_API_KEY=<key with universe.memory-store-queue-item:write,read,delete>
+// \ ROBLOX_TEST_UNIVERSE_ID=<universe id> \ bun
+// packages/open-cloud/scripts/probe-memory-store-queues.ts
+//
+// The script never writes to the repo. Pipe stdout to a file if you
+// want to keep the capture (`... | tee probe.log`).
+
+import process from "node:process";
+
+const API_BASE = "https://apis.roblox.com";
+
+interface ProbeRequest {
+	readonly body?: Record<string, unknown>;
+	readonly method: "DELETE" | "GET" | "PATCH" | "POST";
+	readonly path: string;
+}
+
+interface ProbeContext {
+	readonly basePath: string;
+	readonly discardPath: string;
+	readonly readPath: string;
+}
+
+interface DiscardArgs {
+	readonly apiKey: string;
+	readonly discardPath: string;
+	readonly readId: string;
+}
+
+interface CreateProbe {
+	readonly body: Record<string, unknown>;
+	readonly heading: string;
+}
+
+async function call(apiKey: string, request: ProbeRequest): Promise<string> {
+	const headers: Record<string, string> = { "x-api-key": apiKey };
+	const init: RequestInit = { headers, method: request.method };
+	if (request.body !== undefined) {
+		headers["content-type"] = "application/json";
+		init.body = JSON.stringify(request.body);
+	}
+
+	console.log(`\n>>> ${request.method} ${request.path}`);
+	if (typeof init.body === "string") {
+		console.log(`>>> body: ${init.body}`);
+	}
+
+	const response = await fetch(`${API_BASE}${request.path}`, init);
+	const bodyText = await response.text();
+	console.log(`<<< status: ${response.status.toString()}`);
+	console.log(`<<< body: ${bodyText.length === 0 ? "(empty)" : bodyText}`);
+	return bodyText;
+}
+
+async function discardSilently(args: DiscardArgs): Promise<void> {
+	try {
+		await call(args.apiKey, {
+			body: { readId: args.readId },
+			method: "POST",
+			path: args.discardPath,
+		});
+	} catch (err) {
+		console.error(`!!! cleanup discard failed: ${String(err)}`);
+	}
+}
+
+function makeContext(universeId: string): ProbeContext {
+	const suffix = Date.now().toString(36);
+	const queueId = `bedrock-probe-${suffix}`;
+	const basePath = `/cloud/v2/universes/${universeId}/memory-store/queues/${queueId}/items`;
+	return {
+		basePath,
+		discardPath: `${basePath}:discard`,
+		readPath: `${basePath}:read`,
+	};
+}
+
+function extractReadId(bodyText: string): string | undefined {
+	try {
+		const parsed: unknown = JSON.parse(bodyText);
+		if (parsed !== null && typeof parsed === "object" && "id" in parsed) {
+			const { id } = parsed as { id?: unknown };
+			return typeof id === "string" ? id : undefined;
+		}
+	} catch {
+		return undefined;
+	}
+
+	return undefined;
+}
+
+const CREATE_PROBES: ReadonlyArray<CreateProbe> = [
+	{
+		body: { data: { probe: "queue-protobuf" }, ttl: "5s" },
+		heading: "probe A: create with protobuf-duration ttl `5s` and valid data (patch #4)",
+	},
+	{
+		body: { data: { probe: "queue-iso" }, ttl: "PT5S" },
+		heading:
+			"probe B: create with ISO-8601 ttl `PT5S` (expect rejection if patch #4 is correct)",
+	},
+	{
+		body: { ttl: "5s" },
+		heading: "probe C: create with missing `data` (expect rejection if patch #1 is correct)",
+	},
+	{
+		body: {
+			data: { probe: "queue-path" },
+			path: "cloud/v2/universes/0/memory-store/queues/evil/items/forged",
+		},
+		heading:
+			"probe D: create with caller-supplied `path` (probe patch #2 — readOnly or silent-strip?)",
+	},
+];
+
+async function runCreateProbes(apiKey: string, context: ProbeContext): Promise<void> {
+	for (const [index, entry] of CREATE_PROBES.entries()) {
+		console.log(`${index === 0 ? "" : "\n"}=== ${entry.heading} ===`);
+		await call(apiKey, { body: entry.body, method: "POST", path: context.basePath });
+	}
+}
+
+async function runReadProbes(apiKey: string, context: ProbeContext): Promise<string | undefined> {
+	console.log(
+		"\n=== probe E: read with protobuf invisibilityWindow `3s` (capture response keys for patches #3, #5) ===",
+	);
+	const readBody = await call(apiKey, {
+		method: "GET",
+		path: `${context.readPath}?count=10&invisibilityWindow=3s`,
+	});
+
+	console.log(
+		"\n=== probe F: read with ISO-8601 invisibilityWindow `PT3S` (expect rejection if patch #5 is correct) ===",
+	);
+	await call(apiKey, {
+		method: "GET",
+		path: `${context.readPath}?count=10&invisibilityWindow=PT3S`,
+	});
+
+	return extractReadId(readBody);
+}
+
+async function probe(apiKey: string, universeId: string): Promise<void> {
+	const context = makeContext(universeId);
+	let readId: string | undefined;
+	try {
+		await runCreateProbes(apiKey, context);
+		readId = await runReadProbes(apiKey, context);
+	} finally {
+		console.log("\n=== cleanup ===");
+		if (readId === undefined) {
+			console.log("(no readId captured; remaining items will expire via TTL)");
+		} else {
+			await discardSilently({ apiKey, discardPath: context.discardPath, readId });
+		}
+	}
+}
+
+const API_KEY = process.env["BEDROCK_API_KEY"];
+const UNIVERSE_ID = process.env["ROBLOX_TEST_UNIVERSE_ID"];
+if (API_KEY === undefined || UNIVERSE_ID === undefined) {
+	console.error("BEDROCK_API_KEY and ROBLOX_TEST_UNIVERSE_ID must be set");
+	process.exit(1);
+}
+
+await probe(API_KEY, UNIVERSE_ID);

--- a/packages/open-cloud/scripts/probe-memory-store-queues.ts
+++ b/packages/open-cloud/scripts/probe-memory-store-queues.ts
@@ -99,15 +99,15 @@ function makeContext(universeId: string): ProbeContext {
 function extractReadId(bodyText: string): string | undefined {
 	try {
 		const parsed: unknown = JSON.parse(bodyText);
-		if (parsed !== null && typeof parsed === "object" && "id" in parsed) {
-			const { id } = parsed as { id?: unknown };
-			return typeof id === "string" ? id : undefined;
+		if (parsed === null || typeof parsed !== "object") {
+			return undefined;
 		}
+
+		const id: unknown = Reflect.get(parsed, "id");
+		return typeof id === "string" ? id : undefined;
 	} catch {
 		return undefined;
 	}
-
-	return undefined;
 }
 
 const CREATE_PROBES: ReadonlyArray<CreateProbe> = [

--- a/packages/open-cloud/scripts/probe-memory-store-sorted-maps.ts
+++ b/packages/open-cloud/scripts/probe-memory-store-sorted-maps.ts
@@ -1,0 +1,124 @@
+// Captures the live Open Cloud wire shape for memory-store sorted-map
+// items. The script is invoked manually, hits `apis.roblox.com`
+// directly (bypassing the SDK so the bytes on the wire are
+// caller-controlled), and prints each request/response so the operator
+// has direct evidence of what the server accepts and emits.
+//
+// Use it to:
+//   - regenerate the recorded fixtures under
+//     `tests/fixtures/memory-store-sorted-maps/`
+//   - investigate a suspected drift between the vendored schema and
+//     the live API (the basis for entries in
+//     `vendor/README.md` -> "Local drift patches")
+//
+// Run with:
+// BEDROCK_API_KEY=<key with universe.memory-store-sorted-map-item:write,delete>
+// \ ROBLOX_TEST_UNIVERSE_ID=<universe id> \ bun
+// packages/open-cloud/scripts/probe-memory-store-sorted-maps.ts
+//
+// The script never writes to the repo. Pipe stdout to a file if you
+// want to keep the capture (`... | tee probe.log`).
+
+import process from "node:process";
+
+const API_BASE = "https://apis.roblox.com";
+
+interface ProbeRequest {
+	readonly body?: Record<string, unknown>;
+	readonly method: "DELETE" | "GET" | "PATCH" | "POST";
+	readonly path: string;
+}
+
+interface ProbeContext {
+	readonly basePath: string;
+	readonly isoItemId: string;
+	readonly isoItemPath: string;
+	readonly protobufItemId: string;
+	readonly protobufItemPath: string;
+}
+
+async function call(apiKey: string, request: ProbeRequest): Promise<void> {
+	const headers: Record<string, string> = { "x-api-key": apiKey };
+	const init: RequestInit = { headers, method: request.method };
+	if (request.body !== undefined) {
+		headers["content-type"] = "application/json";
+		init.body = JSON.stringify(request.body);
+	}
+
+	console.log(`\n>>> ${request.method} ${request.path}`);
+	if (typeof init.body === "string") {
+		console.log(`>>> body: ${init.body}`);
+	}
+
+	const response = await fetch(`${API_BASE}${request.path}`, init);
+	const bodyText = await response.text();
+	console.log(`<<< status: ${response.status.toString()}`);
+	console.log(`<<< body: ${bodyText.length === 0 ? "(empty)" : bodyText}`);
+}
+
+async function deleteSilently(apiKey: string, path: string): Promise<void> {
+	try {
+		await call(apiKey, { method: "DELETE", path });
+	} catch (err) {
+		console.error(`!!! cleanup delete failed (${path}): ${String(err)}`);
+	}
+}
+
+function makeContext(universeId: string): ProbeContext {
+	const suffix = Date.now().toString(36);
+	const mapId = `bedrock-probe-${suffix}`;
+	const basePath = `/cloud/v2/universes/${universeId}/memory-store/sorted-maps/${mapId}/items`;
+	const protobufItemId = `ttl-protobuf-${suffix}`;
+	const isoItemId = `ttl-iso-${suffix}`;
+	return {
+		basePath,
+		isoItemId,
+		isoItemPath: `${basePath}/${isoItemId}`,
+		protobufItemId,
+		protobufItemPath: `${basePath}/${protobufItemId}`,
+	};
+}
+
+async function runProbes(apiKey: string, context: ProbeContext): Promise<void> {
+	console.log("=== probe A: create with protobuf-duration ttl `5s` ===");
+	await call(apiKey, {
+		body: { ttl: "5s", value: { probe: "ttl-protobuf" } },
+		method: "POST",
+		path: `${context.basePath}?id=${context.protobufItemId}`,
+	});
+
+	console.log(
+		"\n=== probe B: create with ISO-8601 ttl `PT5S` (expect rejection if patch #7 is correct) ===",
+	);
+	await call(apiKey, {
+		body: { ttl: "PT5S", value: { probe: "ttl-iso" } },
+		method: "POST",
+		path: `${context.basePath}?id=${context.isoItemId}`,
+	});
+
+	console.log("\n=== probe C: get protobuf-ttl item (capture response shape) ===");
+	await call(apiKey, { method: "GET", path: context.protobufItemPath });
+
+	console.log("\n=== probe D: list items (capture array-key name) ===");
+	await call(apiKey, { method: "GET", path: `${context.basePath}?maxPageSize=100` });
+}
+
+async function probe(apiKey: string, universeId: string): Promise<void> {
+	const context = makeContext(universeId);
+	try {
+		await runProbes(apiKey, context);
+	} finally {
+		console.log("\n=== cleanup ===");
+		await deleteSilently(apiKey, context.protobufItemPath);
+		await deleteSilently(apiKey, context.isoItemPath);
+	}
+}
+
+const API_KEY = process.env["BEDROCK_API_KEY"];
+const UNIVERSE_ID = process.env["ROBLOX_TEST_UNIVERSE_ID"];
+if (API_KEY === undefined || UNIVERSE_ID === undefined) {
+	console.error("BEDROCK_API_KEY and ROBLOX_TEST_UNIVERSE_ID must be set");
+	process.exit(1);
+}
+
+await probe(API_KEY, UNIVERSE_ID);

--- a/packages/open-cloud/vendor/README.md
+++ b/packages/open-cloud/vendor/README.md
@@ -4,7 +4,7 @@
 
 **File:** `roblox-openapi.json`
 **Upstream:** <https://github.com/Roblox/creator-docs/blob/main/content/en-us/reference/cloud/openapi.json>
-**Pinned commit:** `0cbea0571b465d97ce870109666d6435e1491449`
+**Pinned commit:** `3dedc83c559bc97392afc7d5add766e74994969f`
 **Format:** OpenAPI 3.0.4 (JSON)
 
 ### Refresh
@@ -30,15 +30,20 @@ fails loudly if any patch's pre-patch shape is absent. That signal
 catches the case where Roblox has fixed a drift upstream: the patch
 becomes obsolete and should be removed before the refresh succeeds.
 
-Active patches as of 2026-05-08:
+Active patches as of 2026-05-14:
 
 1. `components.schemas.MemoryStoreQueueItem.required` includes
    `"data"`. The server returns 400 `INVALID_ARGUMENT` when the
    field is absent or `null`; the schema marks it optional.
 2. `components.schemas.MemoryStoreQueueItem.properties.path.readOnly`
-   is `true`. The server generates the path on creation and
-   rejects client-supplied paths; the schema does not flag the
-   field as read-only.
+   is `true`. The server generates the path on creation and silently
+   ignores any client-supplied `path` in the request body (no
+   validation, no error — the response always carries the
+   server-generated value). The schema does not flag the field as
+   read-only, so without this patch a fixture or builder could ship
+   `path` in a request body and the test surface would not catch the
+   bug. Verified 2026-05-14 via
+   `scripts/probe-memory-store-queues.ts`.
 3. `components.schemas.ReadMemoryStoreQueueItemsResponse.properties`
    uses keys `queueItems` and `id`. The server emits the items
    array under `queueItems` (schema: `items`) and the read
@@ -55,6 +60,16 @@ Active patches as of 2026-05-08:
    `Cloud_ReadMemoryStoreQueueItems` drops `"format": "duration"` for
    the same reason as patch 4. The example is `"3s"` and the server
    rejects ISO 8601 form.
+6. `components.schemas.ListMemoryStoreSortedMapItemsResponse.properties`
+   renames `memoryStoreSortedMapItems` to `items`. Real-API probe
+   (2026-05) shows the list endpoint returns the items array under
+   `items`; without the rename the parser silently drops every real
+   item on a non-empty page.
+7. `components.schemas.MemoryStoreSortedMapItem.properties.ttl` drops
+   `"format": "duration"`. Same drift class as patch 4: the schema's
+   example is `"3s"` but the upstream `format: "duration"` annotation
+   makes Ajv-formats demand ISO 8601. Roblox added this annotation
+   upstream between the prior refresh and 2026-05-14.
 
 When a patched section is fixed upstream, the next `refresh-openapi`
 will fail with the obsolete patch's description. Remove the
@@ -130,3 +145,10 @@ Drift is caught in three places, each with a different failure mode:
    Cloud API with throwaway resources will catch runtime behavior that
    the schema cannot describe (e.g. silent field rename, changed error
    semantics). Not yet implemented.
+4. **Manual probes (on demand).** Per-resource scripts under
+   `scripts/probe-*.ts` hit the live API without going through the
+   SDK and print every request/response so the operator has direct
+   evidence of the wire shape. Use them to investigate a suspected
+   drift or to regenerate the fixtures under `tests/fixtures/`. The
+   scripts require an API key and a throwaway universe; see each
+   script's header comment for the env-var contract.

--- a/packages/open-cloud/vendor/roblox-openapi.json
+++ b/packages/open-cloud/vendor/roblox-openapi.json
@@ -9502,7 +9502,7 @@
           {
             "name": "repository",
             "in": "path",
-            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig",
+            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig\n\nExtendedServicesConfig",
             "required": true,
             "schema": {
               "allOf": [
@@ -9514,13 +9514,15 @@
               "x-enum-varnames": [
                 "InExperienceConfig",
                 "RecommendationServicesConfig",
-                "DataStoresConfig"
+                "DataStoresConfig",
+                "ExtendedServicesConfig"
               ]
             },
             "x-enum-varnames": [
               "InExperienceConfig",
               "RecommendationServicesConfig",
-              "DataStoresConfig"
+              "DataStoresConfig",
+              "ExtendedServicesConfig"
             ]
           }
         ],
@@ -9621,7 +9623,7 @@
           {
             "name": "repository",
             "in": "path",
-            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig",
+            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig\n\nExtendedServicesConfig",
             "required": true,
             "schema": {
               "allOf": [
@@ -9633,13 +9635,15 @@
               "x-enum-varnames": [
                 "InExperienceConfig",
                 "RecommendationServicesConfig",
-                "DataStoresConfig"
+                "DataStoresConfig",
+                "ExtendedServicesConfig"
               ]
             },
             "x-enum-varnames": [
               "InExperienceConfig",
               "RecommendationServicesConfig",
-              "DataStoresConfig"
+              "DataStoresConfig",
+              "ExtendedServicesConfig"
             ]
           }
         ],
@@ -9783,7 +9787,7 @@
           {
             "name": "repository",
             "in": "path",
-            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig",
+            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig\n\nExtendedServicesConfig",
             "required": true,
             "schema": {
               "allOf": [
@@ -9795,13 +9799,15 @@
               "x-enum-varnames": [
                 "InExperienceConfig",
                 "RecommendationServicesConfig",
-                "DataStoresConfig"
+                "DataStoresConfig",
+                "ExtendedServicesConfig"
               ]
             },
             "x-enum-varnames": [
               "InExperienceConfig",
               "RecommendationServicesConfig",
-              "DataStoresConfig"
+              "DataStoresConfig",
+              "ExtendedServicesConfig"
             ]
           }
         ],
@@ -9885,7 +9891,7 @@
       "patch": {
         "tags": ["Configs"],
         "summary": "Partially updates the draft.",
-        "description": "Updates the draft treating the payload as a partial changeset.\r\nIf draftHash is provided, this call will fail if the hash doesn't match.\r\nA key not included will not be changed. To indicate deletion, set key to null.\r\nTo discard a change, set key to its currently published value.",
+        "description": "Updates the draft treating the payload as a partial changeset.\r\nIf draftHash is provided, this call will fail if the hash doesn't match.\r\nA key not included will not be changed. To indicate deletion, set key to null.\r\nTo discard a change, set key to its currently published value.\r\nWhen `conditionalRules` is omitted or empty (`{}`), the CMS update omits the conditional-rules field so existing published rules remain at publish time;\r\nsend a non-empty `conditionalRules` object to merge rule changes.\r\nEntry count and per-value size limits are enforced here via CreatorConfigsPublicApi.Utils.DraftValidationHelper; further schema validation is performed by Config Management.",
         "operationId": "CreatorConfigsPublicApi_UpdateDraft",
         "parameters": [
           {
@@ -9900,7 +9906,7 @@
           {
             "name": "repository",
             "in": "path",
-            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig",
+            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig\n\nExtendedServicesConfig",
             "required": true,
             "schema": {
               "allOf": [
@@ -9912,13 +9918,15 @@
               "x-enum-varnames": [
                 "InExperienceConfig",
                 "RecommendationServicesConfig",
-                "DataStoresConfig"
+                "DataStoresConfig",
+                "ExtendedServicesConfig"
               ]
             },
             "x-enum-varnames": [
               "InExperienceConfig",
               "RecommendationServicesConfig",
-              "DataStoresConfig"
+              "DataStoresConfig",
+              "ExtendedServicesConfig"
             ]
           }
         ],
@@ -9932,7 +9940,7 @@
                     "$ref": "#/components/schemas/UpdateDraftRequest"
                   }
                 ],
-                "description": "Request model for updating a draft (partial update)."
+                "description": "Request model for draft updates: PATCH uses a partial merge; PUT `draft:overwrite` treats the body as the full intended configuration after publish."
               }
             },
             "application/json": {
@@ -9942,7 +9950,7 @@
                     "$ref": "#/components/schemas/UpdateDraftRequest"
                   }
                 ],
-                "description": "Request model for updating a draft (partial update)."
+                "description": "Request model for draft updates: PATCH uses a partial merge; PUT `draft:overwrite` treats the body as the full intended configuration after publish."
               }
             },
             "text/json": {
@@ -9952,7 +9960,7 @@
                     "$ref": "#/components/schemas/UpdateDraftRequest"
                   }
                 ],
-                "description": "Request model for updating a draft (partial update)."
+                "description": "Request model for draft updates: PATCH uses a partial merge; PUT `draft:overwrite` treats the body as the full intended configuration after publish."
               }
             },
             "application/*+json": {
@@ -9962,7 +9970,7 @@
                     "$ref": "#/components/schemas/UpdateDraftRequest"
                   }
                 ],
-                "description": "Request model for updating a draft (partial update)."
+                "description": "Request model for draft updates: PATCH uses a partial merge; PUT `draft:overwrite` treats the body as the full intended configuration after publish."
               }
             }
           }
@@ -10049,7 +10057,7 @@
       "put": {
         "tags": ["Configs"],
         "summary": "Overwrites the entire draft with the request payload.",
-        "description": "Full overwrite of current draft. The payload is the expected final state after publish.\r\nIf a key is not included, it is interpreted as removed.\r\nIf draftHash is provided, this call will fail if the hash doesn't match.",
+        "description": "Full overwrite of current draft. The payload is the expected final state after publish (not a merge with the draft or published config from the client’s perspective).\r\nThe service aligns that intent with CMS validation by emitting explicit deletions for published keys and conditional branches omitted from the body.\r\nIf a key is not included, it is interpreted as removed.\r\nWhen `conditionalRules` is included, `conditionalRules.rules` is authoritative for rule definitions:\r\nany conditional rule that exists on the latest published configuration but is omitted from `rules` is removed (same as sending an empty RPN rule).\r\nWhen `conditionalRules` is omitted, all published conditional rules are removed; entries must not use conditional branches or `.RBX.conditional.*` keys unless you send `conditionalRules`.\r\nIf draftHash is provided, this call will fail if the hash doesn't match.\r\nEntry count and per-value size limits are enforced here via CreatorConfigsPublicApi.Utils.DraftValidationHelper; further schema validation is performed by Config Management.",
         "operationId": "CreatorConfigsPublicApi_OverwriteDraft",
         "parameters": [
           {
@@ -10064,7 +10072,7 @@
           {
             "name": "repository",
             "in": "path",
-            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig",
+            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig\n\nExtendedServicesConfig",
             "required": true,
             "schema": {
               "allOf": [
@@ -10076,13 +10084,15 @@
               "x-enum-varnames": [
                 "InExperienceConfig",
                 "RecommendationServicesConfig",
-                "DataStoresConfig"
+                "DataStoresConfig",
+                "ExtendedServicesConfig"
               ]
             },
             "x-enum-varnames": [
               "InExperienceConfig",
               "RecommendationServicesConfig",
-              "DataStoresConfig"
+              "DataStoresConfig",
+              "ExtendedServicesConfig"
             ]
           }
         ],
@@ -10096,7 +10106,7 @@
                     "$ref": "#/components/schemas/UpdateDraftRequest"
                   }
                 ],
-                "description": "Request model for updating a draft (partial update)."
+                "description": "Request model for draft updates: PATCH uses a partial merge; PUT `draft:overwrite` treats the body as the full intended configuration after publish."
               }
             },
             "application/json": {
@@ -10106,7 +10116,7 @@
                     "$ref": "#/components/schemas/UpdateDraftRequest"
                   }
                 ],
-                "description": "Request model for updating a draft (partial update)."
+                "description": "Request model for draft updates: PATCH uses a partial merge; PUT `draft:overwrite` treats the body as the full intended configuration after publish."
               }
             },
             "text/json": {
@@ -10116,7 +10126,7 @@
                     "$ref": "#/components/schemas/UpdateDraftRequest"
                   }
                 ],
-                "description": "Request model for updating a draft (partial update)."
+                "description": "Request model for draft updates: PATCH uses a partial merge; PUT `draft:overwrite` treats the body as the full intended configuration after publish."
               }
             },
             "application/*+json": {
@@ -10126,7 +10136,7 @@
                     "$ref": "#/components/schemas/UpdateDraftRequest"
                   }
                 ],
-                "description": "Request model for updating a draft (partial update)."
+                "description": "Request model for draft updates: PATCH uses a partial merge; PUT `draft:overwrite` treats the body as the full intended configuration after publish."
               }
             }
           }
@@ -10228,7 +10238,7 @@
           {
             "name": "repository",
             "in": "path",
-            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig",
+            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig\n\nExtendedServicesConfig",
             "required": true,
             "schema": {
               "allOf": [
@@ -10240,13 +10250,15 @@
               "x-enum-varnames": [
                 "InExperienceConfig",
                 "RecommendationServicesConfig",
-                "DataStoresConfig"
+                "DataStoresConfig",
+                "ExtendedServicesConfig"
               ]
             },
             "x-enum-varnames": [
               "InExperienceConfig",
               "RecommendationServicesConfig",
-              "DataStoresConfig"
+              "DataStoresConfig",
+              "ExtendedServicesConfig"
             ]
           }
         ],
@@ -10347,7 +10359,7 @@
           {
             "name": "repository",
             "in": "path",
-            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig",
+            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig\n\nExtendedServicesConfig",
             "required": true,
             "schema": {
               "allOf": [
@@ -10359,13 +10371,15 @@
               "x-enum-varnames": [
                 "InExperienceConfig",
                 "RecommendationServicesConfig",
-                "DataStoresConfig"
+                "DataStoresConfig",
+                "ExtendedServicesConfig"
               ]
             },
             "x-enum-varnames": [
               "InExperienceConfig",
               "RecommendationServicesConfig",
-              "DataStoresConfig"
+              "DataStoresConfig",
+              "ExtendedServicesConfig"
             ]
           }
         ],
@@ -10511,7 +10525,7 @@
           {
             "name": "repository",
             "in": "path",
-            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig",
+            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig\n\nExtendedServicesConfig",
             "required": true,
             "schema": {
               "allOf": [
@@ -10523,13 +10537,15 @@
               "x-enum-varnames": [
                 "InExperienceConfig",
                 "RecommendationServicesConfig",
-                "DataStoresConfig"
+                "DataStoresConfig",
+                "ExtendedServicesConfig"
               ]
             },
             "x-enum-varnames": [
               "InExperienceConfig",
               "RecommendationServicesConfig",
-              "DataStoresConfig"
+              "DataStoresConfig",
+              "ExtendedServicesConfig"
             ]
           },
           {
@@ -10686,7 +10702,7 @@
           {
             "name": "repository",
             "in": "path",
-            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig",
+            "description": "\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig\n\nExtendedServicesConfig",
             "required": true,
             "schema": {
               "allOf": [
@@ -10698,13 +10714,15 @@
               "x-enum-varnames": [
                 "InExperienceConfig",
                 "RecommendationServicesConfig",
-                "DataStoresConfig"
+                "DataStoresConfig",
+                "ExtendedServicesConfig"
               ]
             },
             "x-enum-varnames": [
               "InExperienceConfig",
               "RecommendationServicesConfig",
-              "DataStoresConfig"
+              "DataStoresConfig",
+              "ExtendedServicesConfig"
             ]
           },
           {
@@ -18031,6 +18049,7 @@
     },
     "/legacy-game-internationalization/v1/supported-languages/games/{gameId}/languages/{languageCode}/image-translation-status": {
       "patch": {
+        "tags": ["Localization"],
         "summary": "Enable or disable image translation for a game and language.",
         "parameters": [
           {
@@ -18118,7 +18137,10 @@
           {
             "roblox-oauth2": []
           }
-        ]
+        ],
+        "externalDocs": {
+          "url": "https://create.roblox.com/docs/cloud/reference/features/localization#patch_legacy_game_internationalization_v1_supported_languages_games__gameId__languages__languageCode__image_translation_status"
+        }
       }
     },
     "/legacy-game-internationalization/v1/supported-languages/games/{gameId}/languages/{languageCode}/universe-display-info-automatic-translation-settings": {
@@ -23147,6 +23169,7 @@
     },
     "/thumbnail-personalization-api/v1/universe/{universeId}/personalization": {
       "get": {
+        "tags": ["Thumbnails"],
         "operationId": "HomepageThumbnail_FindThumbnailPersonalizations",
         "parameters": [
           {
@@ -23245,11 +23268,15 @@
           {
             "roblox-legacy-cookie": []
           }
-        ]
+        ],
+        "externalDocs": {
+          "url": "https://create.roblox.com/docs/cloud/reference/features/thumbnails#HomepageThumbnail_FindThumbnailPersonalizations"
+        }
       }
     },
     "/thumbnail-personalization-api/v1/universe/{universeId}/personalization/create": {
       "post": {
+        "tags": ["Thumbnails"],
         "operationId": "HomepageThumbnail_CreateThumbnailPersonalization",
         "parameters": [
           {
@@ -23362,11 +23389,15 @@
           {
             "roblox-legacy-cookie": []
           }
-        ]
+        ],
+        "externalDocs": {
+          "url": "https://create.roblox.com/docs/cloud/reference/features/thumbnails#HomepageThumbnail_CreateThumbnailPersonalization"
+        }
       }
     },
     "/thumbnail-personalization-api/v1/universe/{universeId}/personalization/update": {
       "post": {
+        "tags": ["Thumbnails"],
         "operationId": "HomepageThumbnail_UpdateThumbnailPersonalization",
         "parameters": [
           {
@@ -23479,11 +23510,15 @@
           {
             "roblox-legacy-cookie": []
           }
-        ]
+        ],
+        "externalDocs": {
+          "url": "https://create.roblox.com/docs/cloud/reference/features/thumbnails#HomepageThumbnail_UpdateThumbnailPersonalization"
+        }
       }
     },
     "/thumbnail-personalization-api/v1/universe/{universeId}/thumbnails": {
       "delete": {
+        "tags": ["Thumbnails"],
         "operationId": "HomepageThumbnail_DeleteHomepageThumbnails",
         "parameters": [
           {
@@ -23566,9 +23601,13 @@
           {
             "roblox-legacy-cookie": []
           }
-        ]
+        ],
+        "externalDocs": {
+          "url": "https://create.roblox.com/docs/cloud/reference/features/thumbnails#HomepageThumbnail_DeleteHomepageThumbnails"
+        }
       },
       "get": {
+        "tags": ["Thumbnails"],
         "operationId": "HomepageThumbnail_GetHomepageThumbnails",
         "parameters": [
           {
@@ -23656,11 +23695,15 @@
           {
             "roblox-legacy-cookie": []
           }
-        ]
+        ],
+        "externalDocs": {
+          "url": "https://create.roblox.com/docs/cloud/reference/features/thumbnails#HomepageThumbnail_GetHomepageThumbnails"
+        }
       }
     },
     "/thumbnail-personalization-api/v1/universe/{universeId}/thumbnails/uploads": {
       "post": {
+        "tags": ["Thumbnails"],
         "operationId": "HomepageThumbnail_UploadHomepageThumbnails",
         "parameters": [
           {
@@ -23756,11 +23799,15 @@
           {
             "roblox-legacy-cookie": []
           }
-        ]
+        ],
+        "externalDocs": {
+          "url": "https://create.roblox.com/docs/cloud/reference/features/thumbnails#HomepageThumbnail_UploadHomepageThumbnails"
+        }
       }
     },
     "/thumbnail-personalization-api/v1/universe/{universeId}/thumbnails/uploads/status": {
       "get": {
+        "tags": ["Thumbnails"],
         "operationId": "HomepageThumbnail_GetHomepageThumbnailsStatus",
         "parameters": [
           {
@@ -23843,862 +23890,10 @@
           {
             "roblox-legacy-cookie": []
           }
-        ]
-      }
-    },
-    "/thumbnail-personalization-api/v1/universes/{universeId}/personalization": {
-      "get": {
-        "operationId": "ThumbnailPersonalizationApi.HomepageThumbnail_FindThumbnailPersonalizations",
-        "parameters": [
-          {
-            "name": "universeId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          {
-            "name": "status",
-            "in": "query",
-            "schema": {
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/PersonalizedConfigStatus"
-                }
-              ]
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          {
-            "name": "cursor",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
         ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          }
-        },
-        "x-roblox-stability": "EXPERIMENTAL",
-        "x-roblox-rate-limits": {
-          "perApiKeyOwner": {
-            "period": "MINUTE",
-            "maxInPeriod": 100
-          },
-          "perOauth2Authorization": {
-            "period": "MINUTE",
-            "maxInPeriod": 100
-          }
-        },
-        "x-roblox-scopes": [
-          {
-            "name": "universe:read",
-            "targetResourceSpecifier": "universes"
-          }
-        ],
-        "x-roblox-engine-usability": {
-          "apiKeyWithHttpService": false
-        },
-        "security": [
-          {
-            "roblox-legacy-cookie": []
-          },
-          {
-            "roblox-api-key": []
-          },
-          {
-            "roblox-oauth2": ["universe:read"]
-          }
-        ]
-      }
-    },
-    "/thumbnail-personalization-api/v1/universes/{universeId}/personalization/create": {
-      "post": {
-        "operationId": "ThumbnailPersonalizationApi.HomepageThumbnail_CreateThumbnailPersonalization",
-        "parameters": [
-          {
-            "name": "universeId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json-patch+json": {
-              "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateThumbnailPersonalizationRequest"
-                  }
-                ]
-              }
-            },
-            "application/json": {
-              "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateThumbnailPersonalizationRequest"
-                  }
-                ]
-              }
-            },
-            "text/json": {
-              "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateThumbnailPersonalizationRequest"
-                  }
-                ]
-              }
-            },
-            "application/*+json": {
-              "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/CreateThumbnailPersonalizationRequest"
-                  }
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          }
-        },
-        "x-roblox-stability": "EXPERIMENTAL",
-        "x-roblox-rate-limits": {
-          "perApiKeyOwner": {
-            "period": "MINUTE",
-            "maxInPeriod": 50
-          },
-          "perOauth2Authorization": {
-            "period": "MINUTE",
-            "maxInPeriod": 50
-          }
-        },
-        "x-roblox-scopes": [
-          {
-            "name": "universe:write",
-            "targetResourceSpecifier": "universes"
-          }
-        ],
-        "x-roblox-engine-usability": {
-          "apiKeyWithHttpService": false
-        },
-        "security": [
-          {
-            "roblox-legacy-cookie": []
-          },
-          {
-            "roblox-api-key": []
-          },
-          {
-            "roblox-oauth2": ["universe:write"]
-          }
-        ]
-      }
-    },
-    "/thumbnail-personalization-api/v1/universes/{universeId}/personalization/update": {
-      "post": {
-        "operationId": "ThumbnailPersonalizationApi.HomepageThumbnail_UpdateThumbnailPersonalization",
-        "parameters": [
-          {
-            "name": "universeId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json-patch+json": {
-              "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateThumbnailPersonalizationRequest"
-                  }
-                ]
-              }
-            },
-            "application/json": {
-              "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateThumbnailPersonalizationRequest"
-                  }
-                ]
-              }
-            },
-            "text/json": {
-              "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateThumbnailPersonalizationRequest"
-                  }
-                ]
-              }
-            },
-            "application/*+json": {
-              "schema": {
-                "allOf": [
-                  {
-                    "$ref": "#/components/schemas/UpdateThumbnailPersonalizationRequest"
-                  }
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          }
-        },
-        "x-roblox-stability": "EXPERIMENTAL",
-        "x-roblox-rate-limits": {
-          "perApiKeyOwner": {
-            "period": "MINUTE",
-            "maxInPeriod": 50
-          },
-          "perOauth2Authorization": {
-            "period": "MINUTE",
-            "maxInPeriod": 50
-          }
-        },
-        "x-roblox-scopes": [
-          {
-            "name": "universe:write",
-            "targetResourceSpecifier": "universes"
-          }
-        ],
-        "x-roblox-engine-usability": {
-          "apiKeyWithHttpService": false
-        },
-        "security": [
-          {
-            "roblox-legacy-cookie": []
-          },
-          {
-            "roblox-api-key": []
-          },
-          {
-            "roblox-oauth2": ["universe:write"]
-          }
-        ]
-      }
-    },
-    "/thumbnail-personalization-api/v1/universes/{universeId}/thumbnails": {
-      "delete": {
-        "operationId": "ThumbnailPersonalizationApi.HomepageThumbnail_DeleteHomepageThumbnails",
-        "parameters": [
-          {
-            "name": "universeId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          {
-            "name": "homepageThumbnailIds",
-            "in": "query",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          }
-        },
-        "x-roblox-stability": "EXPERIMENTAL",
-        "x-roblox-rate-limits": {
-          "perApiKeyOwner": {
-            "period": "MINUTE",
-            "maxInPeriod": 50
-          },
-          "perOauth2Authorization": {
-            "period": "MINUTE",
-            "maxInPeriod": 50
-          }
-        },
-        "x-roblox-scopes": [
-          {
-            "name": "universe:write",
-            "targetResourceSpecifier": "universes"
-          }
-        ],
-        "x-roblox-engine-usability": {
-          "apiKeyWithHttpService": false
-        },
-        "security": [
-          {
-            "roblox-legacy-cookie": []
-          },
-          {
-            "roblox-api-key": []
-          },
-          {
-            "roblox-oauth2": ["universe:write"]
-          }
-        ]
-      },
-      "get": {
-        "operationId": "ThumbnailPersonalizationApi.HomepageThumbnail_GetHomepageThumbnails",
-        "parameters": [
-          {
-            "name": "universeId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          {
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer",
-              "format": "int32"
-            }
-          },
-          {
-            "name": "nextCursor",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/FindThumbnailsResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          }
-        },
-        "x-roblox-stability": "EXPERIMENTAL",
-        "x-roblox-rate-limits": {
-          "perApiKeyOwner": {
-            "period": "MINUTE",
-            "maxInPeriod": 100
-          },
-          "perOauth2Authorization": {
-            "period": "MINUTE",
-            "maxInPeriod": 100
-          }
-        },
-        "x-roblox-scopes": [
-          {
-            "name": "universe:read",
-            "targetResourceSpecifier": "universes"
-          }
-        ],
-        "x-roblox-engine-usability": {
-          "apiKeyWithHttpService": false
-        },
-        "security": [
-          {
-            "roblox-legacy-cookie": []
-          },
-          {
-            "roblox-api-key": []
-          },
-          {
-            "roblox-oauth2": ["universe:read"]
-          }
-        ]
-      }
-    },
-    "/thumbnail-personalization-api/v1/universes/{universeId}/thumbnails/uploads": {
-      "post": {
-        "operationId": "ThumbnailPersonalizationApi.HomepageThumbnail_UploadHomepageThumbnails",
-        "parameters": [
-          {
-            "name": "universeId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "files": {
-                    "type": "array",
-                    "items": {
-                      "type": "string",
-                      "format": "binary"
-                    }
-                  }
-                }
-              },
-              "encoding": {
-                "files": {
-                  "style": "form"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UploadThumbnailsResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          }
-        },
-        "x-roblox-stability": "EXPERIMENTAL",
-        "x-roblox-rate-limits": {
-          "perApiKeyOwner": {
-            "period": "MINUTE",
-            "maxInPeriod": 50
-          },
-          "perOauth2Authorization": {
-            "period": "MINUTE",
-            "maxInPeriod": 50
-          }
-        },
-        "x-roblox-scopes": [
-          {
-            "name": "universe:write",
-            "targetResourceSpecifier": "universes"
-          }
-        ],
-        "x-roblox-engine-usability": {
-          "apiKeyWithHttpService": false
-        },
-        "security": [
-          {
-            "roblox-legacy-cookie": []
-          },
-          {
-            "roblox-api-key": []
-          },
-          {
-            "roblox-oauth2": ["universe:write"]
-          }
-        ]
-      }
-    },
-    "/thumbnail-personalization-api/v1/universes/{universeId}/thumbnails/uploads/status": {
-      "get": {
-        "operationId": "ThumbnailPersonalizationApi.HomepageThumbnail_GetHomepageThumbnailsStatus",
-        "parameters": [
-          {
-            "name": "universeId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "integer",
-              "format": "int64"
-            }
-          },
-          {
-            "name": "operationIds",
-            "in": "query",
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UploadThumbnailsStatusResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
-                }
-              }
-            }
-          }
-        },
-        "x-roblox-stability": "EXPERIMENTAL",
-        "x-roblox-rate-limits": {
-          "perApiKeyOwner": {
-            "period": "MINUTE",
-            "maxInPeriod": 100
-          },
-          "perOauth2Authorization": {
-            "period": "MINUTE",
-            "maxInPeriod": 100
-          }
-        },
-        "x-roblox-scopes": [
-          {
-            "name": "universe:read",
-            "targetResourceSpecifier": "universes"
-          }
-        ],
-        "x-roblox-engine-usability": {
-          "apiKeyWithHttpService": false
-        },
-        "security": [
-          {
-            "roblox-legacy-cookie": []
-          },
-          {
-            "roblox-api-key": []
-          },
-          {
-            "roblox-oauth2": ["universe:read"]
-          }
-        ]
+        "externalDocs": {
+          "url": "https://create.roblox.com/docs/cloud/reference/features/thumbnails#HomepageThumbnail_GetHomepageThumbnailsStatus"
+        }
       }
     },
     "/toolbox-service/v1/saves": {
@@ -25700,7 +24895,7 @@
               "minimum": 0,
               "type": "integer",
               "format": "int64",
-              "default": 0
+              "nullable": true
             }
           },
           {
@@ -26109,6 +25304,7 @@
     },
     "/v1/account-creation/metadata": {
       "get": {
+        "tags": ["Accounts"],
         "summary": "Get metadata for adding auth methods.",
         "responses": {
           "200": {
@@ -26131,7 +25327,10 @@
           {
             "url": "https://auth.roblox.com"
           }
-        ]
+        ],
+        "externalDocs": {
+          "url": "https://create.roblox.com/docs/cloud/reference/features/accounts#auth_get_v1_account_creation_metadata"
+        }
       }
     },
     "/v1/account/pin": {
@@ -40349,7 +39548,7 @@
             }
           },
           "400": {
-            "description": "1: The group is invalid or does not exist."
+            "description": "1: The group is invalid or does not exist.\r\n36: The pagination cursor is invalid."
           },
           "401": {
             "description": "0: Authorization has been denied for this request."
@@ -42376,7 +41575,7 @@
             }
           },
           "400": {
-            "description": "1: The group is invalid or does not exist."
+            "description": "1: The group is invalid or does not exist.\r\n36: The pagination cursor is invalid."
           },
           "403": {
             "description": "2: The roleset is invalid or does not exist.\r\n35: You do not have permission to view this group's member list."
@@ -43341,7 +42540,7 @@
             }
           },
           "400": {
-            "description": "1: The group is invalid or does not exist."
+            "description": "1: The group is invalid or does not exist.\r\n36: The pagination cursor is invalid."
           },
           "403": {
             "description": "35: You do not have permission to view this group's member list."
@@ -47755,6 +46954,7 @@
     },
     "/v1/passkey/su-eligibility": {
       "get": {
+        "tags": ["Accounts"],
         "summary": "Checks whether the authenticated user is eligible for silent passkey upgrade.\r\nRoute and response are intentionally obfuscated (\"su-eligibility\" = \"silent-upgrade-eligibility\").",
         "responses": {
           "200": {
@@ -47783,7 +46983,10 @@
           {
             "url": "https://auth.roblox.com"
           }
-        ]
+        ],
+        "externalDocs": {
+          "url": "https://create.roblox.com/docs/cloud/reference/features/accounts#auth_get_v1_passkey_su_eligibility"
+        }
       }
     },
     "/v1/passwords/validate": {
@@ -47997,7 +47200,6 @@
           "apiKeyWithHttpService": false
         },
         "security": [
-          {},
           {
             "roblox-legacy-cookie": []
           }
@@ -48055,7 +47257,6 @@
           "apiKeyWithHttpService": false
         },
         "security": [
-          {},
           {
             "roblox-legacy-cookie": []
           }
@@ -48125,7 +47326,6 @@
           "apiKeyWithHttpService": false
         },
         "security": [
-          {},
           {
             "roblox-legacy-cookie": []
           }
@@ -50389,6 +49589,7 @@
     },
     "/v1/supported-languages/games/{gameId}/languages/{languageCode}/image-translation-status": {
       "patch": {
+        "tags": ["Localization"],
         "summary": "Enable or disable image translation for a game and language.",
         "parameters": [
           {
@@ -50468,7 +49669,10 @@
           {
             "roblox-legacy-cookie": []
           }
-        ]
+        ],
+        "externalDocs": {
+          "url": "https://create.roblox.com/docs/cloud/reference/features/localization#gameinternationalization_patch_v1_supported_languages_games__gameId__languages__languageCode__image_translation_status"
+        }
       }
     },
     "/v1/supported-languages/games/{gameId}/languages/{languageCode}/universe-display-info-automatic-translation-settings": {
@@ -54590,6 +53794,7 @@
     },
     "/v1/username/change/price": {
       "get": {
+        "tags": ["Accounts"],
         "summary": "Get the current price for a username change",
         "responses": {
           "200": {
@@ -54615,7 +53820,10 @@
           {
             "url": "https://auth.roblox.com"
           }
-        ]
+        ],
+        "externalDocs": {
+          "url": "https://create.roblox.com/docs/cloud/reference/features/accounts#auth_get_v1_username_change_price"
+        }
       }
     },
     "/v1/usernames": {
@@ -56104,7 +55312,6 @@
           "apiKeyWithHttpService": false
         },
         "security": [
-          {},
           {
             "roblox-legacy-cookie": []
           }
@@ -56249,7 +55456,6 @@
           "apiKeyWithHttpService": false
         },
         "security": [
-          {},
           {
             "roblox-legacy-cookie": []
           }
@@ -56814,7 +56020,6 @@
           "apiKeyWithHttpService": false
         },
         "security": [
-          {},
           {
             "roblox-legacy-cookie": []
           }
@@ -62813,6 +62018,7 @@
     },
     "/v2/assets/{assetId}/bundles": {
       "get": {
+        "tags": ["Assets"],
         "summary": "Lists bundles that contain the given asset (hydrated search-detail shape for marketplace).",
         "parameters": [
           {
@@ -62910,7 +62116,10 @@
           {
             "roblox-legacy-cookie": []
           }
-        ]
+        ],
+        "externalDocs": {
+          "url": "https://create.roblox.com/docs/cloud/reference/features/assets#catalog_get_v2_assets__assetId__bundles"
+        }
       }
     },
     "/v2/assets/{assetId}/owners": {
@@ -63624,7 +62833,12 @@
         "x-roblox-engine-usability": {
           "apiKeyWithHttpService": false
         },
-        "security": [{}],
+        "security": [
+          {},
+          {
+            "roblox-legacy-cookie": []
+          }
+        ],
         "externalDocs": {
           "url": "https://create.roblox.com/docs/cloud/reference/features/metadata#clientsettings_get_v2_client_version__binaryType__channel__channelName_"
         }
@@ -64838,7 +64052,12 @@
         "x-roblox-engine-usability": {
           "apiKeyWithHttpService": false
         },
-        "security": [{}],
+        "security": [
+          {},
+          {
+            "roblox-legacy-cookie": []
+          }
+        ],
         "externalDocs": {
           "url": "https://create.roblox.com/docs/cloud/reference/features/metadata#clientsettings_get_v2_ota_version__binaryType_"
         }
@@ -68223,6 +67442,7 @@
     },
     "/v2/username/change/price": {
       "get": {
+        "tags": ["Accounts"],
         "summary": "Get the current price for a username change",
         "responses": {
           "200": {
@@ -68248,7 +67468,10 @@
           {
             "url": "https://auth.roblox.com"
           }
-        ]
+        ],
+        "externalDocs": {
+          "url": "https://create.roblox.com/docs/cloud/reference/features/accounts#auth_get_v2_username_change_price"
+        }
       }
     },
     "/v2/usernames": {
@@ -70790,6 +70013,66 @@
         "additionalProperties": false,
         "description": "Set Client Status request."
       },
+      "ConditionalRuleDefinition": {
+        "type": "object",
+        "properties": {
+          "tokens": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RpnTokenDto"
+            },
+            "description": "Postfix RPN token sequence.",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "JSON shape of an RPN conditional rule in public API requests, aligned with `roblox.creatorexperienceconfig.conditionrules.v1.RpnRule`."
+      },
+      "ConditionalRulesChangesPayload": {
+        "type": "object",
+        "properties": {
+          "rulesOrder": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RulesOrderDeltaPayload"
+              }
+            ],
+            "nullable": true
+          },
+          "rules": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/RuleDeltaPayload"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Minimal delta for conditional rules on a revision (optional extension on list revisions)."
+      },
+      "ConditionalRulesPayload": {
+        "type": "object",
+        "properties": {
+          "rules": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ConditionalRuleDefinition"
+            },
+            "description": "RPN rules keyed by condition id. On `draft:overwrite`, omitting a rule id that exists on published removes that rule; JSON `null` tombstones;\r\n`{ \"tokens\": [] }` is an explicit empty rule.",
+            "nullable": true
+          },
+          "rulesOrder": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Evaluation order (condition ids).",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Public JSON shape for conditional rules (`rules` + `rulesOrder`), aligned with CMS `ConditionalRules`."
+      },
       "ConfigDraftEntry": {
         "type": "object",
         "properties": {
@@ -70821,6 +70104,15 @@
             },
             "description": "The configuration entries in the draft (key to value and optional description).",
             "nullable": true
+          },
+          "conditionalRules": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConditionalRulesPayload"
+              }
+            ],
+            "description": "Conditional rules staged on the draft, when any exist.",
+            "nullable": true
           }
         },
         "additionalProperties": false,
@@ -70844,6 +70136,15 @@
               }
             ],
             "description": "Metadata about the configuration repository.",
+            "nullable": true
+          },
+          "conditionalRules": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConditionalRulesPayload"
+              }
+            ],
+            "description": "Conditional RPN rules and evaluation order, when any exist.",
             "nullable": true
           }
         },
@@ -70881,6 +70182,15 @@
             },
             "description": "The configuration entries (key-value pairs) in the repository.",
             "nullable": true
+          },
+          "conditionalRules": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConditionalRulesPayload"
+              }
+            ],
+            "description": "Conditional RPN rules and evaluation order, when any exist.",
+            "nullable": true
           }
         },
         "additionalProperties": false,
@@ -70889,6 +70199,14 @@
       "ConfigValueFull": {
         "type": "object",
         "properties": {
+          "variants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConfigVariantDto"
+            },
+            "description": "Non-default branches (e.g. conditional), when present.",
+            "nullable": true
+          },
           "value": {
             "description": "The value of the configuration entry.",
             "nullable": true
@@ -70911,6 +70229,36 @@
         },
         "additionalProperties": false,
         "description": "A full representation of a configuration value, including its metadata."
+      },
+      "ConfigVariantDto": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConfigVariantType"
+              }
+            ],
+            "description": "Variant discriminator (e.g. conditional branch).\n\nconditional",
+            "x-enum-varnames": ["Conditional"]
+          },
+          "variantTypeId": {
+            "type": "string",
+            "description": "Identifier for this variant within CreatorConfigsPublicApi.Models.ConfigVariantDto.Type (e.g. conditional rule id for CreatorConfigsPublicApi.Models.ConfigVariantType.Conditional).",
+            "nullable": true
+          },
+          "value": {
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "A non-default branch on a config entry (public API discriminated variant)."
+      },
+      "ConfigVariantType": {
+        "enum": ["conditional"],
+        "type": "string",
+        "description": "Discriminator for entries in CreatorConfigsPublicApi.Models.ConfigVariantDto variant lists (full config and revision snapshots).\n\nconditional",
+        "x-enum-varnames": ["Conditional"]
       },
       "ContentMessage": {
         "type": "object",
@@ -74003,6 +73351,11 @@
             },
             "description": "Optional. A mapping of PlaceId to the specific versions to restart/bleed off for that place.\r\nWhen set for a place, only servers running those exact versions will be affected.\r\nIf a place is not in this dictionary or has an empty set, behavior falls back to CloseOldVersionsOnly logic.",
             "nullable": true
+          },
+          "attributes": {
+            "type": "string",
+            "description": "Optional. Attributes string to include in the ServerLifecycleChanged CSM payload published to game servers.",
+            "nullable": true
           }
         },
         "additionalProperties": false,
@@ -74501,6 +73854,29 @@
           }
         },
         "description": "A list of UserRestrictions in the parent collection."
+      },
+      "LiteralValueDto": {
+        "type": "object",
+        "properties": {
+          "booleanValue": {
+            "type": "string",
+            "nullable": true
+          },
+          "integerValue": {
+            "type": "string",
+            "nullable": true
+          },
+          "doubleValue": {
+            "type": "string",
+            "nullable": true
+          },
+          "stringValue": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "Literal constant for an RPN operand (proto `LiteralValue` oneof as independent fields for JSON)."
       },
       "LuauExecutionSessionTask": {
         "type": "object",
@@ -76653,14 +76029,16 @@
         "enum": [
           "InExperienceConfig",
           "RecommendationServicesConfig",
-          "DataStoresConfig"
+          "DataStoresConfig",
+          "ExtendedServicesConfig"
         ],
         "type": "string",
-        "description": "Public API repository identifier. Only values exposed by the public API are included;\r\ninternal repository types are not exposed to allow development and testing before enabling.\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig",
+        "description": "Public API repository identifier. Only values exposed by the public API are included;\r\ninternal repository types are not exposed to allow development and testing before enabling.\n\nInExperienceConfig\n\nRecommendationServicesConfig\n\nDataStoresConfig\n\nExtendedServicesConfig",
         "x-enum-varnames": [
           "InExperienceConfig",
           "RecommendationServicesConfig",
-          "DataStoresConfig"
+          "DataStoresConfig",
+          "ExtendedServicesConfig"
         ]
       },
       "RestartState": {
@@ -76869,6 +76247,15 @@
               "$ref": "#/components/schemas/RevisionChange"
             },
             "description": "The changes in this revision, keyed by entry key.",
+            "nullable": true
+          },
+          "conditionalRulesChanges": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConditionalRulesChangesPayload"
+              }
+            ],
+            "description": "Optional delta for conditional rules when this revision touched rules or evaluation order.",
             "nullable": true
           }
         },
@@ -79931,6 +79318,16 @@
             "description": "The current moderation status of the game if it is for sale in fiat. ['Invalid' = 0, 'NotModerated' = 1, 'Pending' = 2, 'Approved' = 3, 'Rejected' = 4]",
             "enum": [0, 1, 2, 3, 4],
             "type": "integer"
+          },
+          "audiences": {
+            "description": "Audiences allowed to view this universe, sourced from the new UniversePublicitySettings entity\r\nin universe-settings-service. Populated from USS only when UniversePublicitySettingsTreatment\r\nis ReverseShadow or Authority (USS is the source of truth in those modes); an empty list is\r\nreturned for Off and Shadow so clients always see a stable shape, never null.",
+            "type": "array",
+            "items": {
+              "format": "int32",
+              "description": " ['Invalid' = 0, 'Editors' = 1, 'PlayTesters' = 2, 'Friends' = 3, 'Public' = 4]",
+              "enum": [0, 1, 2, 3, 4],
+              "type": "integer"
+            }
           }
         },
         "additionalProperties": false
@@ -82468,8 +81865,8 @@
             "type": "array",
             "items": {
               "format": "int32",
-              "description": "Catalog item status enum. ['New' = 1, 'Sale' = 2, 'SaleTimer' = 7]",
-              "enum": [1, 2, 7],
+              "description": "Catalog item status enum. ['New' = 1, 'Sale' = 2, 'SaleTimer' = 7, 'IsFAE' = 8]",
+              "enum": [1, 2, 7, 8],
               "type": "integer"
             }
           },
@@ -82656,8 +82053,8 @@
             "type": "array",
             "items": {
               "format": "int32",
-              "description": "Catalog item status enum. ['New' = 1, 'Sale' = 2, 'SaleTimer' = 7]",
-              "enum": [1, 2, 7],
+              "description": "Catalog item status enum. ['New' = 1, 'Sale' = 2, 'SaleTimer' = 7, 'IsFAE' = 8]",
+              "enum": [1, 2, 7, 8],
               "type": "integer"
             }
           },
@@ -93827,6 +93224,78 @@
         },
         "additionalProperties": false
       },
+      "RpnOperandDto": {
+        "type": "object",
+        "properties": {
+          "attributeReference": {
+            "type": "string",
+            "nullable": true
+          },
+          "literalValue": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LiteralValueDto"
+              }
+            ],
+            "description": "Literal constant for an RPN operand (proto `LiteralValue` oneof as independent fields for JSON).",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "RPN operand: attribute reference or literal value (same concepts as the proto `RpnOperand` oneof)."
+      },
+      "RpnTokenDto": {
+        "type": "object",
+        "properties": {
+          "operator": {
+            "type": "string",
+            "nullable": true
+          },
+          "operand": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/RpnOperandDto"
+              }
+            ],
+            "description": "RPN operand: attribute reference or literal value (same concepts as the proto `RpnOperand` oneof).",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "One RPN token: either a logical/comparison CreatorConfigsPublicApi.Models.ConditionalRuleOperator (proto JSON `OPERATOR_*`) or an operand object."
+      },
+      "RuleDeltaPayload": {
+        "type": "object",
+        "properties": {
+          "before": {
+            "nullable": true
+          },
+          "after": {
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "RulesOrderDeltaPayload": {
+        "type": "object",
+        "properties": {
+          "before": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "after": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "SalesReportDownloadRequest": {
         "type": "object",
         "properties": {
@@ -94048,7 +93517,8 @@
             "minimum": 0,
             "type": "integer",
             "description": "The minimum price of the asset in cents. If included, must be greater than or equal to 0.",
-            "format": "int64"
+            "format": "int64",
+            "nullable": true
           },
           "maxPriceCents": {
             "maximum": 2147483647,
@@ -95836,12 +95306,21 @@
             "additionalProperties": {
               "nullable": true
             },
-            "description": "The entries to update. Keys not included will not be changed. Set key to null to delete, or set to published value to discard.",
+            "description": "On PATCH, keys not included are unchanged; set a key to null to delete a branch or entry per merge rules.\r\nOn PUT `draft:overwrite`, this map is the authoritative final entry set: any key present on the latest published configuration but omitted here is removed, and any conditional branch omitted for a key that remains is removed.",
+            "nullable": true
+          },
+          "conditionalRules": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/ConditionalRulesPayload"
+              }
+            ],
+            "description": "Optional conditional rules. On PATCH, merges with the current draft rules when this payload is non-empty (any rule id or `rulesOrder` entry).\r\nOmit the property or send an empty object `{}` to leave rules unchanged (draft rules, or latest published rules if the draft has none yet).\r\nOn PUT `draft:overwrite`, when this property is present,\r\nCreatorConfigsPublicApi.Models.ConditionalRulesPayload.Rules is the full intended rule set after publish: rules that exist on the latest published configuration but are omitted are removed.\r\nWhen omitted on overwrite, all published conditional rules are cleared (entries must not reference conditionals unless you provide this object).",
             "nullable": true
           }
         },
         "additionalProperties": false,
-        "description": "Request model for updating a draft (partial update)."
+        "description": "Request model for draft updates: PATCH uses a partial merge; PUT `draft:overwrite` treats the body as the full intended configuration after publish."
       },
       "UpdateEntryRequest": {
         "required": ["value"],
@@ -96914,6 +96393,9 @@
           "auth_get_v1_xbox_connection",
           "auth_post_v1_xbox_disconnect",
           "auth_get_v1_xbox_get_login_consecutive_days",
+          "auth_get_v1_username_change_price",
+          "auth_get_v1_account_creation_metadata",
+          "auth_get_v1_passkey_su_eligibility",
           "auth_post_v1_xbox_translate",
           "auth_get_v2_auth_metadata",
           "auth_post_v2_identity_verification_login",
@@ -96940,6 +96422,7 @@
           "auth_get_v2_usernames",
           "auth_post_v2_usernames_recover",
           "auth_get_v2_usernames_validate",
+          "auth_get_v2_username_change_price",
           "auth_post_v2_usernames_validate",
           "auth_post_v3_logout",
           "auth_post_v3_users__userId__two_step_verification_login",
@@ -97049,6 +96532,7 @@
           "catalog_post_v1_topic_get_topics",
           "catalog_get_v1_users__userId__bundles",
           "catalog_get_v1_users__userId__bundles__bundleType_",
+          "catalog_get_v2_assets__assetId__bundles",
           "catalog_get_v2_search_items_details",
           "develop_get_v1_assets_voting",
           "develop_get_v1_plugins",
@@ -97688,6 +97172,8 @@
           "gameinternationalization_get_v1_supported_languages_games__gameId__automatic_translation_status",
           "patch_legacy_game_internationalization_v1_supported_languages_games__gameId__languages__languageCode__automatic_translation_status",
           "gameinternationalization_patch_v1_supported_languages_games__gameId__languages__languageCode__automatic_translation_status",
+          "patch_legacy_game_internationalization_v1_supported_languages_games__gameId__languages__languageCode__image_translation_status",
+          "gameinternationalization_patch_v1_supported_languages_games__gameId__languages__languageCode__image_translation_status",
           "patch_legacy_game_internationalization_v1_supported_languages_games__gameId__languages__languageCode__universe_display_info_automatic_translation_settings",
           "gameinternationalization_patch_v1_supported_languages_games__gameId__languages__languageCode__universe_display_info_automatic_translation_settings",
           "get_legacy_game_internationalization_v1_supported_languages_games__gameId__universe_display_info_automatic_translation_settings",
@@ -98004,6 +97490,13 @@
         "content": "HTTP APIs for working with user thumbnails on Roblox Cloud.",
         "ordering": [
           "Cloud_GenerateUserThumbnail",
+          "HomepageThumbnail_UploadHomepageThumbnails",
+          "HomepageThumbnail_GetHomepageThumbnailsStatus",
+          "HomepageThumbnail_GetHomepageThumbnails",
+          "HomepageThumbnail_DeleteHomepageThumbnails",
+          "HomepageThumbnail_CreateThumbnailPersonalization",
+          "HomepageThumbnail_UpdateThumbnailPersonalization",
+          "HomepageThumbnail_FindThumbnailPersonalizations",
           "post_legacy_game_internationalization_v1_game_thumbnails_games__gameId__language_codes__languageCode__alt_text",
           "gameinternationalization_post_v1_game_thumbnails_games__gameId__language_codes__languageCode__alt_text",
           "post_legacy_game_internationalization_v1_game_thumbnails_games__gameId__language_codes__languageCode__image",


### PR DESCRIPTION
## Summary

- Refresh vendored Roblox OpenAPI schema (pin `0cbea05…` → `3dedc83…`) and verify every existing drift patch against live API at `apis.roblox.com`. All six pre-existing patches confirmed still corrective.
- Patch #4's regex anchor relied on patch #2's side effect (the trailing comma after `path`'s description, only present after `readOnly: true` is inserted), so `verifyPatchesStillNeeded` was false-positive flagging it obsolete on every unpatched upstream. Re-anchored on `"The priority of the queue item."`, which is unique to `MemoryStoreQueueItem`.
- Roblox added `format: "duration"` to `MemoryStoreSortedMapItem.ttl` upstream since the prior refresh. Server still accepts protobuf `"3s"` and rejects ISO 8601 `"PT3S"` (probed live). Added patch #7 mirroring patch #4 for the sorted-map item schema, so sorted-map create/update integration tests stop failing under the strict schema validator.
- Added two manual probe scripts (`scripts/probe-memory-store-{sorted-maps,queues}.ts`) that hit the live API without the SDK and print every request/response. Invoked explicitly via `bun`, not wired into CI. Cover all seven patches between them.
- Corrected patch #2's README rationale: the server **silently strips** caller-supplied `path` (verified across 5 forged-path variants — well-formed, mismatched-universe, malformed, `null`, all 200), it does **not** reject. The `readOnly: true` patch itself stays.

## Active patches after this PR

| # | Schema location | Drift | Probe |
|---|---|---|---|
| 1 | `MemoryStoreQueueItem.required` adds `"data"` | 400 INVALID_ARGUMENT without `data` | queue probe C |
| 2 | `MemoryStoreQueueItem.path` becomes `readOnly` | Server silently strips client-supplied `path` | queue probe D |
| 3 | `ReadMemoryStoreQueueItemsResponse` renames `items→queueItems`, `readId→id` | Live response uses `queueItems` + `id` | queue probe E |
| 4 | `MemoryStoreQueueItem.ttl` drops `format: "duration"` | Server accepts `"5s"`, rejects `"PT5S"` | queue probes A/B |
| 5 | `Cloud_ReadMemoryStoreQueueItems.invisibilityWindow` drops `format: "duration"` | Server accepts `"3s"`, rejects `"PT3S"` | queue probes E/F |
| 6 | `ListMemoryStoreSortedMapItemsResponse` renames `memoryStoreSortedMapItems→items` | Live list uses `items` | sorted-map probe D |
| 7 | `MemoryStoreSortedMapItem.ttl` drops `format: "duration"` (NEW) | Server accepts `"5s"`, rejects `"PT5S"` | sorted-map probes A/B |

## Reviewer notes

- The probe scripts assume an API key with `universe.memory-store-{queue,sorted-map}-item:read,write,delete` scopes and a throwaway universe. Env vars: `BEDROCK_API_KEY`, `ROBLOX_TEST_UNIVERSE_ID`. They are documented in their header comments and in `vendor/README.md` -> "Drift detection layers" (new layer #4: "Manual probes (on demand)").
- The vendored schema diff is large (`-937 / +431` lines) because the upstream itself was substantially restructured between refreshes. Most of the diff is upstream movement, not our patches; the only patch-driven changes are the seven entries above.
- `apply-schema-patches.spec.ts` bumps the expected-count assertion from 6 to 7 to reflect the new patch.
- All 1493 ocale tests pass; pre-commit ran lint + typecheck + test + build + mutate + commitlint clean.

## Test plan

- [x] `pnpm refresh-openapi` succeeds (no false-positive obsolete patches)
- [x] `pnpm --filter @bedrock-rbx/ocale test` — 1493 passed
- [x] `pnpm lint` — clean (only a pre-existing unrelated warning in `apps/website`)
- [x] `pnpm typecheck` — clean
- [x] Live-API probes confirm each of the 7 patches is corrective

🤖 Generated with [Claude Code](https://claude.com/claude-code)