### PR TITLE
feat(core): two-phase parallel continue-on-failure apply

### DIFF
--- a/docs/adr/023-apply-semantics-parallel-continue-on-failure.md
+++ b/docs/adr/023-apply-semantics-parallel-continue-on-failure.md
@@ -431,3 +431,26 @@ backend failures become observable in practice.
 - [ADR-019](./019-state-data-model-and-diff-algebra.md): diff algebra and
   state data model; `UpdateOperation.changedFields` extends the contract
   described there.
+
+## Amendments
+
+### 2026-05-18: Non-empty `failures` tuple
+
+`AggregateApplyError.failures` ships as `readonly [ApplyError,
+...ReadonlyArray<ApplyError>]` rather than `ReadonlyArray<ApplyError>`.
+The algorithm only returns `Err` when at least one op failed, so the
+non-empty tuple encodes the runtime invariant in the type. The CLI
+renderer reads `failures[0]` and iterates without defensive empty-array
+branches, and consumers narrowing the aggregate can rely on `failures`
+always carrying at least one entry.
+
+### 2026-05-18: Phase 2 dispatches with `Promise.all`
+
+Phase 2 dispatches concurrently via `Promise.all` rather than
+`Promise.allSettled`. The dispatch-boundary try/catch inside `dispatchOp`
+catches any rejection a driver produces outside its `Result` contract
+and translates it into an `unexpectedThrow` `ApplyError`, so by the time
+`Promise.all` awaits the phase-2 map, no individual dispatch can reject.
+`Promise.allSettled`'s rejection-handling branch would be unreachable
+under that contract; `Promise.all` keeps the apply path honest about
+where rejections can come from.

--- a/docs/adr/023-apply-semantics-parallel-continue-on-failure.md
+++ b/docs/adr/023-apply-semantics-parallel-continue-on-failure.md
@@ -447,8 +447,8 @@ always carrying at least one entry.
 ### 2026-05-18: Phase 2 dispatches with `Promise.all`
 
 **This amendment supersedes the `Promise.allSettled` decision recorded in
-the original Decision section (Phase 2 description, lines 71-75) and in
-the Implementation Notes (lines 389-392).**
+the original Decision section's Phase 2 description and in the
+Implementation Notes section.**
 
 Phase 2 dispatches concurrently via `Promise.all` rather than
 `Promise.allSettled`. The dispatch-boundary try/catch inside `dispatchOp`

--- a/docs/adr/023-apply-semantics-parallel-continue-on-failure.md
+++ b/docs/adr/023-apply-semantics-parallel-continue-on-failure.md
@@ -446,6 +446,10 @@ always carrying at least one entry.
 
 ### 2026-05-18: Phase 2 dispatches with `Promise.all`
 
+**This amendment supersedes the `Promise.allSettled` decision recorded in
+the original Decision section (Phase 2 description, lines 71-75) and in
+the Implementation Notes (lines 389-392).**
+
 Phase 2 dispatches concurrently via `Promise.all` rather than
 `Promise.allSettled`. The dispatch-boundary try/catch inside `dispatchOp`
 catches any rejection a driver produces outside its `Result` contract
@@ -453,4 +457,5 @@ and translates it into an `unexpectedThrow` `ApplyError`, so by the time
 `Promise.all` awaits the phase-2 map, no individual dispatch can reject.
 `Promise.allSettled`'s rejection-handling branch would be unreachable
 under that contract; `Promise.all` keeps the apply path honest about
-where rejections can come from.
+where rejections can come from. The original ADR text predated the
+dispatch-boundary catch and assumed rejections could still escape.

--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -127,6 +127,38 @@ describe(renderDeployError, () => {
 					applied: [],
 					failures: [
 						{
+							key: asResourceKey("vip-pass"),
+							cause: new Error("driver crashed"),
+							kind: "unexpectedThrow",
+						},
+					],
+				},
+				kind: "applyFailed",
+			},
+			expected: "apply failed for 'vip-pass': unexpected error: driver crashed",
+		},
+		{
+			err: {
+				cause: {
+					applied: [],
+					failures: [
+						{
+							key: asResourceKey("vip-pass"),
+							cause: "string error",
+							kind: "unexpectedThrow",
+						},
+					],
+				},
+				kind: "applyFailed",
+			},
+			expected: "apply failed for 'vip-pass': unexpected error: string error",
+		},
+		{
+			err: {
+				cause: {
+					applied: [],
+					failures: [
+						{
 							key: asResourceKey("main-place"),
 							cause: new ApiError("auth failed (401)", { statusCode: 401 }),
 							kind: "driverFailure",

--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -301,6 +301,52 @@ describe(renderDeployError, () => {
 
 		expect(port.logError).toHaveBeenCalledExactlyOnceWith(expected);
 	});
+
+	it("should emit one logError line per failure in declaration order when applyFailed carries multiple failures", () => {
+		expect.assertions(4);
+
+		const port = fakeClackPort();
+
+		renderDeployError(
+			{
+				cause: {
+					applied: [],
+					failures: [
+						{
+							key: asResourceKey("main-universe"),
+							cause: new ApiError("auth failed (401)", { statusCode: 401 }),
+							kind: "driverFailure",
+						},
+						{
+							key: asResourceKey("vip-pass"),
+							kind: "updateUnsupported",
+						},
+						{
+							key: asResourceKey("gem-pack"),
+							cause: new Error("driver crashed"),
+							kind: "unexpectedThrow",
+						},
+					],
+				},
+				kind: "applyFailed",
+			},
+			port,
+		);
+
+		expect(port.logError).toHaveBeenCalledTimes(3);
+		expect(port.logError).toHaveBeenNthCalledWith(
+			1,
+			"apply failed for 'main-universe': auth failed (401)",
+		);
+		expect(port.logError).toHaveBeenNthCalledWith(
+			2,
+			"apply failed for 'vip-pass': update not supported",
+		);
+		expect(port.logError).toHaveBeenNthCalledWith(
+			3,
+			"apply failed for 'gem-pack': unexpected error: driver crashed",
+		);
+	});
 });
 
 describe(renderParseError, () => {

--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -159,6 +159,26 @@ describe(renderDeployError, () => {
 					applied: [],
 					failures: [
 						{
+							key: asResourceKey("vip-pass"),
+							cause: {
+								toString() {
+									throw new Error("toString rejected coercion");
+								},
+							},
+							kind: "unexpectedThrow",
+						},
+					],
+				},
+				kind: "applyFailed",
+			},
+			expected: "apply failed for 'vip-pass': unexpected error: <unprintable cause>",
+		},
+		{
+			err: {
+				cause: {
+					applied: [],
+					failures: [
+						{
 							key: asResourceKey("main-place"),
 							cause: new ApiError("auth failed (401)", { statusCode: 401 }),
 							kind: "driverFailure",

--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -109,9 +109,13 @@ describe(renderDeployError, () => {
 		{
 			err: {
 				cause: {
-					key: asResourceKey("vip-pass"),
-					appliedSoFar: [],
-					kind: "updateUnsupported",
+					applied: [],
+					failures: [
+						{
+							key: asResourceKey("vip-pass"),
+							kind: "updateUnsupported",
+						},
+					],
 				},
 				kind: "applyFailed",
 			},
@@ -120,10 +124,14 @@ describe(renderDeployError, () => {
 		{
 			err: {
 				cause: {
-					key: asResourceKey("main-place"),
-					appliedSoFar: [],
-					cause: new ApiError("auth failed (401)", { statusCode: 401 }),
-					kind: "driverFailure",
+					applied: [],
+					failures: [
+						{
+							key: asResourceKey("main-place"),
+							cause: new ApiError("auth failed (401)", { statusCode: 401 }),
+							kind: "driverFailure",
+						},
+					],
 				},
 				kind: "applyFailed",
 			},
@@ -132,14 +140,18 @@ describe(renderDeployError, () => {
 		{
 			err: {
 				cause: {
-					key: asResourceKey("gem-pack"),
-					appliedSoFar: [],
-					cause: new PermissionError("HTTP 403", {
-						operationKey: "developer-products.create",
-						requiredScopes: ["developer-product:write"],
-						statusCode: 403,
-					}),
-					kind: "driverFailure",
+					applied: [],
+					failures: [
+						{
+							key: asResourceKey("gem-pack"),
+							cause: new PermissionError("HTTP 403", {
+								operationKey: "developer-products.create",
+								requiredScopes: ["developer-product:write"],
+								statusCode: 403,
+							}),
+							kind: "driverFailure",
+						},
+					],
 				},
 				kind: "applyFailed",
 			},
@@ -149,14 +161,18 @@ describe(renderDeployError, () => {
 		{
 			err: {
 				cause: {
-					key: asResourceKey("main-place"),
-					appliedSoFar: [],
-					cause: new PermissionError("HTTP 401", {
-						operationKey: "places.publishVersion",
-						requiredScopes: ["universe-places:write", "universe.place:write"],
-						statusCode: 401,
-					}),
-					kind: "driverFailure",
+					applied: [],
+					failures: [
+						{
+							key: asResourceKey("main-place"),
+							cause: new PermissionError("HTTP 401", {
+								operationKey: "places.publishVersion",
+								requiredScopes: ["universe-places:write", "universe.place:write"],
+								statusCode: 401,
+							}),
+							kind: "driverFailure",
+						},
+					],
 				},
 				kind: "applyFailed",
 			},

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -66,12 +66,14 @@ interface MigrationSummaryRender {
 }
 
 /**
- * Render a `DeployError` to the supplied `ClackPort` as a single error line.
- * Each variant produces a distinct, terse diagnostic; wrapped variants
- * (`applyFailed`, `buildDesiredFailed`, `configLoadFailed`, `stateReadFailed`,
- * `stateWriteFailed`) surface the inner cause's actionable detail (file path,
- * resource key, parser message, HTTP failure, validator issue) so the reader
- * does not have to inspect the full cause to act.
+ * Render a `DeployError` to the supplied `ClackPort`. Most variants emit a
+ * single error line; `applyFailed` emits one line per failing op in the
+ * aggregate (in Phase 1 then Phase 2 input order). Wrapped variants
+ * (`applyFailed`, `buildDesiredFailed`, `configLoadFailed`,
+ * `stateReadFailed`, `stateWriteFailed`) surface the inner cause's
+ * actionable detail (file path, resource key, parser message, HTTP failure,
+ * validator issue) so the reader does not have to inspect the full cause to
+ * act.
  * @param err - The deploy error to describe.
  * @param port - The output port the diagnostic is written to.
  */

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -190,20 +190,14 @@ function permissionDetail(err: PermissionError): string {
 	return `${err.message} on ${err.operationKey}: missing required ${label} ${scopeList}. Grant ${pronoun} on the API key at https://create.roblox.com/credentials`;
 }
 
-/**
- * Coerce an arbitrary thrown value to a display string without ever throwing.
- * `String(value)` itself can throw on null-prototype objects or values whose
- * `toString`/`Symbol.toPrimitive` implementations reject coercion; the
- * renderer's contract is to surface the failure, not crash mid-diagnostic.
- * @param value - The thrown value to render.
- * @returns The `message` of an `Error`, the `String()` coercion for other
- *   values, or `"<unprintable cause>"` when even `String()` throws.
- */
 function safeStringify(value: unknown): string {
 	if (value instanceof Error) {
 		return value.message;
 	}
 
+	// `String(value)` can throw on null-prototype objects or values whose
+	// `toString` / `Symbol.toPrimitive` rejects coercion; fall back so the
+	// renderer never crashes mid-diagnostic.
 	try {
 		return String(value);
 	} catch {

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -189,6 +189,11 @@ function applyCauseDetail(cause: ApplyError): string {
 
 			return cause.cause.message;
 		}
+		case "unexpectedThrow": {
+			const message =
+				cause.cause instanceof Error ? cause.cause.message : String(cause.cause);
+			return `unexpected error: ${message}`;
+		}
 		case "updateUnsupported": {
 			return "update not supported";
 		}

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -76,6 +76,14 @@ interface MigrationSummaryRender {
  * @param port - The output port the diagnostic is written to.
  */
 export function renderDeployError(err: DeployError, port: ClackPort): void {
+	if (err.kind === "applyFailed") {
+		for (const failure of err.cause.failures) {
+			port.logError(`apply failed for '${failure.key}': ${applyCauseDetail(failure)}`);
+		}
+
+		return;
+	}
+
 	port.logError(deployErrorMessage(err));
 }
 
@@ -239,12 +247,8 @@ function stateErrorDetail(cause: StateError): string {
 }
 
 /* eslint-disable-next-line max-lines-per-function -- single exhaustive switch over every DeployError variant is clearer than splitting into a wrapped-vs-unwrapped predicate plus a parallel prefix table. */
-function deployErrorMessage(err: DeployError): string {
+function deployErrorMessage(err: Exclude<DeployError, { kind: "applyFailed" }>): string {
 	switch (err.kind) {
-		case "applyFailed": {
-			const first = err.cause.failures[0];
-			return `apply failed for '${first.key}': ${applyCauseDetail(first)}`;
-		}
 		case "buildDesiredFailed": {
 			return `build desired state failed for '${err.cause.key}' ${buildDesiredDetail(err.cause)}`;
 		}

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -237,7 +237,8 @@ function stateErrorDetail(cause: StateError): string {
 function deployErrorMessage(err: DeployError): string {
 	switch (err.kind) {
 		case "applyFailed": {
-			return `apply failed for '${err.cause.key}': ${applyCauseDetail(err.cause)}`;
+			const first = err.cause.failures[0];
+			return `apply failed for '${first.key}': ${applyCauseDetail(first)}`;
 		}
 		case "buildDesiredFailed": {
 			return `build desired state failed for '${err.cause.key}' ${buildDesiredDetail(err.cause)}`;

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -190,6 +190,27 @@ function permissionDetail(err: PermissionError): string {
 	return `${err.message} on ${err.operationKey}: missing required ${label} ${scopeList}. Grant ${pronoun} on the API key at https://create.roblox.com/credentials`;
 }
 
+/**
+ * Coerce an arbitrary thrown value to a display string without ever throwing.
+ * `String(value)` itself can throw on null-prototype objects or values whose
+ * `toString`/`Symbol.toPrimitive` implementations reject coercion; the
+ * renderer's contract is to surface the failure, not crash mid-diagnostic.
+ * @param value - The thrown value to render.
+ * @returns The `message` of an `Error`, the `String()` coercion for other
+ *   values, or `"<unprintable cause>"` when even `String()` throws.
+ */
+function safeStringify(value: unknown): string {
+	if (value instanceof Error) {
+		return value.message;
+	}
+
+	try {
+		return String(value);
+	} catch {
+		return "<unprintable cause>";
+	}
+}
+
 function applyCauseDetail(cause: ApplyError): string {
 	switch (cause.kind) {
 		case "driverFailure": {
@@ -200,9 +221,7 @@ function applyCauseDetail(cause: ApplyError): string {
 			return cause.cause.message;
 		}
 		case "unexpectedThrow": {
-			const message =
-				cause.cause instanceof Error ? cause.cause.message : String(cause.cause);
-			return `unexpected error: ${message}`;
+			return `unexpected error: ${safeStringify(cause.cause)}`;
 		}
 		case "updateUnsupported": {
 			return "update not supported";

--- a/packages/bedrock/src/core/diff.ts
+++ b/packages/bedrock/src/core/diff.ts
@@ -14,8 +14,10 @@ import type { ResourceCurrentState, ResourceDesiredState, ResourceKind } from ".
  * `update` op if any declared field differs or a `noop` op if every field
  * matches.
  *
- * Ops appear in the order their desired entries appear in the input array so
- * callers can rely on declaration order when logging or applying ops.
+ * Ops appear in the order their desired entries appear in the input array;
+ * the persisted post-apply snapshot stays in that declaration order with
+ * Phase 1 universe ops grouped first. The execution order within Phase 2
+ * is not guaranteed because `applyOps` dispatches Phase 2 concurrently.
  *
  * @param desired - Declared desired state from user config, already normalized
  *   (file hashes computed, nullable wire values mapped to `undefined`).

--- a/packages/bedrock/src/core/diff.ts
+++ b/packages/bedrock/src/core/diff.ts
@@ -14,10 +14,12 @@ import type { ResourceCurrentState, ResourceDesiredState, ResourceKind } from ".
  * `update` op if any declared field differs or a `noop` op if every field
  * matches.
  *
- * Ops appear in the order their desired entries appear in the input array;
- * the persisted post-apply snapshot stays in that declaration order with
- * Phase 1 universe ops grouped first. The execution order within Phase 2
- * is not guaranteed because `applyOps` dispatches Phase 2 concurrently.
+ * Ops appear in the order their desired entries appear in the input array.
+ * `applyOps` regroups them into Phase 1 (universe) and Phase 2 (everything
+ * else) when dispatching; the execution order within Phase 2 is not
+ * guaranteed because Phase 2 dispatches concurrently. Persisted state-file
+ * order is determined by the merge in `deploy.runReconcile` (which retains
+ * prior-snapshot positions for unchanged keys), not by this diff output.
  *
  * @param desired - Declared desired state from user config, already normalized
  *   (file hashes computed, nullable wire values mapped to `undefined`).

--- a/packages/bedrock/src/index.spec-d.ts
+++ b/packages/bedrock/src/index.spec-d.ts
@@ -19,7 +19,6 @@ import {
 } from "./index.ts";
 import type {
 	AggregateApplyError,
-	ApplyError,
 	BedrockState,
 	BuildDesiredError,
 	Config,
@@ -140,11 +139,10 @@ describe(buildDesired, () => {
 });
 
 describe(applyOps, () => {
-	it("should resolve to a Result of readonly current state or AggregateApplyError discriminated by ApplyError kind", () => {
+	it("should resolve to a Result of readonly current state or AggregateApplyError", () => {
 		expectTypeOf<Awaited<ReturnType<typeof applyOps>>>().toEqualTypeOf<
 			Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>
 		>();
-		expectTypeOf<ApplyError["kind"]>().toEqualTypeOf<"driverFailure" | "updateUnsupported">();
 	});
 });
 

--- a/packages/bedrock/src/index.spec-d.ts
+++ b/packages/bedrock/src/index.spec-d.ts
@@ -18,6 +18,7 @@ import {
 	loadConfig,
 } from "./index.ts";
 import type {
+	AggregateApplyError,
 	ApplyError,
 	BedrockState,
 	BuildDesiredError,
@@ -139,13 +140,10 @@ describe(buildDesired, () => {
 });
 
 describe(applyOps, () => {
-	it("should resolve to a Result of readonly current state or ApplyError", () => {
+	it("should resolve to a Result of readonly current state or AggregateApplyError discriminated by ApplyError kind", () => {
 		expectTypeOf<Awaited<ReturnType<typeof applyOps>>>().toEqualTypeOf<
-			Result<ReadonlyArray<ResourceCurrentState>, ApplyError>
+			Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>
 		>();
-	});
-
-	it("should discriminate ApplyError on driverFailure and updateUnsupported kinds", () => {
 		expectTypeOf<ApplyError["kind"]>().toEqualTypeOf<"driverFailure" | "updateUnsupported">();
 	});
 });

--- a/packages/bedrock/src/index.spec-d.ts
+++ b/packages/bedrock/src/index.spec-d.ts
@@ -19,6 +19,7 @@ import {
 } from "./index.ts";
 import type {
 	AggregateApplyError,
+	ApplyError,
 	BedrockState,
 	BuildDesiredError,
 	Config,
@@ -138,11 +139,14 @@ describe(buildDesired, () => {
 	});
 });
 
+type ExpectedApplyErrorKind = "driverFailure" | "unexpectedThrow" | "updateUnsupported";
+
 describe(applyOps, () => {
 	it("should resolve to a Result of readonly current state or AggregateApplyError", () => {
 		expectTypeOf<Awaited<ReturnType<typeof applyOps>>>().toEqualTypeOf<
 			Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>
 		>();
+		expectTypeOf<ApplyError["kind"]>().toEqualTypeOf<ExpectedApplyErrorKind>();
 	});
 });
 

--- a/packages/bedrock/src/index.ts
+++ b/packages/bedrock/src/index.ts
@@ -114,7 +114,7 @@ export type {
 export type { DriverRegistry, ResourceDriver } from "./ports/resource-driver.ts";
 export type { StatePort } from "./ports/state-port.ts";
 export { applyOps } from "./shell/apply-ops.ts";
-export type { ApplyError } from "./shell/apply-ops.ts";
+export type { AggregateApplyError, ApplyError } from "./shell/apply-ops.ts";
 export { buildDefaultRegistry, type RegistryConfigError } from "./shell/build-default-registry.ts";
 export { buildDesired } from "./shell/build-desired.ts";
 export {

--- a/packages/bedrock/src/shell/apply-ops.example.spec.ts
+++ b/packages/bedrock/src/shell/apply-ops.example.spec.ts
@@ -23,7 +23,6 @@ it('Example 1', () => {
   }
   const err: ApplyError = {
     key: asResourceKey('vip-pass'),
-    appliedSoFar: [],
     kind: 'updateUnsupported',
   }
   expect(describe(err)).toBe('update not supported for vip-pass')

--- a/packages/bedrock/src/shell/apply-ops.example.spec.ts
+++ b/packages/bedrock/src/shell/apply-ops.example.spec.ts
@@ -3,6 +3,7 @@ import { expect, it } from "vitest";
 import {
   asResourceKey,
   type ApplyError,
+  type AggregateApplyError,
   applyOps,
   asRobloxAssetId,
   asSha256Hex,
@@ -32,6 +33,17 @@ it('Example 1', () => {
 })
 
 it('Example 2', () => {
+  function summarise(err: AggregateApplyError): string {
+    return `${err.applied.length} survived, ${err.failures.length} failed`
+  }
+  const err: AggregateApplyError = {
+    applied: [],
+    failures: [{ key: asResourceKey('vip-pass'), kind: 'updateUnsupported' }],
+  }
+  expect(summarise(err)).toBe('0 survived, 1 failed')
+})
+
+it('Example 3', () => {
   const registry: DriverRegistry = {
     gamePass: {
       async create(desired) {

--- a/packages/bedrock/src/shell/apply-ops.example.spec.ts
+++ b/packages/bedrock/src/shell/apply-ops.example.spec.ts
@@ -16,6 +16,9 @@ it('Example 1', () => {
       case 'driverFailure': {
         return `driver failed for ${err.key}: ${err.cause.message}`
       }
+      case 'unexpectedThrow': {
+        return `unexpected error for ${err.key}`
+      }
       case 'updateUnsupported': {
         return `update not supported for ${err.key}`
       }

--- a/packages/bedrock/src/shell/apply-ops.spec.ts
+++ b/packages/bedrock/src/shell/apply-ops.spec.ts
@@ -136,6 +136,110 @@ describe(applyOps, () => {
 		]);
 	});
 
+	it("should dispatch universe ops in Phase 1 before any non-universe op regardless of input position", async () => {
+		expect.assertions(2);
+
+		const callOrder: Array<string> = [];
+		const gamePassOp = createOp(asResourceKey("vip-pass"));
+		const universeOp = {
+			key: UNIVERSE_SINGLETON_KEY,
+			desired: universeDesired({ voiceChatEnabled: true }),
+			type: "create",
+		} as const satisfies CreateOperation;
+		const placeOp = {
+			key: asResourceKey("start-place"),
+			desired: placeDesired(),
+			type: "create",
+		} as const satisfies CreateOperation;
+		const gamePassCreate = vi
+			.fn<ResourceDriver<"gamePass">["create"]>()
+			.mockImplementation(async (desired) => {
+				callOrder.push(`gamePass:${desired.key}`);
+				return { data: gamePassCurrent({ ...desired }), success: true };
+			});
+		const universeCreate = vi
+			.fn<ResourceDriver<"universe">["create"]>()
+			.mockImplementation(async (desired) => {
+				callOrder.push(`universe:${desired.key}`);
+				return { data: universeCurrent({ ...desired }), success: true };
+			});
+		const placeCreate = vi
+			.fn<ResourceDriver<"place">["create"]>()
+			.mockImplementation(async (desired) => {
+				callOrder.push(`place:${desired.key}`);
+				return { data: placeCurrent({ ...desired }), success: true };
+			});
+		const registry: DriverRegistry = {
+			developerProduct: developerProductStub,
+			gamePass: { create: gamePassCreate },
+			place: { create: placeCreate },
+			universe: { create: universeCreate },
+		};
+
+		const result = await applyOps([gamePassOp, universeOp, placeOp], registry);
+
+		expect(result.success).toBeTrue();
+		expect(callOrder).toStrictEqual([
+			`universe:${UNIVERSE_SINGLETON_KEY}`,
+			"gamePass:vip-pass",
+			"place:start-place",
+		]);
+	});
+
+	it("should still dispatch non-universe ops when no universe op is in the input", async () => {
+		expect.assertions(2);
+
+		const op = createOp(asResourceKey("vip-pass"));
+		const created = gamePassCurrent({ ...op.desired });
+		const create = vi
+			.fn<ResourceDriver<"gamePass">["create"]>()
+			.mockResolvedValue({ data: created, success: true });
+
+		const result = await applyOps([op], registryWith(create));
+
+		expect(result).toStrictEqual({ data: [created], success: true });
+		expect(create).toHaveBeenCalledOnce();
+	});
+
+	it("should treat a 'main'-keyed place and 'main'-keyed universe as independent partitions", async () => {
+		expect.assertions(3);
+
+		const placeOp = {
+			key: UNIVERSE_SINGLETON_KEY,
+			desired: placeDesired({ key: UNIVERSE_SINGLETON_KEY }),
+			type: "create",
+		} as const satisfies CreateOperation;
+		const universeOp = {
+			key: UNIVERSE_SINGLETON_KEY,
+			desired: universeDesired({ voiceChatEnabled: true }),
+			type: "create",
+		} as const satisfies CreateOperation;
+		const placeCreated = placeCurrent({ ...placeOp.desired });
+		const universeCreated = universeCurrent({ ...universeOp.desired });
+		const placeCreate = vi
+			.fn<ResourceDriver<"place">["create"]>()
+			.mockResolvedValue({ data: placeCreated, success: true });
+		const universeCreate = vi
+			.fn<ResourceDriver<"universe">["create"]>()
+			.mockResolvedValue({ data: universeCreated, success: true });
+		const registry: DriverRegistry = {
+			developerProduct: developerProductStub,
+			gamePass: {
+				create() {
+					throw new Error("gamePass driver must not run");
+				},
+			},
+			place: { create: placeCreate },
+			universe: { create: universeCreate },
+		};
+
+		const result = await applyOps([placeOp, universeOp], registry);
+
+		expect(result.success).toBeTrue();
+		expect(placeCreate).toHaveBeenCalledOnce();
+		expect(universeCreate).toHaveBeenCalledOnce();
+	});
+
 	it("should stop dispatching on the first driver failure and surface an aggregate with applied[] and a single-failure failures[]", async () => {
 		expect.assertions(3);
 

--- a/packages/bedrock/src/shell/apply-ops.spec.ts
+++ b/packages/bedrock/src/shell/apply-ops.spec.ts
@@ -240,54 +240,119 @@ describe(applyOps, () => {
 		expect(universeCreate).toHaveBeenCalledOnce();
 	});
 
-	it("should stop dispatching on the first driver failure and surface an aggregate with applied[] and a single-failure failures[]", async () => {
+	it("should dispatch Phase 2 ops concurrently rather than serially", async () => {
+		expect.assertions(3);
+
+		const first = createOp(asResourceKey("first-pass"));
+		const second = createOp(asResourceKey("second-pass"));
+		let resolveFirst!: () => void;
+		const firstGate = new Promise<void>((resolve) => {
+			resolveFirst = resolve;
+		});
+		const firstCurrent = gamePassCurrent({ ...first.desired });
+		const secondCurrent = gamePassCurrent({ ...second.desired });
+		const create = vi
+			.fn<ResourceDriver<"gamePass">["create"]>()
+			.mockImplementationOnce(async () => {
+				await firstGate;
+				return { data: firstCurrent, success: true };
+			})
+			.mockImplementationOnce(async () => {
+				return { data: secondCurrent, success: true };
+			});
+
+		const applyPromise = applyOps([first, second], registryWith(create));
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(create).toHaveBeenCalledTimes(2);
+
+		resolveFirst();
+		const result = await applyPromise;
+
+		expect(result.success).toBeTrue();
+		expect(result).toStrictEqual({ data: [firstCurrent, secondCurrent], success: true });
+	});
+
+	it("should preserve applied[] in declaration order even when Phase 2 ops settle out of order", async () => {
+		expect.assertions(1);
+
+		const first = createOp(asResourceKey("first-pass"));
+		const second = createOp(asResourceKey("second-pass"));
+		let resolveFirst!: () => void;
+		const firstGate = new Promise<void>((resolve) => {
+			resolveFirst = resolve;
+		});
+		const firstCurrent = gamePassCurrent({ ...first.desired });
+		const secondCurrent = gamePassCurrent({ ...second.desired });
+		const create = vi
+			.fn<ResourceDriver<"gamePass">["create"]>()
+			.mockImplementationOnce(async () => {
+				await firstGate;
+				return { data: firstCurrent, success: true };
+			})
+			.mockImplementationOnce(async () => {
+				queueMicrotask(resolveFirst);
+				return { data: secondCurrent, success: true };
+			});
+
+		const result = await applyOps([first, second], registryWith(create));
+
+		expect(result).toStrictEqual({ data: [firstCurrent, secondCurrent], success: true });
+	});
+
+	it("should dispatch every Phase 2 op past a failure and aggregate survivors with the failure", async () => {
 		expect.assertions(3);
 
 		const first = createOp(asResourceKey("first-pass"));
 		const second = createOp(asResourceKey("second-pass"));
 		const third = createOp(asResourceKey("third-pass"));
 		const firstCurrent = gamePassCurrent({ ...first.desired });
+		const thirdCurrent = gamePassCurrent({ ...third.desired });
 		const cause = new OpenCloudError("boom");
 		const create = vi
 			.fn<ResourceDriver<"gamePass">["create"]>()
 			.mockResolvedValueOnce({ data: firstCurrent, success: true })
-			.mockResolvedValueOnce({ err: cause, success: false });
+			.mockResolvedValueOnce({ err: cause, success: false })
+			.mockResolvedValueOnce({ data: thirdCurrent, success: true });
 
 		const result = await applyOps([first, second, third], registryWith(create));
 
 		expect(result).toStrictEqual({
 			err: {
-				applied: [firstCurrent],
+				applied: [firstCurrent, thirdCurrent],
 				failures: [{ key: second.key, cause, kind: "driverFailure" }],
 			},
 			success: false,
 		});
-		expect(create).toHaveBeenCalledTimes(2);
+		expect(create).toHaveBeenCalledTimes(3);
 		expect(create.mock.calls.map((call) => call[0].key)).toStrictEqual([
 			"first-pass",
 			"second-pass",
+			"third-pass",
 		]);
 	});
 
-	it("should return an updateUnsupported failure in the aggregate when the driver has no update method", async () => {
+	it("should aggregate updateUnsupported failures alongside concurrent Phase 2 successes", async () => {
 		expect.assertions(2);
 
 		const update = updateOp(asResourceKey("vip-pass"));
-		const create = vi.fn<ResourceDriver<"gamePass">["create"]>();
+		const otherCreate = createOp(asResourceKey("other-pass"));
+		const otherCurrent = gamePassCurrent({ ...otherCreate.desired });
+		const create = vi
+			.fn<ResourceDriver<"gamePass">["create"]>()
+			.mockResolvedValue({ data: otherCurrent, success: true });
 
-		const result = await applyOps(
-			[update, createOp(asResourceKey("other-pass"))],
-			registryWith(create),
-		);
+		const result = await applyOps([update, otherCreate], registryWith(create));
 
 		expect(result).toStrictEqual({
 			err: {
-				applied: [],
+				applied: [otherCurrent],
 				failures: [{ key: update.key, kind: "updateUnsupported" }],
 			},
 			success: false,
 		});
-		expect(create).not.toHaveBeenCalled();
+		expect(create).toHaveBeenCalledExactlyOnceWith(otherCreate.desired);
 	});
 
 	it("should carry preceding driver outputs in aggregate.applied on updateUnsupported", async () => {
@@ -329,13 +394,16 @@ describe(applyOps, () => {
 		expect(update.mock.calls[0]![1]).toBe(op.desired);
 	});
 
-	it("should stop dispatching on the first update failure and wrap it in driverFailure Err", async () => {
+	it("should aggregate an update failure alongside the concurrent Phase 2 successes", async () => {
 		expect.assertions(2);
 
 		const first = updateOp(asResourceKey("first-pass"));
 		const second = createOp(asResourceKey("second-pass"));
+		const secondCurrent = gamePassCurrent({ ...second.desired });
 		const cause = new OpenCloudError("boom");
-		const create = vi.fn<ResourceDriver<"gamePass">["create"]>();
+		const create = vi
+			.fn<ResourceDriver<"gamePass">["create"]>()
+			.mockResolvedValue({ data: secondCurrent, success: true });
 		const update = vi
 			.fn<NonNullable<ResourceDriver<"gamePass">["update"]>>()
 			.mockResolvedValue({ err: cause, success: false });
@@ -344,12 +412,12 @@ describe(applyOps, () => {
 
 		expect(result).toStrictEqual({
 			err: {
-				applied: [],
+				applied: [secondCurrent],
 				failures: [{ key: first.key, cause, kind: "driverFailure" }],
 			},
 			success: false,
 		});
-		expect(create).not.toHaveBeenCalled();
+		expect(create).toHaveBeenCalledExactlyOnceWith(second.desired);
 	});
 
 	describe("developerProduct kind", () => {

--- a/packages/bedrock/src/shell/apply-ops.spec.ts
+++ b/packages/bedrock/src/shell/apply-ops.spec.ts
@@ -136,7 +136,7 @@ describe(applyOps, () => {
 		]);
 	});
 
-	it("should stop dispatching on the first driver failure and wrap it in driverFailure Err with appliedSoFar", async () => {
+	it("should stop dispatching on the first driver failure and surface an aggregate with applied[] and a single-failure failures[]", async () => {
 		expect.assertions(3);
 
 		const first = createOp(asResourceKey("first-pass"));
@@ -153,10 +153,8 @@ describe(applyOps, () => {
 
 		expect(result).toStrictEqual({
 			err: {
-				key: second.key,
-				appliedSoFar: [firstCurrent],
-				cause,
-				kind: "driverFailure",
+				applied: [firstCurrent],
+				failures: [{ key: second.key, cause, kind: "driverFailure" }],
 			},
 			success: false,
 		});
@@ -167,7 +165,7 @@ describe(applyOps, () => {
 		]);
 	});
 
-	it("should return an updateUnsupported Err when the driver has no update method", async () => {
+	it("should return an updateUnsupported failure in the aggregate when the driver has no update method", async () => {
 		expect.assertions(2);
 
 		const update = updateOp(asResourceKey("vip-pass"));
@@ -179,13 +177,16 @@ describe(applyOps, () => {
 		);
 
 		expect(result).toStrictEqual({
-			err: { key: update.key, appliedSoFar: [], kind: "updateUnsupported" },
+			err: {
+				applied: [],
+				failures: [{ key: update.key, kind: "updateUnsupported" }],
+			},
 			success: false,
 		});
 		expect(create).not.toHaveBeenCalled();
 	});
 
-	it("should carry preceding driver outputs in appliedSoFar on updateUnsupported", async () => {
+	it("should carry preceding driver outputs in aggregate.applied on updateUnsupported", async () => {
 		expect.assertions(1);
 
 		const created = createOp(asResourceKey("first-pass"));
@@ -198,7 +199,10 @@ describe(applyOps, () => {
 		const result = await applyOps([created, update], registryWith(create));
 
 		expect(result).toStrictEqual({
-			err: { key: update.key, appliedSoFar: [createdCurrent], kind: "updateUnsupported" },
+			err: {
+				applied: [createdCurrent],
+				failures: [{ key: update.key, kind: "updateUnsupported" }],
+			},
 			success: false,
 		});
 	});
@@ -235,7 +239,10 @@ describe(applyOps, () => {
 		const result = await applyOps([first, second], registryWith(create, update));
 
 		expect(result).toStrictEqual({
-			err: { key: first.key, appliedSoFar: [], cause, kind: "driverFailure" },
+			err: {
+				applied: [],
+				failures: [{ key: first.key, cause, kind: "driverFailure" }],
+			},
 			success: false,
 		});
 		expect(create).not.toHaveBeenCalled();
@@ -300,7 +307,10 @@ describe(applyOps, () => {
 			const result = await applyOps([op], developerProductRegistry(create));
 
 			expect(result).toStrictEqual({
-				err: { key: op.key, appliedSoFar: [], cause, kind: "driverFailure" },
+				err: {
+					applied: [],
+					failures: [{ key: op.key, cause, kind: "driverFailure" }],
+				},
 				success: false,
 			});
 		});
@@ -314,7 +324,10 @@ describe(applyOps, () => {
 			const result = await applyOps([op], developerProductRegistry(create));
 
 			expect(result).toStrictEqual({
-				err: { key: op.key, appliedSoFar: [], kind: "updateUnsupported" },
+				err: {
+					applied: [],
+					failures: [{ key: op.key, kind: "updateUnsupported" }],
+				},
 				success: false,
 			});
 			expect(create).not.toHaveBeenCalled();
@@ -350,7 +363,10 @@ describe(applyOps, () => {
 			const result = await applyOps([op], developerProductRegistry(create, update));
 
 			expect(result).toStrictEqual({
-				err: { key: op.key, appliedSoFar: [], cause, kind: "driverFailure" },
+				err: {
+					applied: [],
+					failures: [{ key: op.key, cause, kind: "driverFailure" }],
+				},
 				success: false,
 			});
 		});
@@ -415,7 +431,10 @@ describe(applyOps, () => {
 			const result = await applyOps([op], placeRegistry(create));
 
 			expect(result).toStrictEqual({
-				err: { key: op.key, appliedSoFar: [], cause, kind: "driverFailure" },
+				err: {
+					applied: [],
+					failures: [{ key: op.key, cause, kind: "driverFailure" }],
+				},
 				success: false,
 			});
 		});
@@ -429,7 +448,10 @@ describe(applyOps, () => {
 			const result = await applyOps([op], placeRegistry(create));
 
 			expect(result).toStrictEqual({
-				err: { key: op.key, appliedSoFar: [], kind: "updateUnsupported" },
+				err: {
+					applied: [],
+					failures: [{ key: op.key, kind: "updateUnsupported" }],
+				},
 				success: false,
 			});
 			expect(create).not.toHaveBeenCalled();
@@ -465,7 +487,10 @@ describe(applyOps, () => {
 			const result = await applyOps([op], placeRegistry(create, update));
 
 			expect(result).toStrictEqual({
-				err: { key: op.key, appliedSoFar: [], cause, kind: "driverFailure" },
+				err: {
+					applied: [],
+					failures: [{ key: op.key, cause, kind: "driverFailure" }],
+				},
 				success: false,
 			});
 		});
@@ -487,11 +512,12 @@ describe(applyOps, () => {
 			const result = await applyOps([op], placeRegistry(create, update));
 
 			assert(!result.success);
-			assert(result.err.kind === "driverFailure");
+			const failure = result.err.failures[0];
+			assert(failure.kind === "driverFailure");
 
-			expect(result.err.cause.message).toContain("expected place");
-			expect(result.err.cause.message).toContain("got gamePass");
-			expect(result.err.cause.message).toContain(op.key);
+			expect(failure.cause.message).toContain("expected place");
+			expect(failure.cause.message).toContain("got gamePass");
+			expect(failure.cause.message).toContain(op.key);
 			expect(update).not.toHaveBeenCalled();
 		});
 	});
@@ -513,11 +539,12 @@ describe(applyOps, () => {
 			const result = await applyOps([op], registryWith(create, update));
 
 			assert(!result.success);
-			assert(result.err.kind === "driverFailure");
+			const failure = result.err.failures[0];
+			assert(failure.kind === "driverFailure");
 
-			expect(result.err.cause.message).toContain("expected gamePass");
-			expect(result.err.cause.message).toContain("got place");
-			expect(result.err.cause.message).toContain(op.key);
+			expect(failure.cause.message).toContain("expected gamePass");
+			expect(failure.cause.message).toContain("got place");
+			expect(failure.cause.message).toContain(op.key);
 			expect(update).not.toHaveBeenCalled();
 		});
 	});
@@ -585,7 +612,10 @@ describe(applyOps, () => {
 			const result = await applyOps([op], universeRegistry(create));
 
 			expect(result).toStrictEqual({
-				err: { key: op.key, appliedSoFar: [], cause, kind: "driverFailure" },
+				err: {
+					applied: [],
+					failures: [{ key: op.key, cause, kind: "driverFailure" }],
+				},
 				success: false,
 			});
 		});
@@ -599,7 +629,10 @@ describe(applyOps, () => {
 			const result = await applyOps([op], universeRegistry(create));
 
 			expect(result).toStrictEqual({
-				err: { key: op.key, appliedSoFar: [], kind: "updateUnsupported" },
+				err: {
+					applied: [],
+					failures: [{ key: op.key, kind: "updateUnsupported" }],
+				},
 				success: false,
 			});
 			expect(create).not.toHaveBeenCalled();
@@ -635,7 +668,10 @@ describe(applyOps, () => {
 			const result = await applyOps([op], universeRegistry(create, update));
 
 			expect(result).toStrictEqual({
-				err: { key: op.key, appliedSoFar: [], cause, kind: "driverFailure" },
+				err: {
+					applied: [],
+					failures: [{ key: op.key, cause, kind: "driverFailure" }],
+				},
 				success: false,
 			});
 		});
@@ -657,11 +693,12 @@ describe(applyOps, () => {
 			const result = await applyOps([op], universeRegistry(create, update));
 
 			assert(!result.success);
-			assert(result.err.kind === "driverFailure");
+			const failure = result.err.failures[0];
+			assert(failure.kind === "driverFailure");
 
-			expect(result.err.cause.message).toContain("expected universe");
-			expect(result.err.cause.message).toContain("got gamePass");
-			expect(result.err.cause.message).toContain(op.key);
+			expect(failure.cause.message).toContain("expected universe");
+			expect(failure.cause.message).toContain("got gamePass");
+			expect(failure.cause.message).toContain(op.key);
 			expect(update).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/bedrock/src/shell/apply-ops.spec.ts
+++ b/packages/bedrock/src/shell/apply-ops.spec.ts
@@ -240,6 +240,94 @@ describe(applyOps, () => {
 		expect(universeCreate).toHaveBeenCalledOnce();
 	});
 
+	it("should run Phase 2 even when the Phase 1 universe op fails", async () => {
+		expect.assertions(4);
+
+		const universeOp = {
+			key: UNIVERSE_SINGLETON_KEY,
+			desired: universeDesired({ voiceChatEnabled: true }),
+			type: "create",
+		} as const satisfies CreateOperation;
+		const gamePassOp = createOp(asResourceKey("vip-pass"));
+		const placeOp = {
+			key: asResourceKey("start-place"),
+			desired: placeDesired(),
+			type: "create",
+		} as const satisfies CreateOperation;
+		const gamePassCurrentState = gamePassCurrent({ ...gamePassOp.desired });
+		const placeCurrentState = placeCurrent({ ...placeOp.desired });
+		const universeCause = new OpenCloudError("universe boom");
+		const gamePassCreate = vi
+			.fn<ResourceDriver<"gamePass">["create"]>()
+			.mockResolvedValue({ data: gamePassCurrentState, success: true });
+		const universeCreate = vi
+			.fn<ResourceDriver<"universe">["create"]>()
+			.mockResolvedValue({ err: universeCause, success: false });
+		const placeCreate = vi
+			.fn<ResourceDriver<"place">["create"]>()
+			.mockResolvedValue({ data: placeCurrentState, success: true });
+		const registry: DriverRegistry = {
+			developerProduct: developerProductStub,
+			gamePass: { create: gamePassCreate },
+			place: { create: placeCreate },
+			universe: { create: universeCreate },
+		};
+
+		const result = await applyOps([gamePassOp, universeOp, placeOp], registry);
+
+		expect(gamePassCreate).toHaveBeenCalledOnce();
+		expect(placeCreate).toHaveBeenCalledOnce();
+		expect(universeCreate).toHaveBeenCalledOnce();
+		expect(result).toStrictEqual({
+			err: {
+				applied: [gamePassCurrentState, placeCurrentState],
+				failures: [
+					{ key: UNIVERSE_SINGLETON_KEY, cause: universeCause, kind: "driverFailure" },
+				],
+			},
+			success: false,
+		});
+	});
+
+	it("should aggregate failures from both Phase 1 and Phase 2", async () => {
+		expect.assertions(2);
+
+		const universeOp = {
+			key: UNIVERSE_SINGLETON_KEY,
+			desired: universeDesired({ voiceChatEnabled: true }),
+			type: "create",
+		} as const satisfies CreateOperation;
+		const gamePassOp = createOp(asResourceKey("vip-pass"));
+		const universeCause = new OpenCloudError("universe boom");
+		const gamePassCause = new OpenCloudError("gamePass boom");
+		const universeCreate = vi
+			.fn<ResourceDriver<"universe">["create"]>()
+			.mockResolvedValue({ err: universeCause, success: false });
+		const gamePassCreate = vi
+			.fn<ResourceDriver<"gamePass">["create"]>()
+			.mockResolvedValue({ err: gamePassCause, success: false });
+		const registry: DriverRegistry = {
+			developerProduct: developerProductStub,
+			gamePass: { create: gamePassCreate },
+			place: placeStub,
+			universe: { create: universeCreate },
+		};
+
+		const result = await applyOps([universeOp, gamePassOp], registry);
+
+		expect(result.success).toBeFalse();
+
+		assert(!result.success);
+
+		expect(result.err).toStrictEqual({
+			applied: [],
+			failures: [
+				{ key: UNIVERSE_SINGLETON_KEY, cause: universeCause, kind: "driverFailure" },
+				{ key: gamePassOp.key, cause: gamePassCause, kind: "driverFailure" },
+			],
+		});
+	});
+
 	it("should dispatch Phase 2 ops concurrently rather than serially", async () => {
 		expect.assertions(3);
 

--- a/packages/bedrock/src/shell/apply-ops.spec.ts
+++ b/packages/bedrock/src/shell/apply-ops.spec.ts
@@ -389,6 +389,42 @@ describe(applyOps, () => {
 		expect(result).toStrictEqual({ data: [firstCurrent, secondCurrent], success: true });
 	});
 
+	it("should preserve failures[] in declaration order even when Phase 2 failures settle out of order", async () => {
+		expect.assertions(1);
+
+		const first = createOp(asResourceKey("first-pass"));
+		const second = createOp(asResourceKey("second-pass"));
+		let resolveFirst!: () => void;
+		const firstGate = new Promise<void>((resolve) => {
+			resolveFirst = resolve;
+		});
+		const firstCause = new OpenCloudError("first boom");
+		const secondCause = new OpenCloudError("second boom");
+		const create = vi
+			.fn<ResourceDriver<"gamePass">["create"]>()
+			.mockImplementationOnce(async () => {
+				await firstGate;
+				return { err: firstCause, success: false };
+			})
+			.mockImplementationOnce(async () => {
+				queueMicrotask(resolveFirst);
+				return { err: secondCause, success: false };
+			});
+
+		const result = await applyOps([first, second], registryWith(create));
+
+		expect(result).toStrictEqual({
+			err: {
+				applied: [],
+				failures: [
+					{ key: first.key, cause: firstCause, kind: "driverFailure" },
+					{ key: second.key, cause: secondCause, kind: "driverFailure" },
+				],
+			},
+			success: false,
+		});
+	});
+
 	it("should translate a synchronous driver throw into an unexpectedThrow without halting the batch", async () => {
 		expect.assertions(3);
 

--- a/packages/bedrock/src/shell/apply-ops.spec.ts
+++ b/packages/bedrock/src/shell/apply-ops.spec.ts
@@ -389,6 +389,116 @@ describe(applyOps, () => {
 		expect(result).toStrictEqual({ data: [firstCurrent, secondCurrent], success: true });
 	});
 
+	it("should translate a synchronous driver throw into an unexpectedThrow without halting the batch", async () => {
+		expect.assertions(3);
+
+		const first = createOp(asResourceKey("first-pass"));
+		const second = createOp(asResourceKey("second-pass"));
+		const third = createOp(asResourceKey("third-pass"));
+		const firstCurrent = gamePassCurrent({ ...first.desired });
+		const thirdCurrent = gamePassCurrent({ ...third.desired });
+		const thrown = new Error("boom");
+		const create = vi
+			.fn<ResourceDriver<"gamePass">["create"]>()
+			.mockResolvedValueOnce({ data: firstCurrent, success: true })
+			.mockImplementationOnce(() => {
+				throw thrown;
+			})
+			.mockResolvedValueOnce({ data: thirdCurrent, success: true });
+
+		const result = await applyOps([first, second, third], registryWith(create));
+
+		expect(result).toStrictEqual({
+			err: {
+				applied: [firstCurrent, thirdCurrent],
+				failures: [{ key: second.key, cause: thrown, kind: "unexpectedThrow" }],
+			},
+			success: false,
+		});
+		expect(create).toHaveBeenCalledTimes(3);
+		expect(create.mock.calls.map((call) => call[0].key)).toStrictEqual([
+			"first-pass",
+			"second-pass",
+			"third-pass",
+		]);
+	});
+
+	it("should translate an async driver rejection into an unexpectedThrow", async () => {
+		expect.assertions(1);
+
+		const op = createOp(asResourceKey("vip-pass"));
+		const thrown = new Error("async boom");
+		const create = vi.fn<ResourceDriver<"gamePass">["create"]>().mockRejectedValue(thrown);
+
+		const result = await applyOps([op], registryWith(create));
+
+		expect(result).toStrictEqual({
+			err: {
+				applied: [],
+				failures: [{ key: op.key, cause: thrown, kind: "unexpectedThrow" }],
+			},
+			success: false,
+		});
+	});
+
+	it("should preserve a non-Error throw as the unexpectedThrow cause", async () => {
+		expect.assertions(1);
+
+		const op = createOp(asResourceKey("vip-pass"));
+		const create = vi.fn<ResourceDriver<"gamePass">["create"]>().mockImplementation(() => {
+			// eslint-disable-next-line ts/only-throw-error -- exercise non-Error throw
+			throw "string error";
+		});
+
+		const result = await applyOps([op], registryWith(create));
+
+		expect(result).toStrictEqual({
+			err: {
+				applied: [],
+				failures: [{ key: op.key, cause: "string error", kind: "unexpectedThrow" }],
+			},
+			success: false,
+		});
+	});
+
+	it("should translate a universe-driver throw in Phase 1 into an unexpectedThrow alongside Phase 2 ops", async () => {
+		expect.assertions(2);
+
+		const universeOp = {
+			key: UNIVERSE_SINGLETON_KEY,
+			desired: universeDesired({ voiceChatEnabled: true }),
+			type: "create",
+		} as const satisfies CreateOperation;
+		const gamePassOp = createOp(asResourceKey("vip-pass"));
+		const gamePassCurrentState = gamePassCurrent({ ...gamePassOp.desired });
+		const thrown = new Error("universe driver crashed");
+		const universeCreate = vi
+			.fn<ResourceDriver<"universe">["create"]>()
+			.mockImplementation(() => {
+				throw thrown;
+			});
+		const gamePassCreate = vi
+			.fn<ResourceDriver<"gamePass">["create"]>()
+			.mockResolvedValue({ data: gamePassCurrentState, success: true });
+		const registry: DriverRegistry = {
+			developerProduct: developerProductStub,
+			gamePass: { create: gamePassCreate },
+			place: placeStub,
+			universe: { create: universeCreate },
+		};
+
+		const result = await applyOps([universeOp, gamePassOp], registry);
+
+		expect(gamePassCreate).toHaveBeenCalledOnce();
+		expect(result).toStrictEqual({
+			err: {
+				applied: [gamePassCurrentState],
+				failures: [{ key: UNIVERSE_SINGLETON_KEY, cause: thrown, kind: "unexpectedThrow" }],
+			},
+			success: false,
+		});
+	});
+
 	it("should dispatch every Phase 2 op past a failure and aggregate survivors with the failure", async () => {
 		expect.assertions(3);
 

--- a/packages/bedrock/src/shell/apply-ops.ts
+++ b/packages/bedrock/src/shell/apply-ops.ts
@@ -30,6 +30,9 @@ import type { ResourceKey } from "../types/ids.ts";
  *         case "driverFailure": {
  *             return `driver failed for ${err.key}: ${err.cause.message}`;
  *         }
+ *         case "unexpectedThrow": {
+ *             return `unexpected error for ${err.key}`;
+ *         }
  *         case "updateUnsupported": {
  *             return `update not supported for ${err.key}`;
  *         }
@@ -49,6 +52,11 @@ export type ApplyError =
 			readonly cause: OpenCloudError;
 			readonly key: ResourceKey;
 			readonly kind: "driverFailure";
+	  }
+	| {
+			readonly cause: unknown;
+			readonly key: ResourceKey;
+			readonly kind: "unexpectedThrow";
 	  }
 	| {
 			readonly key: ResourceKey;
@@ -96,12 +104,10 @@ type UniverseOp = NonNoopOp & { readonly desired: UniverseDesiredState };
  * @returns `Ok(state)` when every operation succeeds, where `state` holds
  *   driver outputs for each non-noop op in dispatched order; or the first
  *   failure encountered.
- * @throws Whatever a Phase 2 driver rejects with outside its `Result`
- *   contract. Rejections from Phase 2 dispatches surface through
- *   `Promise.allSettled` and are rethrown by `applyOps`; wrap the call
- *   site in a try/catch when drivers are not trusted to contain their
- *   own rejections.
- * @rejects See `@throws`.
+ * A driver that throws outside its `Result` contract is caught at the
+ * dispatch boundary and translated to an `unexpectedThrow`
+ * `ApplyError` scoped to that op alone; the rest of the batch keeps
+ * running.
  * @example
  *
  * ```ts
@@ -201,10 +207,8 @@ export async function applyOps(
 		}
 	}
 
-	const phase2Settled = await Promise.allSettled(
-		phase2.map(async (op) => dispatchOp(op, registry)),
-	);
-	failures.push(...collectPhase2Results(phase2Settled, applied));
+	const phase2Results = await Promise.all(phase2.map(async (op) => dispatchOp(op, registry)));
+	failures.push(...collectPhase2Results(phase2Results, applied));
 
 	const [head, ...tail] = failures;
 	if (head === undefined) {
@@ -215,19 +219,15 @@ export async function applyOps(
 }
 
 function collectPhase2Results(
-	settledResults: ReadonlyArray<PromiseSettledResult<Result<ResourceCurrentState, ApplyError>>>,
+	results: ReadonlyArray<Result<ResourceCurrentState, ApplyError>>,
 	applied: Array<ResourceCurrentState>,
 ): Array<ApplyError> {
 	const failures: Array<ApplyError> = [];
-	for (const settled of settledResults) {
-		if (settled.status === "rejected") {
-			throw settled.reason;
-		}
-
-		if (settled.value.success) {
-			applied.push(settled.value.data);
+	for (const result of results) {
+		if (result.success) {
+			applied.push(result.data);
 		} else {
-			failures.push(settled.value.err);
+			failures.push(result.err);
 		}
 	}
 
@@ -293,7 +293,7 @@ async function applyOne<K extends ResourceKind>(
 	return updated.success ? updated : driverFailure(op.key, updated.err);
 }
 
-async function dispatchOp(
+async function dispatchByKind(
 	op: NonNoopOp,
 	registry: DriverRegistry,
 ): Promise<Result<ResourceCurrentState, ApplyError>> {
@@ -313,5 +313,16 @@ async function dispatchOp(
 		case "universe": {
 			return applyOne(op as UniverseOp, registry.universe);
 		}
+	}
+}
+
+async function dispatchOp(
+	op: NonNoopOp,
+	registry: DriverRegistry,
+): Promise<Result<ResourceCurrentState, ApplyError>> {
+	try {
+		return await dispatchByKind(op, registry);
+	} catch (err) {
+		return { err: { key: op.key, cause: err, kind: "unexpectedThrow" }, success: false };
 	}
 }

--- a/packages/bedrock/src/shell/apply-ops.ts
+++ b/packages/bedrock/src/shell/apply-ops.ts
@@ -1,7 +1,5 @@
 import { ApiError, type OpenCloudError, type Result } from "@bedrock-rbx/ocale";
 
-import type { DistributedOmit } from "type-fest";
-
 import type { Operation } from "../core/operations.ts";
 import type {
 	DeveloperProductDesiredState,
@@ -18,11 +16,9 @@ import type { ResourceKey } from "../types/ids.ts";
 /**
  * Failure surfaced by `applyOps` when an operation cannot be applied.
  * Plain-data discriminated union; narrow on `kind`, do not `instanceof` it.
- *
- * `appliedSoFar` carries the driver outputs from operations that succeeded
- * before the failing one, in dispatched order. Callers persist this so a
- * follow-up reconcile does not duplicate Roblox-side resources that have
- * already been created or updated.
+ * One `ApplyError` describes one failing op; the surrounding
+ * `AggregateApplyError` carries the full batch outcome (every survivor and
+ * every failure).
  *
  * @example
  *
@@ -42,7 +38,6 @@ import type { ResourceKey } from "../types/ids.ts";
  *
  * const err: ApplyError = {
  *     key: asResourceKey("vip-pass"),
- *     appliedSoFar: [],
  *     kind: "updateUnsupported",
  * };
  *
@@ -51,24 +46,32 @@ import type { ResourceKey } from "../types/ids.ts";
  */
 export type ApplyError =
 	| {
-			readonly appliedSoFar: ReadonlyArray<ResourceCurrentState>;
 			readonly cause: OpenCloudError;
 			readonly key: ResourceKey;
 			readonly kind: "driverFailure";
 	  }
 	| {
-			readonly appliedSoFar: ReadonlyArray<ResourceCurrentState>;
 			readonly key: ResourceKey;
 			readonly kind: "updateUnsupported";
 	  };
+
+/**
+ * Aggregate outcome returned by `applyOps` when one or more ops fail.
+ * `applied` is the survivor set in declaration order. `failures` is the
+ * non-empty list of `ApplyError`s, one per failing op.
+ */
+export interface AggregateApplyError {
+	/** Survivors persisted to state, in declaration order. */
+	readonly applied: ReadonlyArray<ResourceCurrentState>;
+	/** Per-op failures, at least one. */
+	readonly failures: readonly [ApplyError, ...ReadonlyArray<ApplyError>];
+}
 
 type NonNoopOp = Exclude<Operation, { readonly type: "noop" }>;
 type DeveloperProductOp = NonNoopOp & { readonly desired: DeveloperProductDesiredState };
 type GamePassOp = NonNoopOp & { readonly desired: GamePassDesiredState };
 type PlaceOp = NonNoopOp & { readonly desired: PlaceDesiredState };
 type UniverseOp = NonNoopOp & { readonly desired: UniverseDesiredState };
-
-type RawApplyError = DistributedOmit<ApplyError, "appliedSoFar">;
 
 /**
  * Dispatch each reconciliation operation to the matching resource driver
@@ -183,7 +186,7 @@ type RawApplyError = DistributedOmit<ApplyError, "appliedSoFar">;
 export async function applyOps(
 	ops: ReadonlyArray<Operation>,
 	registry: DriverRegistry,
-): Promise<Result<ReadonlyArray<ResourceCurrentState>, ApplyError>> {
+): Promise<Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>> {
 	const applied: Array<ResourceCurrentState> = [];
 
 	for (const op of ops) {
@@ -193,7 +196,7 @@ export async function applyOps(
 
 		const outcome = await dispatchOp(op, registry);
 		if (!outcome.success) {
-			return { err: { ...outcome.err, appliedSoFar: applied }, success: false };
+			return { err: { applied, failures: [outcome.err] }, success: false };
 		}
 
 		applied.push(outcome.data);
@@ -205,7 +208,7 @@ export async function applyOps(
 function driverFailure(
 	key: ResourceKey,
 	cause: OpenCloudError,
-): Result<ResourceCurrentState, RawApplyError> {
+): Result<ResourceCurrentState, ApplyError> {
 	return { err: { key, cause, kind: "driverFailure" }, success: false };
 }
 
@@ -219,7 +222,7 @@ function kindMismatch(key: ResourceKey, mismatch: { actual: string; expected: st
 async function applyOne<K extends ResourceKind>(
 	op: NonNoopOp & { readonly desired: Extract<ResourceDesiredState, { kind: K }> },
 	driver: ResourceDriver<K>,
-): Promise<Result<ResourceCurrentState, RawApplyError>> {
+): Promise<Result<ResourceCurrentState, ApplyError>> {
 	if (op.type === "create") {
 		const created = await driver.create(op.desired);
 		return created.success ? created : driverFailure(op.key, created.err);
@@ -243,7 +246,7 @@ async function applyOne<K extends ResourceKind>(
 async function dispatchOp(
 	op: NonNoopOp,
 	registry: DriverRegistry,
-): Promise<Result<ResourceCurrentState, RawApplyError>> {
+): Promise<Result<ResourceCurrentState, ApplyError>> {
 	// Exhaustive switch: adding a new ResourceKind is a compile error here
 	// until an arm lands. Each arm casts because custom type narrowing does
 	// not propagate through a non-distributive union.

--- a/packages/bedrock/src/shell/apply-ops.ts
+++ b/packages/bedrock/src/shell/apply-ops.ts
@@ -65,13 +65,31 @@ export type ApplyError =
 
 /**
  * Aggregate outcome returned by `applyOps` when one or more ops fail.
- * `applied` is the survivor set in declaration order. `failures` is the
- * non-empty list of `ApplyError`s, one per failing op.
+ * `applied` is the survivor set in Phase 1 then Phase 2 input order.
+ * `failures` is the non-empty list of `ApplyError`s, one per failing op,
+ * grouped the same way.
+ *
+ * @example
+ *
+ * ```ts
+ * import { asResourceKey, type AggregateApplyError } from "@bedrock-rbx/core";
+ *
+ * function summarize(err: AggregateApplyError): string {
+ *     return `${err.applied.length} survived, ${err.failures.length} failed`;
+ * }
+ *
+ * const err: AggregateApplyError = {
+ *     applied: [],
+ *     failures: [{ key: asResourceKey("vip-pass"), kind: "updateUnsupported" }],
+ * };
+ *
+ * expect(summarize(err)).toBe("0 survived, 1 failed");
+ * ```
  */
 export interface AggregateApplyError {
-	/** Survivors persisted to state, in declaration order. */
+	/** Survivors persisted to state, in Phase 1 then Phase 2 input order. */
 	readonly applied: ReadonlyArray<ResourceCurrentState>;
-	/** Per-op failures, at least one. */
+	/** Per-op failures, at least one, in Phase 1 then Phase 2 input order. */
 	readonly failures: readonly [ApplyError, ...ReadonlyArray<ApplyError>];
 }
 
@@ -203,20 +221,14 @@ export async function applyOps(
 	registry: DriverRegistry,
 ): Promise<Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>> {
 	const { phase1, phase2 } = partitionByPhase(ops);
-	const applied: Array<ResourceCurrentState> = [];
-	const failures: Array<ApplyError> = [];
 
+	const phase1Outcomes: Array<Result<ResourceCurrentState, ApplyError>> = [];
 	for (const op of phase1) {
-		const outcome = await dispatchOp(op, registry);
-		if (outcome.success) {
-			applied.push(outcome.data);
-		} else {
-			failures.push(outcome.err);
-		}
+		phase1Outcomes.push(await dispatchOp(op, registry));
 	}
 
-	const phase2Results = await Promise.all(phase2.map(async (op) => dispatchOp(op, registry)));
-	failures.push(...collectPhase2Results(phase2Results, applied));
+	const phase2Outcomes = await Promise.all(phase2.map(async (op) => dispatchOp(op, registry)));
+	const { applied, failures } = partitionOutcomes([...phase1Outcomes, ...phase2Outcomes]);
 
 	const [head, ...tail] = failures;
 	if (head === undefined) {
@@ -224,43 +236,6 @@ export async function applyOps(
 	}
 
 	return { err: { applied, failures: [head, ...tail] }, success: false };
-}
-
-function collectPhase2Results(
-	results: ReadonlyArray<Result<ResourceCurrentState, ApplyError>>,
-	applied: Array<ResourceCurrentState>,
-): Array<ApplyError> {
-	const failures: Array<ApplyError> = [];
-	for (const result of results) {
-		if (result.success) {
-			applied.push(result.data);
-		} else {
-			failures.push(result.err);
-		}
-	}
-
-	return failures;
-}
-
-function partitionByPhase(ops: ReadonlyArray<Operation>): {
-	readonly phase1: ReadonlyArray<NonNoopOp>;
-	readonly phase2: ReadonlyArray<NonNoopOp>;
-} {
-	const phase1: Array<NonNoopOp> = [];
-	const phase2: Array<NonNoopOp> = [];
-	for (const op of ops) {
-		if (op.type === "noop") {
-			continue;
-		}
-
-		if (op.desired.kind === "universe") {
-			phase1.push(op);
-		} else {
-			phase2.push(op);
-		}
-	}
-
-	return { phase1, phase2 };
 }
 
 function driverFailure(
@@ -333,4 +308,34 @@ async function dispatchOp(
 	} catch (err) {
 		return { err: { key: op.key, cause: err, kind: "unexpectedThrow" }, success: false };
 	}
+}
+
+function partitionOutcomes(outcomes: ReadonlyArray<Result<ResourceCurrentState, ApplyError>>): {
+	readonly applied: ReadonlyArray<ResourceCurrentState>;
+	readonly failures: ReadonlyArray<ApplyError>;
+} {
+	const applied = outcomes.flatMap((outcome) => (outcome.success ? [outcome.data] : []));
+	const failures = outcomes.flatMap((outcome) => (outcome.success ? [] : [outcome.err]));
+	return { applied, failures };
+}
+
+function partitionByPhase(ops: ReadonlyArray<Operation>): {
+	readonly phase1: ReadonlyArray<NonNoopOp>;
+	readonly phase2: ReadonlyArray<NonNoopOp>;
+} {
+	const phase1: Array<NonNoopOp> = [];
+	const phase2: Array<NonNoopOp> = [];
+	for (const op of ops) {
+		if (op.type === "noop") {
+			continue;
+		}
+
+		if (op.desired.kind === "universe") {
+			phase1.push(op);
+		} else {
+			phase2.push(op);
+		}
+	}
+
+	return { phase1, phase2 };
 }

--- a/packages/bedrock/src/shell/apply-ops.ts
+++ b/packages/bedrock/src/shell/apply-ops.ts
@@ -82,32 +82,39 @@ type PlaceOp = NonNoopOp & { readonly desired: PlaceDesiredState };
 type UniverseOp = NonNoopOp & { readonly desired: UniverseDesiredState };
 
 /**
- * Dispatch each reconciliation operation to the matching resource driver
- * with first-fail semantics: on the first `Err` (driver failure or
- * `updateUnsupported`), the remaining operations are skipped and the error
- * is returned verbatim.
+ * Dispatch reconciliation operations to their matching drivers in two phases
+ * with continue-on-failure semantics. Phase 1 runs universe ops sequentially
+ * (singleton per environment; sequencing it before everything else avoids the
+ * `displayName` race against the root `Place`). Phase 2 dispatches every
+ * remaining non-noop op concurrently via `Promise.all`; every op is
+ * attempted regardless of earlier failures.
  *
  * Behaviour:
- * - `create` operations are routed to `registry[op.desired.kind].create`.
- * - `update` operations are routed to `registry[op.desired.kind].update`
- *   when the driver exposes it; otherwise they short-circuit to an
- *   `updateUnsupported` Err without invoking the driver.
+ * - `create` operations route to `registry[op.desired.kind].create`.
+ * - `update` operations route to `registry[op.desired.kind].update` when the
+ *   driver exposes it; otherwise they yield an `updateUnsupported`
+ *   `ApplyError` without invoking the driver.
  * - `noop` operations are skipped entirely (no I/O, no dispatch).
+ * - A driver that throws outside its `Result` contract is caught at the
+ *   dispatch boundary and translated to an `unexpectedThrow` `ApplyError`
+ *   scoped to that op alone; the rest of the batch keeps running.
  *
- * On success the returned array carries the driver outputs for every
- * non-noop op, in dispatched order. Noops are not represented; callers
- * needing a full post-apply snapshot merge with the pre-apply current
- * state keyed by `ResourceKey`.
+ * On Ok the returned array carries driver outputs for every non-noop op in
+ * declaration order: Phase 1 entries first, then Phase 2 entries in their
+ * input order. Noops are not represented; callers needing a full post-apply
+ * snapshot merge with the pre-apply current state keyed by `ResourceKey`.
  *
- * @param ops - Reconciliation operations produced by `diff`, applied in order.
- * @param registry - Per-kind driver table; dispatch uses `op.desired.kind` as the index.
- * @returns `Ok(state)` when every operation succeeds, where `state` holds
- *   driver outputs for each non-noop op in dispatched order; or the first
- *   failure encountered.
- * A driver that throws outside its `Result` contract is caught at the
- * dispatch boundary and translated to an `unexpectedThrow`
- * `ApplyError` scoped to that op alone; the rest of the batch keeps
- * running.
+ * On Err the aggregate carries every survivor in `applied` (declaration
+ * order) and every failure in `failures` (Phase 1 entries first, then
+ * Phase 2 entries in input order — never completion order).
+ *
+ * @param ops - Reconciliation operations produced by `diff`, applied in
+ *   declaration order.
+ * @param registry - Per-kind driver table; dispatch uses `op.desired.kind`
+ *   as the index.
+ * @returns `Ok(state)` when every op succeeded; otherwise
+ *   `Err(AggregateApplyError)` with the survivors and the non-empty
+ *   failures tuple.
  * @example
  *
  * ```ts

--- a/packages/bedrock/src/shell/apply-ops.ts
+++ b/packages/bedrock/src/shell/apply-ops.ts
@@ -99,14 +99,15 @@ type UniverseOp = NonNoopOp & { readonly desired: UniverseDesiredState };
  *   dispatch boundary and translated to an `unexpectedThrow` `ApplyError`
  *   scoped to that op alone; the rest of the batch keeps running.
  *
- * On Ok the returned array carries driver outputs for every non-noop op in
- * declaration order: Phase 1 entries first, then Phase 2 entries in their
- * input order. Noops are not represented; callers needing a full post-apply
- * snapshot merge with the pre-apply current state keyed by `ResourceKey`.
+ * On Ok the returned array carries driver outputs for every non-noop op
+ * in phase order: Phase 1 universe entries first, then Phase 2 entries in
+ * their input order. Noops are not represented; callers needing a full
+ * post-apply snapshot merge with the pre-apply current state keyed by
+ * `ResourceKey`.
  *
- * On Err the aggregate carries every survivor in `applied` (declaration
- * order) and every failure in `failures` (Phase 1 entries first, then
- * Phase 2 entries in input order — never completion order).
+ * On Err the aggregate carries every survivor in `applied` (Phase 1 first,
+ * then Phase 2 input order) and every failure in `failures` with the same
+ * grouping. Neither array reflects completion order.
  *
  * @param ops - Reconciliation operations produced by `diff`, applied in
  *   declaration order.

--- a/packages/bedrock/src/shell/apply-ops.ts
+++ b/packages/bedrock/src/shell/apply-ops.ts
@@ -190,20 +190,21 @@ export async function applyOps(
 ): Promise<Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>> {
 	const { phase1, phase2 } = partitionByPhase(ops);
 	const applied: Array<ResourceCurrentState> = [];
+	const failures: Array<ApplyError> = [];
 
 	for (const op of phase1) {
 		const outcome = await dispatchOp(op, registry);
-		if (!outcome.success) {
-			return { err: { applied, failures: [outcome.err] }, success: false };
+		if (outcome.success) {
+			applied.push(outcome.data);
+		} else {
+			failures.push(outcome.err);
 		}
-
-		applied.push(outcome.data);
 	}
 
 	const phase2Settled = await Promise.allSettled(
 		phase2.map(async (op) => dispatchOp(op, registry)),
 	);
-	const failures = collectPhase2Results(phase2Settled, applied);
+	failures.push(...collectPhase2Results(phase2Settled, applied));
 
 	const [head, ...tail] = failures;
 	if (head === undefined) {

--- a/packages/bedrock/src/shell/apply-ops.ts
+++ b/packages/bedrock/src/shell/apply-ops.ts
@@ -96,11 +96,12 @@ type UniverseOp = NonNoopOp & { readonly desired: UniverseDesiredState };
  * @returns `Ok(state)` when every operation succeeds, where `state` holds
  *   driver outputs for each non-noop op in dispatched order; or the first
  *   failure encountered.
- * @throws Whatever the dispatched driver rejects with outside its `Result`
- *   return. A driver whose injected I/O (file reads, network calls, etc.)
- *   throws will surface that rejection here rather than translating it into
- *   a `Result` failure; wrap the call site in a try/catch when drivers are
- *   not trusted to contain their own rejections.
+ * @throws Whatever a Phase 2 driver rejects with outside its `Result`
+ *   contract. Rejections from Phase 2 dispatches surface through
+ *   `Promise.allSettled` and are rethrown by `applyOps`; wrap the call
+ *   site in a try/catch when drivers are not trusted to contain their
+ *   own rejections.
+ * @rejects See `@throws`.
  * @example
  *
  * ```ts
@@ -199,16 +200,37 @@ export async function applyOps(
 		applied.push(outcome.data);
 	}
 
-	for (const op of phase2) {
-		const outcome = await dispatchOp(op, registry);
-		if (!outcome.success) {
-			return { err: { applied, failures: [outcome.err] }, success: false };
-		}
+	const phase2Settled = await Promise.allSettled(
+		phase2.map(async (op) => dispatchOp(op, registry)),
+	);
+	const failures = collectPhase2Results(phase2Settled, applied);
 
-		applied.push(outcome.data);
+	const [head, ...tail] = failures;
+	if (head === undefined) {
+		return { data: applied, success: true };
 	}
 
-	return { data: applied, success: true };
+	return { err: { applied, failures: [head, ...tail] }, success: false };
+}
+
+function collectPhase2Results(
+	settledResults: ReadonlyArray<PromiseSettledResult<Result<ResourceCurrentState, ApplyError>>>,
+	applied: Array<ResourceCurrentState>,
+): Array<ApplyError> {
+	const failures: Array<ApplyError> = [];
+	for (const settled of settledResults) {
+		if (settled.status === "rejected") {
+			throw settled.reason;
+		}
+
+		if (settled.value.success) {
+			applied.push(settled.value.data);
+		} else {
+			failures.push(settled.value.err);
+		}
+	}
+
+	return failures;
 }
 
 function partitionByPhase(ops: ReadonlyArray<Operation>): {

--- a/packages/bedrock/src/shell/apply-ops.ts
+++ b/packages/bedrock/src/shell/apply-ops.ts
@@ -187,13 +187,19 @@ export async function applyOps(
 	ops: ReadonlyArray<Operation>,
 	registry: DriverRegistry,
 ): Promise<Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>> {
+	const { phase1, phase2 } = partitionByPhase(ops);
 	const applied: Array<ResourceCurrentState> = [];
 
-	for (const op of ops) {
-		if (op.type === "noop") {
-			continue;
+	for (const op of phase1) {
+		const outcome = await dispatchOp(op, registry);
+		if (!outcome.success) {
+			return { err: { applied, failures: [outcome.err] }, success: false };
 		}
 
+		applied.push(outcome.data);
+	}
+
+	for (const op of phase2) {
 		const outcome = await dispatchOp(op, registry);
 		if (!outcome.success) {
 			return { err: { applied, failures: [outcome.err] }, success: false };
@@ -203,6 +209,27 @@ export async function applyOps(
 	}
 
 	return { data: applied, success: true };
+}
+
+function partitionByPhase(ops: ReadonlyArray<Operation>): {
+	readonly phase1: ReadonlyArray<NonNoopOp>;
+	readonly phase2: ReadonlyArray<NonNoopOp>;
+} {
+	const phase1: Array<NonNoopOp> = [];
+	const phase2: Array<NonNoopOp> = [];
+	for (const op of ops) {
+		if (op.type === "noop") {
+			continue;
+		}
+
+		if (op.desired.kind === "universe") {
+			phase1.push(op);
+		} else {
+			phase2.push(op);
+		}
+	}
+
+	return { phase1, phase2 };
 }
 
 function driverFailure(

--- a/packages/bedrock/src/shell/deploy.spec.ts
+++ b/packages/bedrock/src/shell/deploy.spec.ts
@@ -512,7 +512,7 @@ describe(deploy, () => {
 		});
 	});
 
-	it("should surface applyFailed and still attempt to persist the partial snapshot even when the write then rejects", async () => {
+	it("should surface stateWriteFailed with the partial-success unsavedState when both apply and state-write fail", async () => {
 		expect.assertions(3);
 
 		const alphaCurrent = alphaPassCurrent();
@@ -560,17 +560,13 @@ describe(deploy, () => {
 		expect(writeAttempts[0]!.resources).toStrictEqual([alphaCurrent]);
 		expect(result).toStrictEqual({
 			err: {
-				cause: {
-					applied: [alphaCurrent],
-					failures: [
-						{
-							key: asResourceKey("vip-pass"),
-							cause,
-							kind: "driverFailure",
-						},
-					],
+				cause: stateError,
+				kind: "stateWriteFailed",
+				unsavedState: {
+					environment: "production",
+					resources: [alphaCurrent],
+					version: 1,
 				},
-				kind: "applyFailed",
 			},
 			success: false,
 		});

--- a/packages/bedrock/src/shell/deploy.spec.ts
+++ b/packages/bedrock/src/shell/deploy.spec.ts
@@ -395,10 +395,14 @@ describe(deploy, () => {
 		expect(result).toStrictEqual({
 			err: {
 				cause: {
-					key: asResourceKey("vip-pass"),
-					appliedSoFar: [alphaCurrent],
-					cause,
-					kind: "driverFailure",
+					applied: [alphaCurrent],
+					failures: [
+						{
+							key: asResourceKey("vip-pass"),
+							cause,
+							kind: "driverFailure",
+						},
+					],
 				},
 				kind: "applyFailed",
 			},
@@ -497,10 +501,14 @@ describe(deploy, () => {
 		expect(result).toStrictEqual({
 			err: {
 				cause: {
-					key: asResourceKey("vip-pass"),
-					appliedSoFar: [alphaCurrent],
-					cause,
-					kind: "driverFailure",
+					applied: [alphaCurrent],
+					failures: [
+						{
+							key: asResourceKey("vip-pass"),
+							cause,
+							kind: "driverFailure",
+						},
+					],
 				},
 				kind: "applyFailed",
 			},

--- a/packages/bedrock/src/shell/deploy.spec.ts
+++ b/packages/bedrock/src/shell/deploy.spec.ts
@@ -222,7 +222,7 @@ describe(deploy, () => {
 
 		expect(universeCreate).toHaveBeenCalledOnce();
 		expect(placeCreate).toHaveBeenCalledOnce();
-		expect(writes[0]!.resources).toStrictEqual([placeCreated, universeCreated]);
+		expect(writes[0]!.resources).toStrictEqual([universeCreated, placeCreated]);
 	});
 
 	it("should preserve prior resources of distinct kinds that share a key when desired is empty", async () => {

--- a/packages/bedrock/src/shell/deploy.spec.ts
+++ b/packages/bedrock/src/shell/deploy.spec.ts
@@ -410,6 +410,66 @@ describe(deploy, () => {
 		});
 	});
 
+	it("should persist Phase 2 survivors alongside Phase 1 universe success when one Phase 2 op fails", async () => {
+		expect.assertions(3);
+
+		const placeIdValue = asRobloxAssetId("84607999013117");
+		const universeCreated = universeCurrent();
+		const placeCreated = placeCurrent({ outputs: { versionNumber: 1 } });
+		const alphaCurrent = alphaPassCurrent();
+		const cause = new OpenCloudError("create vip-pass: 503");
+		const universeCreate = vi
+			.fn<ResourceDriver<"universe">["create"]>()
+			.mockResolvedValue({ data: universeCreated, success: true });
+		const placeCreate = vi
+			.fn<ResourceDriver<"place">["create"]>()
+			.mockResolvedValue({ data: placeCreated, success: true });
+		const gamePassCreate = vi
+			.fn<ResourceDriver<"gamePass">["create"]>()
+			.mockImplementation(async (desired) => {
+				if (desired.key === "alpha-pass") {
+					return { data: alphaCurrent, success: true };
+				}
+
+				return { err: cause, success: false };
+			});
+		const registry: DriverRegistry = {
+			developerProduct: developerProductStub,
+			gamePass: { create: gamePassCreate },
+			place: { create: placeCreate },
+			universe: { create: universeCreate },
+		};
+		const { port, writes } = inMemoryStatePort();
+
+		const result = await deploy({
+			config: {
+				...twoPassConfig(),
+				environments: {
+					production: { places: { main: { placeId: placeIdValue } } },
+				},
+				places: { main: { filePath: "anime-rush.rbxl" } },
+				universe: { universeId: "1234567890" },
+			},
+			environment: "production",
+			readFile: readIcon,
+			registry,
+			statePort: port,
+		});
+
+		expect(writes).toHaveLength(1);
+		expect(writes[0]!.resources).toStrictEqual([universeCreated, alphaCurrent, placeCreated]);
+
+		assert(!result.success);
+
+		expect(result.err).toStrictEqual({
+			cause: {
+				applied: [universeCreated, alphaCurrent, placeCreated],
+				failures: [{ key: asResourceKey("vip-pass"), cause, kind: "driverFailure" }],
+			},
+			kind: "applyFailed",
+		});
+	});
+
 	it("should surface stateReadFailed without dispatching drivers or writing state when StatePort.read returns Err", async () => {
 		expect.assertions(3);
 

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -297,10 +297,11 @@ function buildSnapshot(inputs: SnapshotInputs): BedrockState {
 }
 
 function finalize(inputs: FinalizeInputs): Result<BedrockState, DeployError> {
-	if (!inputs.applied.success) {
-		return { err: { cause: inputs.applied.err, kind: "applyFailed" }, success: false };
-	}
-
+	// State-write failure takes priority over apply failure: under continue-
+	// on-failure, the write carries the `unsavedState` snapshot the operator
+	// needs to manually reconcile orphaned remote mutations, while apply
+	// failures will resurface on the next deploy via `diff` once state
+	// catches up.
 	if (!inputs.written.success) {
 		return {
 			err: {
@@ -310,6 +311,10 @@ function finalize(inputs: FinalizeInputs): Result<BedrockState, DeployError> {
 			},
 			success: false,
 		};
+	}
+
+	if (!inputs.applied.success) {
+		return { err: { cause: inputs.applied.err, kind: "applyFailed" }, success: false };
 	}
 
 	return { data: inputs.merged, success: true };

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -21,7 +21,7 @@ import type { BedrockState, StateError } from "../core/state.ts";
 import { validatePlan } from "../core/validate-plan.ts";
 import type { DriverRegistry } from "../ports/resource-driver.ts";
 import type { StatePort } from "../ports/state-port.ts";
-import { type ApplyError, applyOps } from "./apply-ops.ts";
+import { type AggregateApplyError, applyOps } from "./apply-ops.ts";
 import { buildDefaultRegistry, type RegistryConfigError } from "./build-default-registry.ts";
 import { buildDesired, type BuildDesiredError } from "./build-desired.ts";
 import {
@@ -72,7 +72,7 @@ export type DeployError =
 	| StateNotConfiguredError
 	| UnknownEnvironmentError
 	| UnsupportedBackendError
-	| { readonly cause: ApplyError; readonly kind: "applyFailed" }
+	| { readonly cause: AggregateApplyError; readonly kind: "applyFailed" }
 	| { readonly cause: BuildDesiredError; readonly kind: "buildDesiredFailed" }
 	| { readonly cause: ConfigError; readonly kind: "configLoadFailed" }
 	| { readonly cause: StateError; readonly kind: "stateReadFailed" }
@@ -83,13 +83,13 @@ export type DeployError =
 	  };
 
 interface SnapshotInputs {
-	readonly applied: Result<ReadonlyArray<ResourceCurrentState>, ApplyError>;
+	readonly applied: Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>;
 	readonly environment: string;
 	readonly priorResources: ReadonlyArray<ResourceCurrentState>;
 }
 
 interface FinalizeInputs {
-	readonly applied: Result<ReadonlyArray<ResourceCurrentState>, ApplyError>;
+	readonly applied: Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>;
 	readonly merged: BedrockState;
 	readonly written: Result<void, StateError>;
 }
@@ -288,7 +288,7 @@ function mergeResources(
 function buildSnapshot(inputs: SnapshotInputs): BedrockState {
 	const appliedResources = inputs.applied.success
 		? inputs.applied.data
-		: inputs.applied.err.appliedSoFar;
+		: inputs.applied.err.applied;
 	return {
 		environment: inputs.environment,
 		resources: mergeResources(inputs.priorResources, appliedResources),

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -297,11 +297,7 @@ function buildSnapshot(inputs: SnapshotInputs): BedrockState {
 }
 
 function finalize(inputs: FinalizeInputs): Result<BedrockState, DeployError> {
-	// State-write failure takes priority over apply failure: under continue-
-	// on-failure, the write carries the `unsavedState` snapshot the operator
-	// needs to manually reconcile orphaned remote mutations, while apply
-	// failures will resurface on the next deploy via `diff` once state
-	// catches up.
+	// Check write before apply: only the write carries `unsavedState`.
 	if (!inputs.written.success) {
 		return {
 			err: {


### PR DESCRIPTION
## Summary

- Make `bedrock deploy` stop halting at the first apply failure. `applyOps` now runs universe ops sequentially in Phase 1, then dispatches every remaining non-noop op concurrently via `Promise.all` in Phase 2 — every op is attempted, failures aggregate into a non-empty `AggregateApplyError.failures` tuple, survivors persist to state in declaration order.
- Translate driver throws at the dispatch boundary into a new `unexpectedThrow` `ApplyError` variant so a misbehaving driver no longer halts other reconciliations.
- Render N failures as one `logError` line each, preserving the existing single-failure format. CLI keeps exiting non-zero on any partial failure via the existing `failed[]` aggregation in `deployCommand`.

Implements [ADR-023](https://github.com/christopher-buss/bedrock/blob/main/docs/adr/023-apply-semantics-parallel-continue-on-failure.md) (core algorithm slice). Per-op `ProgressPort` events, `UpdateOperation.changedFields`, and the clack adapter changes stay queued for follow-up slices.

Closes #405.

## Commit-by-commit

1. `refactor(core): introduce aggregate-apply-error and drop applied-so-far` — type pivot, sequential first-fail preserved.
2. `refactor(core): partition apply ops by phase with universe first` — Phase 1 universe sequencing.
3. `refactor(core): dispatch phase-2 apply ops concurrently` — Phase 2 via `Promise.allSettled`, continue-on-failure within Phase 2.
4. `refactor(core): continue applying ops past failures across phases` — Phase 1 accumulates failures, Phase 2 always runs.
5. `feat(core): translate driver throws into unexpected-throw apply-error` — dispatch-boundary try/catch, `Promise.all`.
6. `feat(core): render one line per failure on partial apply failure` — multi-failure CLI render.
7. `test(core): lock phase-2 partial success persistence into deploy spec` — regression for state persistence under cross-phase continue-on-failure.
8. `docs(core): describe two-phase continue-on-failure apply contract` — JSDoc, `diff.ts` ordering note, two dated ADR-023 amendments.

## Test plan

- [ ] `pnpm gen:example-tests` regenerates without working-tree drift.
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test` all clean.
- [ ] `pnpm mutate:changed` reports 100% across every touched file in each slice (verified in pre-commit on every slice).
- [ ] End-to-end smoke: construct a config with one universe, one place, and two game-passes (one set to fail via a registry stub); run `bedrock deploy <env>`; observe (a) universe + place apply, (b) first game-pass applies, (c) second game-pass surfaces an `apply failed` line, (d) state file persists the three successes, (e) process exits with code 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Bedrock Code Review: PR `#425` — Two-Phase Parallel Continue-on-Failure Apply

## Architecture (FCIS Pattern) ✅

**Core (Pure Functions):**
- `applyOps` is correctly placed in the Shell layer (not Core) as it orchestrates driver dispatch, which is architecture-appropriate.
- Core layer remains pure: `diff.ts` produces operation arrays; Core functions don't invoke drivers.

**Shell/Orchestration:**
- `deploy.ts` and `apply-ops.ts` properly orchestrate without side effects; driver invocation is delegated to adapters via the `DriverRegistry` port.
- Error propagation follows the design: `AggregateApplyError` flows from Shell back to CLI (render.ts).

**Ports & Adapters:**
- `ResourceDriver` interface is the abstraction boundary.
- Adapters (GamePassDriver, PlaceDriver, etc.) implement the interface.
- No I/O in Core; all I/O happens in Shell orchestration or Adapters.

**No violations detected.**

---

## Testing (TDD Required) ✅

**Coverage & Test Count:**
- `apply-ops.spec.ts`: **39 test cases** covering Phase 1/Phase 2 semantics, concurrency, order preservation, and error variants.
- **Test naming**: All follow `it("should <behavior>")` format.
- **Key coverage areas:**
  - Phase 1 sequential universe ops (singleton) before Phase 2.
  - Phase 2 concurrent dispatch via `Promise.all`.
  - Continue-on-failure semantics: Phase 2 runs even if Phase 1 fails.
  - Declaration-order preservation in both `applied[]` and `failures[]` despite out-of-order settlement.
  - New `unexpectedThrow` variant with safe coercion of unknown thrown values.
  - Partial-success state persistence (deploy.spec.ts).
  - Render behavior: one `logError` per failure (render.spec.ts).

**TDD Compliance:**
- Tests cover both happy path (all ops succeed) and error paths (Phase 1 failure, Phase 2 failure, cross-phase aggregation).
- No mock behavior testing; tests verify real type contracts (mocks return valid `Result` shapes).

**Test Isolation:**
- Fake `ResourceDriver` stubs and `vi.fn()` mocks properly isolate the dispatch logic.
- `fakeClackPort()` used in render tests (render.spec.ts, line 3, 318).
- No real HTTP calls or file I/O in tests.

---

## Security & Constraints ✅

**Open Cloud Only:**
- All failures are typed as `OpenCloudError` (except for the new `unexpectedThrow` catch-all for driver bugs).
- No legacy Roblox APIs referenced.

**State Files (Resource IDs Only):**
- State persistence uses `ResourceCurrentState` which contains output identifiers (asset IDs, version numbers) but no secrets.
- `stateWriteFailed` includes the `unsavedState` snapshot; no credentials or secrets embedded.

**Error Handling:**
- Driver throws outside the `Result` contract are caught at the `dispatchOp` boundary (try/catch, line 331-334) and translated to `unexpectedThrow`, preventing misbehaving drivers from halting other ops.
- `safeStringify` helper (render.ts) safely coerces arbitrary thrown values to strings without re-throwing.

---

## Code Quality & Type Safety ✅

**TypeScript Strict Mode:**
- Extends `@bedrock-rbx/typescript-config/tsconfig.base.json`.
- No unwarranted `any` types found.

**Discriminated Unions:**
- `ApplyError` is a proper three-variant discriminated union (kind: "driverFailure" | "unexpectedThrow" | "updateUnsupported").
- All exhaustive switches include compiler-enforced exhaustion checks (apply-ops.ts, line 308-324).

**Non-Empty Tuple Invariant:**
- `AggregateApplyError.failures: readonly [ApplyError, ...ReadonlyArray<ApplyError>]` encodes the invariant that `Err` is only returned when at least one op fails (apply-ops.ts, line 75; ADR amendments, 2026-05-18).
- Return logic enforces this: if `failures` is empty, returns `Ok`; only constructs `Err` when `failures[0]` exists (apply-ops.ts, line 221-226).

**Documentation:**
- JSDoc is comprehensive and current (apply-ops.ts, lines 16-199).
- Example cases updated to show the three ApplyError variants (line 28-40).
- ADR-023 includes two amendments (2026-05-14, 2026-05-18) documenting the two-phase contract and the `Promise.all` decision (not `Promise.allSettled`).
- Example test auto-generated via `generate-jsdoc-example-tests` (apply-ops.example.spec.ts, line 1).

---

## Semantics & Correctness ✅

**Two-Phase Dispatch:**
- Phase 1: Universe ops run sequentially (singleton per environment, avoids `displayName` race with root Place).
- Phase 2: All non-noop, non-universe ops dispatched concurrently via `Promise.all`.

**Continue-on-Failure:**
- Phase 2 runs regardless of Phase 1 outcome (line 218).
- Every op is attempted; failures are collected and aggregated.

**Order Preservation:**
- `applied[]`: Phase 1 entries first, then Phase 2 entries in input order (line 205-219, 229-243).
- `failures[]`: Same grouping (Phase 1, then Phase 2 input order).
- Not affected by Promise settlement order (test: "preserve applied[] in declaration order even when Phase 2 ops settle out of order", apply-ops.spec.ts, line 365).

**State Persistence:**
- On partial failure, `applied[]` is persisted (deploy.spec.ts: "persist Phase 2 survivors alongside Phase 1 universe success when one Phase 2 op fails").
- On state write failure, `unsavedState` carries the merged snapshot (deploy.ts, line 308-312).

**Promise.all Safety:**
- `dispatchOp` catches any throw at the dispatch boundary and converts it to `unexpectedThrow` ApplyError (apply-ops.ts, line 331-335).
- This ensures no dispatch promise rejects, making `Promise.all` safe (ADR-023 amendment, 2026-05-18).

**CLI/UX:**
- Partial-apply failures render one `logError` line per failure in declaration order (render.spec.ts, line 325-366; render.ts, special-case applyFailed rendering).
- CLI exits non-zero on any partial failure via existing `failed[]` aggregation.

---

## Removed/Updated Artifacts ✅

**Type Pivot:**
- Removed `appliedSoFar` field from all `ApplyError` variants (apply-ops.ts, line 50-64).
- Moved survivor list to `AggregateApplyError.applied` (line 71-76).
- No remaining `appliedSoFar` references found.

**Export Updates:**
- `AggregateApplyError` added to public exports (index.ts, line 1).
- Type tests updated to assert `AggregateApplyError` as the error type (index.spec-d.ts).

**Type Evidence:**
- `applyOps` signature: `Promise<Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>>` (apply-ops.ts, line 204).
- `DeployError["applyFailed"]` now carries `AggregateApplyError` (deploy.ts, line 75).

---

## Potential Observations (Non-Blocking)

1. **Promise.all Guarantees:** The PR correctly relies on `Promise.all` preserving input order. The dispatch-boundary catch is essential for this to work; well-documented in the ADR amendment.

2. **Test Volume:** `apply-ops.spec.ts` (1111 lines) is comprehensive; consider whether future maintainers can quickly locate specific phase or error tests. Currently well-organized via nested `describe` blocks.

3. **Example Generation:** Auto-generated example tests (apply-ops.example.spec.ts) are properly versioned with a "DO NOT EDIT" header. Manual edits to apply-ops.ts JSDoc examples will auto-propagate.

---

## Summary

**All objectives met:**
✅ Two-phase parallel continue-on-failure dispatch with `Promise.all` (Phase 2).
✅ Aggregated error model with `AggregateApplyError`.
✅ Per-op error variants including new `unexpectedThrow` for driver throws.
✅ Order preservation in `applied[]` and `failures[]` despite concurrent settlement.
✅ Partial-success state persistence.
✅ CLI renders multiple failures cleanly, one line per failure.
✅ 100% TypeScript strict compliance, no unsafe types.
✅ Comprehensive test coverage (39 test cases) with proper isolation.
✅ JSDoc, ADR, and example generation all current.
✅ Architecture adheres to FCIS pattern (no I/O in Core, proper Shell orchestration, Adapter abstractions).

**No blocking issues found. Approved for merge.**

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->