### PR TITLE
chore: update agent skills and add handoff skill

### DIFF
--- a/.agents/skills/grill-with-docs/SKILL.md
+++ b/.agents/skills/grill-with-docs/SKILL.md
@@ -73,7 +73,7 @@ When the user states how something works, check whether the code agrees. If you 
 
 When a term is resolved, update `CONTEXT.md` right there. Don't batch these up — capture them as they happen. Use the format in [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md).
 
-Don't couple `CONTEXT.md` to implementation details. Only include terms that are meaningful to domain experts.
+`CONTEXT.md` should be totally devoid of implementation details. Do not treat `CONTEXT.md` as a spec, a scratch pad, or a repository for implementation decisions. It is a glossary and nothing else.
 
 ### Offer ADRs sparingly
 

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: handoff
+description: Compact the current conversation into a handoff document for another agent to pick up.
+argument-hint: "What will the next session be used for?"
+---
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save it to a path produced by `mktemp -t handoff-XXXXXX.md` (read the file before you write to it).
+
+Suggest the skills to be used, if any, by the next session.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.

--- a/.agents/skills/to-issues/SKILL.md
+++ b/.agents/skills/to-issues/SKILL.md
@@ -51,7 +51,7 @@ Iterate until the user approves the breakdown.
 
 ### 5. Publish the issues to the issue tracker
 
-For each approved slice, publish a new issue to the issue tracker. Use the issue body template below. Apply the `needs-triage` triage label so each issue enters the normal triage flow.
+For each approved slice, publish a new issue to the issue tracker. Use the issue body template below. These issues are considered ready for AFK agents, so publish them with the correct triage label unless instructed otherwise.
 
 Publish issues in dependency order (blockers first) so you can reference real issue identifiers in the "Blocked by" field.
 
@@ -63,6 +63,8 @@ A reference to the parent issue on the issue tracker (if the source was an exist
 ## What to build
 
 A concise description of this vertical slice. Describe the end-to-end behavior, not layer-by-layer implementation.
+
+Avoid specific file paths or code snippets — they go stale fast. Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it here and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
 
 ## Acceptance criteria
 

--- a/.agents/skills/to-prd/SKILL.md
+++ b/.agents/skills/to-prd/SKILL.md
@@ -17,7 +17,7 @@ A deep module (as opposed to a shallow module) is one which encapsulates a lot o
 
 Check with the user that these modules match their expectations. Check with the user which modules they want tests written for.
 
-3. Write the PRD using the template below, then publish it to the project issue tracker. Apply the `needs-triage` triage label so it enters the normal triage flow.
+3. Write the PRD using the template below, then publish it to the project issue tracker. Apply the `ready-for-agent` triage label - no need for additional triage.
 
 <prd-template>
 
@@ -54,6 +54,8 @@ A list of implementation decisions that were made. This can include:
 - Specific interactions
 
 Do NOT include specific file paths or code snippets. They may end up being outdated very quickly.
+
+Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it within the relevant decision and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
 
 ## Testing Decisions
 

--- a/.claude/skills/handoff
+++ b/.claude/skills/handoff
@@ -1,0 +1,1 @@
+../../.agents/skills/handoff

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -17,7 +17,13 @@
 			"source": "mattpocock/skills",
 			"sourceType": "github",
 			"skillPath": "skills/engineering/grill-with-docs/SKILL.md",
-			"computedHash": "31a5b1ae116558bf7d3f633f442835f54bd7645923d4f45c7823e52a97317666"
+			"computedHash": "1adf321072f53cce3dcaf5357d91b8230d4aa647bb8a51756745337a6ee567b8"
+		},
+		"handoff": {
+			"source": "mattpocock/skills",
+			"sourceType": "github",
+			"skillPath": "skills/productivity/handoff/SKILL.md",
+			"computedHash": "d543685cbfb0c64b7bc51a8dc3465975528da9b64f987f863765973b2f3867ab"
 		},
 		"humanizer": {
 			"source": "christopher-buss/skills",
@@ -65,13 +71,13 @@
 			"source": "mattpocock/skills",
 			"sourceType": "github",
 			"skillPath": "skills/engineering/to-issues/SKILL.md",
-			"computedHash": "73a91f30784523aa59ec9b02769576ebfc738e2cd5ad8f6441076031f0a5d5ac"
+			"computedHash": "47f648f3414848ccfc62cb41d2828b7e575fb5e7cbd6c4bdf630c063b5dc5e82"
 		},
 		"to-prd": {
 			"source": "mattpocock/skills",
 			"sourceType": "github",
 			"skillPath": "skills/engineering/to-prd/SKILL.md",
-			"computedHash": "fd8c259f9c44eff08e29a1a2fc71a806a3568d279a55387a361f78620b10f2aa"
+			"computedHash": "6d741474efd4bc3db55fabc2722ed78ca9c374cabcb6212936d79d4fd4a30fcb"
 		},
 		"triage": {
 			"source": "mattpocock/skills",


### PR DESCRIPTION
## Summary
- Refines guidance in three existing skills (`grill-with-docs`, `to-issues`, `to-prd`):
  - `grill-with-docs`: tightens `CONTEXT.md` policy (glossary only — not a spec, scratch pad, or implementation-decision dump).
  - `to-issues`: switches default label from `needs-triage` to the appropriate ready label since slices are pre-vetted by the time the skill runs; allows prototype snippets in issue bodies when they encode a decision more precisely than prose.
  - `to-prd`: switches default label from `needs-triage` to `ready-for-agent` for the same reason; same prototype-snippet exception.
- Adds new `handoff` skill (compact the current conversation into a handoff document for another agent to pick up).
- Updates `skills-lock.json` hashes accordingly.

## Test plan
- [ ] Skill content reads correctly
- [ ] `skills-lock.json` hashes match the new SKILL.md contents
- [ ] `.claude/skills/handoff` symlink resolves to `.agents/skills/handoff` (relative, portable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Code Review: PR #407 - Update Agent Skills and Add Handoff Skill

### Scope
This PR updates **agent skill configuration files** (Claude prompt/instruction templates and metadata), not production code. Skills are registered in `skills-lock.json` via content hashes. Traditional FCIS pattern, TDD, and architectural constraints do not apply — these are instructional documents for Claude agents, not executable code.

### Changes Summary

**grill-with-docs/SKILL.md** (1 line changed)
- **Change**: Strengthens guidance on `CONTEXT.md` scope from "don't couple to implementation details" to "totally devoid of implementation details. Do not treat as spec, scratch pad, or implementation-decision dump. It is a glossary and nothing else."
- **Alignment**: Reinforces Bedrock's domain-driven documentation culture (per `CLAUDE.md` and existing practices)
- **Quality**: Clear, explicit—removes ambiguity about what CONTEXT.md is *not*

**to-issues/SKILL.md** (4 lines changed: +3/-1)
- **Changes**: 
  - Default label `needs-triage` → "correct triage label" (acknowledging issues are pre-vetted before the skill runs)
  - New guidance: allow prototype snippets that encode decisions (state machine, reducer, schema, type shape), but avoid file paths and working-demo details
- **Rationale**: Vertical slices in Bedrock are already vetted when `to-issues` skill is invoked; `ready-for-agent`/`ready-for-human` is the right starting label
- **Alignment**: Matches Bedrock's decision-focused issue culture and DDD vocabulary

**to-prd/SKILL.md** (4 lines changed: +3/-1)
- **Changes**:
  - Default label `needs-triage` → `ready-for-agent` with note "no need for additional triage"
  - Same prototype-snippet exception as `to-issues` (decision-rich snippets allowed; working demos not)
- **Alignment**: Consistent with `to-issues` and avoids coupling PRDs to implementation details
- **Clarity**: Exception criteria well-defined ("decision-rich parts — not a working demo")

**handoff/SKILL.md** (new, 13 lines)
- **Purpose**: Enable agent-to-agent handoff of work in progress
- **Key behaviors**:
  - Writes to `mktemp`-generated markdown file (ensures unique, portable artifacts)
  - Suggests next-session skills
  - Avoids duplicating content already in PRDs, plans, ADRs, issues—references them by path/URL instead
  - Tailors output based on user-provided intent
- **Quality**: Clear, actionable structure; follows Bedrock's documented artifact patterns

**.claude/skills/handoff** (new symlink)
- **Target**: `../../.agents/skills/handoff` (relative, portable ✓)
- **Resolution**: Verified `.agents/skills/handoff/SKILL.md` exists

**skills-lock.json** (6 entries changed: +9/-3)
- Updated `computedHash` for `grill-with-docs`, `to-issues`, `to-prd` to reflect content changes
- Added `handoff` entry with correct hash from `mattpocock/skills` external source

### Review Findings

✅ **Guidance Quality**
- All skill instructions are clear, actionable, and non-contradictory
- Exception rules are well-scoped (prototype snippets must encode decisions, not implementation)
- Label changes correctly reflect pre-vetting workflow

✅ **Alignment with Bedrock Culture**
- Reinforces domain-driven design (CONTEXT.md as glossary only)
- Consistent with decision-focused issue and PRD practices
- Aligns with artifact deduplication principle (handoff skill)

✅ **Configuration Correctness**
- Symlink is relative and portable
- Hash values match file contents
- External skill source (`mattpocock/skills`) is properly attributed

✅ **Test Plan Verification**
- ✓ Skill content reads correctly (verified via `git show`)
- ✓ skills-lock.json hashes match SKILL.md contents
- ✓ .claude/skills/handoff symlink resolves to correct target

### No Issues Found
- No production code violations (not applicable to prompt configs)
- No security concerns (skill instructions do not handle secrets or credentials)
- No breaking changes to existing skill interfaces—purely guidance refinements
- PR title (`chore: update agent skills`) is correctly scoped and case-normalized

### Recommendation
**Approve** — All changes are well-justified refinements to agent guidance, properly configured, and aligned with Bedrock's documented practices. The new handoff skill fills a useful gap in agent-to-agent collaboration tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/407)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->