### PR TITLE
feat(core): extend redaction to places with asymmetric default

### DIFF
--- a/docs/adr/024-resource-redaction.md
+++ b/docs/adr/024-resource-redaction.md
@@ -270,3 +270,58 @@ Modified:
 - ADR-020 -- Project Config Definition: this ADR extends the schema ADR-020
   defines. The per-resource entry schema and the env-overlay schema both gain
   the `redacted` field.
+
+## Amendment -- 2026-05-16
+
+The original Decision named `universe` as a redactable kind with a default field
+set of `description` and `icon`. Implementation found that universe owns neither
+field as wire-pushable today:
+
+- `icon` for the universe is blocked upstream. Open Cloud has no endpoint to
+  set a universe's source-language game icon. The block is tracked in the
+  Mantle-feature-blocked register; see issue #362.
+- `description` is not owned by `universe`. The universe's description is
+  derived server-side from the root place's `description` field, which already
+  lives on `PlaceEntry`. The redactable description field is therefore on the
+  `place` kind, not on `universe`.
+
+`displayName` remains the only universe field redactable today, routed through
+`PlacesClient.update` on the root place (same path the universe driver uses).
+
+The asymmetric-default design (preserve `displayName` so Roblox Studio's place
+picker and the Creator Hub experience list still identify the developer's own
+work) transfers from `universe` to `place`. Places already declare both
+`description` and `displayName` on their entry shape, so the same default set
+applies cleanly.
+
+### Per-kind default field sets (revised)
+
+| Kind                | Redacted by default               | Override field set                                   |
+| ------------------- | --------------------------------- | ---------------------------------------------------- |
+| `gamePass`          | `name`, `description`, `icon`     | `{ name?, description?, icon? }`                     |
+| `developerProduct`  | `name`, `description`, `icon`     | `{ name?, description?, icon? }`                     |
+| `badge`             | `name`, `description`, `icon`     | `{ name?, description?, icon? }`                     |
+| `place`             | `description` only                | `{ description?, displayName? }`                     |
+| `universe`          | (none today; see notes)           | `{ displayName? }` once wired                        |
+
+Universe-level redaction is deferred until either the icon endpoint lands
+upstream (resolves the `icon` half) or the design migrates to publishing
+`displayName` overrides through the existing universe path. The `redacted`
+field on `UniverseEntry` is not yet present in the schema and will be added
+when there is a concrete redactable target.
+
+### Placeholder defaults (revised)
+
+| Kind               | Field         | Default                                  |
+| ------------------ | ------------- | ---------------------------------------- |
+| `gamePass`         | `name`        | `"Redacted Pass"`                        |
+| `gamePass`         | `description` | `""`                                     |
+| `gamePass`         | `icon`        | embedded placeholder PNG                 |
+| `developerProduct` | `name`        | `"Redacted Product"`                     |
+| `developerProduct` | `description` | `""`                                     |
+| `developerProduct` | `icon`        | embedded placeholder PNG                 |
+| `badge`            | `name`        | `"Redacted Badge"`                       |
+| `badge`            | `description` | `""`                                     |
+| `badge`            | `icon`        | embedded placeholder PNG                 |
+| `place`            | `description` | `""`                                     |
+| `place`            | `displayName` | (no default; explicit override required) |

--- a/packages/bedrock/src/config.spec-d.ts
+++ b/packages/bedrock/src/config.spec-d.ts
@@ -11,6 +11,7 @@ import type {
 	GistStateConfig,
 	PlaceEntry,
 	RedactedGamePassOverride,
+	RedactedPlaceOverride,
 	ResolvedPlaceEntry,
 	ResourceEntryByKind,
 	SocialLink,
@@ -25,6 +26,7 @@ import type {
 	GistStateConfig as GistStateConfigSource,
 	PlaceEntry as PlaceEntrySource,
 	RedactedGamePassOverride as RedactedGamePassOverrideSource,
+	RedactedPlaceOverride as RedactedPlaceOverrideSource,
 	ResolvedPlaceEntry as ResolvedPlaceEntrySource,
 	ResourceEntryByKind as ResourceEntryByKindSource,
 	StateConfig as StateConfigSource,
@@ -36,7 +38,7 @@ import type {
 	defineConfig as defineConfigSource,
 } from "./shell/define-config.ts";
 
-describe("@bedrock-rbx/core/config resource-entry re-exports", () => {
+describe("@bedrock-rbx/core/config core re-exports", () => {
 	it("should re-export Config with the same identity as core/schema", () => {
 		expectTypeOf<Config>().toEqualTypeOf<ConfigSource>();
 	});
@@ -45,12 +47,22 @@ describe("@bedrock-rbx/core/config resource-entry re-exports", () => {
 		expectTypeOf<EnvironmentEntry>().toEqualTypeOf<EnvironmentEntrySource>();
 	});
 
+	it("should re-export ResourceEntryByKind with the same identity as core/schema", () => {
+		expectTypeOf<ResourceEntryByKind>().toEqualTypeOf<ResourceEntryByKindSource>();
+	});
+});
+
+describe("@bedrock-rbx/core/config resource-entry re-exports", () => {
 	it("should re-export GamePassEntry with the same identity as core/schema", () => {
 		expectTypeOf<GamePassEntry>().toEqualTypeOf<GamePassEntrySource>();
 	});
 
 	it("should re-export RedactedGamePassOverride with the same identity as core/schema", () => {
 		expectTypeOf<RedactedGamePassOverride>().toEqualTypeOf<RedactedGamePassOverrideSource>();
+	});
+
+	it("should re-export RedactedPlaceOverride with the same identity as core/schema", () => {
+		expectTypeOf<RedactedPlaceOverride>().toEqualTypeOf<RedactedPlaceOverrideSource>();
 	});
 
 	it("should re-export DeveloperProductEntry with the same identity as core/schema", () => {
@@ -67,10 +79,6 @@ describe("@bedrock-rbx/core/config resource-entry re-exports", () => {
 
 	it("should re-export UniverseEntry with the same identity as core/schema", () => {
 		expectTypeOf<UniverseEntry>().toEqualTypeOf<UniverseEntrySource>();
-	});
-
-	it("should re-export ResourceEntryByKind with the same identity as core/schema", () => {
-		expectTypeOf<ResourceEntryByKind>().toEqualTypeOf<ResourceEntryByKindSource>();
 	});
 });
 

--- a/packages/bedrock/src/config.ts
+++ b/packages/bedrock/src/config.ts
@@ -18,6 +18,7 @@ export type {
 	PlaceEntry,
 	RedactedDeveloperProductOverride,
 	RedactedGamePassOverride,
+	RedactedPlaceOverride,
 	ResolvedPlaceEntry,
 	ResourceEntryByKind,
 	StateConfig,

--- a/packages/bedrock/src/core/redact-resources.spec.ts
+++ b/packages/bedrock/src/core/redact-resources.spec.ts
@@ -416,6 +416,25 @@ describe(applyRedaction, () => {
 		},
 	);
 
+	it("should redact a flagged place while leaving an unflagged sibling unchanged", () => {
+		expect.assertions(2);
+
+		const plainPlace = {
+			...startPlaceEntry,
+			placeId: "1111",
+		} as const satisfies ResolvedPlaceEntry;
+		const result = applyRedaction({
+			...baseConfig,
+			places: {
+				"plain-place": plainPlace,
+				"secret-place": { ...startPlaceEntry, redacted: true },
+			},
+		});
+
+		expect(result.places?.["plain-place"]).toStrictEqual(plainPlace);
+		expect(result.places?.["secret-place"]?.description).toBe(REDACTED_DESCRIPTION);
+	});
+
 	it("should replace name, description, and icon with placeholders when a product redacted is true", () => {
 		expect.assertions(1);
 

--- a/packages/bedrock/src/core/redact-resources.spec.ts
+++ b/packages/bedrock/src/core/redact-resources.spec.ts
@@ -8,7 +8,12 @@ import {
 	REDACTED_PRODUCT_NAME,
 } from "./redact-resources.ts";
 import { REDACTED_ICON_PATH } from "./redacted-icon.ts";
-import type { DeveloperProductEntry, GamePassEntry, ResolvedConfig } from "./schema.ts";
+import type {
+	DeveloperProductEntry,
+	GamePassEntry,
+	ResolvedConfig,
+	ResolvedPlaceEntry,
+} from "./schema.ts";
 
 const baseConfig: ResolvedConfig = {
 	environments: { production: {} },
@@ -27,6 +32,13 @@ const gemPackEntry = {
 	icon: { "en-us": "assets/gems.png" },
 	price: 100,
 } as const satisfies DeveloperProductEntry;
+
+const startPlaceEntry = {
+	description: "The lobby place.",
+	displayName: "Start Place",
+	filePath: "places/start.rbxl",
+	placeId: "4711",
+} as const satisfies ResolvedPlaceEntry;
 
 describe(applyRedaction, () => {
 	it("should replace name, description, and icon with placeholders when redacted is true", () => {
@@ -74,7 +86,7 @@ describe(applyRedaction, () => {
 		expect(applyRedaction(baseConfig)).toStrictEqual(baseConfig);
 	});
 
-	it("should pass through products, places, and universe collections verbatim", () => {
+	it("should pass through products, places, and universe collections verbatim when no redaction applies", () => {
 		expect.assertions(3);
 
 		const input: ResolvedConfig = {
@@ -115,6 +127,7 @@ describe(applyRedaction, () => {
 		const input: ResolvedConfig = {
 			...baseConfig,
 			passes: { "vip-pass": vipEntry },
+			places: { "start-place": { filePath: "places/start.rbxl", placeId: "4711" } },
 			products: { "gem-pack": gemPackEntry },
 		};
 
@@ -243,6 +256,163 @@ describe(applyRedaction, () => {
 			const expectedName = expectRedacted ? REDACTED_PASS_NAME : vipEntry.name;
 
 			expect(result.passes?.["vip-pass"]?.name).toBe(expectedName);
+		},
+	);
+
+	it("should redact description and preserve displayName on a place when redacted is true", () => {
+		expect.assertions(1);
+
+		const result = applyRedaction({
+			...baseConfig,
+			places: {
+				"start-place": { ...startPlaceEntry, redacted: true },
+			},
+		});
+
+		expect(result.places?.["start-place"]).toStrictEqual({
+			...startPlaceEntry,
+			description: REDACTED_DESCRIPTION,
+			redacted: true,
+		});
+	});
+
+	it("should leave a place unchanged when redacted is false", () => {
+		expect.assertions(1);
+
+		const entry = { ...startPlaceEntry, redacted: false } as const satisfies ResolvedPlaceEntry;
+		const result = applyRedaction({
+			...baseConfig,
+			places: { "start-place": entry },
+		});
+
+		expect(result.places?.["start-place"]).toStrictEqual(entry);
+	});
+
+	it("should leave a place unchanged when redacted is omitted", () => {
+		expect.assertions(1);
+
+		const result = applyRedaction({
+			...baseConfig,
+			places: { "start-place": startPlaceEntry },
+		});
+
+		expect(result.places?.["start-place"]).toStrictEqual(startPlaceEntry);
+	});
+
+	it("should substitute displayName only when supplied explicitly in the override", () => {
+		expect.assertions(1);
+
+		const result = applyRedaction({
+			...baseConfig,
+			places: {
+				"start-place": {
+					...startPlaceEntry,
+					redacted: { displayName: "Hidden Project" },
+				},
+			},
+		});
+
+		expect(result.places?.["start-place"]).toStrictEqual({
+			...startPlaceEntry,
+			description: REDACTED_DESCRIPTION,
+			displayName: "Hidden Project",
+			redacted: { displayName: "Hidden Project" },
+		});
+	});
+
+	it("should substitute both description and displayName when the override supplies both", () => {
+		expect.assertions(1);
+
+		const override = { description: "Coming soon.", displayName: "Hidden" };
+		const result = applyRedaction({
+			...baseConfig,
+			places: {
+				"start-place": { ...startPlaceEntry, redacted: override },
+			},
+		});
+
+		expect(result.places?.["start-place"]).toStrictEqual({
+			...startPlaceEntry,
+			description: "Coming soon.",
+			displayName: "Hidden",
+			redacted: override,
+		});
+	});
+
+	it("should preserve a real displayName when redacted true cascades from the environment", () => {
+		expect.assertions(2);
+
+		const result = applyRedaction(
+			{ ...baseConfig, places: { "start-place": startPlaceEntry } },
+			true,
+		);
+
+		expect(result.places?.["start-place"]?.description).toBe(REDACTED_DESCRIPTION);
+		expect(result.places?.["start-place"]?.displayName).toBe(startPlaceEntry.displayName);
+	});
+
+	it("should not mutate the input config when redacting a place", () => {
+		expect.assertions(2);
+
+		const places = { "start-place": { ...startPlaceEntry, redacted: true } };
+		const input = { ...baseConfig, places } as const satisfies ResolvedConfig;
+
+		const result = applyRedaction(input);
+
+		expect(input.places["start-place"]).toStrictEqual({ ...startPlaceEntry, redacted: true });
+		expect(result.places?.["start-place"]).not.toBe(input.places["start-place"]);
+	});
+
+	it.for([
+		{
+			caseName: "no flags set",
+			entryRedacted: undefined,
+			envRedacted: undefined,
+			expectRedacted: false,
+		},
+		{
+			caseName: "env-level true, no resource flag",
+			entryRedacted: undefined,
+			envRedacted: true,
+			expectRedacted: true,
+		},
+		{
+			caseName: "env-level false, no resource flag",
+			entryRedacted: undefined,
+			envRedacted: false,
+			expectRedacted: false,
+		},
+		{
+			caseName: "resource false carves out env-level true",
+			entryRedacted: false,
+			envRedacted: true,
+			expectRedacted: false,
+		},
+		{
+			caseName: "resource true redacts despite env-level false",
+			entryRedacted: true,
+			envRedacted: false,
+			expectRedacted: true,
+		},
+	] as const)(
+		"should redact a place description according to overlay > root > env precedence ($caseName)",
+		({ entryRedacted, envRedacted, expectRedacted }) => {
+			expect.assertions(1);
+
+			const placeEntry = (
+				entryRedacted === undefined
+					? startPlaceEntry
+					: { ...startPlaceEntry, redacted: entryRedacted }
+			) satisfies ResolvedPlaceEntry;
+			const result = applyRedaction(
+				{ ...baseConfig, places: { "start-place": placeEntry } },
+				envRedacted,
+			);
+			const expectedDescription = expectRedacted
+				? REDACTED_DESCRIPTION
+				: startPlaceEntry.description;
+
+			expect(result.places?.["start-place"]?.description).toBe(expectedDescription);
 		},
 	);
 

--- a/packages/bedrock/src/core/redact-resources.ts
+++ b/packages/bedrock/src/core/redact-resources.ts
@@ -6,7 +6,9 @@ import type {
 	GamePassEntry,
 	RedactedDeveloperProductOverride,
 	RedactedGamePassOverride,
+	RedactedPlaceOverride,
 	ResolvedConfig,
+	ResolvedPlaceEntry,
 } from "./schema.ts";
 
 /** Default placeholder name pushed for a redacted game-pass. */
@@ -57,15 +59,17 @@ export function applyRedaction(
 	environmentRedacted = false,
 ): ResolvedConfig {
 	const passes = redactPasses(config.passes, environmentRedacted);
+	const places = redactPlaces(config.places, environmentRedacted);
 	const products = redactProducts(config.products, environmentRedacted);
 
-	if (passes === config.passes && products === config.products) {
+	if (passes === config.passes && places === config.places && products === config.products) {
 		return config;
 	}
 
 	return {
 		...config,
 		...(passes === undefined ? {} : { passes }),
+		...(places === undefined ? {} : { places }),
 		...(products === undefined ? {} : { products }),
 	};
 }
@@ -144,6 +148,45 @@ function redactPasses(
 			const override: RedactedGamePassOverride =
 				typeof effective === "object" ? effective : {};
 			return [key, redactPass(entry, override)] as const;
+		}),
+	);
+}
+
+function redactPlace(
+	entry: ResolvedPlaceEntry,
+	override: RedactedPlaceOverride,
+): ResolvedPlaceEntry {
+	return {
+		...entry,
+		description: override.description ?? REDACTED_DESCRIPTION,
+		displayName: override.displayName ?? entry.displayName,
+	};
+}
+
+function redactPlaces(
+	places: ResolvedConfig["places"],
+	environmentRedacted: boolean,
+): ResolvedConfig["places"] {
+	if (places === undefined) {
+		return undefined;
+	}
+
+	const hasAnyRedaction = Object.values(places).some(
+		(entry) => (entry.redacted ?? environmentRedacted) !== false,
+	);
+	if (!hasAnyRedaction) {
+		return places;
+	}
+
+	return Object.fromEntries(
+		Object.entries(places).map(([key, entry]) => {
+			const effective = entry.redacted ?? environmentRedacted;
+			if (effective === false) {
+				return [key, entry] as const;
+			}
+
+			const override: RedactedPlaceOverride = typeof effective === "object" ? effective : {};
+			return [key, redactPlace(entry, override)] as const;
 		}),
 	);
 }

--- a/packages/bedrock/src/core/schema.example.spec.ts
+++ b/packages/bedrock/src/core/schema.example.spec.ts
@@ -3,6 +3,8 @@ import { expect, it } from "vitest";
 import type {
   GamePassEntry,
   RedactedGamePassOverride,
+  PlaceEntry,
+  RedactedPlaceOverride,
   DeveloperProductEntry,
   RedactedDeveloperProductOverride,
   ResourceEntryByKind,
@@ -28,6 +30,17 @@ it('Example 1', () => {
 })
 
 it('Example 2', () => {
+  const override: RedactedPlaceOverride = { displayName: 'Hidden Project' }
+  const entry: PlaceEntry = {
+    description: 'The lobby place.',
+    displayName: 'Start Place',
+    filePath: 'places/start.rbxl',
+    redacted: override,
+  }
+  expect(entry.redacted).toStrictEqual({ displayName: 'Hidden Project' })
+})
+
+it('Example 3', () => {
   const override: RedactedDeveloperProductOverride = {
     name: 'Closed Beta Pack',
   }
@@ -39,7 +52,7 @@ it('Example 2', () => {
   expect(entry.redacted).toStrictEqual({ name: 'Closed Beta Pack' })
 })
 
-it('Example 3', () => {
+it('Example 4', () => {
   const entry: ResourceEntryByKind['gamePass'] = {
     description: 'Grants VIP perks.',
     icon: { 'en-us': 'assets/vip-icon.png' },
@@ -49,7 +62,7 @@ it('Example 3', () => {
   expect(entry.name).toBe('VIP Pass')
 })
 
-it('Example 4', () => {
+it('Example 5', () => {
   const config: Config = {
     environments: { production: {} },
     state: { backend: 'gist', gistId: 'abc123def456' },
@@ -65,7 +78,7 @@ it('Example 4', () => {
   expect(config.passes!['vip-pass']!.name).toBe('VIP Pass')
 })
 
-it('Example 5', () => {
+it('Example 6', () => {
   const config: Config = {
     environments: {
       production: { places: { 'start-place': { placeId: '4711' } } },
@@ -81,7 +94,7 @@ it('Example 5', () => {
   }
 })
 
-it('Example 6', () => {
+it('Example 7', () => {
   const config: StateConfig = { backend: 'gist', gistId: 'abc' }
   expect(isGistStateConfig(config)).toBeTrue()
   if (isGistStateConfig(config)) {
@@ -89,7 +102,7 @@ it('Example 6', () => {
   }
 })
 
-it('Example 7', () => {
+it('Example 8', () => {
   const ok = validateConfig(
     {
       environments: { production: {} },

--- a/packages/bedrock/src/core/schema.spec-d.ts
+++ b/packages/bedrock/src/core/schema.spec-d.ts
@@ -204,7 +204,7 @@ describe("UniverseEntry / ResolvedUniverseEntry split", () => {
 describe("PlaceEntry / ResolvedPlaceEntry split", () => {
 	it("should expose filePath plus the optional metadata fields at the root PlaceEntry level", () => {
 		expectTypeOf<keyof PlaceEntry>().toEqualTypeOf<
-			"description" | "displayName" | "filePath" | "serverSize"
+			"description" | "displayName" | "filePath" | "redacted" | "serverSize"
 		>();
 		expectTypeOf<PlaceEntry["filePath"]>().toEqualTypeOf<string>();
 		expectTypeOf<PlaceEntry["displayName"]>().toEqualTypeOf<string | undefined>();
@@ -214,7 +214,7 @@ describe("PlaceEntry / ResolvedPlaceEntry split", () => {
 
 	it("should add placeId on ResolvedPlaceEntry as the post-merge invariant alongside the metadata fields", () => {
 		expectTypeOf<keyof ResolvedPlaceEntry>().toEqualTypeOf<
-			"description" | "displayName" | "filePath" | "placeId" | "serverSize"
+			"description" | "displayName" | "filePath" | "placeId" | "redacted" | "serverSize"
 		>();
 		expectTypeOf<ResolvedPlaceEntry["filePath"]>().toEqualTypeOf<string>();
 		expectTypeOf<ResolvedPlaceEntry["placeId"]>().toEqualTypeOf<string>();

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -1023,6 +1023,157 @@ describe(validateConfig, () => {
 		expect(result.err.issues[0]!.path).toStrictEqual(["places", "bad key!"]);
 	});
 
+	it.for([
+		["true", true],
+		["false", false],
+	] as const)("should accept a places entry with redacted: %s", ([, redacted]) => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: MinEnvironments,
+				places: {
+					"start-place": {
+						filePath: "places/start.rbxl",
+						redacted,
+					},
+				},
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.places!["start-place"]!.redacted).toBe(redacted);
+	});
+
+	it.for([
+		["partial description override", { description: "Coming soon." }],
+		["partial displayName override", { displayName: "Hidden Project" }],
+		["full override", { description: "Coming soon.", displayName: "Hidden Project" }],
+	] as const)(
+		"should accept a places entry with redacted as the %s object form",
+		([, redacted]) => {
+			expect.assertions(1);
+
+			const result = validateConfig(
+				{
+					environments: MinEnvironments,
+					places: {
+						"start-place": {
+							filePath: "places/start.rbxl",
+							redacted,
+						},
+					},
+				},
+				SOURCE,
+			);
+
+			assert(result.success);
+
+			expect(result.data.places!["start-place"]!.redacted).toStrictEqual(redacted);
+		},
+	);
+
+	it("should default redacted to undefined when omitted on a places entry", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: MinEnvironments,
+				places: {
+					"start-place": { filePath: "places/start.rbxl" },
+				},
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.places!["start-place"]!.redacted).toBeUndefined();
+	});
+
+	it.for([
+		["string", "true"],
+		["number", 1],
+		// eslint-disable-next-line unicorn/no-null -- testing that arktype rejects the json null literal
+		["null", null],
+	] as const)(
+		"should reject %s as a places redacted field and attribute the issue path to that field",
+		([, redacted]) => {
+			expect.assertions(1);
+
+			const result = validateConfig(
+				{
+					environments: MinEnvironments,
+					places: {
+						"start-place": {
+							filePath: "places/start.rbxl",
+							redacted,
+						},
+					},
+				},
+				SOURCE,
+			);
+
+			assert(!result.success);
+			assert(result.err.kind === "validationFailed");
+
+			expect(result.err.issues[0]!.path).toStrictEqual(["places", "start-place", "redacted"]);
+		},
+	);
+
+	it("should reject an empty places redacted object and recommend redacted: true for default placeholders", () => {
+		expect.assertions(2);
+
+		const result = validateConfig(
+			{
+				environments: MinEnvironments,
+				places: {
+					"start-place": {
+						filePath: "places/start.rbxl",
+						redacted: {},
+					},
+				},
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual(["places", "start-place", "redacted"]);
+		expect(result.err.issues[0]!.message).toContain("redacted: true");
+	});
+
+	it("should reject an unknown key in a places redacted override and attribute the issue path to the offending key", () => {
+		expect.assertions(2);
+
+		const result = validateConfig(
+			{
+				environments: MinEnvironments,
+				places: {
+					"start-place": {
+						filePath: "places/start.rbxl",
+						redacted: { filePath: "nope" },
+					},
+				},
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual([
+			"places",
+			"start-place",
+			"redacted",
+			"filePath",
+		]);
+		expect(result.err.issues[0]!.message).toContain("filePath");
+	});
+
 	it("should accept a universe block declaring only universeId", () => {
 		expect.assertions(2);
 
@@ -1841,6 +1992,66 @@ describe(validateConfig, () => {
 			"staging",
 			"passes",
 			"vip-pass",
+			"redacted",
+		]);
+	});
+
+	it.for([
+		["true", true],
+		["false", false],
+	] as const)(
+		"should accept a per-environment places overlay that declares redacted: %s",
+		([, redacted]) => {
+			expect.assertions(1);
+
+			const result = validateConfig(
+				{
+					environments: {
+						staging: { places: { "start-place": { placeId: "5555", redacted } } },
+					},
+					places: { "start-place": { filePath: "places/start.rbxl" } },
+					state: { backend: "gist", gistId: "root-gist" },
+				},
+				SOURCE,
+			);
+
+			assert(result.success);
+
+			expect(result.data.environments["staging"]?.places?.["start-place"]?.redacted).toBe(
+				redacted,
+			);
+		},
+	);
+
+	it("should reject an object override form on a per-environment places overlay redacted field", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: {
+					staging: {
+						places: {
+							"start-place": {
+								placeId: "5555",
+								redacted: { displayName: "Hidden" },
+							},
+						},
+					},
+				},
+				places: { "start-place": { filePath: "places/start.rbxl" } },
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual([
+			"environments",
+			"staging",
+			"places",
+			"start-place",
 			"redacted",
 		]);
 	});

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -749,6 +749,9 @@ const OPTIONAL_STRING = "string | undefined";
 
 const REDACTED_KEY = "redacted?";
 
+const NON_EMPTY_OVERRIDE_MESSAGE =
+	"a non-empty override object; use `redacted: true` for default placeholders";
+
 /**
  * Shared arktype constraint for any optional positive-integer field.
  * Reused by per-kind entry schemas so positive-integer fields validate
@@ -775,9 +778,7 @@ const gamePassRedactedOverride = type({
 	.onUndeclaredKey("reject")
 	.narrow((value, ctx) => {
 		if (Object.keys(value).length === 0) {
-			return ctx.mustBe(
-				"a non-empty override object; use `redacted: true` for default placeholders",
-			);
+			return ctx.mustBe(NON_EMPTY_OVERRIDE_MESSAGE);
 		}
 
 		return true;
@@ -792,9 +793,7 @@ const placeRedactedOverride = type({
 	.onUndeclaredKey("reject")
 	.narrow((value, ctx) => {
 		if (Object.keys(value).length === 0) {
-			return ctx.mustBe(
-				"a non-empty override object; use `redacted: true` for default placeholders",
-			);
+			return ctx.mustBe(NON_EMPTY_OVERRIDE_MESSAGE);
 		}
 
 		return true;
@@ -810,9 +809,7 @@ const productRedactedOverride = type({
 	.onUndeclaredKey("reject")
 	.narrow((value, ctx) => {
 		if (Object.keys(value).length === 0) {
-			return ctx.mustBe(
-				"a non-empty override object; use `redacted: true` for default placeholders",
-			);
+			return ctx.mustBe(NON_EMPTY_OVERRIDE_MESSAGE);
 		}
 
 		return true;

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -45,6 +45,39 @@ export interface RedactedGamePassOverride {
 }
 
 /**
+ * Per-field redaction override for a place entry. Each supplied field
+ * replaces the matching bedrock-supplied placeholder; omitted `description`
+ * falls through to the placeholder default. `displayName` has no
+ * placeholder default; an omitted `displayName` preserves the real value
+ * declared on the entry. The object form implies redaction is enabled, so
+ * authors who want only the description default should write
+ * `redacted: true` instead of an empty object.
+ *
+ * @example
+ *
+ * ```ts
+ * import type { PlaceEntry, RedactedPlaceOverride } from "@bedrock-rbx/core/config";
+ *
+ * const override: RedactedPlaceOverride = { displayName: "Hidden Project" };
+ *
+ * const entry: PlaceEntry = {
+ *     description: "The lobby place.",
+ *     displayName: "Start Place",
+ *     filePath: "places/start.rbxl",
+ *     redacted: override,
+ * };
+ *
+ * expect(entry.redacted).toStrictEqual({ displayName: "Hidden Project" });
+ * ```
+ */
+export interface RedactedPlaceOverride {
+	/** Override description; falls through to the bedrock default when omitted. */
+	description?: string | undefined;
+	/** Override display name; preserves the real entry value when omitted (no default). */
+	displayName?: string | undefined;
+}
+
+/**
  * Body of a single entry in the `passes` collection. Keys in the parent
  * record are `ResourceKey`-shaped strings enforced at schema validation.
  */
@@ -169,6 +202,18 @@ export interface PlaceEntry {
 	displayName?: string | undefined;
 	/** Path to the `.rbxl` or `.rbxlx` file; handed to `readFile` verbatim by `buildDesired`. */
 	filePath: string;
+	/**
+	 * Set to `true` to deploy this place with bedrock-supplied placeholder
+	 * content (empty description) in place of the real values declared
+	 * above. `displayName` is preserved by default because it surfaces in
+	 * Roblox Studio's place picker and the Creator Hub experience list;
+	 * authors who want full opacity write the object form
+	 * {@link RedactedPlaceOverride} to substitute selected placeholders
+	 * with custom values, including `displayName`. The object form
+	 * implies redaction is enabled. Omit or set `false` to push the real
+	 * values unchanged. Environment overlays accept only the boolean form.
+	 */
+	redacted?: boolean | RedactedPlaceOverride | undefined;
 	/** Maximum players per server; positive integer. */
 	serverSize?: number | undefined;
 }
@@ -193,6 +238,12 @@ export interface ResolvedPlaceEntry {
 	filePath: string;
 	/** Existing Roblox place ID. */
 	placeId: string;
+	/**
+	 * Resolved redaction setting after merging the per-environment overlay
+	 * (boolean only at the overlay level) onto the root entry. See
+	 * {@link PlaceEntry.redacted} for the authored shape.
+	 */
+	redacted?: boolean | RedactedPlaceOverride | undefined;
 	/** Maximum players per server; positive integer. */
 	serverSize?: number | undefined;
 }
@@ -696,6 +747,8 @@ const OPTIONAL_BOOLEAN = "boolean | undefined";
 
 const OPTIONAL_STRING = "string | undefined";
 
+const REDACTED_KEY = "redacted?";
+
 /**
  * Shared arktype constraint for any optional positive-integer field.
  * Reused by per-kind entry schemas so positive-integer fields validate
@@ -730,7 +783,24 @@ const gamePassRedactedOverride = type({
 		return true;
 	});
 
-const gamePassRedacted = gamePassRedactedOverride.or("boolean | undefined");
+const gamePassRedacted = gamePassRedactedOverride.or(OPTIONAL_BOOLEAN);
+
+const placeRedactedOverride = type({
+	"description?": "string",
+	"displayName?": "string",
+})
+	.onUndeclaredKey("reject")
+	.narrow((value, ctx) => {
+		if (Object.keys(value).length === 0) {
+			return ctx.mustBe(
+				"a non-empty override object; use `redacted: true` for default placeholders",
+			);
+		}
+
+		return true;
+	});
+
+const placeRedacted = placeRedactedOverride.or(OPTIONAL_BOOLEAN);
 
 const productRedactedOverride = type({
 	"description?": "string",
@@ -761,7 +831,7 @@ const gamePassEntry = type({
 	"description": "string",
 	"icon": iconMap,
 	"price?": OPTIONAL_ROBUX_PRICE,
-	"redacted?": gamePassRedacted,
+	[REDACTED_KEY]: gamePassRedacted,
 });
 
 const passesCollection = type({
@@ -774,7 +844,7 @@ const developerProductEntry = type({
 	"icon?": iconMap,
 	"isRegionalPricingEnabled?": OPTIONAL_BOOLEAN,
 	"price?": OPTIONAL_ROBUX_PRICE,
-	"redacted?": productRedacted,
+	[REDACTED_KEY]: productRedacted,
 	"storePageEnabled?": OPTIONAL_BOOLEAN,
 }).onUndeclaredKey("reject");
 
@@ -788,6 +858,7 @@ const placeEntry = type({
 	"description?": OPTIONAL_STRING,
 	"displayName?": OPTIONAL_STRING,
 	"filePath": "string",
+	[REDACTED_KEY]: placeRedacted,
 	"serverSize?": OPTIONAL_POSITIVE_INTEGER,
 }).onUndeclaredKey("reject");
 
@@ -835,7 +906,7 @@ const gamePassOverlay = type({
 	"icon?": iconMap,
 	"name?": "string",
 	"price?": OPTIONAL_ROBUX_PRICE,
-	"redacted?": OPTIONAL_BOOLEAN,
+	[REDACTED_KEY]: OPTIONAL_BOOLEAN,
 }).onUndeclaredKey("reject");
 
 const passesOverlayCollection = type({
@@ -848,7 +919,7 @@ const developerProductOverlay = type({
 	"isRegionalPricingEnabled?": OPTIONAL_BOOLEAN,
 	"name?": "string",
 	"price?": OPTIONAL_ROBUX_PRICE,
-	"redacted?": OPTIONAL_BOOLEAN,
+	[REDACTED_KEY]: OPTIONAL_BOOLEAN,
 	"storePageEnabled?": OPTIONAL_BOOLEAN,
 }).onUndeclaredKey("reject");
 
@@ -861,6 +932,7 @@ const placeOverlay = type({
 	"displayName?": OPTIONAL_STRING,
 	"filePath?": "string",
 	"placeId": ROBLOX_ID_DIGITS,
+	[REDACTED_KEY]: OPTIONAL_BOOLEAN,
 	"serverSize?": OPTIONAL_POSITIVE_INTEGER,
 }).onUndeclaredKey("reject");
 
@@ -881,7 +953,7 @@ const environmentEntry: Type<EnvironmentEntry> = type({
 	"passes?": passesOverlayCollection,
 	"places?": placesOverlayCollection,
 	"products?": productsOverlayCollection,
-	"redacted?": OPTIONAL_BOOLEAN,
+	[REDACTED_KEY]: OPTIONAL_BOOLEAN,
 	"state?": stateConfig,
 	"universe?": universeOverlay,
 }).onUndeclaredKey("reject");

--- a/packages/bedrock/src/core/select-environment.spec.ts
+++ b/packages/bedrock/src/core/select-environment.spec.ts
@@ -820,6 +820,103 @@ describe(selectEnvironment, () => {
 		expect(result.data.passes?.["vip-pass"]?.name).toBe(REDACTED_PASS_NAME);
 		expect(result.data.places?.["start-place"]?.displayName).toBe("[STAGING] Start Place");
 	});
+
+	it("should redact a place description and preserve the real displayName under the prefix when redacted is true", () => {
+		expect.assertions(2);
+
+		const config: Config = {
+			environments: {
+				staging: {
+					label: "staging",
+					places: { "start-place": { placeId: "5555" } },
+				},
+			},
+			places: {
+				"start-place": {
+					description: "The lobby place.",
+					displayName: "Start Place",
+					filePath: "places/start.rbxl",
+					redacted: true,
+				},
+			},
+			state: ROOT_STATE,
+		};
+
+		const result = selectEnvironment(config, "staging");
+
+		assert(result.success);
+
+		expect(result.data.places?.["start-place"]?.description).toBe(REDACTED_DESCRIPTION);
+		expect(result.data.places?.["start-place"]?.displayName).toBe("[STAGING] Start Place");
+	});
+
+	it("should compose the display-name prefix with an explicit place displayName override", () => {
+		expect.assertions(2);
+
+		const config: Config = {
+			environments: {
+				staging: {
+					label: "staging",
+					places: { "start-place": { placeId: "5555" } },
+				},
+			},
+			places: {
+				"start-place": {
+					description: "The lobby place.",
+					displayName: "Start Place",
+					filePath: "places/start.rbxl",
+					redacted: { displayName: "Hidden" },
+				},
+			},
+			state: ROOT_STATE,
+		};
+
+		const result = selectEnvironment(config, "staging");
+
+		assert(result.success);
+
+		expect(result.data.places?.["start-place"]?.description).toBe(REDACTED_DESCRIPTION);
+		expect(result.data.places?.["start-place"]?.displayName).toBe("[STAGING] Hidden");
+	});
+
+	it("should redact every place description while preserving displayNames when the env-level toggle is true", () => {
+		expect.assertions(4);
+
+		const config: Config = {
+			environments: {
+				staging: {
+					label: "staging",
+					places: {
+						"lobby": { placeId: "2222" },
+						"start-place": { placeId: "5555" },
+					},
+					redacted: true,
+				},
+			},
+			places: {
+				"lobby": {
+					description: "The hub.",
+					displayName: "Lobby",
+					filePath: "places/lobby.rbxl",
+				},
+				"start-place": {
+					description: "The lobby place.",
+					displayName: "Start Place",
+					filePath: "places/start.rbxl",
+				},
+			},
+			state: ROOT_STATE,
+		};
+
+		const result = selectEnvironment(config, "staging");
+
+		assert(result.success);
+
+		expect(result.data.places?.["lobby"]?.description).toBe(REDACTED_DESCRIPTION);
+		expect(result.data.places?.["lobby"]?.displayName).toBe("[STAGING] Lobby");
+		expect(result.data.places?.["start-place"]?.description).toBe(REDACTED_DESCRIPTION);
+		expect(result.data.places?.["start-place"]?.displayName).toBe("[STAGING] Start Place");
+	});
 });
 
 describe(selectMergedEnvironment, () => {

--- a/packages/bedrock/src/index.spec-d.ts
+++ b/packages/bedrock/src/index.spec-d.ts
@@ -253,7 +253,7 @@ describe(loadConfig, () => {
 describe("PlaceEntry", () => {
 	it("should expose filePath plus the optional metadata fields at the root entry level", () => {
 		expectTypeOf<keyof PlaceEntry>().toEqualTypeOf<
-			"description" | "displayName" | "filePath" | "serverSize"
+			"description" | "displayName" | "filePath" | "redacted" | "serverSize"
 		>();
 		expectTypeOf<PlaceEntry["filePath"]>().toEqualTypeOf<string>();
 		expectTypeOf<PlaceEntry["serverSize"]>().toEqualTypeOf<number | undefined>();
@@ -263,7 +263,7 @@ describe("PlaceEntry", () => {
 describe("ResolvedPlaceEntry", () => {
 	it("should add placeId as the post-merge invariant alongside the optional metadata fields", () => {
 		expectTypeOf<keyof ResolvedPlaceEntry>().toEqualTypeOf<
-			"description" | "displayName" | "filePath" | "placeId" | "serverSize"
+			"description" | "displayName" | "filePath" | "placeId" | "redacted" | "serverSize"
 		>();
 		expectTypeOf<ResolvedPlaceEntry["placeId"]>().toEqualTypeOf<string>();
 	});

--- a/packages/bedrock/src/index.ts
+++ b/packages/bedrock/src/index.ts
@@ -85,6 +85,7 @@ export {
 	type PlaceEntry,
 	type RedactedDeveloperProductOverride,
 	type RedactedGamePassOverride,
+	type RedactedPlaceOverride,
 	type ResolvedConfig,
 	type ResolvedPlaceEntry,
 	type ResolvedUniverseEntry,

--- a/packages/bedrock/tests/integration/places-redacted.spec.ts
+++ b/packages/bedrock/tests/integration/places-redacted.spec.ts
@@ -1,0 +1,286 @@
+import {
+	applyOps,
+	asRobloxAssetId,
+	buildDesired,
+	createPlaceDriver,
+	defineConfig,
+	diff,
+	type DriverRegistry,
+	flattenConfig,
+	type ResourceCurrentState,
+	type ResourceDesiredState,
+	type ResourceDriver,
+	selectEnvironment,
+} from "@bedrock-rbx/core";
+import { PlacesClient } from "@bedrock-rbx/ocale/places";
+import { createFakeHttpClient, validPlaceBody } from "@bedrock-rbx/ocale/testing";
+
+import { REDACTED_DESCRIPTION } from "#src/core/redact-resources";
+import { assert, describe, expect, it } from "vitest";
+
+const UNIVERSE_ID = asRobloxAssetId("1234567890");
+const PLACE_ID = asRobloxAssetId("4711");
+const RBXL_BYTES = new Uint8Array([
+	0x3c, 0x72, 0x6f, 0x62, 0x6c, 0x6f, 0x78, 0x21, 0x89, 0xff, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
+const DEVELOPER_PRODUCT_TRAP: ResourceDriver<"developerProduct"> = {
+	create() {
+		throw new Error("DeveloperProductDriver.create must not run for redacted-place fixtures");
+	},
+};
+
+const GAME_PASS_TRAP: ResourceDriver<"gamePass"> = {
+	create() {
+		throw new Error("GamePassDriver.create must not run for redacted-place fixtures");
+	},
+};
+
+const UNIVERSE_TRAP: ResourceDriver<"universe"> = {
+	create() {
+		throw new Error("UniverseDriver.create must not run for redacted-place fixtures");
+	},
+};
+
+async function readPlaceFile(): Promise<Uint8Array> {
+	return RBXL_BYTES;
+}
+
+function findPlaceDesired(
+	desired: ReadonlyArray<ResourceDesiredState>,
+): Extract<ResourceDesiredState, { readonly kind: "place" }> {
+	const entry = desired.find((value) => value.kind === "place");
+	assert(entry !== undefined);
+	return entry;
+}
+
+function persistedPlace(
+	desired: ReadonlyArray<ResourceDesiredState>,
+	overrides: Partial<ResourceCurrentState<"place">> = {},
+): ResourceCurrentState<"place"> {
+	return {
+		...findPlaceDesired(desired),
+		outputs: { versionNumber: 1 },
+		...overrides,
+	};
+}
+
+describe("places-redacted pipeline end-to-end", () => {
+	it("should send empty description and the real displayName when a place declares redacted: true", async () => {
+		expect.assertions(3);
+
+		const config = defineConfig({
+			environments: { production: { places: { "start-place": { placeId: "4711" } } } },
+			places: {
+				"start-place": {
+					description: "The lobby place.",
+					displayName: "Start Place",
+					filePath: "places/start.rbxl",
+					redacted: true,
+					serverSize: 50,
+				},
+			},
+		});
+
+		const resolved = selectEnvironment(config, "production");
+		assert(resolved.success);
+
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readPlaceFile);
+		assert(desiredResult.success);
+
+		const httpClient = createFakeHttpClient()
+			.mockResponse({ body: { versionNumber: 1 }, status: 200 })
+			.mockResponse({
+				body: validPlaceBody({
+					description: REDACTED_DESCRIPTION,
+					displayName: "Start Place",
+					serverSize: 50,
+				}),
+				status: 200,
+			});
+
+		const registry: DriverRegistry = {
+			developerProduct: DEVELOPER_PRODUCT_TRAP,
+			gamePass: GAME_PASS_TRAP,
+			place: createPlaceDriver({
+				client: new PlacesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: async () => {},
+				}),
+				readFile: readPlaceFile,
+				universeId: UNIVERSE_ID,
+			}),
+			universe: UNIVERSE_TRAP,
+		};
+
+		const applyResult = await applyOps(diff(desiredResult.data, []), registry);
+
+		assert(applyResult.success);
+
+		expect(httpClient.requests).toHaveLength(2);
+
+		const [, metadata] = httpClient.requests;
+		assert(metadata);
+
+		expect(metadata.request.url).toBe(
+			`/cloud/v2/universes/${UNIVERSE_ID}/places/${PLACE_ID}?updateMask=displayName,description,serverSize`,
+		);
+		expect(metadata.request.body).toStrictEqual({
+			description: REDACTED_DESCRIPTION,
+			displayName: "Start Place",
+			serverSize: 50,
+		});
+	});
+
+	it("should compose the displayNamePrefix with an explicit displayName override on a redacted place", async () => {
+		expect.assertions(1);
+
+		const config = defineConfig({
+			environments: {
+				staging: { label: "staging", places: { "start-place": { placeId: "4711" } } },
+			},
+			places: {
+				"start-place": {
+					description: "The lobby place.",
+					displayName: "Start Place",
+					filePath: "places/start.rbxl",
+					redacted: { displayName: "Hidden" },
+				},
+			},
+		});
+
+		const resolved = selectEnvironment(config, "staging");
+		assert(resolved.success);
+
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readPlaceFile);
+		assert(desiredResult.success);
+
+		const httpClient = createFakeHttpClient()
+			.mockResponse({ body: { versionNumber: 1 }, status: 200 })
+			.mockResponse({
+				body: validPlaceBody({
+					description: REDACTED_DESCRIPTION,
+					displayName: "[STAGING] Hidden",
+				}),
+				status: 200,
+			});
+
+		const registry: DriverRegistry = {
+			developerProduct: DEVELOPER_PRODUCT_TRAP,
+			gamePass: GAME_PASS_TRAP,
+			place: createPlaceDriver({
+				client: new PlacesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: async () => {},
+				}),
+				readFile: readPlaceFile,
+				universeId: UNIVERSE_ID,
+			}),
+			universe: UNIVERSE_TRAP,
+		};
+
+		const applyResult = await applyOps(diff(desiredResult.data, []), registry);
+
+		assert(applyResult.success);
+
+		const [, metadata] = httpClient.requests;
+		assert(metadata);
+
+		expect(metadata.request.body).toStrictEqual({
+			description: REDACTED_DESCRIPTION,
+			displayName: "[STAGING] Hidden",
+		});
+	});
+
+	it("should redact every place description while preserving real displayNames when the env-level toggle is true", async () => {
+		expect.assertions(2);
+
+		const config = defineConfig({
+			environments: {
+				staging: {
+					places: { "lobby": { placeId: "2222" }, "start-place": { placeId: "4711" } },
+					redacted: true,
+				},
+			},
+			places: {
+				"lobby": {
+					description: "The hub.",
+					displayName: "Lobby",
+					filePath: "places/lobby.rbxl",
+				},
+				"start-place": {
+					description: "The lobby place.",
+					displayName: "Start Place",
+					filePath: "places/start.rbxl",
+				},
+			},
+		});
+
+		const resolved = selectEnvironment(config, "staging");
+		assert(resolved.success);
+
+		expect(resolved.data.places?.["lobby"]).toStrictEqual({
+			description: REDACTED_DESCRIPTION,
+			displayName: "Lobby",
+			filePath: "places/lobby.rbxl",
+			placeId: "2222",
+		});
+		expect(resolved.data.places?.["start-place"]).toStrictEqual({
+			description: REDACTED_DESCRIPTION,
+			displayName: "Start Place",
+			filePath: "places/start.rbxl",
+			placeId: "4711",
+		});
+	});
+
+	it("should treat a config-side description edit as a noop while redacted stays true", async () => {
+		expect.assertions(1);
+
+		const config = defineConfig({
+			environments: { production: { places: { "start-place": { placeId: "4711" } } } },
+			places: {
+				"start-place": {
+					description: "Edited copy that must not ship.",
+					displayName: "Start Place",
+					filePath: "places/start.rbxl",
+					redacted: true,
+				},
+			},
+		});
+
+		const resolved = selectEnvironment(config, "production");
+		assert(resolved.success);
+
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readPlaceFile);
+		assert(desiredResult.success);
+
+		const ops = diff(desiredResult.data, [persistedPlace(desiredResult.data)]);
+
+		expect(ops.every((op) => op.type === "noop")).toBeTrue();
+	});
+
+	it("should push the real description when an env-overlay flips redacted to false while the root sets true", async () => {
+		expect.assertions(1);
+
+		const config = defineConfig({
+			environments: {
+				production: { places: { "start-place": { placeId: "4711", redacted: false } } },
+			},
+			places: {
+				"start-place": {
+					description: "The lobby place.",
+					displayName: "Start Place",
+					filePath: "places/start.rbxl",
+					redacted: true,
+				},
+			},
+		});
+
+		const resolved = selectEnvironment(config, "production");
+		assert(resolved.success);
+
+		expect(resolved.data.places?.["start-place"]?.description).toBe("The lobby place.");
+	});
+});


### PR DESCRIPTION
## Summary

- Adds the `redacted` field to `PlaceEntry` (boolean or object override `{ description?, displayName? }`). `redacted: true` substitutes the placeholder description (an empty string) and preserves the real `displayName` so the place stays identifiable in Roblox Studio's place picker and the Creator Hub experience list.
- Authors opt into redacting the `displayName` explicitly via the override form `redacted: { displayName: 'Hidden Project' }`. The override composes with `displayNamePrefix` to produce e.g. `"[DEV] Hidden Project"`.
- Environment overlays accept the boolean form only. Precedence mirrors game-pass: per-resource overlay > root > env-level.
- ADR-024 picks up a dated amendment that corrects the original universe row. Universe owns no redactable description of its own (root-place derived) and `icon` is blocked upstream by [#362](https://github.com/christopher-buss/bedrock/issues/362), so the asymmetric-default design moves to `place`, which actually owns `description` and `displayName`.

## Why this supersedes [#414](https://github.com/christopher-buss/bedrock/issues/414)

The original issue scoped redaction to `universe` with a `description + icon` default field set lifted from the ADR. Investigation found both fields are mis-attributed: universe `description` is derived from the root place's description, and universe `icon` cannot be set via Open Cloud today ([#362](https://github.com/christopher-buss/bedrock/issues/362)). The only universe field redactable today is `displayName`, which the prior PRs already cover through the prefix path. The asymmetric-default design lands naturally on `place` instead, which owns both fields. ADR-024 is amended rather than rewritten.

## Test plan

- [x] `pnpm gen:example-tests` — generated `RedactedPlaceOverride` example test
- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 3504 passing, 16 skipped, 0 failed
- [x] `pnpm build` — clean
- [x] `pnpm mutate:changed` — 100% mutation score on touched `src/**` files (20 killed, 0 survivors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Bedrock PR `#421`: Place Redaction with Asymmetric Default

## Architecture Compliance (FCIS Pattern) ✅

**Core Layer (Pure Functions)**
- `applyRedaction()`, `redactPlace()`, `redactPlaces()` are pure functions with **zero I/O, zero side effects, zero mutations** of input config
- Fast-path optimization correctly returns early when no redaction is needed (preserving object identity for `===` checks)
- All redaction logic resides in `core/redact-resources.ts` with no Shell/Adapter involvement

**Type Safety**
- Type exports properly re-exported in `index.ts` and `config.ts` (`RedactedPlaceOverride`)
- Schema validation enforced via `arktype` (pure validation library)

**Compliance**: ✅ Architecture patterns strictly observed.

---

## TDD Requirements ✅

**Test Coverage is Exemplary**

| Test File | Lines | Coverage |
|-----------|-------|----------|
| `schema.spec.ts` | +211 | Validation of boolean/object forms, empty-object rejection, unknown keys, env-overlay boolean-only enforcement |
| `redact-resources.spec.ts` | +191 | Description redaction, displayName preservation, overrides, fast-path non-mutation, precedence (overlay > root > env) |
| `select-environment.spec.ts` | +97 | Environment label composition with displayName overrides |
| `places-redacted.spec.ts` | +286 | End-to-end: fake HTTP client, real `PlacesClient`, redacted description + real displayName assertions |
| Type tests (*.spec-d.ts) | +17 | `keyof PlaceEntry`/`keyof ResolvedPlaceEntry` include `redacted` field |

**Test Naming Convention**: All tests follow `should <behavior>` format (e.g., "should accept a places entry with redacted: true", "should leave a place unchanged when redacted is false", "should reject an empty redacted object and recommend redacted: true").

**Mutation Testing**: 100% mutation score claimed on touched source files; tests specifically target short-circuit conditionals and carve-out logic (mixed redacted/non-redacted places).

**Compliance**: ✅ Comprehensive RED-GREEN-REFACTOR discipline with full coverage.

---

## Test Isolation ✅

| Layer | Test Strategy | Isolation |
|-------|---------------|-----------|
| **Core** (`applyRedaction`, `redactPlace`) | Unit tests in `redact-resources.spec.ts` | No isolation needed (pure functions) |
| **Core Validation** (arktype schemas) | Unit tests in `schema.spec.ts` | Validation library is pure |
| **Shell Integration** (`selectEnvironment` flow) | Integration test in `select-environment.spec.ts` | No adapter stubs needed (orchestration only) |
| **Adapter Integration** (`PlacesClient` HTTP) | Integration test in `places-redacted.spec.ts` | Fake HTTP client (`createFakeHttpClient`) + trap stubs for unrelated drivers (universe, gamePass, developerProduct) |

**Compliance**: ✅ Proper isolation by layer.

---

## Security & Constraints ✅

**Threat Model**: Addressed in ADR-024 — redaction defends against page-access bypass leaking in-dev monetization metadata, not state-file compromise or credential theft.

**State Files**: Contain only placeholders (public data) and resource IDs; no secrets. No state-file schema bump required.

**API Compliance**: Bedrock uses Open Cloud only. ADR-024 amendment explicitly removed `universe.icon` redaction (blocked upstream, no Open Cloud endpoint per issue `#362`) and transferred description redaction to `place` (universe description derived server-side from root place).

**Input Validation**: All external input validated at arktype boundary:
- Rejects `redacted: {}` with guidance: "use `redacted: true` for default placeholders"
- Rejects unknown override keys (e.g., `redacted: { price: 0 }`) with path attribution
- Rejects object form in environment overlays (boolean-only enforced)

**Compliance**: ✅ No legacy APIs, no secrets in state, proper input validation.

---

## Code Quality ✅

**Type Safety**
- Zero `any` types; zero `@ts-ignore` or `@ts-nocheck`
- Interfaces properly defined: `RedactedPlaceOverride` with optional `description` and `displayName` fields
- Type tests confirm `redacted` field in `keyof PlaceEntry` and `keyof ResolvedPlaceEntry`

**Shared Constants** (DRY principle)
- `REDACTED_KEY = "redacted?"` — single source for schema property name
- `NON_EMPTY_OVERRIDE_MESSAGE` — single error message reused across validation narrows (passes, products, places, env overlays)
- Reduces duplication in schema validation refactor commit

**Error Messages**
- Path-specific attribution (e.g., `["places", "start-place", "redacted"]`)
- Actionable guidance (e.g., "recommend `redacted: true`" for empty object)

**Compliance**: ✅ Strict TypeScript, no unsafe patterns, proper error handling.

---

## Asymmetric Default Design (Per ADR-024 Amendment)

**Correctly Implemented**:
- `redacted: true` → `description` redacted (empty string), **`displayName` preserved** (identifiable in Studio/Creator Hub)
- `redacted: { displayName: 'Hidden Project' }` → description empty, displayName overridden; composes with env labels (e.g., `[STAGING] Hidden Project`)
- `redacted: false` → no redaction
- Environment overlays accept **boolean only**; override objects rejected

**Precedence Chain** (Consistent with game-pass):
1. Per-resource overlay (most specific) → 2. Per-resource root → 3. Environment-level (least specific)

**Placeholder Defaults**:
- Place `description` → `""` (empty string)
- Place `displayName` → **no default** (explicit override required if redaction needed)

**ADR Amendment Rationale**: Moved from universe to place because:
- Universe `icon` upstream-blocked (no Open Cloud endpoint)
- Universe `description` derived from root place server-side
- Place actually owns both `description` and `displayName` today

**Compliance**: ✅ Asymmetric default correctly applied and justified.

---

## Summary

This is a **high-quality, production-ready PR** that exemplifies Bedrock's standards:

✅ **Architecture**: Pure Core functions, no I/O, strict FCIS pattern  
✅ **Testing**: 700+ lines of new tests (unit + integration); 100% mutation coverage claimed  
✅ **Test Isolation**: Proper layer-by-layer isolation (unit for Core, fake adapters for integration)  
✅ **Security**: No legacy APIs, no secrets in state, comprehensive input validation  
✅ **Code Quality**: Strict TypeScript, shared constants, actionable error messages  
✅ **Design**: Asymmetric default correctly motivated and implemented per ADR-024 amendment

**Ready to merge.**

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->