### PR TITLE
feat(core): extend redaction to developer-product

### DIFF
--- a/packages/bedrock/src/adapters/developer-product-driver.ts
+++ b/packages/bedrock/src/adapters/developer-product-driver.ts
@@ -7,6 +7,7 @@ import type {
 import { derivePriceFields } from "../core/derive-price-fields.ts";
 import { shouldReuploadIcon } from "../core/icons.ts";
 import { planFollowUpPatch } from "../core/plan-follow-up-patch.ts";
+import { withRedactedIcon } from "../core/redacted-icon.ts";
 import type { DeveloperProductDesiredState, ResourceCurrentState } from "../core/resources.ts";
 import type { ResourceDriver } from "../ports/resource-driver.ts";
 import { asRobloxAssetId, type RobloxAssetId } from "../types/ids.ts";
@@ -144,12 +145,16 @@ interface FollowUpPatchInputs {
 export function createDeveloperProductDriver(
 	deps: DeveloperProductDriverDeps,
 ): ResourceDriver<"developerProduct"> {
+	const effective: DeveloperProductDriverDeps = {
+		...deps,
+		readFile: withRedactedIcon(deps.readFile),
+	};
 	return {
 		async create(desired) {
-			return createOne(deps, desired);
+			return createOne(effective, desired);
 		},
 		async update(current, desired) {
-			return updateOne(deps, { current, desired });
+			return updateOne(effective, { current, desired });
 		},
 	};
 }

--- a/packages/bedrock/src/config.ts
+++ b/packages/bedrock/src/config.ts
@@ -16,6 +16,7 @@ export type {
 	GamePassEntry,
 	GistStateConfig,
 	PlaceEntry,
+	RedactedDeveloperProductOverride,
 	RedactedGamePassOverride,
 	ResolvedPlaceEntry,
 	ResourceEntryByKind,

--- a/packages/bedrock/src/core/kinds/developer-product.ts
+++ b/packages/bedrock/src/core/kinds/developer-product.ts
@@ -17,6 +17,7 @@ const entrySchema = type({
 	"icon?": iconMap,
 	"isRegionalPricingEnabled?": OPTIONAL_BOOLEAN,
 	"price?": OPTIONAL_ROBUX_PRICE,
+	"redacted?": "boolean | undefined",
 	"storePageEnabled?": OPTIONAL_BOOLEAN,
 });
 

--- a/packages/bedrock/src/core/redact-resources.spec.ts
+++ b/packages/bedrock/src/core/redact-resources.spec.ts
@@ -521,4 +521,121 @@ describe(collectRedactionAnnotations, () => {
 			]);
 		},
 	);
+
+	it("should return an empty array when no product has redacted set to true", () => {
+		expect.assertions(1);
+
+		const result = collectRedactionAnnotations({
+			...baseConfig,
+			products: {
+				"opt-out-pack": { ...gemPackEntry, redacted: false },
+				"plain-pack": gemPackEntry,
+			},
+		});
+
+		expect(result).toStrictEqual([]);
+	});
+
+	it("should emit one developerProduct annotation per product flagged redacted true with hasRealValueEdits false when the author already typed placeholder values literally", () => {
+		expect.assertions(1);
+
+		const placeholderEntry: DeveloperProductEntry = {
+			name: REDACTED_PRODUCT_NAME,
+			description: REDACTED_DESCRIPTION,
+			icon: { "en-us": REDACTED_ICON_PATH },
+			redacted: true,
+		};
+
+		const result = collectRedactionAnnotations({
+			...baseConfig,
+			products: {
+				"elite-pack": placeholderEntry,
+				"gem-pack": placeholderEntry,
+				"plain-pack": gemPackEntry,
+			},
+		});
+
+		expect(result).toIncludeSameMembers([
+			{ key: "gem-pack", hasRealValueEdits: false, kind: "developerProduct" },
+			{ key: "elite-pack", hasRealValueEdits: false, kind: "developerProduct" },
+		]);
+	});
+
+	it("should set hasRealValueEdits false when a redacted product carries no icon at all", () => {
+		expect.assertions(1);
+
+		const result = collectRedactionAnnotations({
+			...baseConfig,
+			products: {
+				"plain-pack": {
+					name: REDACTED_PRODUCT_NAME,
+					description: REDACTED_DESCRIPTION,
+					redacted: true,
+				},
+			},
+		});
+
+		expect(result).toStrictEqual([
+			{ key: "plain-pack", hasRealValueEdits: false, kind: "developerProduct" },
+		]);
+	});
+
+	it.for<{ entry: DeveloperProductEntry; label: string }>([
+		{
+			entry: {
+				name: "Real Pack",
+				description: REDACTED_DESCRIPTION,
+				icon: { "en-us": REDACTED_ICON_PATH },
+				redacted: true,
+			},
+			label: "name",
+		},
+		{
+			entry: {
+				name: REDACTED_PRODUCT_NAME,
+				description: "Real description.",
+				icon: { "en-us": REDACTED_ICON_PATH },
+				redacted: true,
+			},
+			label: "description",
+		},
+		{
+			entry: {
+				name: REDACTED_PRODUCT_NAME,
+				description: REDACTED_DESCRIPTION,
+				icon: { "en-us": "assets/real.png" },
+				redacted: true,
+			},
+			label: "icon",
+		},
+	])(
+		"should set hasRealValueEdits true when only the real product $label diverges from the placeholder default",
+		({ entry }) => {
+			expect.assertions(1);
+
+			const result = collectRedactionAnnotations({
+				...baseConfig,
+				products: { "gem-pack": entry },
+			});
+
+			expect(result).toStrictEqual([
+				{ key: "gem-pack", hasRealValueEdits: true, kind: "developerProduct" },
+			]);
+		},
+	);
+
+	it("should emit annotations for both passes and products when each kind declares a redacted entry", () => {
+		expect.assertions(1);
+
+		const result = collectRedactionAnnotations({
+			...baseConfig,
+			passes: { "vip-pass": { ...vipEntry, redacted: true } },
+			products: { "gem-pack": { ...gemPackEntry, redacted: true } },
+		});
+
+		expect(result).toIncludeSameMembers([
+			{ key: "vip-pass", hasRealValueEdits: true, kind: "gamePass" },
+			{ key: "gem-pack", hasRealValueEdits: true, kind: "developerProduct" },
+		]);
+	});
 });

--- a/packages/bedrock/src/core/redact-resources.spec.ts
+++ b/packages/bedrock/src/core/redact-resources.spec.ts
@@ -367,6 +367,70 @@ describe(applyRedaction, () => {
 			expect(result.products?.["gem-pack"]?.name).toBe(expectedName);
 		},
 	);
+
+	it("should substitute only the supplied product override fields and fall back to defaults for the rest", () => {
+		expect.assertions(1);
+
+		const result = applyRedaction({
+			...baseConfig,
+			products: {
+				"gem-pack": { ...gemPackEntry, redacted: { name: "Closed Beta Pack" } },
+			},
+		});
+
+		expect(result.products?.["gem-pack"]).toStrictEqual({
+			name: "Closed Beta Pack",
+			description: REDACTED_DESCRIPTION,
+			icon: { "en-us": REDACTED_ICON_PATH },
+			price: 100,
+			redacted: { name: "Closed Beta Pack" },
+		});
+	});
+
+	it("should substitute every product field when the override object supplies name, description, and icon", () => {
+		expect.assertions(1);
+
+		const override = {
+			name: "Beta Pack",
+			description: "Beta description",
+			icon: { "en-us": "assets/beta.png" },
+		};
+
+		const result = applyRedaction({
+			...baseConfig,
+			products: { "gem-pack": { ...gemPackEntry, redacted: override } },
+		});
+
+		expect(result.products?.["gem-pack"]).toStrictEqual({
+			name: "Beta Pack",
+			description: "Beta description",
+			icon: { "en-us": "assets/beta.png" },
+			price: 100,
+			redacted: override,
+		});
+	});
+
+	it("should substitute the product icon override path while leaving non-icon fields at defaults", () => {
+		expect.assertions(1);
+
+		const result = applyRedaction({
+			...baseConfig,
+			products: {
+				"gem-pack": {
+					...gemPackEntry,
+					redacted: { icon: { "en-us": "assets/override-icon.png" } },
+				},
+			},
+		});
+
+		expect(result.products?.["gem-pack"]).toStrictEqual({
+			name: REDACTED_PRODUCT_NAME,
+			description: REDACTED_DESCRIPTION,
+			icon: { "en-us": "assets/override-icon.png" },
+			price: 100,
+			redacted: { icon: { "en-us": "assets/override-icon.png" } },
+		});
+	});
 });
 
 describe(collectRedactionAnnotations, () => {

--- a/packages/bedrock/src/core/redact-resources.spec.ts
+++ b/packages/bedrock/src/core/redact-resources.spec.ts
@@ -5,9 +5,10 @@ import {
 	collectRedactionAnnotations,
 	REDACTED_DESCRIPTION,
 	REDACTED_PASS_NAME,
+	REDACTED_PRODUCT_NAME,
 } from "./redact-resources.ts";
 import { REDACTED_ICON_PATH } from "./redacted-icon.ts";
-import type { GamePassEntry, ResolvedConfig } from "./schema.ts";
+import type { DeveloperProductEntry, GamePassEntry, ResolvedConfig } from "./schema.ts";
 
 const baseConfig: ResolvedConfig = {
 	environments: { production: {} },
@@ -19,6 +20,13 @@ const vipEntry = {
 	icon: { "en-us": "assets/vip.png" },
 	price: 500,
 } as const satisfies GamePassEntry;
+
+const gemPackEntry = {
+	name: "Gem Pack",
+	description: "Stocks the player up with 1,000 premium gems.",
+	icon: { "en-us": "assets/gems.png" },
+	price: 100,
+} as const satisfies DeveloperProductEntry;
 
 describe(applyRedaction, () => {
 	it("should replace name, description, and icon with placeholders when redacted is true", () => {
@@ -86,6 +94,31 @@ describe(applyRedaction, () => {
 		expect(result.places).toBe(input.places);
 		expect(result.products).toBe(input.products);
 		expect(result.universe).toBe(input.universe);
+	});
+
+	it("should preserve the passes reference when no entry needs redaction", () => {
+		expect.assertions(1);
+
+		const input: ResolvedConfig = {
+			...baseConfig,
+			passes: { "vip-pass": vipEntry },
+		};
+
+		const result = applyRedaction(input);
+
+		expect(result.passes).toBe(input.passes);
+	});
+
+	it("should return the input config when no resource needs redaction", () => {
+		expect.assertions(1);
+
+		const input: ResolvedConfig = {
+			...baseConfig,
+			passes: { "vip-pass": vipEntry },
+			products: { "gem-pack": gemPackEntry },
+		};
+
+		expect(applyRedaction(input)).toBe(input);
 	});
 
 	it("should not mutate the input config when redacting a pass", () => {
@@ -210,6 +243,128 @@ describe(applyRedaction, () => {
 			const expectedName = expectRedacted ? REDACTED_PASS_NAME : vipEntry.name;
 
 			expect(result.passes?.["vip-pass"]?.name).toBe(expectedName);
+		},
+	);
+
+	it("should replace name, description, and icon with placeholders when a product redacted is true", () => {
+		expect.assertions(1);
+
+		const result = applyRedaction({
+			...baseConfig,
+			products: { "gem-pack": { ...gemPackEntry, redacted: true } },
+		});
+
+		expect(result.products?.["gem-pack"]).toStrictEqual({
+			name: REDACTED_PRODUCT_NAME,
+			description: REDACTED_DESCRIPTION,
+			icon: { "en-us": REDACTED_ICON_PATH },
+			price: 100,
+			redacted: true,
+		});
+	});
+
+	it("should assign the placeholder icon to a redacted product even when the source entry declares no icon", () => {
+		expect.assertions(1);
+
+		const result = applyRedaction({
+			...baseConfig,
+			products: {
+				"plain-pack": {
+					name: "Plain Pack",
+					description: "Pack without an icon.",
+					redacted: true,
+				},
+			},
+		});
+
+		expect(result.products?.["plain-pack"]?.icon).toStrictEqual({
+			"en-us": REDACTED_ICON_PATH,
+		});
+	});
+
+	it("should leave a product unchanged when redacted is false", () => {
+		expect.assertions(1);
+
+		const entry = { ...gemPackEntry, redacted: false } as const satisfies DeveloperProductEntry;
+		const result = applyRedaction({
+			...baseConfig,
+			products: { "gem-pack": entry },
+		});
+
+		expect(result.products?.["gem-pack"]).toStrictEqual(entry);
+	});
+
+	it("should leave a product unchanged when redacted is omitted", () => {
+		expect.assertions(1);
+
+		const result = applyRedaction({
+			...baseConfig,
+			products: { "gem-pack": gemPackEntry },
+		});
+
+		expect(result.products?.["gem-pack"]).toStrictEqual(gemPackEntry);
+	});
+
+	it("should not mutate the input config when redacting a product", () => {
+		expect.assertions(2);
+
+		const products = { "gem-pack": { ...gemPackEntry, redacted: true } };
+		const input = { ...baseConfig, products } as const satisfies ResolvedConfig;
+
+		const result = applyRedaction(input);
+
+		expect(input.products["gem-pack"]).toStrictEqual({ ...gemPackEntry, redacted: true });
+		expect(result.products?.["gem-pack"]).not.toBe(input.products["gem-pack"]);
+	});
+
+	it.for([
+		{
+			caseName: "no flags set",
+			entryRedacted: undefined,
+			envRedacted: undefined,
+			expectRedacted: false,
+		},
+		{
+			caseName: "env-level true, no resource flag",
+			entryRedacted: undefined,
+			envRedacted: true,
+			expectRedacted: true,
+		},
+		{
+			caseName: "env-level false, no resource flag",
+			entryRedacted: undefined,
+			envRedacted: false,
+			expectRedacted: false,
+		},
+		{
+			caseName: "resource false carves out env-level true",
+			entryRedacted: false,
+			envRedacted: true,
+			expectRedacted: false,
+		},
+		{
+			caseName: "resource true redacts despite env-level false",
+			entryRedacted: true,
+			envRedacted: false,
+			expectRedacted: true,
+		},
+	] as const)(
+		"should redact a product according to overlay > root > env precedence ($caseName)",
+		({ entryRedacted, envRedacted, expectRedacted }) => {
+			expect.assertions(1);
+
+			const productEntry = (
+				entryRedacted === undefined
+					? gemPackEntry
+					: { ...gemPackEntry, redacted: entryRedacted }
+			) satisfies DeveloperProductEntry;
+			const result = applyRedaction(
+				{ ...baseConfig, products: { "gem-pack": productEntry } },
+				envRedacted,
+			);
+			const expectedName = expectRedacted ? REDACTED_PRODUCT_NAME : gemPackEntry.name;
+
+			expect(result.products?.["gem-pack"]?.name).toBe(expectedName);
 		},
 	);
 });

--- a/packages/bedrock/src/core/redact-resources.ts
+++ b/packages/bedrock/src/core/redact-resources.ts
@@ -88,19 +88,26 @@ export function applyRedaction(
 export function collectRedactionAnnotations(
 	merged: ResolvedConfig,
 ): ReadonlyArray<RedactionAnnotation> {
-	if (merged.passes === undefined) {
-		return [];
-	}
-
-	return Object.entries(merged.passes)
+	const passes = Object.entries(merged.passes ?? {})
 		.filter(([, entry]) => entry.redacted === true)
-		.map(([key, entry]) => {
+		.map(([key, entry]): RedactionAnnotation => {
 			return {
 				key: asResourceKey(key),
 				hasRealValueEdits: passHasRealValueEdits(entry),
-				kind: "gamePass" as const,
+				kind: "gamePass",
 			};
 		});
+	const products = Object.entries(merged.products ?? {})
+		.filter(([, entry]) => entry.redacted === true)
+		.map(([key, entry]): RedactionAnnotation => {
+			return {
+				key: asResourceKey(key),
+				hasRealValueEdits: productHasRealValueEdits(entry),
+				kind: "developerProduct",
+			};
+		});
+
+	return [...passes, ...products];
 }
 
 function redactPass(entry: GamePassEntry, override: RedactedGamePassOverride): GamePassEntry {
@@ -187,5 +194,13 @@ function passHasRealValueEdits(entry: GamePassEntry): boolean {
 		entry.name !== REDACTED_PASS_NAME ||
 		entry.description !== REDACTED_DESCRIPTION ||
 		entry.icon["en-us"] !== REDACTED_ICON_PATH
+	);
+}
+
+function productHasRealValueEdits(entry: DeveloperProductEntry): boolean {
+	return (
+		entry.name !== REDACTED_PRODUCT_NAME ||
+		entry.description !== REDACTED_DESCRIPTION ||
+		(entry.icon !== undefined && entry.icon["en-us"] !== REDACTED_ICON_PATH)
 	);
 }

--- a/packages/bedrock/src/core/redact-resources.ts
+++ b/packages/bedrock/src/core/redact-resources.ts
@@ -4,6 +4,7 @@ import type { ResourceKind } from "./resources.ts";
 import type {
 	DeveloperProductEntry,
 	GamePassEntry,
+	RedactedDeveloperProductOverride,
 	RedactedGamePassOverride,
 	ResolvedConfig,
 } from "./schema.ts";
@@ -140,12 +141,15 @@ function redactPasses(
 	);
 }
 
-function redactProduct(entry: DeveloperProductEntry): DeveloperProductEntry {
+function redactProduct(
+	entry: DeveloperProductEntry,
+	override: RedactedDeveloperProductOverride,
+): DeveloperProductEntry {
 	return {
 		...entry,
-		name: REDACTED_PRODUCT_NAME,
-		description: REDACTED_DESCRIPTION,
-		icon: { "en-us": REDACTED_ICON_PATH },
+		name: override.name ?? REDACTED_PRODUCT_NAME,
+		description: override.description ?? REDACTED_DESCRIPTION,
+		icon: override.icon ?? { "en-us": REDACTED_ICON_PATH },
 	};
 }
 
@@ -166,11 +170,14 @@ function redactProducts(
 
 	return Object.fromEntries(
 		Object.entries(products).map(([key, entry]) => {
-			if (!(entry.redacted ?? environmentRedacted)) {
+			const effective = entry.redacted ?? environmentRedacted;
+			if (effective === false) {
 				return [key, entry] as const;
 			}
 
-			return [key, redactProduct(entry)] as const;
+			const override: RedactedDeveloperProductOverride =
+				typeof effective === "object" ? effective : {};
+			return [key, redactProduct(entry, override)] as const;
 		}),
 	);
 }

--- a/packages/bedrock/src/core/redact-resources.ts
+++ b/packages/bedrock/src/core/redact-resources.ts
@@ -1,10 +1,18 @@
 import { asResourceKey, type ResourceKey } from "../types/ids.ts";
 import { REDACTED_ICON_PATH } from "./redacted-icon.ts";
 import type { ResourceKind } from "./resources.ts";
-import type { GamePassEntry, RedactedGamePassOverride, ResolvedConfig } from "./schema.ts";
+import type {
+	DeveloperProductEntry,
+	GamePassEntry,
+	RedactedGamePassOverride,
+	ResolvedConfig,
+} from "./schema.ts";
 
 /** Default placeholder name pushed for a redacted game-pass. */
 export const REDACTED_PASS_NAME = "Redacted Pass";
+
+/** Default placeholder name pushed for a redacted developer-product. */
+export const REDACTED_PRODUCT_NAME = "Redacted Product";
 
 /** Default placeholder description pushed for any redacted resource. */
 export const REDACTED_DESCRIPTION = "";
@@ -47,24 +55,18 @@ export function applyRedaction(
 	config: ResolvedConfig,
 	environmentRedacted = false,
 ): ResolvedConfig {
-	if (config.passes === undefined) {
+	const passes = redactPasses(config.passes, environmentRedacted);
+	const products = redactProducts(config.products, environmentRedacted);
+
+	if (passes === config.passes && products === config.products) {
 		return config;
 	}
 
-	const passes = Object.fromEntries(
-		Object.entries(config.passes).map(([key, entry]) => {
-			const effective = entry.redacted ?? environmentRedacted;
-			if (effective === false) {
-				return [key, entry] as const;
-			}
-
-			const override: RedactedGamePassOverride =
-				typeof effective === "object" ? effective : {};
-			return [key, redactPass(entry, override)] as const;
-		}),
-	);
-
-	return { ...config, passes };
+	return {
+		...config,
+		...(passes === undefined ? {} : { passes }),
+		...(products === undefined ? {} : { products }),
+	};
 }
 
 /**
@@ -107,6 +109,70 @@ function redactPass(entry: GamePassEntry, override: RedactedGamePassOverride): G
 		description: override.description ?? REDACTED_DESCRIPTION,
 		icon: override.icon ?? { "en-us": REDACTED_ICON_PATH },
 	};
+}
+
+function redactPasses(
+	passes: ResolvedConfig["passes"],
+	environmentRedacted: boolean,
+): ResolvedConfig["passes"] {
+	if (passes === undefined) {
+		return undefined;
+	}
+
+	const hasAnyRedaction = Object.values(passes).some(
+		(entry) => (entry.redacted ?? environmentRedacted) !== false,
+	);
+	if (!hasAnyRedaction) {
+		return passes;
+	}
+
+	return Object.fromEntries(
+		Object.entries(passes).map(([key, entry]) => {
+			const effective = entry.redacted ?? environmentRedacted;
+			if (effective === false) {
+				return [key, entry] as const;
+			}
+
+			const override: RedactedGamePassOverride =
+				typeof effective === "object" ? effective : {};
+			return [key, redactPass(entry, override)] as const;
+		}),
+	);
+}
+
+function redactProduct(entry: DeveloperProductEntry): DeveloperProductEntry {
+	return {
+		...entry,
+		name: REDACTED_PRODUCT_NAME,
+		description: REDACTED_DESCRIPTION,
+		icon: { "en-us": REDACTED_ICON_PATH },
+	};
+}
+
+function redactProducts(
+	products: ResolvedConfig["products"],
+	environmentRedacted: boolean,
+): ResolvedConfig["products"] {
+	if (products === undefined) {
+		return undefined;
+	}
+
+	const hasAnyRedaction = Object.values(products).some((entry) => {
+		return Boolean(entry.redacted ?? environmentRedacted);
+	});
+	if (!hasAnyRedaction) {
+		return products;
+	}
+
+	return Object.fromEntries(
+		Object.entries(products).map(([key, entry]) => {
+			if (!(entry.redacted ?? environmentRedacted)) {
+				return [key, entry] as const;
+			}
+
+			return [key, redactProduct(entry)] as const;
+		}),
+	);
 }
 
 function passHasRealValueEdits(entry: GamePassEntry): boolean {

--- a/packages/bedrock/src/core/redact-resources.ts
+++ b/packages/bedrock/src/core/redact-resources.ts
@@ -168,9 +168,9 @@ function redactProducts(
 		return undefined;
 	}
 
-	const hasAnyRedaction = Object.values(products).some((entry) => {
-		return Boolean(entry.redacted ?? environmentRedacted);
-	});
+	const hasAnyRedaction = Object.values(products).some(
+		(entry) => (entry.redacted ?? environmentRedacted) !== false,
+	);
 	if (!hasAnyRedaction) {
 		return products;
 	}

--- a/packages/bedrock/src/core/schema.example.spec.ts
+++ b/packages/bedrock/src/core/schema.example.spec.ts
@@ -3,6 +3,8 @@ import { expect, it } from "vitest";
 import type {
   GamePassEntry,
   RedactedGamePassOverride,
+  DeveloperProductEntry,
+  RedactedDeveloperProductOverride,
   ResourceEntryByKind,
   Config,
   StateConfig,
@@ -26,6 +28,18 @@ it('Example 1', () => {
 })
 
 it('Example 2', () => {
+  const override: RedactedDeveloperProductOverride = {
+    name: 'Closed Beta Pack',
+  }
+  const entry: DeveloperProductEntry = {
+    name: 'Gem Pack',
+    description: 'Stocks the player up with 1,000 premium gems.',
+    redacted: override,
+  }
+  expect(entry.redacted).toStrictEqual({ name: 'Closed Beta Pack' })
+})
+
+it('Example 3', () => {
   const entry: ResourceEntryByKind['gamePass'] = {
     description: 'Grants VIP perks.',
     icon: { 'en-us': 'assets/vip-icon.png' },
@@ -35,7 +49,7 @@ it('Example 2', () => {
   expect(entry.name).toBe('VIP Pass')
 })
 
-it('Example 3', () => {
+it('Example 4', () => {
   const config: Config = {
     environments: { production: {} },
     state: { backend: 'gist', gistId: 'abc123def456' },
@@ -51,7 +65,7 @@ it('Example 3', () => {
   expect(config.passes!['vip-pass']!.name).toBe('VIP Pass')
 })
 
-it('Example 4', () => {
+it('Example 5', () => {
   const config: Config = {
     environments: {
       production: { places: { 'start-place': { placeId: '4711' } } },
@@ -67,7 +81,7 @@ it('Example 4', () => {
   }
 })
 
-it('Example 5', () => {
+it('Example 6', () => {
   const config: StateConfig = { backend: 'gist', gistId: 'abc' }
   expect(isGistStateConfig(config)).toBeTrue()
   if (isGistStateConfig(config)) {
@@ -75,7 +89,7 @@ it('Example 5', () => {
   }
 })
 
-it('Example 6', () => {
+it('Example 7', () => {
   const ok = validateConfig(
     {
       environments: { production: {} },

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -636,6 +636,83 @@ describe(validateConfig, () => {
 		},
 	);
 
+	it.for([
+		["true", true],
+		["false", false],
+	] as const)("should accept a products entry with redacted: %s", ([, redacted]) => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: MinEnvironments,
+				products: {
+					"gem-pack": {
+						name: "Gem Pack",
+						description: "Stocks the player up with 1,000 premium gems.",
+						redacted,
+					},
+				},
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.products!["gem-pack"]!.redacted).toBe(redacted);
+	});
+
+	it("should default redacted to undefined when omitted on a products entry", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: MinEnvironments,
+				products: {
+					"gem-pack": {
+						name: "Gem Pack",
+						description: "Stocks the player up with 1,000 premium gems.",
+					},
+				},
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.products!["gem-pack"]!.redacted).toBeUndefined();
+	});
+
+	it.for([
+		["string", "true"],
+		["number", 1],
+		// eslint-disable-next-line unicorn/no-null -- testing that arktype rejects the json null literal
+		["null", null],
+	] as const)(
+		"should reject %s as a products redacted field and attribute the issue path to that field",
+		([, redacted]) => {
+			expect.assertions(1);
+
+			const result = validateConfig(
+				{
+					environments: MinEnvironments,
+					products: {
+						"gem-pack": {
+							name: "Gem Pack",
+							description: "Stocks the player up with 1,000 premium gems.",
+							redacted,
+						},
+					},
+				},
+				SOURCE,
+			);
+
+			assert(!result.success);
+			assert(result.err.kind === "validationFailed");
+
+			expect(result.err.issues[0]!.path).toStrictEqual(["products", "gem-pack", "redacted"]);
+		},
+	);
+
 	it("should accept a root places collection that declares only filePath", () => {
 		expect.assertions(1);
 
@@ -1838,6 +1915,38 @@ describe(validateConfig, () => {
 			"bad key!",
 		]);
 	});
+
+	it.for([
+		["true", true],
+		["false", false],
+	] as const)(
+		"should accept a per-environment products overlay that declares redacted: %s",
+		([, redacted]) => {
+			expect.assertions(1);
+
+			const result = validateConfig(
+				{
+					environments: {
+						staging: { products: { "gem-pack": { redacted } } },
+					},
+					products: {
+						"gem-pack": {
+							name: "Gem Pack",
+							description: "Stocks the player up with 1,000 premium gems.",
+						},
+					},
+					state: { backend: "gist", gistId: "root-gist" },
+				},
+				SOURCE,
+			);
+
+			assert(result.success);
+
+			expect(result.data.environments["staging"]?.products?.["gem-pack"]?.redacted).toBe(
+				redacted,
+			);
+		},
+	);
 
 	it.for(INVALID_ROBUX_PRICES)(
 		"should reject %s as a per-environment passes overlay price",

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -713,6 +713,96 @@ describe(validateConfig, () => {
 		},
 	);
 
+	it.for([
+		["partial name override", { name: "Closed Beta Pack" }],
+		["partial description override", { description: "Coming soon." }],
+		["partial icon override", { icon: { "en-us": "assets/closed-beta.png" } }],
+		[
+			"full override",
+			{
+				name: "Closed Beta Pack",
+				description: "Coming soon.",
+				icon: { "en-us": "assets/closed-beta.png" },
+			},
+		],
+	] as const)(
+		"should accept a products entry with redacted as the %s object form",
+		([, redacted]) => {
+			expect.assertions(1);
+
+			const result = validateConfig(
+				{
+					environments: MinEnvironments,
+					products: {
+						"gem-pack": {
+							name: "Gem Pack",
+							description: "Stocks the player up with 1,000 premium gems.",
+							redacted,
+						},
+					},
+				},
+				SOURCE,
+			);
+
+			assert(result.success);
+
+			expect(result.data.products!["gem-pack"]!.redacted).toStrictEqual(redacted);
+		},
+	);
+
+	it("should reject an empty redacted object on a products entry and recommend redacted: true for default placeholders", () => {
+		expect.assertions(2);
+
+		const result = validateConfig(
+			{
+				environments: MinEnvironments,
+				products: {
+					"gem-pack": {
+						name: "Gem Pack",
+						description: "Stocks the player up with 1,000 premium gems.",
+						redacted: {},
+					},
+				},
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual(["products", "gem-pack", "redacted"]);
+		expect(result.err.issues[0]!.message).toContain("redacted: true");
+	});
+
+	it("should reject an unknown key in a products redacted override and attribute the issue path to the offending key", () => {
+		expect.assertions(2);
+
+		const result = validateConfig(
+			{
+				environments: MinEnvironments,
+				products: {
+					"gem-pack": {
+						name: "Gem Pack",
+						description: "Stocks the player up with 1,000 premium gems.",
+						redacted: { price: 0 },
+					},
+				},
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual([
+			"products",
+			"gem-pack",
+			"redacted",
+			"price",
+		]);
+		expect(result.err.issues[0]!.message).toContain("price");
+	});
+
 	it("should accept a root places collection that declares only filePath", () => {
 		expect.assertions(1);
 
@@ -1947,6 +2037,39 @@ describe(validateConfig, () => {
 			);
 		},
 	);
+
+	it("should reject an object override form on a per-environment products overlay redacted field", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: {
+					staging: {
+						products: { "gem-pack": { redacted: { name: "Closed Beta Pack" } } },
+					},
+				},
+				products: {
+					"gem-pack": {
+						name: "Gem Pack",
+						description: "Stocks the player up with 1,000 premium gems.",
+					},
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual([
+			"environments",
+			"staging",
+			"products",
+			"gem-pack",
+			"redacted",
+		]);
+	});
 
 	it.for(INVALID_ROBUX_PRICES)(
 		"should reject %s as a per-environment passes overlay price",

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -101,6 +101,14 @@ export interface DeveloperProductEntry {
 	 */
 	price?: number | undefined;
 	/**
+	 * Set to `true` to deploy this product with bedrock-supplied placeholder
+	 * content (default name, empty description, embedded placeholder icon)
+	 * in place of the real values declared above. Omit or set `false` to
+	 * push the real values unchanged. Environment overlays accept only the
+	 * boolean form.
+	 */
+	redacted?: boolean | undefined;
+	/**
 	 * Whether the product appears on the universe's external store page.
 	 * Tri-state: omit (or set `undefined`) to leave the flag unmanaged.
 	 * The Roblox v2 create endpoint does not accept this field, so the
@@ -705,6 +713,7 @@ const developerProductEntry = type({
 	"icon?": iconMap,
 	"isRegionalPricingEnabled?": OPTIONAL_BOOLEAN,
 	"price?": OPTIONAL_ROBUX_PRICE,
+	"redacted?": OPTIONAL_BOOLEAN,
 	"storePageEnabled?": OPTIONAL_BOOLEAN,
 }).onUndeclaredKey("reject");
 
@@ -778,6 +787,7 @@ const developerProductOverlay = type({
 	"isRegionalPricingEnabled?": OPTIONAL_BOOLEAN,
 	"name?": "string",
 	"price?": OPTIONAL_ROBUX_PRICE,
+	"redacted?": OPTIONAL_BOOLEAN,
 	"storePageEnabled?": OPTIONAL_BOOLEAN,
 }).onUndeclaredKey("reject");
 

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -75,6 +75,41 @@ export interface GamePassEntry {
 }
 
 /**
+ * Per-field redaction override for a developer-product entry. Each supplied
+ * field replaces the matching bedrock-supplied placeholder; omitted fields
+ * fall through to the placeholder defaults. The object form implies
+ * redaction is enabled, so authors who want only defaults should write
+ * `redacted: true` instead of an empty object.
+ *
+ * @example
+ *
+ * ```ts
+ * import type {
+ *     DeveloperProductEntry,
+ *     RedactedDeveloperProductOverride,
+ * } from "@bedrock-rbx/core/config";
+ *
+ * const override: RedactedDeveloperProductOverride = { name: "Closed Beta Pack" };
+ *
+ * const entry: DeveloperProductEntry = {
+ *     name: "Gem Pack",
+ *     description: "Stocks the player up with 1,000 premium gems.",
+ *     redacted: override,
+ * };
+ *
+ * expect(entry.redacted).toStrictEqual({ name: "Closed Beta Pack" });
+ * ```
+ */
+export interface RedactedDeveloperProductOverride {
+	/** Override name; falls through to the bedrock default when omitted. */
+	name?: string | undefined;
+	/** Override description; falls through to the bedrock default when omitted. */
+	description?: string | undefined;
+	/** Override icon path; falls through to the embedded placeholder when omitted. */
+	icon?: Record<"en-us", string> | undefined;
+}
+
+/**
  * Body of a single entry in the `products` collection. Keys in the parent
  * record are `ResourceKey`-shaped strings enforced at schema validation.
  */
@@ -103,11 +138,14 @@ export interface DeveloperProductEntry {
 	/**
 	 * Set to `true` to deploy this product with bedrock-supplied placeholder
 	 * content (default name, empty description, embedded placeholder icon)
-	 * in place of the real values declared above. Omit or set `false` to
-	 * push the real values unchanged. Environment overlays accept only the
-	 * boolean form.
+	 * in place of the real values declared above. Set to a
+	 * {@link RedactedDeveloperProductOverride} to substitute selected
+	 * placeholders with custom values while leaving the rest at bedrock
+	 * defaults; the object form implies redaction is enabled. Omit or set
+	 * `false` to push the real values unchanged. Environment overlays accept
+	 * only the boolean form.
 	 */
-	redacted?: boolean | undefined;
+	redacted?: boolean | RedactedDeveloperProductOverride | undefined;
 	/**
 	 * Whether the product appears on the universe's external store page.
 	 * Tri-state: omit (or set `undefined`) to leave the flag unmanaged.
@@ -312,9 +350,14 @@ export interface EnvironmentEntry {
 	 * missing fields fall through to the matching root `products` entry at
 	 * merge time. Mirrors the `passes` shape because developer products
 	 * also have no user-supplied identity key (Open Cloud mints the
-	 * `productId`).
+	 * `productId`). The `redacted` field narrows to a boolean here:
+	 * per-field overrides (the {@link RedactedDeveloperProductOverride}
+	 * object form) are valid only on the root resource entry.
 	 */
-	products?: Record<string, Partial<DeveloperProductEntry>>;
+	products?: Record<
+		string,
+		Partial<WithoutKey<DeveloperProductEntry, "redacted">> & { redacted?: boolean | undefined }
+	>;
 	/** Per-environment redaction toggle. Per-resource `redacted` flags on the merged config take precedence; `false` carves out exceptions. */
 	redacted?: boolean | undefined;
 	/** Per-environment state override; takes precedence over root `state`. */
@@ -689,6 +732,24 @@ const gamePassRedactedOverride = type({
 
 const gamePassRedacted = gamePassRedactedOverride.or("boolean | undefined");
 
+const productRedactedOverride = type({
+	"description?": "string",
+	"icon?": iconMap,
+	"name?": "string",
+})
+	.onUndeclaredKey("reject")
+	.narrow((value, ctx) => {
+		if (Object.keys(value).length === 0) {
+			return ctx.mustBe(
+				"a non-empty override object; use `redacted: true` for default placeholders",
+			);
+		}
+
+		return true;
+	});
+
+const productRedacted = productRedactedOverride.or(OPTIONAL_BOOLEAN);
+
 // Resource-kind entry schemas. Adding a new kind is two additions:
 // 1. Declare its entry schema and keyed-map collection below.
 // 2. Reference that collection as an optional property on `rootSchema`.
@@ -713,7 +774,7 @@ const developerProductEntry = type({
 	"icon?": iconMap,
 	"isRegionalPricingEnabled?": OPTIONAL_BOOLEAN,
 	"price?": OPTIONAL_ROBUX_PRICE,
-	"redacted?": OPTIONAL_BOOLEAN,
+	"redacted?": productRedacted,
 	"storePageEnabled?": OPTIONAL_BOOLEAN,
 }).onUndeclaredKey("reject");
 

--- a/packages/bedrock/src/index.ts
+++ b/packages/bedrock/src/index.ts
@@ -83,6 +83,7 @@ export {
 	type GamePassEntry,
 	type GistStateConfig,
 	type PlaceEntry,
+	type RedactedDeveloperProductOverride,
 	type RedactedGamePassOverride,
 	type ResolvedConfig,
 	type ResolvedPlaceEntry,

--- a/packages/bedrock/tests/integration/fixtures/products-redacted-env/bedrock.config.ts
+++ b/packages/bedrock/tests/integration/fixtures/products-redacted-env/bedrock.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "@bedrock-rbx/core";
+
+export default defineConfig({
+	environments: {
+		dev: {
+			products: { "carve-out-pack": { redacted: false } },
+			redacted: true,
+		},
+		production: {},
+	},
+	products: {
+		"carve-out-pack": {
+			name: "Carve Out",
+			description: "Stays real in dev.",
+			icon: { "en-us": "assets/carve.png" },
+			price: 50,
+		},
+		"gem-pack": {
+			name: "Gem Pack",
+			description: "Stocks the player up with 1,000 premium gems.",
+			icon: { "en-us": "assets/gems.png" },
+			price: 100,
+		},
+	},
+	universe: { universeId: "1234567890" },
+});

--- a/packages/bedrock/tests/integration/fixtures/products-redacted/bedrock.config.ts
+++ b/packages/bedrock/tests/integration/fixtures/products-redacted/bedrock.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "@bedrock-rbx/core";
+
+export default defineConfig({
+	environments: {
+		production: {},
+	},
+	products: {
+		"gem-pack": {
+			name: "Gem Pack",
+			description: "Stocks the player up with 1,000 premium gems.",
+			icon: { "en-us": "assets/gems.png" },
+			price: 100,
+			redacted: true,
+		},
+	},
+	universe: { universeId: "1234567890" },
+});

--- a/packages/bedrock/tests/integration/products-redacted.spec.ts
+++ b/packages/bedrock/tests/integration/products-redacted.spec.ts
@@ -243,6 +243,138 @@ describe("products-redacted pipeline end-to-end", () => {
 		expect(ops.every((op) => op.type === "noop")).toBeTrue();
 	});
 
+	it("should upload the icon override bytes and default name and description when redacted is an object with icon", async () => {
+		expect.assertions(3);
+
+		const overrideIconPath = "assets/closed-beta.png";
+		const overrideIconBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0xaa, 0xbb, 0xcc]);
+
+		const config = defineConfig({
+			environments: { production: {} },
+			products: {
+				"gem-pack": {
+					name: "Gem Pack",
+					description: "Stocks the player up with 1,000 premium gems.",
+					icon: { "en-us": "assets/gems.png" },
+					price: 100,
+					redacted: { icon: { "en-us": overrideIconPath } },
+				},
+			},
+			universe: { universeId: "1234567890" },
+		});
+
+		const resolved = selectEnvironment(config, "production");
+		assert(resolved.success);
+
+		async function readOverrideIcon(path: string): Promise<Uint8Array> {
+			if (path === overrideIconPath) {
+				return overrideIconBytes;
+			}
+
+			throw new Error(`readFile must not run for path: ${path}`);
+		}
+
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readOverrideIcon);
+		assert(desiredResult.success);
+
+		const httpClient = createFakeHttpClient().mockResponse({
+			body: validDeveloperProductBody({
+				name: REDACTED_PRODUCT_NAME,
+				description: REDACTED_DESCRIPTION,
+				productId: 8_172_635_495,
+				universeId: 1_234_567_890,
+			}),
+			status: 200,
+		});
+
+		const registry: DriverRegistry = {
+			developerProduct: createDeveloperProductDriver({
+				client: new DeveloperProductsClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: async () => {},
+				}),
+				readFile: readOverrideIcon,
+				universeId: UNIVERSE_ID,
+			}),
+			gamePass: GAME_PASS_TRAP,
+			place: PLACE_TRAP,
+			universe: UNIVERSE_DRIVER,
+		};
+
+		const applyResult = await applyOps(diff(desiredResult.data, []), registry);
+		assert(applyResult.success);
+
+		const captured = httpClient.requests[0]!;
+
+		expect(readFormString(captured.request.body, "name")).toBe(REDACTED_PRODUCT_NAME);
+		expect(readFormString(captured.request.body, "description")).toBe(REDACTED_DESCRIPTION);
+		await expect(readFormBytes(captured.request.body, "imageFile")).resolves.toStrictEqual(
+			overrideIconBytes,
+		);
+	});
+
+	it("should upload the name override and default placeholders when redacted is an object with name", async () => {
+		expect.assertions(3);
+
+		const config = defineConfig({
+			environments: { production: {} },
+			products: {
+				"gem-pack": {
+					name: "Gem Pack",
+					description: "Stocks the player up with 1,000 premium gems.",
+					icon: { "en-us": "assets/gems.png" },
+					price: 100,
+					redacted: { name: "Closed Beta Pack" },
+				},
+			},
+			universe: { universeId: "1234567890" },
+		});
+
+		const resolved = selectEnvironment(config, "production");
+		assert(resolved.success);
+
+		const readFile = panicOnRealPath;
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		assert(desiredResult.success);
+
+		const httpClient = createFakeHttpClient().mockResponse({
+			body: validDeveloperProductBody({
+				name: "Closed Beta Pack",
+				description: REDACTED_DESCRIPTION,
+				productId: 8_172_635_495,
+				universeId: 1_234_567_890,
+			}),
+			status: 200,
+		});
+
+		const registry: DriverRegistry = {
+			developerProduct: createDeveloperProductDriver({
+				client: new DeveloperProductsClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: async () => {},
+				}),
+				readFile,
+				universeId: UNIVERSE_ID,
+			}),
+			gamePass: GAME_PASS_TRAP,
+			place: PLACE_TRAP,
+			universe: UNIVERSE_DRIVER,
+		};
+
+		const applyResult = await applyOps(diff(desiredResult.data, []), registry);
+		assert(applyResult.success);
+
+		const captured = httpClient.requests[0]!;
+
+		expect(readFormString(captured.request.body, "name")).toBe("Closed Beta Pack");
+		expect(readFormString(captured.request.body, "description")).toBe(REDACTED_DESCRIPTION);
+		await expect(readFormBytes(captured.request.body, "imageFile")).resolves.toStrictEqual(
+			REDACTED_ICON_BYTES,
+		);
+	});
+
 	it("should push real values on the next deploy when redacted flips from true to false", async () => {
 		expect.assertions(3);
 

--- a/packages/bedrock/tests/integration/products-redacted.spec.ts
+++ b/packages/bedrock/tests/integration/products-redacted.spec.ts
@@ -1,0 +1,390 @@
+import {
+	applyOps,
+	asRobloxAssetId,
+	buildDesired,
+	createDeveloperProductDriver,
+	defineConfig,
+	diff,
+	type DriverRegistry,
+	flattenConfig,
+	loadConfig,
+	type ResourceCurrentState,
+	type ResourceDesiredState,
+	type ResourceDriver,
+	selectEnvironment,
+	UNIVERSE_SINGLETON_KEY,
+} from "@bedrock-rbx/core";
+import { DeveloperProductsClient } from "@bedrock-rbx/ocale/developer-products";
+import { createFakeHttpClient, validDeveloperProductBody } from "@bedrock-rbx/ocale/testing";
+
+import { REDACTED_DESCRIPTION, REDACTED_PRODUCT_NAME } from "#src/core/redact-resources";
+import { REDACTED_ICON_BYTES, REDACTED_ICON_PATH } from "#src/core/redacted-icon";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { assert, describe, expect, it } from "vitest";
+
+const FIXTURES_ROOT = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
+const PRODUCTS_FIXTURE_DIR = join(FIXTURES_ROOT, "products-redacted");
+const PRODUCTS_ENV_FIXTURE_DIR = join(FIXTURES_ROOT, "products-redacted-env");
+const UNIVERSE_ID = asRobloxAssetId("1234567890");
+const ROOT_PLACE_ID = asRobloxAssetId("4711");
+
+const GAME_PASS_TRAP: ResourceDriver<"gamePass"> = {
+	create() {
+		throw new Error("GamePassDriver.create must not run for redacted-product fixtures");
+	},
+};
+
+const PLACE_TRAP: ResourceDriver<"place"> = {
+	create() {
+		throw new Error("PlaceDriver.create must not run for redacted-product fixtures");
+	},
+};
+
+const UNIVERSE_ADOPTED: ResourceCurrentState<"universe"> = {
+	key: UNIVERSE_SINGLETON_KEY,
+	consoleEnabled: undefined,
+	desktopEnabled: undefined,
+	displayName: undefined,
+	kind: "universe",
+	mobileEnabled: undefined,
+	outputs: { rootPlaceId: ROOT_PLACE_ID },
+	tabletEnabled: undefined,
+	universeId: UNIVERSE_ID,
+	voiceChatEnabled: undefined,
+	vrEnabled: undefined,
+};
+
+const UNIVERSE_DRIVER: ResourceDriver<"universe"> = {
+	async create() {
+		return { data: UNIVERSE_ADOPTED, success: true };
+	},
+};
+
+const UNIVERSE_TRAP: ResourceDriver<"universe"> = {
+	create() {
+		throw new Error(
+			"UniverseDriver.create must not run when current state already adopts the universe",
+		);
+	},
+};
+
+const REAL_ICON_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x01, 0x02, 0x03]);
+
+async function panicOnRealPath(path: string): Promise<Uint8Array> {
+	throw new Error(`readFile must not run for path: ${path}`);
+}
+
+async function readRealIcon(path: string): Promise<Uint8Array> {
+	if (path === "assets/gems.png") {
+		return REAL_ICON_BYTES;
+	}
+
+	throw new Error(`readFile must not run for path: ${path}`);
+}
+
+async function readFormBytes(body: unknown, key: string): Promise<Uint8Array> {
+	assert(body instanceof FormData);
+	const value = body.get(key);
+	assert(value instanceof Blob);
+	return new Uint8Array(await value.arrayBuffer());
+}
+
+function readFormString(body: unknown, key: string): string {
+	assert(body instanceof FormData);
+	const value = body.get(key);
+	assert(typeof value === "string");
+	return value;
+}
+
+function findProductDesired(
+	desired: ReadonlyArray<ResourceDesiredState>,
+	key: string,
+): Extract<ResourceDesiredState, { readonly kind: "developerProduct" }> {
+	const entry = desired.find((value) => value.kind === "developerProduct" && value.key === key);
+	assert(entry?.kind === "developerProduct");
+	return entry;
+}
+
+function persistedProduct(
+	desired: Extract<ResourceDesiredState, { readonly kind: "developerProduct" }>,
+	overrides: Partial<ResourceCurrentState<"developerProduct">> = {},
+): ResourceCurrentState<"developerProduct"> {
+	return {
+		...desired,
+		outputs: { productId: asRobloxAssetId("8172635495") },
+		...overrides,
+	};
+}
+
+describe("products-redacted pipeline end-to-end", () => {
+	it("should upload placeholder name, description, and embedded icon bytes when redacted is true", async () => {
+		expect.assertions(4);
+
+		const loaded = await loadConfig({ cwd: PRODUCTS_FIXTURE_DIR });
+		assert(loaded.success);
+
+		const resolved = selectEnvironment(loaded.data, "production");
+		assert(resolved.success);
+
+		const readFile = panicOnRealPath;
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		assert(desiredResult.success);
+
+		const httpClient = createFakeHttpClient().mockResponse({
+			body: validDeveloperProductBody({
+				name: REDACTED_PRODUCT_NAME,
+				description: REDACTED_DESCRIPTION,
+				productId: 8_172_635_495,
+				universeId: 1_234_567_890,
+			}),
+			status: 200,
+		});
+
+		const registry: DriverRegistry = {
+			developerProduct: createDeveloperProductDriver({
+				client: new DeveloperProductsClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: async () => {},
+				}),
+				readFile,
+				universeId: UNIVERSE_ID,
+			}),
+			gamePass: GAME_PASS_TRAP,
+			place: PLACE_TRAP,
+			universe: UNIVERSE_DRIVER,
+		};
+
+		const applyResult = await applyOps(diff(desiredResult.data, []), registry);
+		assert(applyResult.success);
+
+		const captured = httpClient.requests[0]!;
+
+		expect(readFormString(captured.request.body, "name")).toBe(REDACTED_PRODUCT_NAME);
+		expect(readFormString(captured.request.body, "description")).toBe(REDACTED_DESCRIPTION);
+		await expect(readFormBytes(captured.request.body, "imageFile")).resolves.toStrictEqual(
+			REDACTED_ICON_BYTES,
+		);
+
+		const created = applyResult.data.find((entry) => entry.kind === "developerProduct");
+		assert(created !== undefined);
+
+		expect(created.name).toBe(REDACTED_PRODUCT_NAME);
+	});
+
+	it("should re-deploy as a noop when the persisted state already carries the placeholder values", async () => {
+		expect.assertions(2);
+
+		const loaded = await loadConfig({ cwd: PRODUCTS_FIXTURE_DIR });
+		assert(loaded.success);
+
+		const resolved = selectEnvironment(loaded.data, "production");
+		assert(resolved.success);
+
+		const readFile = panicOnRealPath;
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		assert(desiredResult.success);
+
+		const httpClient = createFakeHttpClient();
+		const registry: DriverRegistry = {
+			developerProduct: createDeveloperProductDriver({
+				client: new DeveloperProductsClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: async () => {},
+				}),
+				readFile,
+				universeId: UNIVERSE_ID,
+			}),
+			gamePass: GAME_PASS_TRAP,
+			place: PLACE_TRAP,
+			universe: UNIVERSE_TRAP,
+		};
+
+		const gemPack = findProductDesired(desiredResult.data, "gem-pack");
+		const ops = diff(desiredResult.data, [persistedProduct(gemPack), UNIVERSE_ADOPTED]);
+
+		expect(ops.every((op) => op.type === "noop")).toBeTrue();
+
+		const applyResult = await applyOps(ops, registry);
+		assert(applyResult.success);
+
+		expect(httpClient.requests).toBeEmpty();
+	});
+
+	it("should treat a config-side name edit as a noop while redacted stays true", async () => {
+		expect.assertions(1);
+
+		const config = defineConfig({
+			environments: { production: {} },
+			products: {
+				"gem-pack": {
+					name: "Gem Pack v2",
+					description: "Edited copy that must not ship.",
+					icon: { "en-us": "assets/gems.png" },
+					price: 100,
+					redacted: true,
+				},
+			},
+			universe: { universeId: "1234567890" },
+		});
+
+		const resolved = selectEnvironment(config, "production");
+		assert(resolved.success);
+
+		const readFile = panicOnRealPath;
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		assert(desiredResult.success);
+
+		const gemPack = findProductDesired(desiredResult.data, "gem-pack");
+		const ops = diff(desiredResult.data, [persistedProduct(gemPack), UNIVERSE_ADOPTED]);
+
+		expect(ops.every((op) => op.type === "noop")).toBeTrue();
+	});
+
+	it("should push real values on the next deploy when redacted flips from true to false", async () => {
+		expect.assertions(3);
+
+		const config = defineConfig({
+			environments: { production: {} },
+			products: {
+				"gem-pack": {
+					name: "Gem Pack",
+					description: "Stocks the player up with 1,000 premium gems.",
+					icon: { "en-us": "assets/gems.png" },
+					price: 100,
+					redacted: false,
+				},
+			},
+			universe: { universeId: "1234567890" },
+		});
+
+		const resolved = selectEnvironment(config, "production");
+		assert(resolved.success);
+
+		const readFile = readRealIcon;
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		assert(desiredResult.success);
+
+		const httpClient = createFakeHttpClient().mockResponse({
+			body: undefined,
+			status: 204,
+		});
+
+		const registry: DriverRegistry = {
+			developerProduct: createDeveloperProductDriver({
+				client: new DeveloperProductsClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: async () => {},
+				}),
+				readFile,
+				universeId: UNIVERSE_ID,
+			}),
+			gamePass: GAME_PASS_TRAP,
+			place: PLACE_TRAP,
+			universe: UNIVERSE_TRAP,
+		};
+
+		const gemPack = findProductDesired(desiredResult.data, "gem-pack");
+		const placeholderHash = await hashPlaceholderIcon();
+		const prior = persistedProduct(gemPack, {
+			name: REDACTED_PRODUCT_NAME,
+			description: REDACTED_DESCRIPTION,
+			icon: { "en-us": REDACTED_ICON_PATH },
+			iconFileHashes: { "en-us": placeholderHash },
+		});
+
+		expect(gemPack.icon?.["en-us"]).toBe("assets/gems.png");
+
+		const ops = diff(desiredResult.data, [prior, UNIVERSE_ADOPTED]);
+		const nonNoop = ops.filter((op) => op.type !== "noop");
+
+		expect(nonNoop.map((op) => op.type)).toStrictEqual(["update"]);
+
+		const applyResult = await applyOps(ops, registry);
+		assert(applyResult.success);
+
+		const captured = httpClient.requests[0]!;
+
+		await expect(readFormBytes(captured.request.body, "imageFile")).resolves.toStrictEqual(
+			REAL_ICON_BYTES,
+		);
+	});
+});
+
+describe("products-redacted env-level toggle", () => {
+	it("should redact a product with no redacted flag when the env-level redacted toggle is true", async () => {
+		expect.assertions(3);
+
+		const loaded = await loadConfig({ cwd: PRODUCTS_ENV_FIXTURE_DIR });
+		assert(loaded.success);
+
+		const resolved = selectEnvironment(loaded.data, "dev");
+		assert(resolved.success);
+
+		const gemPack = resolved.data.products?.["gem-pack"];
+		assert(gemPack !== undefined);
+
+		expect(gemPack.name).toBe(REDACTED_PRODUCT_NAME);
+		expect(gemPack.description).toBe(REDACTED_DESCRIPTION);
+		expect(gemPack.icon?.["en-us"]).toBe(REDACTED_ICON_PATH);
+	});
+
+	it("should leave a product real when its overlay sets redacted false despite an env-level redacted true", async () => {
+		expect.assertions(3);
+
+		const loaded = await loadConfig({ cwd: PRODUCTS_ENV_FIXTURE_DIR });
+		assert(loaded.success);
+
+		const resolved = selectEnvironment(loaded.data, "dev");
+		assert(resolved.success);
+
+		const carve = resolved.data.products?.["carve-out-pack"];
+		assert(carve !== undefined);
+
+		expect(carve.name).toBe("Carve Out");
+		expect(carve.description).toBe("Stays real in dev.");
+		expect(carve.icon?.["en-us"]).toBe("assets/carve.png");
+	});
+
+	it("should not redact products in an env whose redacted toggle is absent", async () => {
+		expect.assertions(2);
+
+		const loaded = await loadConfig({ cwd: PRODUCTS_ENV_FIXTURE_DIR });
+		assert(loaded.success);
+
+		const resolved = selectEnvironment(loaded.data, "production");
+		assert(resolved.success);
+
+		const gemPack = resolved.data.products?.["gem-pack"];
+		const carve = resolved.data.products?.["carve-out-pack"];
+
+		expect(gemPack?.name).toBe("Gem Pack");
+		expect(carve?.name).toBe("Carve Out");
+	});
+});
+
+async function hashPlaceholderIcon(): Promise<
+	NonNullable<ResourceCurrentState<"developerProduct">["iconFileHashes"]>["en-us"]
+> {
+	const probe = defineConfig({
+		environments: { production: {} },
+		products: {
+			probe: {
+				name: "probe",
+				description: "probe",
+				icon: { "en-us": "assets/gems.png" },
+				redacted: true,
+			},
+		},
+	});
+	const resolved = selectEnvironment(probe, "production");
+	assert(resolved.success);
+	const desired = await buildDesired(flattenConfig(resolved.data), panicOnRealPath);
+	assert(desired.success);
+	const entry = findProductDesired(desired.data, "probe");
+	assert(entry.iconFileHashes !== undefined);
+	return entry.iconFileHashes["en-us"];
+}


### PR DESCRIPTION
## Summary

Closes [#413](https://github.com/christopher-buss/bedrock/issues/413). Extends the ADR-024 redaction surface from game passes to developer products: per-resource boolean toggle, per-field override object, env-level toggle, and annotation collection.

- **Boolean redaction** (`products['x'].redacted: true`) substitutes `"Redacted Product"`, an empty description, and the embedded placeholder PNG. The env-level toggle `environments['x'].redacted: true` redacts every declared product in that env; per-resource `redacted: false` carves out an exception. Precedence mirrors game-pass (per-resource > env-level).
- **Override form** (`products['x'].redacted: { name, description?, icon? }`) substitutes only the supplied fields and falls back to bedrock defaults for the rest. The new public type `RedactedDeveloperProductOverride` is re-exported from `@bedrock-rbx/core/config`. Empty objects and unknown keys are validation errors; env overlays remain boolean-only.
- **Annotation collection**: `collectRedactionAnnotations` now iterates `products` alongside `passes` and emits `kind: \"developerProduct\"` annotations. The renderer change is deferred to a follow-up; this PR only widens the annotation source.

Implementation notes:

- The developer-product driver now wraps `readFile` with `withRedactedIcon`, matching the game-pass driver, so the icon-sentinel resolves to the embedded placeholder bytes at upload time.
- `applyRedaction` short-circuits when no resource needs redaction, preserving the input config and per-collection references. Three new unit tests guard this invariant against mutation regressions.

## Test plan

- [x] Unit: `packages/bedrock/src/core/redact-resources.spec.ts` covers boolean form, override form, precedence truth table, mutation-safe short-circuit, and annotation collection for products (including \`hasRealValueEdits\` tolerating an absent icon).
- [x] Schema: `packages/bedrock/src/core/schema.spec.ts` covers root \`redacted\` boolean/object/empty-object/unknown-key/wrongly-typed paths, plus env-overlay boolean-acceptance and object-form rejection.
- [x] Integration: `packages/bedrock/tests/integration/products-redacted.spec.ts` covers end-to-end deploys for boolean form (placeholder upload, noop on re-deploy, real-edit suppression, flip-to-false re-push) plus icon-only and name-only override deploys, plus env-toggle redact-all and carve-out semantics.
- [x] \`pnpm lint\` / \`pnpm typecheck\` / \`pnpm build\` / \`pnpm test\` / \`pnpm mutate:changed\` (100% mutation score on touched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)