### PR TITLE
feat(core): redact game-pass content per environment

### DIFF
--- a/.config/cspell.config.yaml
+++ b/.config/cspell.config.yaml
@@ -18,6 +18,7 @@ words:
   - pulumi
   - rbxl
   - rbxlx
+  - redactable
   - redactions
   - retryable
   - shiki

--- a/packages/bedrock/src/core/redact-resources.spec.ts
+++ b/packages/bedrock/src/core/redact-resources.spec.ts
@@ -163,6 +163,55 @@ describe(applyRedaction, () => {
 			redacted: { icon: { "en-us": "assets/override-icon.png" } },
 		});
 	});
+
+	it.for([
+		{
+			caseName: "no flags set",
+			entryRedacted: undefined,
+			envRedacted: undefined,
+			expectRedacted: false,
+		},
+		{
+			caseName: "env-level true, no resource flag",
+			entryRedacted: undefined,
+			envRedacted: true,
+			expectRedacted: true,
+		},
+		{
+			caseName: "env-level false, no resource flag",
+			entryRedacted: undefined,
+			envRedacted: false,
+			expectRedacted: false,
+		},
+		{
+			caseName: "resource false carves out env-level true",
+			entryRedacted: false,
+			envRedacted: true,
+			expectRedacted: false,
+		},
+		{
+			caseName: "resource true redacts despite env-level false",
+			entryRedacted: true,
+			envRedacted: false,
+			expectRedacted: true,
+		},
+	] as const)(
+		"should redact a pass according to overlay > root > env precedence ($caseName)",
+		({ entryRedacted, envRedacted, expectRedacted }) => {
+			expect.assertions(1);
+
+			const passEntry = (
+				entryRedacted === undefined ? vipEntry : { ...vipEntry, redacted: entryRedacted }
+			) satisfies GamePassEntry;
+			const result = applyRedaction(
+				{ ...baseConfig, passes: { "vip-pass": passEntry } },
+				envRedacted,
+			);
+			const expectedName = expectRedacted ? REDACTED_PASS_NAME : vipEntry.name;
+
+			expect(result.passes?.["vip-pass"]?.name).toBe(expectedName);
+		},
+	);
 });
 
 describe(collectRedactionAnnotations, () => {

--- a/packages/bedrock/src/core/redact-resources.ts
+++ b/packages/bedrock/src/core/redact-resources.ts
@@ -1,7 +1,7 @@
 import { asResourceKey, type ResourceKey } from "../types/ids.ts";
 import { REDACTED_ICON_PATH } from "./redacted-icon.ts";
 import type { ResourceKind } from "./resources.ts";
-import type { GamePassEntry, ResolvedConfig } from "./schema.ts";
+import type { GamePassEntry, RedactedGamePassOverride, ResolvedConfig } from "./schema.ts";
 
 /** Default placeholder name pushed for a redacted game-pass. */
 export const REDACTED_PASS_NAME = "Redacted Pass";
@@ -27,26 +27,40 @@ export interface RedactionAnnotation {
 
 /**
  * Pure transform that substitutes bedrock-supplied placeholder content for
- * every resource flagged `redacted: true` or `redacted: { ... }`. The
- * object form replaces matching fields with the supplied values and falls
- * back to the bedrock defaults for the rest. Runs between env-overlay
- * merge and display-name prefix render so the rest of the pipeline
- * (flatten, normalize, diff, apply) operates on already-redacted values
- * and needs no special-case redaction logic.
+ * every resource whose effective `redacted` flag is truthy. The effective
+ * flag is the per-resource `redacted` value when set, otherwise the
+ * `environmentRedacted` fallback. A `redacted` object form replaces
+ * matching fields with the supplied values and falls back to the bedrock
+ * defaults for the rest. Runs between env-overlay merge and display-name
+ * prefix render so the rest of the pipeline (flatten, normalize, diff,
+ * apply) operates on already-redacted values and needs no special-case
+ * redaction logic.
  *
  * @param config - Post-merge `ResolvedConfig` produced by `selectEnvironment`.
+ * @param environmentRedacted - Environment-level redaction toggle. Resources
+ *   that omit a per-resource `redacted` flag inherit this value.
  * @returns A `ResolvedConfig` whose redacted entries carry placeholder
  *   values; non-redacted entries pass through verbatim, and the input is
  *   not mutated.
  */
-export function applyRedaction(config: ResolvedConfig): ResolvedConfig {
+export function applyRedaction(
+	config: ResolvedConfig,
+	environmentRedacted = false,
+): ResolvedConfig {
 	if (config.passes === undefined) {
 		return config;
 	}
 
 	const passes = Object.fromEntries(
 		Object.entries(config.passes).map(([key, entry]) => {
-			return [key, redactPass(entry)] as const;
+			const effective = entry.redacted ?? environmentRedacted;
+			if (effective === false) {
+				return [key, entry] as const;
+			}
+
+			const override: RedactedGamePassOverride =
+				typeof effective === "object" ? effective : {};
+			return [key, redactPass(entry, override)] as const;
 		}),
 	);
 
@@ -86,13 +100,7 @@ export function collectRedactionAnnotations(
 		});
 }
 
-function redactPass(entry: GamePassEntry): GamePassEntry {
-	if (entry.redacted === undefined || entry.redacted === false) {
-		return entry;
-	}
-
-	const override = entry.redacted === true ? {} : entry.redacted;
-
+function redactPass(entry: GamePassEntry, override: RedactedGamePassOverride): GamePassEntry {
 	return {
 		...entry,
 		name: override.name ?? REDACTED_PASS_NAME,

--- a/packages/bedrock/src/core/schema.spec-d.ts
+++ b/packages/bedrock/src/core/schema.spec-d.ts
@@ -231,7 +231,7 @@ describe("PlaceEntry / ResolvedPlaceEntry split", () => {
 // counterpart. Adding to or removing from these unions is the explicit way to
 // opt new fields out of the symmetric overlay surface.
 type NonOverridableConfigKey = "displayNamePrefix" | "environments" | "extends";
-type EnvironmentMetadataKey = "label";
+type EnvironmentMetadataKey = "label" | "redacted";
 type OverridableConfigKey = Exclude<keyof Config, NonOverridableConfigKey>;
 type EnvironmentEntryKey = Exclude<keyof Required<EnvironmentEntry>, EnvironmentMetadataKey>;
 

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -1943,12 +1943,15 @@ describe(validateConfig, () => {
 		]);
 	});
 
-	it("should accept a bare redacted toggle on an environments entry", () => {
+	it.for([
+		["true", true],
+		["false", false],
+	] as const)("should accept a bare redacted: %s on an environments entry", ([, redacted]) => {
 		expect.assertions(1);
 
 		const result = validateConfig(
 			{
-				environments: { production: { redacted: true } },
+				environments: { production: { redacted } },
 				state: { backend: "gist", gistId: "root-gist" },
 			},
 			SOURCE,
@@ -1956,7 +1959,7 @@ describe(validateConfig, () => {
 
 		assert(result.success);
 
-		expect(result.data.environments["production"]?.redacted).toBeTrue();
+		expect(result.data.environments["production"]?.redacted).toBe(redacted);
 	});
 
 	it("should reject an object-form redacted on an environments entry", () => {

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -1943,12 +1943,28 @@ describe(validateConfig, () => {
 		]);
 	});
 
-	it("should reject a bare redacted toggle on an environments entry until env-level redaction lands", () => {
+	it("should accept a bare redacted toggle on an environments entry", () => {
 		expect.assertions(1);
 
 		const result = validateConfig(
 			{
 				environments: { production: { redacted: true } },
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.environments["production"]?.redacted).toBeTrue();
+	});
+
+	it("should reject an object-form redacted on an environments entry", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: { production: { redacted: { name: "Closed Beta" } } },
 				state: { backend: "gist", gistId: "root-gist" },
 			},
 			SOURCE,

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- centralized public-API schema; growing the surface here is expected. */
 import type { Result } from "@bedrock-rbx/ocale";
 import type { SocialLink } from "@bedrock-rbx/ocale/universes";
 
@@ -306,6 +307,8 @@ export interface EnvironmentEntry {
 	 * `productId`).
 	 */
 	products?: Record<string, Partial<DeveloperProductEntry>>;
+	/** Per-environment redaction toggle. Per-resource `redacted` flags on the merged config take precedence; `false` carves out exceptions. */
+	redacted?: boolean | undefined;
 	/** Per-environment state override; takes precedence over root `state`. */
 	state?: StateConfig;
 	/**
@@ -807,6 +810,7 @@ const environmentEntry: Type<EnvironmentEntry> = type({
 	"passes?": passesOverlayCollection,
 	"places?": placesOverlayCollection,
 	"products?": productsOverlayCollection,
+	"redacted?": OPTIONAL_BOOLEAN,
 	"state?": stateConfig,
 	"universe?": universeOverlay,
 }).onUndeclaredKey("reject");

--- a/packages/bedrock/src/core/select-environment.ts
+++ b/packages/bedrock/src/core/select-environment.ts
@@ -469,7 +469,7 @@ function redactAndPrefix(inputs: {
 	readonly merged: ResolvedConfig;
 }): ResolvedConfig {
 	const { config, entry, merged } = inputs;
-	const redacted = applyRedaction(merged);
+	const redacted = applyRedaction(merged, entry.redacted);
 	const prefix = resolvePrefix(config, entry);
 	const places = applyPlacesPrefix(redacted.places, prefix);
 	const universe = applyUniversePrefix(redacted.universe, prefix);

--- a/packages/bedrock/tests/integration/fixtures/passes-redacted-env/bedrock.config.ts
+++ b/packages/bedrock/tests/integration/fixtures/passes-redacted-env/bedrock.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "@bedrock-rbx/core";
+
+export default defineConfig({
+	environments: {
+		dev: {
+			passes: { "carve-out-pass": { redacted: false } },
+			redacted: true,
+		},
+		production: {},
+	},
+	passes: {
+		"carve-out-pass": {
+			name: "Carve Out",
+			description: "Stays real in dev.",
+			icon: { "en-us": "assets/carve.png" },
+			price: 100,
+		},
+		"vip-pass": {
+			name: "VIP Pass",
+			description: "Grants VIP perks.",
+			icon: { "en-us": "assets/vip.png" },
+			price: 500,
+		},
+	},
+	universe: { universeId: "1234567890" },
+});

--- a/packages/bedrock/tests/integration/passes-redacted.spec.ts
+++ b/packages/bedrock/tests/integration/passes-redacted.spec.ts
@@ -25,6 +25,7 @@ import { assert, describe, expect, it } from "vitest";
 
 const FIXTURES_ROOT = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
 const PASSES_FIXTURE_DIR = join(FIXTURES_ROOT, "passes-redacted");
+const PASSES_ENV_FIXTURE_DIR = join(FIXTURES_ROOT, "passes-redacted-env");
 const UNIVERSE_ID = asRobloxAssetId("1234567890");
 const ROOT_PLACE_ID = asRobloxAssetId("4711");
 
@@ -448,6 +449,58 @@ describe("passes-redacted pipeline end-to-end", () => {
 		await expect(readFormBytes(captured.request.body, "file")).resolves.toStrictEqual(
 			REAL_ICON_BYTES,
 		);
+	});
+});
+
+describe("passes-redacted env-level toggle", () => {
+	it("should redact a pass with no redacted flag when the env-level redacted toggle is true", async () => {
+		expect.assertions(3);
+
+		const loaded = await loadConfig({ cwd: PASSES_ENV_FIXTURE_DIR });
+		assert(loaded.success);
+
+		const resolved = selectEnvironment(loaded.data, "dev");
+		assert(resolved.success);
+
+		const vip = resolved.data.passes?.["vip-pass"];
+		assert(vip !== undefined);
+
+		expect(vip.name).toBe(REDACTED_PASS_NAME);
+		expect(vip.description).toBe(REDACTED_DESCRIPTION);
+		expect(vip.icon["en-us"]).toBe(REDACTED_ICON_PATH);
+	});
+
+	it("should leave a pass real when its overlay sets redacted false despite an env-level redacted true", async () => {
+		expect.assertions(3);
+
+		const loaded = await loadConfig({ cwd: PASSES_ENV_FIXTURE_DIR });
+		assert(loaded.success);
+
+		const resolved = selectEnvironment(loaded.data, "dev");
+		assert(resolved.success);
+
+		const carve = resolved.data.passes?.["carve-out-pass"];
+		assert(carve !== undefined);
+
+		expect(carve.name).toBe("Carve Out");
+		expect(carve.description).toBe("Stays real in dev.");
+		expect(carve.icon["en-us"]).toBe("assets/carve.png");
+	});
+
+	it("should not redact passes in an env whose redacted toggle is absent", async () => {
+		expect.assertions(2);
+
+		const loaded = await loadConfig({ cwd: PASSES_ENV_FIXTURE_DIR });
+		assert(loaded.success);
+
+		const resolved = selectEnvironment(loaded.data, "production");
+		assert(resolved.success);
+
+		const vip = resolved.data.passes?.["vip-pass"];
+		const carve = resolved.data.passes?.["carve-out-pass"];
+
+		expect(vip?.name).toBe("VIP Pass");
+		expect(carve?.name).toBe("Carve Out");
 	});
 });
 


### PR DESCRIPTION
## Summary

- Add `environments.<env>.redacted?: boolean` env-level toggle to `EnvironmentEntry` (TS interface + arktype overlay schema). When `true`, every game-pass in that environment is redacted unless an entry on the merged config (root or overlay) sets `redacted: false`.
- Extend `applyRedaction(config, environmentRedacted)` to thread the toggle. Per-resource `entry.redacted ?? environmentRedacted` keeps overlay > root > env-level precedence from ADR-024. `redactPass` becomes a pure transform (no predicate, no dead default); the predicate lives at the call site.
- Closes [#410](https://github.com/christopher-buss/bedrock/issues/410). Tracer-bullet slice for the per-resource flag landed in [#416](https://github.com/christopher-buss/bedrock/pull/416); this is the env-level extension that ADR-024 anticipated. Object override form, developer-product / universe support, and plan-output annotation remain out of scope.

## Test plan

- [x] `pnpm test` — 3433 pass, 0 fail across the repo.
- [x] `pnpm typecheck` — clean (includes `EnvironmentEntry` exhaustiveness type test acknowledging `redacted` as env-only metadata).
- [x] `pnpm lint` — clean.
- [x] `pnpm build` — clean.
- [x] `pnpm mutate:changed` — 100 % (2/2 mutants killed on `redact-resources.ts`).
- [x] Unit truth table in `redact-resources.spec.ts` exercises all five non-redundant precedence cells (the `(false, true)` row is the `??` vs `||` carve-out mutant killer).
- [x] Integration tests in `passes-redacted.spec.ts` thread the env-level toggle through `loadConfig` → arktype validation → `selectEnvironment` → `applyRedaction`, plus the previously-failing guard-rail schema test (`"reject [...] until env-level redaction lands"`) flipped to acceptance, with a new sibling test that keeps the boolean-only restriction from ADR-024 enforced (object-form `redacted` on env entry still rejects).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Architecture & FCIS Compliance

✅ **Pattern enforcement is sound.** The PR maintains strict FCIS separation:
- **Core**: `applyRedaction()` is a pure transform with no I/O, side effects, or dependencies on external state
- **Shell**: `redactAndPrefix()` in `select-environment.ts` properly threads the environment-level toggle into the core function
- **Result types**: `selectEnvironment()` correctly returns `Result<ResolvedConfig, SelectEnvironmentError>` with proper success/error handling
- No violations of Open Cloud constraints; schema validates at arktype boundaries

## TDD & Test Coverage

✅ **Red-Green-Refactor discipline is evident.** Test structure indicates tests drove implementation:
- **Unit tests** (`redact-resources.spec.ts`): 49 new lines covering all 5 precedence cases (no flags, env-true/false, resource carve-out, resource override). Table-driven `it.for()` exercises exhaustively: `undefined/undefined` → unredacted, `undefined/true` → redacted, `false/true` → resource wins, `true/false` → resource wins. Each precedence path is separately observable.
- **Integration tests** (`passes-redacted.spec.ts`): Three new suites validating threading from `loadConfig` → `arktype validation` → `selectEnvironment` → `applyRedaction`. Tests confirm real config merging (not mock behavior). Fixture demonstrates overlay precedence: `dev` sets `redacted: true` at env level while carving out `carve-out-pass` with `redacted: false`.
- **Type-level tests** (`schema.spec-d.ts`): Updated `EnvironmentMetadataKey` union to include `"redacted"`, ensuring exhaustiveness checks pass. Confirms `redacted` is treated as environment-only overlay metadata.
- **Schema guard-rail tests** (`schema.spec.ts`): Guard-rails properly tightened (lines 1949–1984): accepts bare boolean `redacted` on `EnvironmentEntry`, rejects object form on env entry (only on per-resource root/overlay), maintains proper issue-path attribution.
- **Mutation testing**: PR claims 100% coverage on `redact-resources.ts`; no surviving mutants implies all branches are exercised (redaction true, false, object form paths all covered).

## Type Safety & API Design

✅ **TypeScript strict mode compliance verified:**
- No `: any` annotations in modified code
- `RedactedGamePassOverride` properly imported and typed for override object form
- `EnvironmentEntry.redacted?: boolean` correctly branded as optional, allowing `undefined` as distinct from `false`
- `applyRedaction(config: ResolvedConfig, environmentRedacted = false): ResolvedConfig` signature extends naturally with optional second parameter

✅ **Precedence implementation matches ADR-024:**
- Per-resource value (overlay/root) takes precedence: `entry.redacted ?? environmentRedacted`
- Private `redactPass()` helper properly delegates to override fallback chain: `override.name ?? REDACTED_PASS_NAME`
- Boolean form triggers default placeholders; object form supplies custom values while falling back to defaults for omitted keys
- Environment toggle only affects entries without explicit per-resource flags (correct nullish-coalescing semantics)

## Integration & Threading

✅ **Redaction toggle properly threaded through pipeline:**
- `selectEnvironment()` → `redactAndPrefix()` calls `applyRedaction(merged, entry.redacted)` — environment entry's toggle is passed to core
- `loadConfig()` → `validateConfig()` (arktype) → `selectEnvironment()` chain maintains type safety across boundaries
- Fixture config demonstrates real-world usage: `dev: { redacted: true, passes: { "carve-out-pass": { redacted: false } } }` shows env-level toggle with per-resource opt-out

## Documentation & Constraints

✅ **Public API fully documented:**
- `applyRedaction()` JSDoc (lines 28–45) explains precedence, environment toggle fallback, and object override semantics
- `EnvironmentEntry.redacted` JSDoc explains per-environment toggle overrides per-resource flags
- Out-of-scope items correctly noted: object override form, developer-product/universe support, plan-output annotation deferred

✅ **Out-of-scope remains properly bounded:** No attempt to extend redaction beyond game-passes; developer-products and universe entries unchanged. Plan-output annotation (detecting real-value divergence during redaction) is tracked separately in `collectRedactionAnnotations()` logic, not mixed into `applyRedaction()`.

## Minor Observations

- **cspell.config.yaml**: Adding `redactable` to the allowlist is appropriate (minimal change, low review effort)
- **Schema lint suppression**: Top-of-file `eslint-disable max-lines` comment properly placed to handle growing public API surface
- **Private helper safety**: `redactPass()` internal function stays private; no public API surface creep

## Summary

This PR implements environment-level redaction with strong architectural discipline, comprehensive test coverage following TDD, correct precedence semantics, and proper threading through the pipeline. All architectural constraints are respected, type safety is maintained, and public API documentation clearly explains usage and bounds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/419?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->