### PR TITLE
feat(core): extend redaction to game-pass and developer-product prices

### DIFF
--- a/packages/bedrock/src/core/redact-resources.spec.ts
+++ b/packages/bedrock/src/core/redact-resources.spec.ts
@@ -5,6 +5,7 @@ import {
 	collectRedactionAnnotations,
 	REDACTED_DESCRIPTION,
 	REDACTED_PASS_NAME,
+	REDACTED_PRICE,
 	REDACTED_PRODUCT_NAME,
 } from "./redact-resources.ts";
 import { REDACTED_ICON_PATH } from "./redacted-icon.ts";
@@ -41,7 +42,7 @@ const startPlaceEntry = {
 } as const satisfies ResolvedPlaceEntry;
 
 describe(applyRedaction, () => {
-	it("should replace name, description, and icon with placeholders when redacted is true", () => {
+	it("should replace name, description, icon, and price with placeholders when redacted is true", () => {
 		expect.assertions(1);
 
 		const result = applyRedaction({
@@ -53,9 +54,76 @@ describe(applyRedaction, () => {
 			name: REDACTED_PASS_NAME,
 			description: REDACTED_DESCRIPTION,
 			icon: { "en-us": REDACTED_ICON_PATH },
-			price: 500,
+			price: REDACTED_PRICE,
 			redacted: true,
 		});
+	});
+
+	it("should preserve an off-sale pass as off-sale when redacted is true", () => {
+		expect.assertions(1);
+
+		const offSale = {
+			name: "Coming Soon Pass",
+			description: "Reveal at launch.",
+			icon: { "en-us": "assets/soon.png" },
+		} as const satisfies GamePassEntry;
+
+		const result = applyRedaction({
+			...baseConfig,
+			passes: { "soon-pass": { ...offSale, redacted: true } },
+		});
+
+		expect(result.passes?.["soon-pass"]).toStrictEqual({
+			name: REDACTED_PASS_NAME,
+			description: REDACTED_DESCRIPTION,
+			icon: { "en-us": REDACTED_ICON_PATH },
+			redacted: true,
+		});
+	});
+
+	it("should substitute the price override on a redacted pass while leaving other fields at defaults", () => {
+		expect.assertions(1);
+
+		const result = applyRedaction({
+			...baseConfig,
+			passes: { "vip-pass": { ...vipEntry, redacted: { price: 500 } } },
+		});
+
+		expect(result.passes?.["vip-pass"]).toStrictEqual({
+			name: REDACTED_PASS_NAME,
+			description: REDACTED_DESCRIPTION,
+			icon: { "en-us": REDACTED_ICON_PATH },
+			price: 500,
+			redacted: { price: 500 },
+		});
+	});
+
+	it("should honour a price override of 0 on a redacted pass without falling back to the default", () => {
+		expect.assertions(1);
+
+		const result = applyRedaction({
+			...baseConfig,
+			passes: { "vip-pass": { ...vipEntry, redacted: { price: 0 } } },
+		});
+
+		expect(result.passes?.["vip-pass"]?.price).toBe(0);
+	});
+
+	it("should ignore a price override on a redacted pass that is off-sale", () => {
+		expect.assertions(1);
+
+		const offSale = {
+			name: "Coming Soon Pass",
+			description: "Reveal at launch.",
+			icon: { "en-us": "assets/soon.png" },
+		} as const satisfies GamePassEntry;
+
+		const result = applyRedaction({
+			...baseConfig,
+			passes: { "soon-pass": { ...offSale, redacted: { price: 500 } } },
+		});
+
+		expect(result.passes?.["soon-pass"]).not.toHaveProperty("price");
 	});
 
 	it("should leave a pass unchanged when redacted is false", () => {
@@ -160,7 +228,7 @@ describe(applyRedaction, () => {
 			name: "Closed Beta",
 			description: REDACTED_DESCRIPTION,
 			icon: { "en-us": REDACTED_ICON_PATH },
-			price: 500,
+			price: REDACTED_PRICE,
 			redacted: { name: "Closed Beta" },
 		});
 	});
@@ -183,7 +251,7 @@ describe(applyRedaction, () => {
 			name: "Beta Pass",
 			description: "Beta description",
 			icon: { "en-us": "assets/beta.png" },
-			price: 500,
+			price: REDACTED_PRICE,
 			redacted: override,
 		});
 	});
@@ -205,7 +273,7 @@ describe(applyRedaction, () => {
 			name: REDACTED_PASS_NAME,
 			description: REDACTED_DESCRIPTION,
 			icon: { "en-us": "assets/override-icon.png" },
-			price: 500,
+			price: REDACTED_PRICE,
 			redacted: { icon: { "en-us": "assets/override-icon.png" } },
 		});
 	});
@@ -435,7 +503,7 @@ describe(applyRedaction, () => {
 		expect(result.places?.["secret-place"]?.description).toBe(REDACTED_DESCRIPTION);
 	});
 
-	it("should replace name, description, and icon with placeholders when a product redacted is true", () => {
+	it("should replace name, description, icon, and price with placeholders when a product redacted is true", () => {
 		expect.assertions(1);
 
 		const result = applyRedaction({
@@ -447,9 +515,76 @@ describe(applyRedaction, () => {
 			name: REDACTED_PRODUCT_NAME,
 			description: REDACTED_DESCRIPTION,
 			icon: { "en-us": REDACTED_ICON_PATH },
-			price: 100,
+			price: REDACTED_PRICE,
 			redacted: true,
 		});
+	});
+
+	it("should preserve an off-sale product as off-sale when redacted is true", () => {
+		expect.assertions(1);
+
+		const offSale = {
+			name: "Coming Soon Pack",
+			description: "Reveal at launch.",
+			icon: { "en-us": "assets/soon.png" },
+		} as const satisfies DeveloperProductEntry;
+
+		const result = applyRedaction({
+			...baseConfig,
+			products: { "soon-pack": { ...offSale, redacted: true } },
+		});
+
+		expect(result.products?.["soon-pack"]).toStrictEqual({
+			name: REDACTED_PRODUCT_NAME,
+			description: REDACTED_DESCRIPTION,
+			icon: { "en-us": REDACTED_ICON_PATH },
+			redacted: true,
+		});
+	});
+
+	it("should substitute the price override on a redacted product while leaving other fields at defaults", () => {
+		expect.assertions(1);
+
+		const result = applyRedaction({
+			...baseConfig,
+			products: { "gem-pack": { ...gemPackEntry, redacted: { price: 500 } } },
+		});
+
+		expect(result.products?.["gem-pack"]).toStrictEqual({
+			name: REDACTED_PRODUCT_NAME,
+			description: REDACTED_DESCRIPTION,
+			icon: { "en-us": REDACTED_ICON_PATH },
+			price: 500,
+			redacted: { price: 500 },
+		});
+	});
+
+	it("should honour a price override of 0 on a redacted product without falling back to the default", () => {
+		expect.assertions(1);
+
+		const result = applyRedaction({
+			...baseConfig,
+			products: { "gem-pack": { ...gemPackEntry, redacted: { price: 0 } } },
+		});
+
+		expect(result.products?.["gem-pack"]?.price).toBe(0);
+	});
+
+	it("should ignore a price override on a redacted product that is off-sale", () => {
+		expect.assertions(1);
+
+		const offSale = {
+			name: "Coming Soon Pack",
+			description: "Reveal at launch.",
+			icon: { "en-us": "assets/soon.png" },
+		} as const satisfies DeveloperProductEntry;
+
+		const result = applyRedaction({
+			...baseConfig,
+			products: { "soon-pack": { ...offSale, redacted: { price: 500 } } },
+		});
+
+		expect(result.products?.["soon-pack"]).not.toHaveProperty("price");
 	});
 
 	it("should assign the placeholder icon to a redacted product even when the source entry declares no icon", () => {
@@ -571,7 +706,7 @@ describe(applyRedaction, () => {
 			name: "Closed Beta Pack",
 			description: REDACTED_DESCRIPTION,
 			icon: { "en-us": REDACTED_ICON_PATH },
-			price: 100,
+			price: REDACTED_PRICE,
 			redacted: { name: "Closed Beta Pack" },
 		});
 	});
@@ -594,7 +729,7 @@ describe(applyRedaction, () => {
 			name: "Beta Pack",
 			description: "Beta description",
 			icon: { "en-us": "assets/beta.png" },
-			price: 100,
+			price: REDACTED_PRICE,
 			redacted: override,
 		});
 	});
@@ -616,7 +751,7 @@ describe(applyRedaction, () => {
 			name: REDACTED_PRODUCT_NAME,
 			description: REDACTED_DESCRIPTION,
 			icon: { "en-us": "assets/override-icon.png" },
-			price: 100,
+			price: REDACTED_PRICE,
 			redacted: { icon: { "en-us": "assets/override-icon.png" } },
 		});
 	});
@@ -694,6 +829,16 @@ describe(collectRedactionAnnotations, () => {
 				redacted: true,
 			},
 			label: "icon",
+		},
+		{
+			entry: {
+				name: REDACTED_PASS_NAME,
+				description: REDACTED_DESCRIPTION,
+				icon: { "en-us": REDACTED_ICON_PATH },
+				price: 500,
+				redacted: true,
+			},
+			label: "price",
 		},
 	])(
 		"should set hasRealValueEdits true when only the real $label diverges from the placeholder default",
@@ -797,6 +942,16 @@ describe(collectRedactionAnnotations, () => {
 			},
 			label: "icon",
 		},
+		{
+			entry: {
+				name: REDACTED_PRODUCT_NAME,
+				description: REDACTED_DESCRIPTION,
+				icon: { "en-us": REDACTED_ICON_PATH },
+				price: 250,
+				redacted: true,
+			},
+			label: "price",
+		},
 	])(
 		"should set hasRealValueEdits true when only the real product $label diverges from the placeholder default",
 		({ entry }) => {
@@ -812,6 +967,72 @@ describe(collectRedactionAnnotations, () => {
 			]);
 		},
 	);
+
+	it.for<{ entry: GamePassEntry; label: string }>([
+		{
+			entry: {
+				name: REDACTED_PASS_NAME,
+				description: REDACTED_DESCRIPTION,
+				icon: { "en-us": REDACTED_ICON_PATH },
+				price: REDACTED_PRICE,
+				redacted: true,
+			},
+			label: "price matches the placeholder default",
+		},
+		{
+			entry: {
+				name: REDACTED_PASS_NAME,
+				description: REDACTED_DESCRIPTION,
+				icon: { "en-us": REDACTED_ICON_PATH },
+				redacted: true,
+			},
+			label: "the pass is off-sale",
+		},
+	])("should set hasRealValueEdits false on a redacted pass when $label", ({ entry }) => {
+		expect.assertions(1);
+
+		const result = collectRedactionAnnotations({
+			...baseConfig,
+			passes: { "vip-pass": entry },
+		});
+
+		expect(result).toStrictEqual([
+			{ key: "vip-pass", hasRealValueEdits: false, kind: "gamePass" },
+		]);
+	});
+
+	it.for<{ entry: DeveloperProductEntry; label: string }>([
+		{
+			entry: {
+				name: REDACTED_PRODUCT_NAME,
+				description: REDACTED_DESCRIPTION,
+				icon: { "en-us": REDACTED_ICON_PATH },
+				price: REDACTED_PRICE,
+				redacted: true,
+			},
+			label: "price matches the placeholder default",
+		},
+		{
+			entry: {
+				name: REDACTED_PRODUCT_NAME,
+				description: REDACTED_DESCRIPTION,
+				icon: { "en-us": REDACTED_ICON_PATH },
+				redacted: true,
+			},
+			label: "the product is off-sale",
+		},
+	])("should set hasRealValueEdits false on a redacted product when $label", ({ entry }) => {
+		expect.assertions(1);
+
+		const result = collectRedactionAnnotations({
+			...baseConfig,
+			products: { "gem-pack": entry },
+		});
+
+		expect(result).toStrictEqual([
+			{ key: "gem-pack", hasRealValueEdits: false, kind: "developerProduct" },
+		]);
+	});
 
 	it("should emit annotations for both passes and products when each kind declares a redacted entry", () => {
 		expect.assertions(1);

--- a/packages/bedrock/src/core/redact-resources.ts
+++ b/packages/bedrock/src/core/redact-resources.ts
@@ -21,6 +21,14 @@ export const REDACTED_PRODUCT_NAME = "Redacted Product";
 export const REDACTED_DESCRIPTION = "";
 
 /**
+ * Default placeholder Robux price pushed for a redacted game-pass or
+ * developer-product whose config price is defined. Off-sale resources
+ * (`price === undefined`) keep their off-sale state through redaction so a
+ * hidden product is never accidentally listed for sale.
+ */
+export const REDACTED_PRICE = 1;
+
+/**
  * Per-resource annotation surfaced in plan output for entries that are
  * redacted in the active environment. `hasRealValueEdits` is true when the
  * pre-redaction merged config carries real display values that diverge from
@@ -120,6 +128,7 @@ function redactPass(entry: GamePassEntry, override: RedactedGamePassOverride): G
 		name: override.name ?? REDACTED_PASS_NAME,
 		description: override.description ?? REDACTED_DESCRIPTION,
 		icon: override.icon ?? { "en-us": REDACTED_ICON_PATH },
+		...(entry.price === undefined ? {} : { price: override.price ?? REDACTED_PRICE }),
 	};
 }
 
@@ -200,6 +209,7 @@ function redactProduct(
 		name: override.name ?? REDACTED_PRODUCT_NAME,
 		description: override.description ?? REDACTED_DESCRIPTION,
 		icon: override.icon ?? { "en-us": REDACTED_ICON_PATH },
+		...(entry.price === undefined ? {} : { price: override.price ?? REDACTED_PRICE }),
 	};
 }
 
@@ -236,7 +246,8 @@ function passHasRealValueEdits(entry: GamePassEntry): boolean {
 	return (
 		entry.name !== REDACTED_PASS_NAME ||
 		entry.description !== REDACTED_DESCRIPTION ||
-		entry.icon["en-us"] !== REDACTED_ICON_PATH
+		entry.icon["en-us"] !== REDACTED_ICON_PATH ||
+		(entry.price !== undefined && entry.price !== REDACTED_PRICE)
 	);
 }
 
@@ -244,6 +255,7 @@ function productHasRealValueEdits(entry: DeveloperProductEntry): boolean {
 	return (
 		entry.name !== REDACTED_PRODUCT_NAME ||
 		entry.description !== REDACTED_DESCRIPTION ||
-		(entry.icon !== undefined && entry.icon["en-us"] !== REDACTED_ICON_PATH)
+		(entry.icon !== undefined && entry.icon["en-us"] !== REDACTED_ICON_PATH) ||
+		(entry.price !== undefined && entry.price !== REDACTED_PRICE)
 	);
 }

--- a/packages/bedrock/src/core/schema.example.spec.ts
+++ b/packages/bedrock/src/core/schema.example.spec.ts
@@ -19,14 +19,15 @@ import {
 } from '@bedrock-rbx/core'
 
 it('Example 1', () => {
-  const override: RedactedGamePassOverride = { name: 'Closed Beta' }
+  const override: RedactedGamePassOverride = { name: 'Closed Beta', price: 500 }
   const entry: GamePassEntry = {
     name: 'VIP Pass',
     description: 'Grants VIP perks.',
     icon: { 'en-us': 'assets/vip.png' },
+    price: 1500,
     redacted: override,
   }
-  expect(entry.redacted).toStrictEqual({ name: 'Closed Beta' })
+  expect(entry.redacted).toStrictEqual({ name: 'Closed Beta', price: 500 })
 })
 
 it('Example 2', () => {
@@ -43,13 +44,15 @@ it('Example 2', () => {
 it('Example 3', () => {
   const override: RedactedDeveloperProductOverride = {
     name: 'Closed Beta Pack',
+    price: 500,
   }
   const entry: DeveloperProductEntry = {
     name: 'Gem Pack',
     description: 'Stocks the player up with 1,000 premium gems.',
+    price: 1500,
     redacted: override,
   }
-  expect(entry.redacted).toStrictEqual({ name: 'Closed Beta Pack' })
+  expect(entry.redacted).toStrictEqual({ name: 'Closed Beta Pack', price: 500 })
 })
 
 it('Example 4', () => {

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -285,12 +285,14 @@ describe(validateConfig, () => {
 		["partial name override", { name: "Closed Beta" }],
 		["partial description override", { description: "Coming soon." }],
 		["partial icon override", { icon: { "en-us": "assets/closed-beta.png" } }],
+		["partial price override", { price: 500 }],
 		[
 			"full override",
 			{
 				name: "Closed Beta",
 				description: "Coming soon.",
 				icon: { "en-us": "assets/closed-beta.png" },
+				price: 500,
 			},
 		],
 	] as const)(
@@ -409,7 +411,42 @@ describe(validateConfig, () => {
 						name: "VIP Pass",
 						description: "Grants VIP perks.",
 						icon: { "en-us": "assets/vip.png" },
-						redacted: { price: 0 },
+						redacted: { bogus: "value" },
+					},
+				},
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual([
+			"passes",
+			"vip-pass",
+			"redacted",
+			"bogus",
+		]);
+		expect(result.err.issues[0]!.message).toContain("bogus");
+	});
+
+	it.for([
+		["negative", -1],
+		["fractional", 1.5],
+		["NaN", Number.NaN],
+		["Infinity", Number.POSITIVE_INFINITY],
+	] as const)("should reject %s as a redacted price override on a passes entry", ([, price]) => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: MinEnvironments,
+				passes: {
+					"vip-pass": {
+						name: "VIP Pass",
+						description: "Grants VIP perks.",
+						icon: { "en-us": "assets/vip.png" },
+						redacted: { price },
 					},
 				},
 			},
@@ -425,7 +462,29 @@ describe(validateConfig, () => {
 			"redacted",
 			"price",
 		]);
-		expect(result.err.issues[0]!.message).toContain("price");
+	});
+
+	it("should accept zero as a redacted price override on a passes entry", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: MinEnvironments,
+				passes: {
+					"vip-pass": {
+						name: "VIP Pass",
+						description: "Grants VIP perks.",
+						icon: { "en-us": "assets/vip.png" },
+						redacted: { price: 0 },
+					},
+				},
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.passes!["vip-pass"]!.redacted).toStrictEqual({ price: 0 });
 	});
 
 	it("should accept a products collection with a valid developer-product entry", () => {
@@ -717,12 +776,14 @@ describe(validateConfig, () => {
 		["partial name override", { name: "Closed Beta Pack" }],
 		["partial description override", { description: "Coming soon." }],
 		["partial icon override", { icon: { "en-us": "assets/closed-beta.png" } }],
+		["partial price override", { price: 500 }],
 		[
 			"full override",
 			{
 				name: "Closed Beta Pack",
 				description: "Coming soon.",
 				icon: { "en-us": "assets/closed-beta.png" },
+				price: 500,
 			},
 		],
 	] as const)(
@@ -784,7 +845,7 @@ describe(validateConfig, () => {
 					"gem-pack": {
 						name: "Gem Pack",
 						description: "Stocks the player up with 1,000 premium gems.",
-						redacted: { price: 0 },
+						redacted: { bogus: "value" },
 					},
 				},
 			},
@@ -798,9 +859,67 @@ describe(validateConfig, () => {
 			"products",
 			"gem-pack",
 			"redacted",
-			"price",
+			"bogus",
 		]);
-		expect(result.err.issues[0]!.message).toContain("price");
+		expect(result.err.issues[0]!.message).toContain("bogus");
+	});
+
+	it.for([
+		["negative", -1],
+		["fractional", 1.5],
+		["NaN", Number.NaN],
+		["Infinity", Number.POSITIVE_INFINITY],
+	] as const)(
+		"should reject %s as a redacted price override on a products entry",
+		([, price]) => {
+			expect.assertions(1);
+
+			const result = validateConfig(
+				{
+					environments: MinEnvironments,
+					products: {
+						"gem-pack": {
+							name: "Gem Pack",
+							description: "Stocks the player up with 1,000 premium gems.",
+							redacted: { price },
+						},
+					},
+				},
+				SOURCE,
+			);
+
+			assert(!result.success);
+			assert(result.err.kind === "validationFailed");
+
+			expect(result.err.issues[0]!.path).toStrictEqual([
+				"products",
+				"gem-pack",
+				"redacted",
+				"price",
+			]);
+		},
+	);
+
+	it("should accept zero as a redacted price override on a products entry", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: MinEnvironments,
+				products: {
+					"gem-pack": {
+						name: "Gem Pack",
+						description: "Stocks the player up with 1,000 premium gems.",
+						redacted: { price: 0 },
+					},
+				},
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.products!["gem-pack"]!.redacted).toStrictEqual({ price: 0 });
 	});
 
 	it("should accept a root places collection that declares only filePath", () => {

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -23,16 +23,17 @@ import { collectUniverseIdIssues } from "./validate-universe-xor.ts";
  * ```ts
  * import type { GamePassEntry, RedactedGamePassOverride } from "@bedrock-rbx/core/config";
  *
- * const override: RedactedGamePassOverride = { name: "Closed Beta" };
+ * const override: RedactedGamePassOverride = { name: "Closed Beta", price: 500 };
  *
  * const entry: GamePassEntry = {
  *     name: "VIP Pass",
  *     description: "Grants VIP perks.",
  *     icon: { "en-us": "assets/vip.png" },
+ *     price: 1500,
  *     redacted: override,
  * };
  *
- * expect(entry.redacted).toStrictEqual({ name: "Closed Beta" });
+ * expect(entry.redacted).toStrictEqual({ name: "Closed Beta", price: 500 });
  * ```
  */
 export interface RedactedGamePassOverride {
@@ -42,6 +43,12 @@ export interface RedactedGamePassOverride {
 	description?: string | undefined;
 	/** Override icon path; falls through to the embedded placeholder when omitted. */
 	icon?: Record<"en-us", string> | undefined;
+	/**
+	 * Override Robux price; falls through to the bedrock default (`1`) when
+	 * omitted. Ignored when the entry's `price` is `undefined` so an off-sale
+	 * pass stays off-sale through redaction.
+	 */
+	price?: number | undefined;
 }
 
 /**
@@ -96,13 +103,14 @@ export interface GamePassEntry {
 	price?: number | undefined;
 	/**
 	 * Set to `true` to deploy this pass with bedrock-supplied placeholder
-	 * content (default name, empty description, embedded placeholder icon)
-	 * in place of the real values declared above. Set to a
-	 * {@link RedactedGamePassOverride} to substitute selected placeholders
-	 * with custom values while leaving the rest at bedrock defaults; the
-	 * object form implies redaction is enabled. Omit or set `false` to
-	 * push the real values unchanged. Environment overlays accept only the
-	 * boolean form.
+	 * content (default name, empty description, embedded placeholder icon,
+	 * price `1` Robux when the entry is on-sale) in place of the real values
+	 * declared above. Off-sale passes (`price` omitted) stay off-sale. Set
+	 * to a {@link RedactedGamePassOverride} to substitute selected
+	 * placeholders with custom values while leaving the rest at bedrock
+	 * defaults; the object form implies redaction is enabled. Omit or set
+	 * `false` to push the real values unchanged. Environment overlays accept
+	 * only the boolean form.
 	 */
 	redacted?: boolean | RedactedGamePassOverride | undefined;
 }
@@ -122,15 +130,19 @@ export interface GamePassEntry {
  *     RedactedDeveloperProductOverride,
  * } from "@bedrock-rbx/core/config";
  *
- * const override: RedactedDeveloperProductOverride = { name: "Closed Beta Pack" };
+ * const override: RedactedDeveloperProductOverride = {
+ *     name: "Closed Beta Pack",
+ *     price: 500,
+ * };
  *
  * const entry: DeveloperProductEntry = {
  *     name: "Gem Pack",
  *     description: "Stocks the player up with 1,000 premium gems.",
+ *     price: 1500,
  *     redacted: override,
  * };
  *
- * expect(entry.redacted).toStrictEqual({ name: "Closed Beta Pack" });
+ * expect(entry.redacted).toStrictEqual({ name: "Closed Beta Pack", price: 500 });
  * ```
  */
 export interface RedactedDeveloperProductOverride {
@@ -140,6 +152,12 @@ export interface RedactedDeveloperProductOverride {
 	description?: string | undefined;
 	/** Override icon path; falls through to the embedded placeholder when omitted. */
 	icon?: Record<"en-us", string> | undefined;
+	/**
+	 * Override Robux price; falls through to the bedrock default (`1`) when
+	 * omitted. Ignored when the entry's `price` is `undefined` so an off-sale
+	 * product stays off-sale through redaction.
+	 */
+	price?: number | undefined;
 }
 
 /**
@@ -170,9 +188,10 @@ export interface DeveloperProductEntry {
 	price?: number | undefined;
 	/**
 	 * Set to `true` to deploy this product with bedrock-supplied placeholder
-	 * content (default name, empty description, embedded placeholder icon)
-	 * in place of the real values declared above. Set to a
-	 * {@link RedactedDeveloperProductOverride} to substitute selected
+	 * content (default name, empty description, embedded placeholder icon,
+	 * price `1` Robux when the entry is on-sale) in place of the real values
+	 * declared above. Off-sale products (`price` omitted) stay off-sale. Set
+	 * to a {@link RedactedDeveloperProductOverride} to substitute selected
 	 * placeholders with custom values while leaving the rest at bedrock
 	 * defaults; the object form implies redaction is enabled. Omit or set
 	 * `false` to push the real values unchanged. Environment overlays accept
@@ -774,6 +793,7 @@ const gamePassRedactedOverride = type({
 	"description?": "string",
 	"icon?": iconMap,
 	"name?": "string",
+	"price?": OPTIONAL_ROBUX_PRICE,
 })
 	.onUndeclaredKey("reject")
 	.narrow((value, ctx) => {
@@ -805,6 +825,7 @@ const productRedactedOverride = type({
 	"description?": "string",
 	"icon?": iconMap,
 	"name?": "string",
+	"price?": OPTIONAL_ROBUX_PRICE,
 })
 	.onUndeclaredKey("reject")
 	.narrow((value, ctx) => {

--- a/packages/bedrock/src/core/select-environment.spec.ts
+++ b/packages/bedrock/src/core/select-environment.spec.ts
@@ -1,6 +1,6 @@
 import { assert, describe, expect, it } from "vitest";
 
-import { REDACTED_DESCRIPTION, REDACTED_PASS_NAME } from "./redact-resources.ts";
+import { REDACTED_DESCRIPTION, REDACTED_PASS_NAME, REDACTED_PRICE } from "./redact-resources.ts";
 import { REDACTED_ICON_PATH } from "./redacted-icon.ts";
 import type {
 	Config,
@@ -694,7 +694,7 @@ describe(selectEnvironment, () => {
 			name: REDACTED_PASS_NAME,
 			description: REDACTED_DESCRIPTION,
 			icon: { "en-us": REDACTED_ICON_PATH },
-			price: 500,
+			price: REDACTED_PRICE,
 			redacted: true,
 		});
 	});

--- a/packages/bedrock/tests/integration/passes-redacted.spec.ts
+++ b/packages/bedrock/tests/integration/passes-redacted.spec.ts
@@ -17,7 +17,11 @@ import {
 import { GamePassesClient } from "@bedrock-rbx/ocale/game-passes";
 import { createFakeHttpClient, validGamePassBody } from "@bedrock-rbx/ocale/testing";
 
-import { REDACTED_DESCRIPTION, REDACTED_PASS_NAME } from "#src/core/redact-resources";
+import {
+	REDACTED_DESCRIPTION,
+	REDACTED_PASS_NAME,
+	REDACTED_PRICE,
+} from "#src/core/redact-resources";
 import { REDACTED_ICON_BYTES, REDACTED_ICON_PATH } from "#src/core/redacted-icon";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -120,8 +124,8 @@ function persistedPass(
 }
 
 describe("passes-redacted pipeline end-to-end", () => {
-	it("should upload placeholder name, description, and embedded icon bytes when redacted is true", async () => {
-		expect.assertions(4);
+	it("should upload placeholder name, description, embedded icon bytes, and the placeholder price when redacted is true", async () => {
+		expect.assertions(5);
 
 		const loaded = await loadConfig({ cwd: PASSES_FIXTURE_DIR });
 		assert(loaded.success);
@@ -165,6 +169,7 @@ describe("passes-redacted pipeline end-to-end", () => {
 
 		expect(readFormString(captured.request.body, "name")).toBe(REDACTED_PASS_NAME);
 		expect(readFormString(captured.request.body, "description")).toBe(REDACTED_DESCRIPTION);
+		expect(readFormString(captured.request.body, "price")).toBe(String(REDACTED_PRICE));
 		await expect(readFormBytes(captured.request.body, "imageFile")).resolves.toStrictEqual(
 			REDACTED_ICON_BYTES,
 		);
@@ -173,6 +178,122 @@ describe("passes-redacted pipeline end-to-end", () => {
 		assert(created !== undefined);
 
 		expect(created.name).toBe(REDACTED_PASS_NAME);
+	});
+
+	it("should upload the price override and default placeholders when redacted is an object with price", async () => {
+		expect.assertions(2);
+
+		const config = defineConfig({
+			environments: { production: {} },
+			passes: {
+				"vip-pass": {
+					name: "VIP Pass",
+					description: "Grants VIP perks.",
+					icon: { "en-us": "assets/vip.png" },
+					price: 1500,
+					redacted: { price: 500 },
+				},
+			},
+			universe: { universeId: "1234567890" },
+		});
+
+		const resolved = selectEnvironment(config, "production");
+		assert(resolved.success);
+
+		const readFile = panicOnRealPath;
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		assert(desiredResult.success);
+
+		const httpClient = createFakeHttpClient().mockResponse({
+			body: validGamePassBody({
+				name: REDACTED_PASS_NAME,
+				description: REDACTED_DESCRIPTION,
+				gamePassId: 9_876_543_210,
+				iconAssetId: 1_122_334_455,
+			}),
+			status: 200,
+		});
+
+		const registry: DriverRegistry = {
+			developerProduct: DEVELOPER_PRODUCT_TRAP,
+			gamePass: createGamePassDriver({
+				client: new GamePassesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: async () => {},
+				}),
+				readFile,
+				universeId: UNIVERSE_ID,
+			}),
+			place: PLACE_TRAP,
+			universe: UNIVERSE_DRIVER,
+		};
+
+		const applyResult = await applyOps(diff(desiredResult.data, []), registry);
+		assert(applyResult.success);
+
+		const captured = httpClient.requests[0]!;
+
+		expect(readFormString(captured.request.body, "price")).toBe("500");
+		expect(readFormString(captured.request.body, "name")).toBe(REDACTED_PASS_NAME);
+	});
+
+	it("should keep an off-sale pass off-sale on the wire when redacted is true", async () => {
+		expect.assertions(2);
+
+		const config = defineConfig({
+			environments: { production: {} },
+			passes: {
+				"soon-pass": {
+					name: "Coming Soon Pass",
+					description: "Reveal at launch.",
+					icon: { "en-us": "assets/vip.png" },
+					redacted: true,
+				},
+			},
+			universe: { universeId: "1234567890" },
+		});
+
+		const resolved = selectEnvironment(config, "production");
+		assert(resolved.success);
+
+		const readFile = panicOnRealPath;
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		assert(desiredResult.success);
+
+		const httpClient = createFakeHttpClient().mockResponse({
+			body: validGamePassBody({
+				name: REDACTED_PASS_NAME,
+				description: REDACTED_DESCRIPTION,
+				gamePassId: 9_876_543_210,
+				iconAssetId: 1_122_334_455,
+			}),
+			status: 200,
+		});
+
+		const registry: DriverRegistry = {
+			developerProduct: DEVELOPER_PRODUCT_TRAP,
+			gamePass: createGamePassDriver({
+				client: new GamePassesClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: async () => {},
+				}),
+				readFile,
+				universeId: UNIVERSE_ID,
+			}),
+			place: PLACE_TRAP,
+			universe: UNIVERSE_DRIVER,
+		};
+
+		const applyResult = await applyOps(diff(desiredResult.data, []), registry);
+		assert(applyResult.success);
+
+		const captured = httpClient.requests[0]!;
+		assert(captured.request.body instanceof FormData);
+
+		expect(captured.request.body.has("price")).toBeFalse();
+		expect(readFormString(captured.request.body, "name")).toBe(REDACTED_PASS_NAME);
 	});
 
 	it("should re-deploy as a noop when the persisted state already carries the placeholder values", async () => {

--- a/packages/bedrock/tests/integration/products-redacted.spec.ts
+++ b/packages/bedrock/tests/integration/products-redacted.spec.ts
@@ -17,7 +17,11 @@ import {
 import { DeveloperProductsClient } from "@bedrock-rbx/ocale/developer-products";
 import { createFakeHttpClient, validDeveloperProductBody } from "@bedrock-rbx/ocale/testing";
 
-import { REDACTED_DESCRIPTION, REDACTED_PRODUCT_NAME } from "#src/core/redact-resources";
+import {
+	REDACTED_DESCRIPTION,
+	REDACTED_PRICE,
+	REDACTED_PRODUCT_NAME,
+} from "#src/core/redact-resources";
 import { REDACTED_ICON_BYTES, REDACTED_ICON_PATH } from "#src/core/redacted-icon";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -118,8 +122,8 @@ function persistedProduct(
 }
 
 describe("products-redacted pipeline end-to-end", () => {
-	it("should upload placeholder name, description, and embedded icon bytes when redacted is true", async () => {
-		expect.assertions(4);
+	it("should upload placeholder name, description, embedded icon bytes, and the placeholder price when redacted is true", async () => {
+		expect.assertions(5);
 
 		const loaded = await loadConfig({ cwd: PRODUCTS_FIXTURE_DIR });
 		assert(loaded.success);
@@ -163,6 +167,7 @@ describe("products-redacted pipeline end-to-end", () => {
 
 		expect(readFormString(captured.request.body, "name")).toBe(REDACTED_PRODUCT_NAME);
 		expect(readFormString(captured.request.body, "description")).toBe(REDACTED_DESCRIPTION);
+		expect(readFormString(captured.request.body, "price")).toBe(String(REDACTED_PRICE));
 		await expect(readFormBytes(captured.request.body, "imageFile")).resolves.toStrictEqual(
 			REDACTED_ICON_BYTES,
 		);
@@ -171,6 +176,122 @@ describe("products-redacted pipeline end-to-end", () => {
 		assert(created !== undefined);
 
 		expect(created.name).toBe(REDACTED_PRODUCT_NAME);
+	});
+
+	it("should upload the price override and default placeholders when redacted is an object with price", async () => {
+		expect.assertions(2);
+
+		const config = defineConfig({
+			environments: { production: {} },
+			products: {
+				"gem-pack": {
+					name: "Gem Pack",
+					description: "Stocks the player up with 1,000 premium gems.",
+					icon: { "en-us": "assets/gems.png" },
+					price: 1500,
+					redacted: { price: 500 },
+				},
+			},
+			universe: { universeId: "1234567890" },
+		});
+
+		const resolved = selectEnvironment(config, "production");
+		assert(resolved.success);
+
+		const readFile = panicOnRealPath;
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		assert(desiredResult.success);
+
+		const httpClient = createFakeHttpClient().mockResponse({
+			body: validDeveloperProductBody({
+				name: REDACTED_PRODUCT_NAME,
+				description: REDACTED_DESCRIPTION,
+				productId: 8_172_635_495,
+				universeId: 1_234_567_890,
+			}),
+			status: 200,
+		});
+
+		const registry: DriverRegistry = {
+			developerProduct: createDeveloperProductDriver({
+				client: new DeveloperProductsClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: async () => {},
+				}),
+				readFile,
+				universeId: UNIVERSE_ID,
+			}),
+			gamePass: GAME_PASS_TRAP,
+			place: PLACE_TRAP,
+			universe: UNIVERSE_DRIVER,
+		};
+
+		const applyResult = await applyOps(diff(desiredResult.data, []), registry);
+		assert(applyResult.success);
+
+		const captured = httpClient.requests[0]!;
+
+		expect(readFormString(captured.request.body, "price")).toBe("500");
+		expect(readFormString(captured.request.body, "name")).toBe(REDACTED_PRODUCT_NAME);
+	});
+
+	it("should keep an off-sale product off-sale on the wire when redacted is true", async () => {
+		expect.assertions(2);
+
+		const config = defineConfig({
+			environments: { production: {} },
+			products: {
+				"soon-pack": {
+					name: "Coming Soon Pack",
+					description: "Reveal at launch.",
+					icon: { "en-us": "assets/gems.png" },
+					redacted: true,
+				},
+			},
+			universe: { universeId: "1234567890" },
+		});
+
+		const resolved = selectEnvironment(config, "production");
+		assert(resolved.success);
+
+		const readFile = panicOnRealPath;
+		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		assert(desiredResult.success);
+
+		const httpClient = createFakeHttpClient().mockResponse({
+			body: validDeveloperProductBody({
+				name: REDACTED_PRODUCT_NAME,
+				description: REDACTED_DESCRIPTION,
+				productId: 8_172_635_495,
+				universeId: 1_234_567_890,
+			}),
+			status: 200,
+		});
+
+		const registry: DriverRegistry = {
+			developerProduct: createDeveloperProductDriver({
+				client: new DeveloperProductsClient({
+					apiKey: "test-key",
+					httpClient,
+					sleep: async () => {},
+				}),
+				readFile,
+				universeId: UNIVERSE_ID,
+			}),
+			gamePass: GAME_PASS_TRAP,
+			place: PLACE_TRAP,
+			universe: UNIVERSE_DRIVER,
+		};
+
+		const applyResult = await applyOps(diff(desiredResult.data, []), registry);
+		assert(applyResult.success);
+
+		const captured = httpClient.requests[0]!;
+		assert(captured.request.body instanceof FormData);
+
+		expect(captured.request.body.has("price")).toBeFalse();
+		expect(readFormString(captured.request.body, "name")).toBe(REDACTED_PRODUCT_NAME);
 	});
 
 	it("should re-deploy as a noop when the persisted state already carries the placeholder values", async () => {


### PR DESCRIPTION
## Summary

- Extend the redaction set on `gamePass` and `developerProduct` to include `price`, defaulting to `1` Robux when the entry is on-sale.
- Off-sale resources (`price` omitted) stay off-sale through redaction so a hidden product is never accidentally listed for sale.
- The `redacted` object form gains a `price?` field that mirrors how `name` / `description` / `icon` already work; `redacted: { price: 500 }` (and `price: 0` for free) are honoured.
- `hasRealValueEdits` now flags price divergence so plan output keeps surfacing the "real values not pushed" warning when the author's config price differs from the placeholder.

## Why

Until now, the redaction system substituted placeholder name, description, and icon for redacted resources but pushed the real `price` verbatim. A redacted closed-beta pass would still advertise its real cost on Roblox.

## Test plan

- [x] `pnpm gen:example-tests`
- [x] `pnpm build`
- [x] `pnpm test` (3673 passed, 17 skipped) including new slices: default placeholder, off-sale preservation, override (incl. `0`), schema validation (rejects negative / fractional / NaN / Infinity, accepts `0`), wire-level integration assertions for both pass and product.
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm mutate:changed` — 100% mutation score on `redact-resources.ts` (27 killed / 0 survived).