### PR TITLE
docs: add adr-024 for resource redaction

### DIFF
--- a/docs/adr/024-resource-redaction.md
+++ b/docs/adr/024-resource-redaction.md
@@ -1,0 +1,274 @@
+# ADR-024: Resource Redaction for Pre-Release Environments
+
+**Date:** 2026-05-14  **Status:** Accepted
+
+Decision Makers: Maintainer  
+Tags: config, core, schema, wire-contract, security
+
+## Context
+
+Bedrock pushes each resource's real `name`, `description`, and `icon` to Open
+Cloud on every deploy. Those fields render on the experience's roblox.com page.
+A Roblox browser extension that bypasses the unreleased-place gate can expose
+that page to anyone who knows the URL, leaking in-development monetization
+metadata before a release.
+
+No mechanism exists to deploy "structurally real but content-hidden" resources.
+Manual workarounds -- editing placeholders on the dashboard, maintaining a
+parallel dev-names config -- break IaC reproducibility.
+
+The threat model is a Roblox-rendered page made accessible through an
+access-control bypass. This is not a defense against an actor with the
+developer's Open Cloud credentials or access to the source config repository.
+
+## Decision
+
+Add a `redacted` field to the project config schema (ADR-020) that opts a
+resource or environment into bedrock-supplied placeholder content. When active,
+bedrock substitutes placeholders for display metadata before pushing to Open
+Cloud. The real values stay in config and ship only when redaction is lifted.
+
+### Authored shape
+
+Resource-entry shape varies by kind, reflecting each kind's underlying field names.
+
+For `gamePass`, `developerProduct`, and `badge`:
+
+```ts
+interface PassEntry {
+	redacted?:
+		| boolean
+		| { description?: string; icon?: Record<"en-us", string>; name?: string };
+}
+```
+
+For `universe` (note `displayName`, not `name`):
+
+```ts
+interface UniverseEntry {
+	redacted?:
+		| boolean
+		| { description?: string; displayName?: string; icon?: Record<"en-us", string> };
+}
+```
+
+Environment-overlay level:
+
+```ts
+interface EnvironmentEntry {
+	redacted?: boolean;
+}
+```
+
+No project-root-level field. Enabling per-env on each non-production environment
+is the expected pattern.
+
+The object form implies redaction is enabled (specifying an override turns it
+on). An empty object (`redacted: {}`) is a validation error; authors must write
+`redacted: true` for defaults. Override keys are restricted to the redactable
+field set for that kind; unknown keys (e.g. `price`) are validation errors.
+Both rejections attribute the offending field path.
+
+### Resource-kind scope
+
+- In scope: `universe`, `gamePass`, `developerProduct`, `badge`
+- Out of scope: `place` (the `.rbxl` file is the content, not metadata);
+  `module` (no display surface)
+
+### Per-kind default field sets
+
+| Kind                | Redacted by default               |
+| ------------------- | --------------------------------- |
+| `gamePass`          | `name`, `description`, `icon`     |
+| `developerProduct`  | `name`, `description`, `icon`     |
+| `badge`             | `name`, `description`, `icon`     |
+| `universe`          | `description`, `icon` only        |
+
+The universe asymmetry is deliberate: `displayName` surfaces in Roblox Studio's
+place picker and the Creator Hub experience list -- developer-facing tools the
+experience owner needs to identify their own work. Redacting it by default would
+make the experience harder to locate during development than before redaction was
+enabled. Authors who need full opacity write
+`universe.redacted: { displayName: 'Hidden Project' }` explicitly.
+
+### Precedence
+
+Most-specific layer wins:
+
+```text
+environments['x'].passes['k'].redacted
+  > passes['k'].redacted
+  > environments['x'].redacted
+```
+
+Per-resource inside an env overlay beats per-resource at root, which beats the
+env-level boolean. `redacted: false` at a more-specific layer carves out an
+exception in an otherwise-redacted env.
+
+### Bedrock-supplied placeholder defaults
+
+| Kind               | Name field    | Default                                  | `description` | `icon`                    |
+| ------------------ | ------------- | ---------------------------------------- | ------------- | ------------------------- |
+| `gamePass`         | `name`        | `"Redacted Pass"`                        | `""`          | embedded placeholder PNG  |
+| `developerProduct` | `name`        | `"Redacted Product"`                     | `""`          | embedded placeholder PNG  |
+| `badge`            | `name`        | `"Redacted Badge"`                       | `""`          | embedded placeholder PNG  |
+| `universe`         | `displayName` | (no default; explicit override required) | `""`          | embedded placeholder PNG  |
+
+The placeholder PNG ships as an inlined `Uint8Array` in `@bedrock-rbx/core`. A
+sentinel path constant is assigned when `applyRedaction` substitutes an icon;
+`readBytes` recognizes the sentinel and returns the embedded bytes. Downstream
+normalize and driver upload paths receive bytes through the existing interface
+unchanged.
+
+### Pipeline placement
+
+```text
+load config
+  -> validate
+  -> select environment (merge env overlay)
+  -> applyRedaction         <-- new pure transform
+  -> render displayName prefix
+  -> flatten per-kind
+  -> normalize per-kind (hash icons; sentinel resolves through readBytes)
+  -> diff
+  -> apply via drivers
+```
+
+`applyRedaction` is a pure function in `core/redact-resources.ts`. It receives a
+`ResolvedConfig` and returns a `ResolvedConfig`; no I/O. Placement between
+env-overlay merge and display-name-prefix application means an explicitly
+redacted universe `displayName` composes with the prefix: `[DEV] Hidden`, not
+the real name with a prefix.
+
+### State and diff
+
+The state file records the values that were actually pushed -- placeholders for
+redacted resources. Diff compares desired against current with no special-cased
+path. A redacted resource whose config-level real name is edited produces a noop
+(the placeholder did not change); the plan output surfaces this case explicitly
+so the noop is not silent.
+
+No state-file schema bump. No diff-algebra change. ADR-019 is unaffected.
+
+### Validation
+
+arktype narrows enforce:
+
+- `redacted: {}` -- rejected; error attributed to the field path
+- `redacted: { price: 0 }` -- rejected; error names `price` as an unknown override key
+- `environments['x'].redacted: { name: 'X' }` -- rejected; env overlay accepts boolean only
+- `redacted: true`, `redacted: false`, `redacted: { name: 'X' }` -- all accepted
+
+## Consequences
+
+### Positive
+
+- Developers can deploy to a dev environment without exposing real monetization
+  metadata on the roblox.com experience page.
+- Additive config extension: authors who do not declare `redacted` see exactly
+  current behavior. No migration, no state-file bump.
+- Redaction state is reproducible: the same config produces the same placeholders
+  on every deploy, preserving IaC guarantees.
+- Drift detection works without modification: the state records placeholders, so
+  a manual dashboard edit to a redacted resource shows as drift on the next run.
+- `applyRedaction` is pure and independently testable. No adapters, no I/O.
+- The sentinel-path approach keeps the normalize and driver upload paths
+  unchanged; no per-kind code needs to know about redaction.
+
+### Negative
+
+- Universe `displayName` asymmetry is a wart: `redacted: true` on universe does
+  not redact the display name, which may surprise authors who expect uniform
+  treatment. The override escape hatch exists but requires extra explicit config.
+- A per-resource override at root (e.g. `passes['x'].redacted: { name: 'Closed Beta' }`)
+  is overridden by any redacted setting on the same resource inside an env overlay,
+  including a bare `redacted: true`. Authors who want a root-level custom placeholder
+  to apply in every env must leave that resource's `redacted` field absent from
+  env overlays, or repeat the override on each env overlay's entry.
+- Plan output must explicitly surface the "noop due to redaction" case to prevent
+  silent surprises when the real name changes in config but the placeholder does
+  not. Failing to implement that annotation faithfully would undermine user story
+  8 (the plan-output story).
+- Localized `name` and `description` redaction is out of scope: those fields are
+  single strings in the current schema. When per-locale name and description land,
+  redaction will need to fold them into the default field set.
+
+## Alternatives Considered
+
+### Env-level override object (`environments.dev.redacted: { name: 'Closed Beta' }`)
+
+An env-level field that accepts the full override object, not just boolean, would
+allow a single custom placeholder applied across all kinds in that env.
+
+**Rejected.** The use cases that motivated this feature are satisfied by
+per-resource overrides at the resource entry level. A cross-kind env-level
+override object introduces questions about kind-specific field eligibility
+(e.g. universe does not redact `name` by default) that per-resource overrides
+do not. Complexity deferred until a concrete use case demands it.
+
+### Project-root-level redaction toggle
+
+A top-level `redacted: true` that redacts every redactable resource across all
+environments.
+
+**Rejected.** Bedrock configs enumerate environments explicitly. Redacting
+everything in all environments, including production, is not a use case the
+feature serves; the threat is dev/staging leakage, not production leakage.
+Per-env redaction on non-production environments is sufficient and less dangerous.
+
+### Separate placeholder config file
+
+A sidecar file (e.g. `bedrock.redacted.config.ts`) holding placeholder values,
+merged at load time.
+
+**Rejected.** Adds a second config-discovery concern and a new load-time artifact
+for a feature that composes naturally as a field on existing resource entries.
+The `redacted` field is authored alongside the resource it affects, keeping the
+config self-contained.
+
+### Encrypt or omit real values from the state file
+
+Rather than storing placeholder content, store encrypted real values or omit
+display metadata from state entirely.
+
+**Rejected.** Encryption requires key management and makes `diff` dependent on a
+secret at runtime. Omitting display metadata from state breaks drift detection.
+The threat model is Roblox-side leakage through a page-access bypass, not state
+file compromise; authors who need state-file confidentiality should choose a
+locked-down state backend.
+
+## Implementation Notes
+
+New modules in `core/`:
+
+- `redact-resources.ts` -- `applyRedaction(config: ResolvedConfig): ResolvedConfig`.
+  Owns precedence resolution, per-kind default field sets, and substitution.
+  Single exported function; no I/O.
+- `redacted-icon.ts` -- embedded placeholder PNG as `Uint8Array`, sentinel path
+  constant, `isRedactedIconPath` predicate.
+
+Modified:
+
+- `core/schema.ts` -- extends each redactable entry type with `redacted?:
+  boolean | RedactedOverride` and each env-overlay type with `redacted?: boolean`.
+  arktype narrows reject empty-object form, unknown override keys, and object form
+  on env overlays.
+- `core/select-environment.ts` -- calls `applyRedaction` between env-overlay
+  merge and display-name-prefix application.
+- `core/kinds/read-bytes.ts` -- short-circuits the sentinel path to embedded
+  bytes.
+- `shell/preview-diff.ts` (or the diff renderer) -- annotates plan output with a
+  "redacted in \<env\>" line per redacted resource so real-value edits that
+  produce a noop are surfaced.
+
+## Related Decisions
+
+- ADR-017 -- Product Framing: the `redacted` field is part of the public config
+  API surface.
+- ADR-018 -- FCIS + Ports: `applyRedaction` is a pure core transform; no I/O,
+  no ports.
+- ADR-019 -- State Data Model and Diff Algebra: explicitly not amended; this
+  design is additive within the existing data model and diff contract.
+- ADR-020 -- Project Config Definition: this ADR extends the schema ADR-020
+  defines. The per-resource entry schema and the env-overlay schema both gain
+  the `redacted` field.

--- a/docs/adr/024-resource-redaction.md
+++ b/docs/adr/024-resource-redaction.md
@@ -36,9 +36,7 @@ For `gamePass`, `developerProduct`, and `badge`:
 
 ```ts
 interface PassEntry {
-	redacted?:
-		| boolean
-		| { description?: string; icon?: Record<"en-us", string>; name?: string };
+	redacted?: boolean | { description?: string; icon?: Record<"en-us", string>; name?: string };
 }
 ```
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,7 @@ things are the way they are.
 | [021](./021-file-backed-resource-kinds.md) | Resource Update Capability for File-Backed Kinds | Accepted | 2026-04-22 |
 | [022](./022-by-domain-folder-layout-for-ocale.md) | By-Domain Folder Layout for `@bedrock-rbx/ocale` | Accepted | 2026-04-30 |
 | [023](./023-apply-semantics-parallel-continue-on-failure.md) | Apply Semantics — Parallel, Continue-on-Failure, Per-Op Progress Events | Accepted | 2026-05-14 |
+| [024](./024-resource-redaction.md) | Resource Redaction for Pre-Release Environments | Accepted | 2026-05-14 |
 
 ## Creating a New ADR
 

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,5 +1,5 @@
-amends "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Config.pkl"
-import "package://github.com/jdx/hk/releases/download/v1.42.0/hk@1.42.0#/Builtins.pkl"
+amends "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.45.0/hk@1.45.0#/Builtins.pkl"
 
 // Workaround: hk util commands fail on Windows via cmd.exe, bash -c fixes it
 local bash: String = "bash -c"
@@ -29,17 +29,16 @@ local genExampleTests = new Step {
 }
 
 local lint = new Step {
-	glob = List("*.ts", "*.tsx")
 	check = "pnpm lint:affected"
+	fix = "pnpm lint:affected --fix"
 	shell = bash
-	exclusive = true
 }
 
 local typecheck = new Step {
     glob = List("*.ts", "*.tsx")
     check = "pnpm typecheck:affected"
     shell = bash
-    exclusive = true
+	stomp = true
 }
 
 local test = new Step {
@@ -62,7 +61,6 @@ local build = new Step {
     glob = List("*.ts", "*.tsx")
     check = "pnpm build:affected"
     shell = bash
-    exclusive = true
 }
 
 local mutate = new Step {
@@ -91,25 +89,26 @@ local unused = new Step {
 
 hooks {
     ["pre-commit"] {
+		fix = true
         stash = "none"
         steps {
             ...sharedGuards
             ["no-commit-to-branch"] = preCommitBranchGuard
-			["lint"] = (lint)
             ["typecheck"] = (typecheck)
+            ["build"] = (build) { condition = isAgent }
+			["lint"] = (lint)
             ["gen-example-tests"] = (genExampleTests) { condition = isAgent }
             ["test"] = (test) { condition = isAgent }
-            ["build"] = (build) { condition = isAgent }
             ["mutate"] = (mutate) { condition = isAgent }
         }
     }
     ["pre-push"] {
         steps {
-			["lint"] = lint
             ["typecheck"] = typecheck
-            ["gen-example-tests"] = genExampleTests
-            ["unused"] = unused
             ["build"] = build
+            ["unused"] = unused
+			["lint"] = lint
+            ["gen-example-tests"] = genExampleTests
             ["test"] = test
             ["mutate"] = (mutatePush) { condition = isAgent }
         }
@@ -139,11 +138,11 @@ hooks {
     ["check"] {
         steps {
             ...sharedGuards
-			["lint"] = lint
             ["typecheck"] = typecheck
-            ["gen-example-tests"] = genExampleTests
-            ["unused"] = unused
             ["build"] = build
+            ["unused"] = unused
+			["lint"] = lint
+            ["gen-example-tests"] = genExampleTests
             ["test"] = testCi
         }
     }


### PR DESCRIPTION
## Summary

- Adds [ADR-024](docs/adr/024-resource-redaction.md), Accepted, documenting the design for an opt-in `redacted` field on resources and env overlays. Per-resource and env-level scopes compose with most-specific-wins precedence. Universe carries an asymmetric default that preserves `displayName`. State and diff are unchanged; placeholder substitution lives as a pure transform in `core/`.
- Updates `docs/adr/README.md` index.

Implementation work is tracked separately in #408 (PRD) and slice issues #409, #410, #411, #412, #413, #414.

## Test plan

- [ ] Index renders ADR-024 row with correct status and date
- [ ] ADR file renders cleanly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# PR Review: ADR-024 Resource Redaction for Pre-Release Environments

## Summary
This PR introduces ADR-024, documenting the design for an opt-in `redacted` field that allows resources to use Bedrock-supplied placeholder display metadata in pre-release environments. The ADR index (docs/adr/README.md) is updated to include the new record.

## ADR Justification ✅
This ADR appropriately addresses a **state/wire contract** decision (per Bedrock's ADR criteria): it defines config schema extension (ADR-020), state/diff expectations, and a security boundary for pre-release environment metadata leakage.

## Architecture Compliance ✅

**FCIS + Ports Pattern:**
- `applyRedaction` correctly scoped as a pure function in `core/redact-resources.ts` (no I/O, no side effects)
- Icon placeholders handled via sentinel path constant → `readBytes` adapter (existing interface preserved, no per-kind driver changes)
- Pipeline placement specified between environment overlay merge and display-name-prefix rendering
- All driven-port boundaries respected; adapters remain unchanged

**Cross-Architecture References:**
- Properly links to ADR-017 (config API surface), ADR-018 (FCIS + Ports), ADR-019 (state/diff unmodified), ADR-020 (schema extension)
- No violations of referenced architectures; additive design

## Security & Constraints ✅

**Open Cloud Scope:**
- All design assumes Open Cloud APIs only; no legacy Roblox API references
- Threat model explicitly scoped to Roblox-rendered page leakage via access-control bypass; **not** a defense against developer-credential compromise or config repository access
- Correctly clarifies scope with "This is not a defense against an actor with the developer's Open Cloud credentials"

**State Confidentiality:**
- State files record placeholders actually pushed (public metadata only), consistent with "state files = resource IDs only" constraint
- Drift detection works unchanged; real values never leave config
- No encryption or secret-management complexity

## Decision Quality ✅

**Rigor:**
- Context frames threat clearly (monetization metadata leakage in pre-release)
- Authored shapes precisely defined (TypeScript interfaces for each kind)
- Per-kind defaults tabulated (universe asymmetry explained: `displayName` excluded to preserve developer visibility in Studio place picker)
- Precedence rules unambiguous: most-specific-wins across per-resource and environment scopes
- Validation constraints detailed (empty object rejection, unknown keys rejected, env-overlay boolean-only constraint with rationale)

**Consequences Honestly Documented:**
- Positives: reproducibility, drift detection, additive (no migration), pure-function testability, existing adapter paths unchanged
- Negatives: universe `displayName` asymmetry acknowledged as intentional (may surprise authors); per-resource root overrides require careful env-overlay handling; plan output must explicitly surface "noop due to redaction" case; localized name/description redaction deferred
- Negative consequences frame implementation obligations (e.g., plan-output annotation requirement)

**Alternatives Carefully Rejected:**
- Env-level override objects: defers complexity until concrete use case
- Project-root toggle: scope mismatch (production not threatened)
- Sidecar placeholder file: self-contained field more maintainable
- State encryption/omission: threat model is page-access bypass, not state compromise

**Implementation Specificity:**
- Modules clearly listed: `core/redact-resources.ts` (pure transform), `core/redacted-icon.ts` (placeholder PNG + sentinel)
- Modification points explicit: schema (per ADR-020), env-overlay merge, `readBytes`, diff renderer
- No ambiguity about placement or responsibility

## Documentation Completeness ✅

- README index entry correctly added: status "Accepted", date "2026-05-14"
- All required ADR sections present and well-structured
- Scope clearly delineated (in-scope: universe, gamePass, developerProduct, badge; out-of-scope: place, module)
- Per-kind defaults and precedence rules precisely documented

## Implementation Readiness

**Covered in this PR:**
- Design documentation with full implementation notes
- README index updated
- ADR follows Bedrock's ADR enforcement standards (ADR-006)

**Deferred to implementation PRs (#408, #409-#414):**
- Unit tests for `applyRedaction` (core pure function—unit test level)
- Integration tests for env-overlay merging and precedence
- Validation test coverage for arktype narrows (empty object, unknown keys, env-boolean-only)
- Plan output annotation for "noop due to redaction" case
- Type-level tests for public config schema changes (per Bedrock convention)

## Minor Notes

**Universe `displayName` Asymmetry:** Intentional and defensible. Developers need to locate their work in Studio place picker and Creator Hub; redacting it by default would worsen the development experience. Override escape hatch (`redacted: { displayName: 'Hidden Project' }`) exists for authors needing full opacity. This design choice is transparent and documented in Consequences.

**Test Plan Checklist:** The PR description includes two test-plan items (index render, ADR file rendering). These are documentation-level checks. Full test coverage (unit, integration, validation, type-level) should be verified in the implementation PR against the test requirements outlined above.

---

**Recommendation:** ✅ **Approve.** This ADR is well-architected, properly justified, respects Bedrock's FCIS + Ports and Open Cloud constraints, and documents a thoughtful decision with implementation path. The design is additive (no breaking changes) and security-conscious with a clearly-scoped threat model. The universe `displayName` asymmetry is intentional, explained, and defensible. Proceed with implementation tracking PRD #408 and slices #409–#414.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/415)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->