### PR TITLE
feat(core): surface changed fields per update op in plan output

### DIFF
--- a/packages/bedrock/src/cli/commands/diff.spec.ts
+++ b/packages/bedrock/src/cli/commands/diff.spec.ts
@@ -62,6 +62,7 @@ function updatePlaceOp(key: string): Operation {
 	};
 	return {
 		key: asResourceKey(key),
+		changedFields: ["fileHash"],
 		current: { ...desired, outputs: { versionNumber: 1 } },
 		desired,
 		type: "update",

--- a/packages/bedrock/src/cli/commands/diff.spec.ts
+++ b/packages/bedrock/src/cli/commands/diff.spec.ts
@@ -8,7 +8,7 @@ import type { Operation } from "../../core/operations.ts";
 import type { RedactionAnnotation } from "../../core/redact-resources.ts";
 import type { Config } from "../../core/schema.ts";
 import type { DiffPreview, PreviewDiffError } from "../../shell/preview-diff.ts";
-import { asResourceKey, asSha256Hex } from "../../types/ids.ts";
+import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../../types/ids.ts";
 import type { ProgDeps } from "../index.ts";
 import { diffCommand } from "./diff.ts";
 
@@ -57,7 +57,7 @@ function updatePlaceOp(key: string): Operation {
 		fileHash: SAMPLE_HASH,
 		filePath: "places/start.rbxl",
 		kind: "place" as const,
-		placeId: asResourceKey("4711") as never,
+		placeId: asRobloxAssetId("4711"),
 		serverSize: undefined,
 	};
 	return {
@@ -77,7 +77,7 @@ function multiFieldUpdatePlaceOp(key: string): Operation {
 		fileHash: SAMPLE_HASH,
 		filePath: "places/start.rbxl",
 		kind: "place" as const,
-		placeId: asResourceKey("4711") as never,
+		placeId: asRobloxAssetId("4711"),
 		serverSize: undefined,
 	};
 	const current = {

--- a/packages/bedrock/src/cli/commands/diff.spec.ts
+++ b/packages/bedrock/src/cli/commands/diff.spec.ts
@@ -69,6 +69,32 @@ function updatePlaceOp(key: string): Operation {
 	};
 }
 
+function multiFieldUpdatePlaceOp(key: string): Operation {
+	const desired = {
+		key: asResourceKey(key),
+		description: "New body",
+		displayName: "New name",
+		fileHash: SAMPLE_HASH,
+		filePath: "places/start.rbxl",
+		kind: "place" as const,
+		placeId: asResourceKey("4711") as never,
+		serverSize: undefined,
+	};
+	const current = {
+		...desired,
+		description: "Old body",
+		displayName: "Old name",
+		outputs: { versionNumber: 1 },
+	};
+	return {
+		key: asResourceKey(key),
+		changedFields: ["displayName", "description"],
+		current,
+		desired,
+		type: "update",
+	};
+}
+
 function preview(input: {
 	environment: string;
 	ops: ReadonlyArray<Operation>;
@@ -254,11 +280,34 @@ describe(diffCommand, () => {
 			'Pending changes for "production":',
 		);
 		expect(deps.clack?.logMessage).toHaveBeenNthCalledWith(2, "+ gamePass:vip-pass");
-		expect(deps.clack?.logMessage).toHaveBeenNthCalledWith(3, "~ place:start-place");
+		expect(deps.clack?.logMessage).toHaveBeenNthCalledWith(
+			3,
+			"~ place:start-place fileHash updated",
+		);
 		expect(deps.clack?.outro).toHaveBeenCalledExactlyOnceWith(
 			"run bedrock deploy to apply pending changes",
 		);
 		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(0);
+	});
+
+	it("should join multiple changed fields with ' + ' for an update op", async () => {
+		expect.assertions(1);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const previewDiff = fakePreview([
+			preview({
+				environment: "production",
+				ops: [multiFieldUpdatePlaceOp("start-place")],
+			}),
+		]);
+		const deps = makeDeps({ loadConfig, previewDiff });
+
+		await diffCommand(deps)({ env: "production" });
+
+		expect(deps.clack?.logMessage).toHaveBeenNthCalledWith(
+			2,
+			"~ place:start-place displayName + description updated",
+		);
 	});
 
 	it("should render the redacted section after the drift section and skip redactions whose op is a create or update", async () => {

--- a/packages/bedrock/src/cli/commands/diff.ts
+++ b/packages/bedrock/src/cli/commands/diff.ts
@@ -84,7 +84,7 @@ function describeOp(op: CreateOperation | UpdateOperation): string {
 			return `+ ${op.desired.kind}:${op.key}`;
 		}
 		case "update": {
-			return `~ ${op.desired.kind}:${op.key}`;
+			return `~ ${op.desired.kind}:${op.key} ${op.changedFields.join(" + ")} updated`;
 		}
 	}
 }

--- a/packages/bedrock/src/core/diff.example.spec.ts
+++ b/packages/bedrock/src/core/diff.example.spec.ts
@@ -51,4 +51,8 @@ it('Example 1', () => {
   ]
   const ops = diff([unchanged, drifted, fresh], current)
   expect(ops.map((op) => op.type)).toEqual(['noop', 'update', 'create'])
+  const updateOp = ops[1]!
+  if (updateOp.type === 'update') {
+    expect(updateOp.changedFields).toStrictEqual(['name'])
+  }
 })

--- a/packages/bedrock/src/core/diff.spec.ts
+++ b/packages/bedrock/src/core/diff.spec.ts
@@ -154,6 +154,7 @@ describe(diff, () => {
 			{ key: matchingKey, type: "noop" },
 			{
 				key: driftedKey,
+				changedFields: ["name"],
 				current: currentDrifted,
 				desired: desiredDrifted,
 				type: "update",
@@ -182,6 +183,7 @@ describe(diff, () => {
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 				{
 					key: desiredEntry.key,
+					changedFields: ["name"],
 					current: currentEntry,
 					desired: desiredEntry,
 					type: "update",
@@ -198,6 +200,7 @@ describe(diff, () => {
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 				{
 					key: desiredEntry.key,
+					changedFields: ["price"],
 					current: currentEntry,
 					desired: desiredEntry,
 					type: "update",
@@ -214,6 +217,7 @@ describe(diff, () => {
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 				{
 					key: desiredEntry.key,
+					changedFields: ["price"],
 					current: currentEntry,
 					desired: desiredEntry,
 					type: "update",
@@ -230,6 +234,7 @@ describe(diff, () => {
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 				{
 					key: desiredEntry.key,
+					changedFields: ["price"],
 					current: currentEntry,
 					desired: desiredEntry,
 					type: "update",
@@ -276,7 +281,13 @@ describe(diff, () => {
 			const currentEntry = placeCurrent();
 
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-				{ key: PLACE_KEY, current: currentEntry, desired: desiredEntry, type: "update" },
+				{
+					key: PLACE_KEY,
+					changedFields: ["fileHash"],
+					current: currentEntry,
+					desired: desiredEntry,
+					type: "update",
+				},
 			]);
 		});
 
@@ -287,7 +298,13 @@ describe(diff, () => {
 			const currentEntry = placeCurrent();
 
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-				{ key: PLACE_KEY, current: currentEntry, desired: desiredEntry, type: "update" },
+				{
+					key: PLACE_KEY,
+					changedFields: ["filePath"],
+					current: currentEntry,
+					desired: desiredEntry,
+					type: "update",
+				},
 			]);
 		});
 
@@ -298,13 +315,19 @@ describe(diff, () => {
 			const currentEntry = placeCurrent();
 
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-				{ key: PLACE_KEY, current: currentEntry, desired: desiredEntry, type: "update" },
+				{
+					key: PLACE_KEY,
+					changedFields: ["placeId"],
+					current: currentEntry,
+					desired: desiredEntry,
+					type: "update",
+				},
 			]);
 		});
 
 		it.for<
 			[
-				label: string,
+				field: string,
 				desiredOverrides: Partial<PlaceDesiredState>,
 				currentOverrides: Partial<ResourceCurrentState<"place">>,
 			]
@@ -314,7 +337,7 @@ describe(diff, () => {
 			["serverSize", { serverSize: 25 }, { serverSize: 50 }],
 		])(
 			"should emit an update op when the place %s differs",
-			([, desiredOverrides, currentOverrides]) => {
+			([field, desiredOverrides, currentOverrides]) => {
 				expect.assertions(1);
 
 				const desiredEntry = placeDesired(desiredOverrides);
@@ -323,6 +346,7 @@ describe(diff, () => {
 				expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 					{
 						key: PLACE_KEY,
+						changedFields: [field],
 						current: currentEntry,
 						desired: desiredEntry,
 						type: "update",
@@ -394,6 +418,7 @@ describe(diff, () => {
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 				{
 					key: UNIVERSE_SINGLETON_KEY,
+					changedFields: ["universeId"],
 					current: currentEntry,
 					desired: desiredEntry,
 					type: "update",
@@ -432,6 +457,7 @@ describe(diff, () => {
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 				{
 					key: UNIVERSE_SINGLETON_KEY,
+					changedFields: ["voiceChatEnabled"],
 					current: currentEntry,
 					desired: desiredEntry,
 					type: "update",
@@ -451,6 +477,7 @@ describe(diff, () => {
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 				{
 					key: UNIVERSE_SINGLETON_KEY,
+					changedFields: ["universeId"],
 					current: currentEntry,
 					desired: desiredEntry,
 					type: "update",
@@ -480,6 +507,7 @@ describe(diff, () => {
 				expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 					{
 						key: UNIVERSE_SINGLETON_KEY,
+						changedFields: [flag],
 						current: currentEntry,
 						desired: desiredEntry,
 						type: "update",
@@ -552,6 +580,7 @@ describe(diff, () => {
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 				{
 					key: UNIVERSE_SINGLETON_KEY,
+					changedFields: ["mobileEnabled"],
 					current: currentEntry,
 					desired: desiredEntry,
 					type: "update",
@@ -586,6 +615,7 @@ describe(diff, () => {
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 				{
 					key: UNIVERSE_SINGLETON_KEY,
+					changedFields: ["displayName"],
 					current: currentEntry,
 					desired: desiredEntry,
 					type: "update",
@@ -627,6 +657,7 @@ describe(diff, () => {
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 				{
 					key: UNIVERSE_SINGLETON_KEY,
+					changedFields: ["privateServerPriceRobux"],
 					current: currentEntry,
 					desired: desiredEntry,
 					type: "update",
@@ -643,6 +674,7 @@ describe(diff, () => {
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 				{
 					key: UNIVERSE_SINGLETON_KEY,
+					changedFields: ["privateServerPriceRobux"],
 					current: currentEntry,
 					desired: desiredEntry,
 					type: "update",
@@ -702,6 +734,7 @@ describe(diff, () => {
 					expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 						{
 							key: UNIVERSE_SINGLETON_KEY,
+							changedFields: [field],
 							current: currentEntry,
 							desired: desiredEntry,
 							type: "update",
@@ -723,6 +756,7 @@ describe(diff, () => {
 					expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 						{
 							key: UNIVERSE_SINGLETON_KEY,
+							changedFields: [field],
 							current: currentEntry,
 							desired: desiredEntry,
 							type: "update",
@@ -742,6 +776,7 @@ describe(diff, () => {
 					expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 						{
 							key: UNIVERSE_SINGLETON_KEY,
+							changedFields: [field],
 							current: currentEntry,
 							desired: desiredEntry,
 							type: "update",
@@ -761,6 +796,7 @@ describe(diff, () => {
 					expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 						{
 							key: UNIVERSE_SINGLETON_KEY,
+							changedFields: [field],
 							current: currentEntry,
 							desired: desiredEntry,
 							type: "update",
@@ -855,6 +891,7 @@ describe(diff, () => {
 				expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
 					{
 						key: UNIVERSE_SINGLETON_KEY,
+						changedFields: ["discordSocialLink"],
 						current: currentEntry,
 						desired: desiredEntry,
 						type: "update",

--- a/packages/bedrock/src/core/diff.ts
+++ b/packages/bedrock/src/core/diff.ts
@@ -106,8 +106,6 @@ function operationFor(
 		return { key: desired.key, desired, type: "create" };
 	}
 
-	// Composite-key matching guarantees `desired.kind === current.kind`,
-	// so the per-kind module is consulted directly without a kind guard.
 	const module = defaultKindRegistry[desired.kind] as ResourceKindModule<ResourceKind>;
 	const changedFields = module.changedFieldsBetween(desired, current);
 	if (changedFields.length === 0) {

--- a/packages/bedrock/src/core/diff.ts
+++ b/packages/bedrock/src/core/diff.ts
@@ -79,6 +79,11 @@ import type { ResourceCurrentState, ResourceDesiredState, ResourceKind } from ".
  * const ops = diff([unchanged, drifted, fresh], current);
  *
  * expect(ops.map((op) => op.type)).toEqual(["noop", "update", "create"]);
+ *
+ * const updateOp = ops[1]!;
+ * if (updateOp.type === "update") {
+ *     expect(updateOp.changedFields).toStrictEqual(["name"]);
+ * }
  * ```
  */
 export function diff(
@@ -93,13 +98,6 @@ function compositeKey(resource: { readonly key: string; readonly kind: ResourceK
 	return `${resource.kind}:${resource.key}`;
 }
 
-function desiredFieldsEqual(desired: ResourceDesiredState, current: ResourceCurrentState): boolean {
-	// Composite-key matching guarantees `desired.kind === current.kind`,
-	// so the per-kind module is consulted directly without a kind guard.
-	const module = defaultKindRegistry[desired.kind] as ResourceKindModule<ResourceKind>;
-	return module.fieldsEqual(desired, current);
-}
-
 function operationFor(
 	desired: ResourceDesiredState,
 	current: ResourceCurrentState | undefined,
@@ -108,9 +106,13 @@ function operationFor(
 		return { key: desired.key, desired, type: "create" };
 	}
 
-	if (desiredFieldsEqual(desired, current)) {
+	// Composite-key matching guarantees `desired.kind === current.kind`,
+	// so the per-kind module is consulted directly without a kind guard.
+	const module = defaultKindRegistry[desired.kind] as ResourceKindModule<ResourceKind>;
+	const changedFields = module.changedFieldsBetween(desired, current);
+	if (changedFields.length === 0) {
 		return { key: desired.key, type: "noop" };
 	}
 
-	return { key: desired.key, current, desired, type: "update" };
+	return { key: desired.key, changedFields, current, desired, type: "update" };
 }

--- a/packages/bedrock/src/core/kinds/developer-product.spec.ts
+++ b/packages/bedrock/src/core/kinds/developer-product.spec.ts
@@ -592,6 +592,126 @@ describe("developerProductKind", () => {
 			},
 		);
 	});
+
+	describe("changedFieldsBetween", () => {
+		it("should return an empty list when every managed field matches", () => {
+			expect.assertions(1);
+
+			expect(
+				developerProductKind.changedFieldsBetween(
+					developerProductDesired(),
+					developerProductCurrent(),
+				),
+			).toStrictEqual([]);
+		});
+
+		it.for<[field: string, currentOverrides: Partial<ResourceCurrentStateDeveloperProduct>]>([
+			["description", { description: "Other description" }],
+			["name", { name: "Other Name" }],
+			["price", { price: 100 }],
+		])("should return [%s] when only %s differs", ([field, overrides]) => {
+			expect.assertions(1);
+
+			expect(
+				developerProductKind.changedFieldsBetween(
+					developerProductDesired(),
+					developerProductCurrent(overrides),
+				),
+			).toStrictEqual([field]);
+		});
+
+		it("should return [icon] when only the icon path differs", () => {
+			expect.assertions(1);
+
+			const sharedHashes = { "en-us": ICON_HASH };
+
+			expect(
+				developerProductKind.changedFieldsBetween(
+					developerProductDesired({
+						icon: { "en-us": "assets/gem-pack.png" },
+						iconFileHashes: sharedHashes,
+					}),
+					developerProductCurrent({
+						icon: { "en-us": "assets/other.png" },
+						iconFileHashes: sharedHashes,
+					}),
+				),
+			).toStrictEqual(["icon"]);
+		});
+
+		it("should return [iconFileHashes] when only the icon hash differs", () => {
+			expect.assertions(1);
+
+			const SharedIcon = { "en-us": "assets/gem-pack.png" } as const;
+
+			expect(
+				developerProductKind.changedFieldsBetween(
+					developerProductDesired({
+						icon: SharedIcon,
+						iconFileHashes: { "en-us": ICON_HASH },
+					}),
+					developerProductCurrent({
+						icon: SharedIcon,
+						iconFileHashes: { "en-us": ALT_ICON_HASH },
+					}),
+				),
+			).toStrictEqual(["iconFileHashes"]);
+		});
+
+		it.for([["isRegionalPricingEnabled"] as const, ["storePageEnabled"] as const])(
+			"should return [%s] when desired.%s differs from current",
+			([flag]) => {
+				expect.assertions(1);
+
+				expect(
+					developerProductKind.changedFieldsBetween(
+						developerProductDesired({ [flag]: true }),
+						developerProductCurrent({ [flag]: false }),
+					),
+				).toStrictEqual([flag]);
+			},
+		);
+
+		it.for([["isRegionalPricingEnabled"] as const, ["storePageEnabled"] as const])(
+			"should return an empty list when desired leaves %s unmanaged but current carries a value",
+			([flag]) => {
+				expect.assertions(1);
+
+				expect(
+					developerProductKind.changedFieldsBetween(
+						developerProductDesired({ [flag]: undefined }),
+						developerProductCurrent({ [flag]: true }),
+					),
+				).toStrictEqual([]);
+			},
+		);
+
+		it("should return every changed field in declaration order when many differ", () => {
+			expect.assertions(1);
+
+			expect(
+				developerProductKind.changedFieldsBetween(
+					developerProductDesired({
+						name: "New",
+						description: "New",
+						isRegionalPricingEnabled: true,
+						price: 999,
+						storePageEnabled: false,
+					}),
+					developerProductCurrent({
+						isRegionalPricingEnabled: false,
+						storePageEnabled: true,
+					}),
+				),
+			).toStrictEqual([
+				"description",
+				"name",
+				"price",
+				"isRegionalPricingEnabled",
+				"storePageEnabled",
+			]);
+		});
+	});
 });
 
 type ResourceCurrentStateDeveloperProduct = Parameters<typeof developerProductKind.fieldsEqual>[1];

--- a/packages/bedrock/src/core/kinds/developer-product.ts
+++ b/packages/bedrock/src/core/kinds/developer-product.ts
@@ -67,24 +67,38 @@ async function normalize(
 	};
 }
 
+function changedFieldsBetween(
+	desired: DeveloperProductDesiredState,
+	current: ResourceCurrentState<"developerProduct">,
+): ReadonlyArray<string> {
+	// `isRegionalPricingEnabled` and `storePageEnabled` are tri-state:
+	// `undefined` on the desired side means the user does not manage the
+	// field, so any current value is accepted as a match and the field is
+	// omitted from the change list.
+	return [
+		...(desired.description === current.description ? [] : ["description"]),
+		...(desired.icon?.["en-us"] === current.icon?.["en-us"] ? [] : ["icon"]),
+		...(iconHashesEqual(current.iconFileHashes, desired.iconFileHashes)
+			? []
+			: ["iconFileHashes"]),
+		...(desired.name === current.name ? [] : ["name"]),
+		...(desired.price === current.price ? [] : ["price"]),
+		...(desired.isRegionalPricingEnabled === undefined ||
+		desired.isRegionalPricingEnabled === current.isRegionalPricingEnabled
+			? []
+			: ["isRegionalPricingEnabled"]),
+		...(desired.storePageEnabled === undefined ||
+		desired.storePageEnabled === current.storePageEnabled
+			? []
+			: ["storePageEnabled"]),
+	];
+}
+
 function fieldsEqual(
 	desired: DeveloperProductDesiredState,
 	current: ResourceCurrentState<"developerProduct">,
 ): boolean {
-	// `isRegionalPricingEnabled` and `storePageEnabled` are tri-state:
-	// `undefined` on the desired side means the user does not manage the
-	// field, so any current value is accepted as a match.
-	return (
-		desired.description === current.description &&
-		desired.icon?.["en-us"] === current.icon?.["en-us"] &&
-		iconHashesEqual(current.iconFileHashes, desired.iconFileHashes) &&
-		desired.name === current.name &&
-		desired.price === current.price &&
-		(desired.isRegionalPricingEnabled === undefined ||
-			desired.isRegionalPricingEnabled === current.isRegionalPricingEnabled) &&
-		(desired.storePageEnabled === undefined ||
-			desired.storePageEnabled === current.storePageEnabled)
-	);
+	return changedFieldsBetween(desired, current).length === 0;
 }
 
 function assertReconcilable(
@@ -112,6 +126,7 @@ function assertReconcilable(
  */
 export const developerProductKind: ResourceKindModule<"developerProduct"> = {
 	assertReconcilable,
+	changedFieldsBetween,
 	entrySchema,
 	fieldsEqual,
 	flatten,

--- a/packages/bedrock/src/core/kinds/developer-product.ts
+++ b/packages/bedrock/src/core/kinds/developer-product.ts
@@ -71,10 +71,6 @@ function changedFieldsBetween(
 	desired: DeveloperProductDesiredState,
 	current: ResourceCurrentState<"developerProduct">,
 ): ReadonlyArray<string> {
-	// `isRegionalPricingEnabled` and `storePageEnabled` are tri-state:
-	// `undefined` on the desired side means the user does not manage the
-	// field, so any current value is accepted as a match and the field is
-	// omitted from the change list.
 	return [
 		...(desired.description === current.description ? [] : ["description"]),
 		...(desired.icon?.["en-us"] === current.icon?.["en-us"] ? [] : ["icon"]),

--- a/packages/bedrock/src/core/kinds/game-pass.spec.ts
+++ b/packages/bedrock/src/core/kinds/game-pass.spec.ts
@@ -210,6 +210,47 @@ describe("gamePassKind", () => {
 			).toBeFalse();
 		});
 	});
+
+	describe("changedFieldsBetween", () => {
+		it("should return an empty list when every managed field matches", () => {
+			expect.assertions(1);
+
+			expect(
+				gamePassKind.changedFieldsBetween(gamePassDesired(), gamePassCurrent()),
+			).toStrictEqual([]);
+		});
+
+		it.for<[field: string, currentOverrides: Partial<ResourceCurrentStateGamePass>]>([
+			["description", { description: "Other" }],
+			["icon", { icon: { "en-us": "assets/other.png" } }],
+			["iconFileHashes", { iconFileHashes: { "en-us": ALT_HASH } }],
+			["name", { name: "Other Name" }],
+			["price", { price: 999 }],
+		])("should return [%s] when only %s differs", ([field, overrides]) => {
+			expect.assertions(1);
+
+			expect(
+				gamePassKind.changedFieldsBetween(gamePassDesired(), gamePassCurrent(overrides)),
+			).toStrictEqual([field]);
+		});
+
+		it("should return every changed field in declaration order when many differ", () => {
+			expect.assertions(1);
+
+			expect(
+				gamePassKind.changedFieldsBetween(
+					gamePassDesired({
+						name: "New",
+						description: "New",
+						icon: { "en-us": "assets/new.png" },
+						iconFileHashes: { "en-us": ALT_HASH },
+						price: 999,
+					}),
+					gamePassCurrent(),
+				),
+			).toStrictEqual(["description", "icon", "iconFileHashes", "name", "price"]);
+		});
+	});
 });
 
 type ResourceCurrentStateGamePass = Parameters<typeof gamePassKind.fieldsEqual>[1];

--- a/packages/bedrock/src/core/kinds/game-pass.ts
+++ b/packages/bedrock/src/core/kinds/game-pass.ts
@@ -53,17 +53,26 @@ async function normalize(
 	};
 }
 
+function changedFieldsBetween(
+	desired: GamePassDesiredState,
+	current: ResourceCurrentState<"gamePass">,
+): ReadonlyArray<string> {
+	return [
+		...(desired.description === current.description ? [] : ["description"]),
+		...(desired.icon["en-us"] === current.icon["en-us"] ? [] : ["icon"]),
+		...(iconHashesEqual(current.iconFileHashes, desired.iconFileHashes)
+			? []
+			: ["iconFileHashes"]),
+		...(desired.name === current.name ? [] : ["name"]),
+		...(desired.price === current.price ? [] : ["price"]),
+	];
+}
+
 function fieldsEqual(
 	desired: GamePassDesiredState,
 	current: ResourceCurrentState<"gamePass">,
 ): boolean {
-	return (
-		desired.description === current.description &&
-		desired.icon["en-us"] === current.icon["en-us"] &&
-		iconHashesEqual(current.iconFileHashes, desired.iconFileHashes) &&
-		desired.name === current.name &&
-		desired.price === current.price
-	);
+	return changedFieldsBetween(desired, current).length === 0;
 }
 
 /**
@@ -72,6 +81,7 @@ function fieldsEqual(
  * `gamePass` kind.
  */
 export const gamePassKind: ResourceKindModule<"gamePass"> = {
+	changedFieldsBetween,
 	entrySchema,
 	fieldsEqual,
 	flatten,

--- a/packages/bedrock/src/core/kinds/module.example.spec.ts
+++ b/packages/bedrock/src/core/kinds/module.example.spec.ts
@@ -54,6 +54,8 @@ it('Example 3', () => {
       },
       success: true,
     }),
+    changedFieldsBetween: (desired, current) =>
+      desired.name === current.name ? [] : ['name'],
     fieldsEqual: (desired, current) => desired.name === current.name,
   }
   expect(stubKind.kind).toBe('gamePass')

--- a/packages/bedrock/src/core/kinds/module.ts
+++ b/packages/bedrock/src/core/kinds/module.ts
@@ -117,6 +117,8 @@ export interface KindIo {
  *         },
  *         success: true,
  *     }),
+ *     changedFieldsBetween: (desired, current) =>
+ *         desired.name === current.name ? [] : ["name"],
  *     fieldsEqual: (desired, current) => desired.name === current.name,
  * };
  *
@@ -136,6 +138,19 @@ export interface ResourceKindModule<K extends ResourceKind> {
 		current: ResourceCurrentState<K>,
 		desired: DesiredFor<K>,
 	) => Result<undefined, BuildDesiredError>;
+
+	/**
+	 * Top-level field names that differ between `desired` and `current`,
+	 * in a kind-specific deterministic order. Mirrors `fieldsEqual`
+	 * semantics, so `fieldsEqual(d, c)` is `true` iff this returns `[]`.
+	 * Granularity is top-level: `discordSocialLink`, not
+	 * `discordSocialLink.uri`. Plan and apply renderers consume this as
+	 * the single source of truth for "what changed" on an update op.
+	 */
+	changedFieldsBetween(
+		desired: DesiredFor<K>,
+		current: ResourceCurrentState<K>,
+	): ReadonlyArray<string>;
 
 	/** ArkType schema for the authored entry body of this kind. */
 	readonly entrySchema: Type<ResourceEntryByKind[K]>;

--- a/packages/bedrock/src/core/kinds/place.spec.ts
+++ b/packages/bedrock/src/core/kinds/place.spec.ts
@@ -227,6 +227,82 @@ describe("placeKind", () => {
 			},
 		);
 	});
+
+	describe("changedFieldsBetween", () => {
+		it("should return an empty list when every managed field matches", () => {
+			expect.assertions(1);
+
+			expect(placeKind.changedFieldsBetween(placeDesired(), placeCurrent())).toStrictEqual(
+				[],
+			);
+		});
+
+		it.for<[field: string, currentOverrides: Partial<ResourceCurrentStatePlace>]>([
+			["fileHash", { fileHash: ALT_HASH }],
+			["filePath", { filePath: "places/renamed.rbxl" }],
+			["placeId", { placeId: asRobloxAssetId("9999") }],
+		])("should return [%s] when only the identity field %s differs", ([field, overrides]) => {
+			expect.assertions(1);
+
+			expect(
+				placeKind.changedFieldsBetween(placeDesired(), placeCurrent(overrides)),
+			).toStrictEqual([field]);
+		});
+
+		it.for<
+			[
+				field: string,
+				desiredOverrides: Partial<PlaceDesiredStateOnly>,
+				currentOverrides: Partial<ResourceCurrentStatePlace>,
+			]
+		>([
+			["displayName", { displayName: "Lobby v2" }, { displayName: "Lobby" }],
+			["description", { description: "New body." }, { description: "Old body." }],
+			["serverSize", { serverSize: 25 }, { serverSize: 50 }],
+		])(
+			"should return [%s] when desired declares a different %s than current",
+			([field, desiredOverrides, currentOverrides]) => {
+				expect.assertions(1);
+
+				expect(
+					placeKind.changedFieldsBetween(
+						placeDesired(desiredOverrides),
+						placeCurrent(currentOverrides),
+					),
+				).toStrictEqual([field]);
+			},
+		);
+
+		it.for<[field: string, currentOverrides: Partial<ResourceCurrentStatePlace>]>([
+			["displayName", { displayName: "Server Owned" }],
+			["description", { description: "Server owned body." }],
+			["serverSize", { serverSize: 100 }],
+		])(
+			"should return an empty list when desired leaves %s unmanaged but current carries a value",
+			([, currentOverrides]) => {
+				expect.assertions(1);
+
+				expect(
+					placeKind.changedFieldsBetween(placeDesired(), placeCurrent(currentOverrides)),
+				).toStrictEqual([]);
+			},
+		);
+
+		it("should return every changed field in declaration order when many differ", () => {
+			expect.assertions(1);
+
+			expect(
+				placeKind.changedFieldsBetween(
+					placeDesired({
+						description: "New body.",
+						displayName: "New",
+						fileHash: ALT_HASH,
+					}),
+					placeCurrent({ description: "Old body.", displayName: "Old" }),
+				),
+			).toStrictEqual(["fileHash", "displayName", "description"]);
+		});
+	});
 });
 
 type ResourceCurrentStatePlace = Parameters<typeof placeKind.fieldsEqual>[1];

--- a/packages/bedrock/src/core/kinds/place.ts
+++ b/packages/bedrock/src/core/kinds/place.ts
@@ -58,19 +58,23 @@ async function normalize(
 	};
 }
 
-function fieldsEqual(desired: PlaceDesiredState, current: ResourceCurrentState<"place">): boolean {
-	if (
-		desired.fileHash !== current.fileHash ||
-		desired.filePath !== current.filePath ||
-		desired.placeId !== current.placeId
-	) {
-		return false;
-	}
+function changedFieldsBetween(
+	desired: PlaceDesiredState,
+	current: ResourceCurrentState<"place">,
+): ReadonlyArray<string> {
+	return [
+		...(desired.fileHash === current.fileHash ? [] : ["fileHash"]),
+		...(desired.filePath === current.filePath ? [] : ["filePath"]),
+		...(desired.placeId === current.placeId ? [] : ["placeId"]),
+		...PLACE_MANAGED_METADATA_FIELDS.filter((field) => {
+			const desiredValue = desired[field];
+			return desiredValue !== undefined && desiredValue !== current[field];
+		}),
+	];
+}
 
-	return PLACE_MANAGED_METADATA_FIELDS.every((field) => {
-		const desiredValue = desired[field];
-		return desiredValue === undefined || desiredValue === current[field];
-	});
+function fieldsEqual(desired: PlaceDesiredState, current: ResourceCurrentState<"place">): boolean {
+	return changedFieldsBetween(desired, current).length === 0;
 }
 
 /**
@@ -79,6 +83,7 @@ function fieldsEqual(desired: PlaceDesiredState, current: ResourceCurrentState<"
  * kind.
  */
 export const placeKind: ResourceKindModule<"place"> = {
+	changedFieldsBetween,
 	entrySchema,
 	fieldsEqual,
 	flatten,

--- a/packages/bedrock/src/core/kinds/universe.spec.ts
+++ b/packages/bedrock/src/core/kinds/universe.spec.ts
@@ -1,9 +1,9 @@
-import { universeCurrent, universeDesired } from "#tests/helpers/resources";
+import { PLATFORM_FLAG_ROWS, universeCurrent, universeDesired } from "#tests/helpers/resources";
 import { ArkErrors } from "arktype";
 import { assert, describe, expect, it } from "vitest";
 
 import { asRobloxAssetId } from "../../types/ids.ts";
-import { UNIVERSE_SINGLETON_KEY } from "../resources.ts";
+import { SOCIAL_LINK_FIELDS, UNIVERSE_SINGLETON_KEY } from "../resources.ts";
 import { universeKind } from "./universe.ts";
 
 const NORMALIZE_IO_NEVER = {
@@ -118,6 +118,196 @@ describe("universeKind", () => {
 			expect(
 				universeKind.fieldsEqual(universeDesired(), universeCurrent(overrides)),
 			).toBeFalse();
+		});
+	});
+
+	describe("changedFieldsBetween", () => {
+		const sampleLink = { title: "Old", uri: "https://example.com/old" };
+
+		it("should return an empty list when every managed field matches", () => {
+			expect.assertions(1);
+
+			expect(
+				universeKind.changedFieldsBetween(universeDesired(), universeCurrent()),
+			).toStrictEqual([]);
+		});
+
+		it("should return [universeId] when only the universeId differs", () => {
+			expect.assertions(1);
+
+			expect(
+				universeKind.changedFieldsBetween(
+					universeDesired(),
+					universeCurrent({ universeId: asRobloxAssetId("9999999999") }),
+				),
+			).toStrictEqual(["universeId"]);
+		});
+
+		it.for(PLATFORM_FLAG_ROWS)(
+			"should return [%s] when a declared %s flag flips from current",
+			([flag]) => {
+				expect.assertions(1);
+
+				expect(
+					universeKind.changedFieldsBetween(
+						universeDesired({ [flag]: true }),
+						universeCurrent({ [flag]: false }),
+					),
+				).toStrictEqual([flag]);
+			},
+		);
+
+		it.for(PLATFORM_FLAG_ROWS)(
+			"should return an empty list when desired leaves %s unmanaged but current carries a value",
+			([flag]) => {
+				expect.assertions(1);
+
+				expect(
+					universeKind.changedFieldsBetween(
+						universeDesired(),
+						universeCurrent({ [flag]: true }),
+					),
+				).toStrictEqual([]);
+			},
+		);
+
+		it("should return [voiceChatEnabled] when a declared voiceChatEnabled flips from current", () => {
+			expect.assertions(1);
+
+			expect(
+				universeKind.changedFieldsBetween(
+					universeDesired({ voiceChatEnabled: true }),
+					universeCurrent({ voiceChatEnabled: false }),
+				),
+			).toStrictEqual(["voiceChatEnabled"]);
+		});
+
+		it("should return [displayName] when a declared displayName differs from current", () => {
+			expect.assertions(1);
+
+			expect(
+				universeKind.changedFieldsBetween(
+					universeDesired({ displayName: "New Name" }),
+					universeCurrent({ displayName: "Old Name" }),
+				),
+			).toStrictEqual(["displayName"]);
+		});
+
+		it("should return an empty list when desired leaves displayName unmanaged but current carries a value", () => {
+			expect.assertions(1);
+
+			expect(
+				universeKind.changedFieldsBetween(
+					universeDesired(),
+					universeCurrent({ displayName: "Server Owned" }),
+				),
+			).toStrictEqual([]);
+		});
+
+		it("should return [privateServerPriceRobux] when the key is present and the value differs from current", () => {
+			expect.assertions(1);
+
+			expect(
+				universeKind.changedFieldsBetween(
+					universeDesired({ privateServerPriceRobux: 250 }),
+					universeCurrent({ privateServerPriceRobux: 100 }),
+				),
+			).toStrictEqual(["privateServerPriceRobux"]);
+		});
+
+		it("should return [privateServerPriceRobux] when the key is present with undefined and current has a value", () => {
+			expect.assertions(1);
+
+			expect(
+				universeKind.changedFieldsBetween(
+					universeDesired({ privateServerPriceRobux: undefined }),
+					universeCurrent({ privateServerPriceRobux: 100 }),
+				),
+			).toStrictEqual(["privateServerPriceRobux"]);
+		});
+
+		it("should return an empty list when privateServerPriceRobux key is absent in desired", () => {
+			expect.assertions(1);
+
+			expect(
+				universeKind.changedFieldsBetween(
+					universeDesired(),
+					universeCurrent({ privateServerPriceRobux: 100 }),
+				),
+			).toStrictEqual([]);
+		});
+
+		it.for(SOCIAL_LINK_FIELDS)(
+			"should return [%s] when a declared %s social link drifts from current",
+			(field) => {
+				expect.assertions(1);
+
+				expect(
+					universeKind.changedFieldsBetween(
+						universeDesired({
+							[field]: { title: "New", uri: "https://example.com/new" },
+						}),
+						universeCurrent({ [field]: sampleLink }),
+					),
+				).toStrictEqual([field]);
+			},
+		);
+
+		it.for(SOCIAL_LINK_FIELDS)(
+			"should return [%s] when desired declares %s as undefined and current has a link",
+			(field) => {
+				expect.assertions(1);
+
+				expect(
+					universeKind.changedFieldsBetween(
+						universeDesired({ [field]: undefined }),
+						universeCurrent({ [field]: sampleLink }),
+					),
+				).toStrictEqual([field]);
+			},
+		);
+
+		it.for(SOCIAL_LINK_FIELDS)(
+			"should return an empty list when %s is absent from desired regardless of current",
+			(field) => {
+				expect.assertions(1);
+
+				expect(
+					universeKind.changedFieldsBetween(
+						universeDesired(),
+						universeCurrent({ [field]: sampleLink }),
+					),
+				).toStrictEqual([]);
+			},
+		);
+
+		it("should return every changed field in declaration order when many differ", () => {
+			expect.assertions(1);
+
+			expect(
+				universeKind.changedFieldsBetween(
+					universeDesired({
+						desktopEnabled: true,
+						discordSocialLink: { title: "New", uri: "https://discord.gg/new" },
+						displayName: "New",
+						privateServerPriceRobux: 250,
+						voiceChatEnabled: true,
+					}),
+					universeCurrent({
+						desktopEnabled: false,
+						discordSocialLink: sampleLink,
+						displayName: "Old",
+						privateServerPriceRobux: 100,
+						voiceChatEnabled: false,
+					}),
+				),
+			).toStrictEqual([
+				"desktopEnabled",
+				"voiceChatEnabled",
+				"displayName",
+				"privateServerPriceRobux",
+				"discordSocialLink",
+			]);
 		});
 	});
 });

--- a/packages/bedrock/src/core/kinds/universe.ts
+++ b/packages/bedrock/src/core/kinds/universe.ts
@@ -116,10 +116,6 @@ function changedFieldsBetween(
 ): ReadonlyArray<string> {
 	return [
 		...(desired.universeId === current.universeId ? [] : ["universeId"]),
-		// Only compare flags the user has declared. An undeclared flag
-		// stays owned by whoever else writes to the universe (Creator
-		// Hub, another tool), so a concrete current value for it is not
-		// drift.
 		...UNIVERSE_MANAGED_FLAGS.filter((flag) => {
 			const isDesiredEnabled = desired[flag];
 			return isDesiredEnabled !== undefined && isDesiredEnabled !== current[flag];

--- a/packages/bedrock/src/core/kinds/universe.ts
+++ b/packages/bedrock/src/core/kinds/universe.ts
@@ -110,53 +110,38 @@ function socialLinkEqual(a: SocialLink | undefined, b: SocialLink | undefined): 
 	return a.title === b.title && a.uri === b.uri;
 }
 
-function declaredSocialLinksEqual(
+function changedFieldsBetween(
 	desired: UniverseDesiredState,
 	current: ResourceCurrentState<"universe">,
-): boolean {
-	for (const field of SOCIAL_LINK_FIELDS) {
-		if (!(field in desired)) {
-			continue;
-		}
-
-		if (!socialLinkEqual(desired[field], current[field])) {
-			return false;
-		}
-	}
-
-	return true;
+): ReadonlyArray<string> {
+	return [
+		...(desired.universeId === current.universeId ? [] : ["universeId"]),
+		// Only compare flags the user has declared. An undeclared flag
+		// stays owned by whoever else writes to the universe (Creator
+		// Hub, another tool), so a concrete current value for it is not
+		// drift.
+		...UNIVERSE_MANAGED_FLAGS.filter((flag) => {
+			const isDesiredEnabled = desired[flag];
+			return isDesiredEnabled !== undefined && isDesiredEnabled !== current[flag];
+		}),
+		...(desired.displayName === undefined || desired.displayName === current.displayName
+			? []
+			: ["displayName"]),
+		...("privateServerPriceRobux" in desired &&
+		desired.privateServerPriceRobux !== current.privateServerPriceRobux
+			? ["privateServerPriceRobux"]
+			: []),
+		...SOCIAL_LINK_FIELDS.filter(
+			(field) => field in desired && !socialLinkEqual(desired[field], current[field]),
+		),
+	];
 }
 
 function fieldsEqual(
 	desired: UniverseDesiredState,
 	current: ResourceCurrentState<"universe">,
 ): boolean {
-	if (desired.universeId !== current.universeId) {
-		return false;
-	}
-
-	// Only compare flags the user has declared. An undeclared flag stays
-	// owned by whoever else writes to the universe (Creator Hub, another
-	// tool), so a concrete current value for it is not drift.
-	for (const flag of UNIVERSE_MANAGED_FLAGS) {
-		const isDesiredEnabled = desired[flag];
-		if (isDesiredEnabled !== undefined && isDesiredEnabled !== current[flag]) {
-			return false;
-		}
-	}
-
-	if (desired.displayName !== undefined && desired.displayName !== current.displayName) {
-		return false;
-	}
-
-	if (
-		"privateServerPriceRobux" in desired &&
-		desired.privateServerPriceRobux !== current.privateServerPriceRobux
-	) {
-		return false;
-	}
-
-	return declaredSocialLinksEqual(desired, current);
+	return changedFieldsBetween(desired, current).length === 0;
 }
 
 /**
@@ -165,6 +150,7 @@ function fieldsEqual(
  * drift-equality for the `universe` kind.
  */
 export const universeKind: ResourceKindModule<"universe"> = {
+	changedFieldsBetween,
 	entrySchema,
 	fieldsEqual,
 	flatten,

--- a/packages/bedrock/src/core/operations.example.spec.ts
+++ b/packages/bedrock/src/core/operations.example.spec.ts
@@ -70,10 +70,12 @@ it('Example 3', () => {
       name: 'VIP Pass',
       price: 750,
     },
+    changedFields: ['description', 'price'],
     key: asResourceKey('vip-pass'),
     type: 'update',
   }
   expect(op.type).toBe('update')
+  expect(op.changedFields).toStrictEqual(['description', 'price'])
   if (op.desired.kind === 'gamePass') {
     expect(op.desired.price).toBe(750)
   }

--- a/packages/bedrock/src/core/operations.spec-d.ts
+++ b/packages/bedrock/src/core/operations.spec-d.ts
@@ -44,6 +44,10 @@ describe("UpdateOperation", () => {
 	it("should carry the current resource state", () => {
 		expectTypeOf<UpdateOperation["current"]>().toEqualTypeOf<ResourceCurrentState>();
 	});
+
+	it("should carry changedFields as a readonly array of strings", () => {
+		expectTypeOf<UpdateOperation["changedFields"]>().toEqualTypeOf<ReadonlyArray<string>>();
+	});
 });
 
 describe("NoopOperation", () => {
@@ -53,5 +57,9 @@ describe("NoopOperation", () => {
 
 	it("should not carry a current resource state", () => {
 		expectTypeOf<NoopOperation>().not.toHaveProperty("current");
+	});
+
+	it("should not carry a changedFields array", () => {
+		expectTypeOf<NoopOperation>().not.toHaveProperty("changedFields");
 	});
 });

--- a/packages/bedrock/src/core/operations.ts
+++ b/packages/bedrock/src/core/operations.ts
@@ -113,11 +113,13 @@ export interface CreateOperation extends BaseOperation {
  *         name: "VIP Pass",
  *         price: 750,
  *     },
+ *     changedFields: ["description", "price"],
  *     key: asResourceKey("vip-pass"),
  *     type: "update",
  * };
  *
  * expect(op.type).toBe("update");
+ * expect(op.changedFields).toStrictEqual(["description", "price"]);
  * if (op.desired.kind === "gamePass") {
  *     expect(op.desired.price).toBe(750);
  * }
@@ -127,6 +129,13 @@ export interface CreateOperation extends BaseOperation {
  * ```
  */
 export interface UpdateOperation extends BaseOperation {
+	/**
+	 * Top-level field names that differ between `current` and `desired`,
+	 * populated by `diff` from the kind module's `changedFieldsBetween`.
+	 * Plan and apply renderers consume this as the single source of truth
+	 * for "what changed" on this op; never empty for an `update` variant.
+	 */
+	readonly changedFields: ReadonlyArray<string>;
 	/** Last-known live state; the driver computes a patch against `desired`. */
 	readonly current: ResourceCurrentState;
 	/** Declared desired state to converge toward. */

--- a/packages/bedrock/src/shell/apply-ops.spec.ts
+++ b/packages/bedrock/src/shell/apply-ops.spec.ts
@@ -45,7 +45,8 @@ function updateOp(key: ResourceKey) {
 	const desired = gamePassDesired({ key });
 	return {
 		key,
-		current: gamePassCurrent({ ...desired }),
+		changedFields: ["name"],
+		current: gamePassCurrent({ ...desired, name: "Outdated" }),
 		desired,
 		type: "update",
 	} as const satisfies UpdateOperation;
@@ -267,7 +268,8 @@ describe(applyOps, () => {
 			const desired = developerProductDesired({ key });
 			return {
 				key,
-				current: developerProductCurrent({ ...desired }),
+				changedFields: ["name"],
+				current: developerProductCurrent({ ...desired, name: "Outdated" }),
 				desired,
 				type: "update",
 			} as const satisfies UpdateOperation;
@@ -379,10 +381,11 @@ describe(applyOps, () => {
 		}
 
 		function placeUpdateOp(key: ResourceKey) {
-			const desired = placeDesired({ key });
+			const desired = placeDesired({ key, displayName: "New" });
 			return {
 				key,
-				current: placeCurrent({ ...desired }),
+				changedFields: ["displayName"],
+				current: placeCurrent({ ...desired, displayName: "Old" }),
 				desired,
 				type: "update",
 			} as const satisfies UpdateOperation;
@@ -477,6 +480,7 @@ describe(applyOps, () => {
 			const crossKindCurrent = gamePassCurrent({ key: placeDesiredState.key });
 			const op: UpdateOperation = {
 				key: placeDesiredState.key,
+				changedFields: ["fileHash"],
 				current: crossKindCurrent,
 				desired: placeDesiredState,
 				type: "update",
@@ -503,6 +507,7 @@ describe(applyOps, () => {
 			const crossKindCurrent = placeCurrent({ key: asResourceKey("vip-pass") });
 			const op: UpdateOperation = {
 				key: crossKindCurrent.key,
+				changedFields: ["name"],
 				current: crossKindCurrent,
 				desired: gamePassDesired({ key: crossKindCurrent.key }),
 				type: "update",
@@ -552,6 +557,7 @@ describe(applyOps, () => {
 			const desired = universeDesired({ voiceChatEnabled: true });
 			return {
 				key: UNIVERSE_SINGLETON_KEY,
+				changedFields: ["voiceChatEnabled"],
 				current: universeCurrent({ ...desired, voiceChatEnabled: false }),
 				desired,
 				type: "update",
@@ -647,6 +653,7 @@ describe(applyOps, () => {
 			const crossKindCurrent = gamePassCurrent({ key: universeDesiredState.key });
 			const op: UpdateOperation = {
 				key: universeDesiredState.key,
+				changedFields: ["voiceChatEnabled"],
 				current: crossKindCurrent,
 				desired: universeDesiredState,
 				type: "update",


### PR DESCRIPTION
## Summary

- Resolves [#404](https://github.com/christopher-buss/bedrock/issues/404) — `bedrock diff` now renders which top-level fields will change for each `update` op.
- Each `ResourceKindModule` exposes a `changedFieldsBetween(desired, current)` helper that returns the drifted top-level field names; `fieldsEqual` delegates to it so the two never go out of sync.
- `UpdateOperation` carries `changedFields: ReadonlyArray<string>`, populated by `diff()`. `bedrock diff` renders the line as `~ kind:key f1 + f2 updated` (matches the wording the upcoming apply renderer in PRD [#403](https://github.com/christopher-buss/bedrock/issues/403) will use, so plan and apply share one source of truth).

## Slices

Landed as three RED+GREEN commits per project TDD cadence:

1. [74bcebc](https://github.com/christopher-buss/bedrock/commit/74bcebc) — `changedFieldsBetween` on every kind module, spec coverage for empty / single / multi / tri-state on all four kinds, `fieldsEqual` delegation.
2. [f0d3ef2](https://github.com/christopher-buss/bedrock/commit/f0d3ef2) — `UpdateOperation.changedFields`, `diff()` wiring, `@example` and `*.spec-d.ts` refresh, ripple through every `update`-op assertion in `diff.spec.ts` / `apply-ops.spec.ts`.
3. [58208de](https://github.com/christopher-buss/bedrock/commit/58208de) — CLI render: `describeOp` emits the `f1 + f2 + ... updated` suffix; new multi-field rendering test joins fields with ` + `.

## Test plan

- [x] `pnpm gen:example-tests` regenerates `*.example.spec.ts` clean
- [x] `pnpm lint && pnpm typecheck && pnpm build && pnpm test` all pass (2018 tests)
- [x] `pnpm mutate:changed` shows 100% mutation score on all touched `src/**` files for every slice (no `Stryker disable` directives)
- [x] Plan output verified via inline snapshots in [diff.spec.ts](packages/bedrock/src/cli/commands/diff.spec.ts) — single-field renders `~ place:start-place fileHash updated`, multi-field renders `~ place:start-place displayName + description updated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/423?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->