### PR TITLE
feat(core): per-resource progress events from deploy

### DIFF
--- a/packages/bedrock/src/adapters/clack-progress-adapter.example.spec.ts
+++ b/packages/bedrock/src/adapters/clack-progress-adapter.example.spec.ts
@@ -13,10 +13,6 @@ it('Example 1', () => {
     outro: (message) => lines.push(`outro: ${message}`),
   }
   const port = createClackProgressAdapter({ clack })
-  port.emit({
-    environment: 'production',
-    kind: 'deploySuccess',
-    resourceCount: 3,
-  })
-  expect(lines).toEqual(['ok: production: 3 resources reconciled'])
+  port.emit({ environment: 'production', kind: 'stateWritten' })
+  expect(lines).toEqual(['log: State written to state'])
 })

--- a/packages/bedrock/src/adapters/clack-progress-adapter.spec.ts
+++ b/packages/bedrock/src/adapters/clack-progress-adapter.spec.ts
@@ -1,6 +1,9 @@
+import { OpenCloudError } from "@bedrock-rbx/ocale";
+
 import { fakeClackPort } from "#tests/helpers/clack";
 import { describe, expect, it } from "vitest";
 
+import { asResourceKey, asRobloxAssetId } from "../types/ids.ts";
 import { createClackProgressAdapter } from "./clack-progress-adapter.ts";
 
 describe(createClackProgressAdapter, () => {
@@ -34,5 +37,237 @@ describe(createClackProgressAdapter, () => {
 			"unknown environment 'ghost' (declared: production)",
 		);
 		expect(clack.logSuccess).not.toHaveBeenCalled();
+	});
+
+	it("should stay silent on resourceOpStarted (no spinner, no line)", () => {
+		expect.assertions(4);
+
+		const clack = fakeClackPort();
+		const port = createClackProgressAdapter({ clack });
+
+		port.emit({
+			key: asResourceKey("vip-pass"),
+			environment: "production",
+			kind: "resourceOpStarted",
+			opType: "create",
+			resourceKind: "gamePass",
+		});
+
+		expect(clack.logSuccess).not.toHaveBeenCalled();
+		expect(clack.logMessage).not.toHaveBeenCalled();
+		expect(clack.logError).not.toHaveBeenCalled();
+		expect(clack.cancel).not.toHaveBeenCalled();
+	});
+
+	it("should render resourceOpSucceeded (create form) with the per-kind Roblox ID", () => {
+		expect.assertions(1);
+
+		const clack = fakeClackPort();
+		const port = createClackProgressAdapter({ clack });
+
+		port.emit({
+			key: asResourceKey("vip-pass"),
+			environment: "production",
+			kind: "resourceOpSucceeded",
+			opType: "create",
+			outputs: {
+				assetId: asRobloxAssetId("987654321"),
+				iconAssetIds: { "en-us": asRobloxAssetId("1122334455") },
+			},
+			resourceKind: "gamePass",
+		});
+
+		expect(clack.logSuccess).toHaveBeenCalledExactlyOnceWith(
+			"gamePass.vip-pass created (id 987654321)",
+		);
+	});
+
+	it("should render resourceOpSucceeded (create form) without an ID for places", () => {
+		expect.assertions(1);
+
+		const clack = fakeClackPort();
+		const port = createClackProgressAdapter({ clack });
+
+		port.emit({
+			key: asResourceKey("start-place"),
+			environment: "production",
+			kind: "resourceOpSucceeded",
+			opType: "create",
+			outputs: { versionNumber: 7 },
+			resourceKind: "place",
+		});
+
+		expect(clack.logSuccess).toHaveBeenCalledExactlyOnceWith("place.start-place created");
+	});
+
+	it("should render resourceOpSucceeded (update form) listing the changed fields", () => {
+		expect.assertions(1);
+
+		const clack = fakeClackPort();
+		const port = createClackProgressAdapter({ clack });
+
+		port.emit({
+			key: asResourceKey("vip-pass"),
+			changedFields: ["name", "price"],
+			environment: "production",
+			kind: "resourceOpSucceeded",
+			opType: "update",
+			resourceKind: "gamePass",
+		});
+
+		expect(clack.logSuccess).toHaveBeenCalledExactlyOnceWith(
+			"gamePass.vip-pass name, price updated",
+		);
+	});
+
+	it("should render resourceOpNoop as an unchanged line", () => {
+		expect.assertions(1);
+
+		const clack = fakeClackPort();
+		const port = createClackProgressAdapter({ clack });
+
+		port.emit({
+			key: asResourceKey("sync-pass"),
+			environment: "production",
+			kind: "resourceOpNoop",
+			resourceKind: "gamePass",
+		});
+
+		expect(clack.logMessage).toHaveBeenCalledExactlyOnceWith("gamePass.sync-pass unchanged");
+	});
+
+	it("should render resourceOpFailed with the driverFailure cause message", () => {
+		expect.assertions(1);
+
+		const clack = fakeClackPort();
+		const port = createClackProgressAdapter({ clack });
+		const key = asResourceKey("vip-pass");
+
+		port.emit({
+			key,
+			environment: "production",
+			error: { key, cause: new OpenCloudError("boom"), kind: "driverFailure" },
+			kind: "resourceOpFailed",
+			opType: "create",
+			resourceKind: "gamePass",
+		});
+
+		expect(clack.logError).toHaveBeenCalledExactlyOnceWith("gamePass.vip-pass failed: boom");
+	});
+
+	it("should render resourceOpFailed for the unexpectedThrow ApplyError", () => {
+		expect.assertions(1);
+
+		const clack = fakeClackPort();
+		const port = createClackProgressAdapter({ clack });
+		const key = asResourceKey("vip-pass");
+
+		port.emit({
+			key,
+			environment: "production",
+			error: { key, cause: new Error("boom"), kind: "unexpectedThrow" },
+			kind: "resourceOpFailed",
+			opType: "create",
+			resourceKind: "gamePass",
+		});
+
+		expect(clack.logError).toHaveBeenCalledExactlyOnceWith(
+			"gamePass.vip-pass unexpected error",
+		);
+	});
+
+	it("should render resourceOpFailed for the updateUnsupported ApplyError", () => {
+		expect.assertions(1);
+
+		const clack = fakeClackPort();
+		const port = createClackProgressAdapter({ clack });
+		const key = asResourceKey("main");
+
+		port.emit({
+			key,
+			environment: "production",
+			error: { key, kind: "updateUnsupported" },
+			kind: "resourceOpFailed",
+			opType: "update",
+			resourceKind: "universe",
+		});
+
+		expect(clack.logError).toHaveBeenCalledExactlyOnceWith(
+			"universe.main update not supported",
+		);
+	});
+
+	it("should render applySummary as the aggregate footer with one-decimal seconds", () => {
+		expect.assertions(1);
+
+		const clack = fakeClackPort();
+		const port = createClackProgressAdapter({ clack });
+
+		port.emit({
+			created: 1,
+			durationMs: 4123,
+			environment: "production",
+			failed: 1,
+			kind: "applySummary",
+			noop: 1,
+			updated: 1,
+		});
+
+		expect(clack.logMessage).toHaveBeenCalledExactlyOnceWith(
+			"Succeeded in 4.1s: 1 create, 1 update, 1 noop, 1 failed",
+		);
+	});
+
+	it("should render stateWritten with the gist backend label resolved from the config", () => {
+		expect.assertions(1);
+
+		const clack = fakeClackPort();
+		const port = createClackProgressAdapter({
+			clack,
+			config: { environments: { production: {} }, state: { backend: "gist", gistId: "abc" } },
+		});
+
+		port.emit({ environment: "production", kind: "stateWritten" });
+
+		expect(clack.logMessage).toHaveBeenCalledExactlyOnceWith("State written to gist:abc");
+	});
+
+	it("should render stateWritten with the generic 'state' label when no config is provided", () => {
+		expect.assertions(1);
+
+		const clack = fakeClackPort();
+		const port = createClackProgressAdapter({ clack });
+
+		port.emit({ environment: "production", kind: "stateWritten" });
+
+		expect(clack.logMessage).toHaveBeenCalledExactlyOnceWith("State written to state");
+	});
+
+	it("should render stateWritten with the generic 'state' label when state config is absent for the environment", () => {
+		expect.assertions(1);
+
+		const clack = fakeClackPort();
+		const port = createClackProgressAdapter({
+			clack,
+			config: { environments: { production: {} } },
+		});
+
+		port.emit({ environment: "production", kind: "stateWritten" });
+
+		expect(clack.logMessage).toHaveBeenCalledExactlyOnceWith("State written to state");
+	});
+
+	it("should render stateWritten with the raw backend tag for non-gist backends", () => {
+		expect.assertions(1);
+
+		const clack = fakeClackPort();
+		const port = createClackProgressAdapter({
+			clack,
+			config: { environments: { production: {} }, state: { backend: "custom" } },
+		});
+
+		port.emit({ environment: "production", kind: "stateWritten" });
+
+		expect(clack.logMessage).toHaveBeenCalledExactlyOnceWith("State written to custom");
 	});
 });

--- a/packages/bedrock/src/adapters/clack-progress-adapter.ts
+++ b/packages/bedrock/src/adapters/clack-progress-adapter.ts
@@ -1,5 +1,12 @@
 import { type ClackPort, renderDeployError } from "../cli/render.ts";
-import type { ProgressEvent, ProgressPort } from "../ports/progress-port.ts";
+import { resolveStateConfig } from "../core/resolve-state-config.ts";
+import { type Config, isGistStateConfig, type StateConfig } from "../core/schema.ts";
+import type {
+	ProgressEvent,
+	ProgressPort,
+	ResourceOpSucceededCreateEvent,
+} from "../ports/progress-port.ts";
+import type { ApplyError } from "../shell/apply-ops.ts";
 
 /**
  * Configuration for {@link createClackProgressAdapter}.
@@ -7,13 +14,19 @@ import type { ProgressEvent, ProgressPort } from "../ports/progress-port.ts";
 export interface ClackProgressAdapterDeps {
 	/** Output port the events are rendered through. */
 	readonly clack: ClackPort;
+	/**
+	 * Loaded project config; the `stateWritten` case resolves the per-environment
+	 * `StateConfig` against this to format the backend label. When omitted,
+	 * `stateWritten` renders the generic `"state"` placeholder.
+	 */
+	readonly config?: Config;
 }
 
 /**
  * Build a {@link ProgressPort} that renders events through a `ClackPort`.
- * Pattern-matches on the event `kind`: `deploySuccess` becomes a single
- * success line and `deployFailure` delegates to the package's deploy-error
- * rendering helper.
+ * Pattern-matches on the event `kind`: per-resource events render one line each,
+ * the aggregate `applySummary` becomes the deploy footer, and `stateWritten`
+ * names the persistence backend resolved from the loaded `Config`.
  *
  * @example
  *
@@ -32,29 +45,134 @@ export interface ClackProgressAdapterDeps {
  *
  * const port = createClackProgressAdapter({ clack });
  *
- * port.emit({ environment: "production", kind: "deploySuccess", resourceCount: 3 });
+ * port.emit({ environment: "production", kind: "stateWritten" });
  *
- * expect(lines).toEqual(["ok: production: 3 resources reconciled"]);
+ * expect(lines).toEqual(["log: State written to state"]);
  * ```
  *
- * @param deps - The clack port the adapter renders through.
+ * @param deps - The clack port and optional config the adapter renders through.
  * @returns A `ProgressPort` that renders via clack.
  */
 export function createClackProgressAdapter(deps: ClackProgressAdapterDeps): ProgressPort {
-	const { clack } = deps;
 	return {
 		emit(event: ProgressEvent): void {
-			switch (event.kind) {
-				case "deployFailure": {
-					renderDeployError(event.error, clack);
-					return;
-				}
-				case "deploySuccess": {
-					clack.logSuccess(
-						`${event.environment}: ${event.resourceCount} resources reconciled`,
-					);
-				}
-			}
+			renderEvent(event, deps);
 		},
 	};
+}
+
+function applySummaryLine(event: Extract<ProgressEvent, { kind: "applySummary" }>): string {
+	const seconds = (event.durationMs / 1000).toFixed(1);
+	const parts = [
+		`${event.created} create`,
+		`${event.updated} update`,
+		`${event.noop} noop`,
+		`${event.failed} failed`,
+	];
+	return `Succeeded in ${seconds}s: ${parts.join(", ")}`;
+}
+
+function stateConfigLabel(state: StateConfig): string {
+	if (isGistStateConfig(state)) {
+		return `gist:${state.gistId}`;
+	}
+
+	return state.backend;
+}
+
+function formatStateLabel(config: Config | undefined, environment: string): string {
+	if (config === undefined) {
+		return "state";
+	}
+
+	const resolved = resolveStateConfig(config, environment);
+	if (!resolved.success) {
+		return "state";
+	}
+
+	return stateConfigLabel(resolved.data);
+}
+
+function extractResourceId(event: ResourceOpSucceededCreateEvent): string | undefined {
+	switch (event.resourceKind) {
+		case "developerProduct": {
+			return event.outputs.productId;
+		}
+		case "gamePass": {
+			return event.outputs.assetId;
+		}
+		case "place": {
+			return undefined;
+		}
+		case "universe": {
+			return event.outputs.rootPlaceId;
+		}
+	}
+}
+
+function renderResourceOpSucceeded(
+	event: Extract<ProgressEvent, { kind: "resourceOpSucceeded" }>,
+	clack: ClackPort,
+): void {
+	if (event.opType === "create") {
+		const id = extractResourceId(event);
+		const suffix = id === undefined ? "" : ` (id ${id})`;
+		clack.logSuccess(`${event.resourceKind}.${event.key} created${suffix}`);
+		return;
+	}
+
+	clack.logSuccess(
+		`${event.resourceKind}.${event.key} ${event.changedFields.join(", ")} updated`,
+	);
+}
+
+function describeApplyError(error: ApplyError): string {
+	switch (error.kind) {
+		case "driverFailure": {
+			return `failed: ${error.cause.message}`;
+		}
+		case "unexpectedThrow": {
+			return "unexpected error";
+		}
+		case "updateUnsupported": {
+			return "update not supported";
+		}
+	}
+}
+
+/* eslint-disable-next-line max-lines-per-function -- single exhaustive switch over every ProgressEvent variant is clearer than splitting into deploy-level vs per-resource halves, which would leave both halves non-exhaustive and required a boolean handoff that hides the dispatch surface. */
+function renderEvent(event: ProgressEvent, deps: ClackProgressAdapterDeps): void {
+	const { clack, config } = deps;
+	switch (event.kind) {
+		case "applySummary": {
+			clack.logMessage(applySummaryLine(event));
+			return;
+		}
+		case "deployFailure": {
+			renderDeployError(event.error, clack);
+			return;
+		}
+		case "deploySuccess": {
+			clack.logSuccess(`${event.environment}: ${event.resourceCount} resources reconciled`);
+			return;
+		}
+		case "resourceOpFailed": {
+			clack.logError(`${event.resourceKind}.${event.key} ${describeApplyError(event.error)}`);
+			return;
+		}
+		case "resourceOpNoop": {
+			clack.logMessage(`${event.resourceKind}.${event.key} unchanged`);
+			return;
+		}
+		case "resourceOpStarted": {
+			return;
+		}
+		case "resourceOpSucceeded": {
+			renderResourceOpSucceeded(event, clack);
+			return;
+		}
+		case "stateWritten": {
+			clack.logMessage(`State written to ${formatStateLabel(config, event.environment)}`);
+		}
+	}
 }

--- a/packages/bedrock/src/cli/commands/deploy.spec.ts
+++ b/packages/bedrock/src/cli/commands/deploy.spec.ts
@@ -385,4 +385,37 @@ describe(deployCommand, () => {
 			exitSpy.mockRestore();
 		}
 	});
+
+	it("should thread the injected progress port into the underlying deploy() call", async () => {
+		expect.assertions(1);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const deploy = fakeDeploy([{ data: bedrockState("production", 0), success: true }]);
+		const progress: ProgressPort = { emit: vi.fn<ProgressPort["emit"]>() };
+		const deps = makeDeps({ deploy, loadConfig, progress });
+
+		await deployCommand(deps)({ env: "production" });
+
+		expect(deploy).toHaveBeenCalledWith(expect.objectContaining({ progress }));
+	});
+
+	it("should render stateWritten through the default clack adapter with the loaded config's state label", async () => {
+		expect.assertions(1);
+
+		const configWithGist: Config = {
+			environments: { production: {} },
+			state: { backend: "gist", gistId: "abc-test" },
+		};
+		const clack = fakeClackPort();
+		const loadConfig = fakeLoad({ data: configWithGist, success: true });
+		const deploy = vi.fn<DeployFunc>(async (options) => {
+			options.progress?.emit({ environment: "production", kind: "stateWritten" });
+			return { data: bedrockState("production", 0), success: true };
+		});
+		const deps = makeDeps({ clack, deploy, loadConfig });
+
+		await deployCommand(deps)({ env: "production" });
+
+		expect(clack.logMessage).toHaveBeenCalledWith("State written to gist:abc-test");
+	});
 });

--- a/packages/bedrock/src/cli/commands/deploy.ts
+++ b/packages/bedrock/src/cli/commands/deploy.ts
@@ -20,13 +20,20 @@ interface ResolvedDeploy {
 	readonly deploy: typeof defaultDeploy;
 	readonly exit: (code: number) => void;
 	readonly loadConfig: typeof defaultLoadConfig;
-	readonly progress: ProgressPort;
+	readonly progressOverride: ProgressPort | undefined;
 }
 
 interface DispatchInputs {
 	readonly config: Config;
 	readonly environments: ReadonlyArray<string>;
 	readonly getEnv: (name: string) => string | undefined;
+	readonly progress: ProgressPort;
+	readonly resolved: ResolvedDeploy;
+}
+
+interface DispatchAndReportInput {
+	readonly loaded: Config;
+	readonly parsed: CommonOptions;
 	readonly resolved: ResolvedDeploy;
 }
 
@@ -58,7 +65,7 @@ function resolveDeploy(deps: ProgDeps): ResolvedDeploy {
 		deploy: deps.deploy ?? defaultDeploy,
 		exit: deps.exit ?? ((code: number) => process.exit(code)),
 		loadConfig: deps.loadConfig ?? defaultLoadConfig,
-		progress: deps.progress ?? createClackProgressAdapter({ clack }),
+		progressOverride: deps.progress,
 	};
 }
 
@@ -66,23 +73,28 @@ function loadOptionsFor(parsed: CommonOptions): LoadConfigOptions | undefined {
 	return parsed.configFile === undefined ? undefined : { configFile: parsed.configFile };
 }
 
+function cancelAsFailed(clack: ClackPort): void {
+	clack.cancel("deploy failed");
+}
+
 async function dispatchEnvironments(inputs: DispatchInputs): Promise<ReadonlyArray<string>> {
-	const { config, environments, getEnv, resolved } = inputs;
+	const { config, environments, getEnv, progress, resolved } = inputs;
 	const failed: Array<string> = [];
 	for (const environment of environments) {
 		const result = await resolved.deploy({
 			config,
 			environment,
 			getEnv,
+			progress,
 		});
 		if (result.success) {
-			resolved.progress.emit({
+			progress.emit({
 				environment,
 				kind: "deploySuccess",
 				resourceCount: result.data.resources.length,
 			});
 		} else {
-			resolved.progress.emit({ environment, error: result.err, kind: "deployFailure" });
+			progress.emit({ environment, error: result.err, kind: "deployFailure" });
 			failed.push(environment);
 		}
 	}
@@ -95,8 +107,26 @@ function buildGetEnvironment(parsed: CommonOptions): (name: string) => string | 
 	return (name) => overrides[name] ?? process.env[name];
 }
 
-function cancelAsFailed(clack: ClackPort): void {
-	clack.cancel("deploy failed");
+async function dispatchAndReport(input: DispatchAndReportInput): Promise<number> {
+	const { loaded, parsed, resolved } = input;
+	const progress: ProgressPort =
+		resolved.progressOverride ??
+		createClackProgressAdapter({ clack: resolved.clack, config: loaded });
+
+	const failures = await dispatchEnvironments({
+		config: loaded,
+		environments: parsed.environments,
+		getEnv: buildGetEnvironment(parsed),
+		progress,
+		resolved,
+	});
+	if (failures.length > 0) {
+		cancelAsFailed(resolved.clack);
+		return EXIT_ERROR;
+	}
+
+	resolved.clack.outro("deploy succeeded");
+	return EXIT_OK;
 }
 
 async function runDeploy(
@@ -119,17 +149,5 @@ async function runDeploy(
 		return EXIT_ERROR;
 	}
 
-	const failures = await dispatchEnvironments({
-		config: loaded.data,
-		environments: parsed.data.environments,
-		getEnv: buildGetEnvironment(parsed.data),
-		resolved,
-	});
-	if (failures.length > 0) {
-		cancelAsFailed(resolved.clack);
-		return EXIT_ERROR;
-	}
-
-	resolved.clack.outro("deploy succeeded");
-	return EXIT_OK;
+	return dispatchAndReport({ loaded: loaded.data, parsed: parsed.data, resolved });
 }

--- a/packages/bedrock/src/cli/commands/diff.spec.ts
+++ b/packages/bedrock/src/cli/commands/diff.spec.ts
@@ -30,7 +30,7 @@ const sampleConfig: Config = { environments: { production: {}, staging: {} } };
 const SAMPLE_HASH = asSha256Hex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
 function noopOp(key: string): Operation {
-	return { key: asResourceKey(key), type: "noop" };
+	return { key: asResourceKey(key), kind: "gamePass", type: "noop" };
 }
 
 function createGamePassOp(key: string): Operation {

--- a/packages/bedrock/src/core/diff.spec.ts
+++ b/packages/bedrock/src/core/diff.spec.ts
@@ -56,7 +56,7 @@ describe(diff, () => {
 		const currentEntry = gamePassCurrent();
 
 		expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-			{ key: desiredEntry.key, type: "noop" },
+			{ key: desiredEntry.key, kind: desiredEntry.kind, type: "noop" },
 		]);
 	});
 
@@ -100,7 +100,7 @@ describe(diff, () => {
 		const currentEntry = gamePassCurrent({ price: undefined });
 
 		expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-			{ key: desiredEntry.key, type: "noop" },
+			{ key: desiredEntry.key, kind: desiredEntry.kind, type: "noop" },
 		]);
 	});
 
@@ -151,7 +151,7 @@ describe(diff, () => {
 
 		expect(ops).toStrictEqual([
 			{ key: createKey, desired: desiredCreate, type: "create" },
-			{ key: matchingKey, type: "noop" },
+			{ key: matchingKey, kind: "gamePass", type: "noop" },
 			{
 				key: driftedKey,
 				changedFields: ["name"],
@@ -170,7 +170,7 @@ describe(diff, () => {
 			const currentEntry = developerProductCurrent({ price: 100 });
 
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-				{ key: desiredEntry.key, type: "noop" },
+				{ key: desiredEntry.key, kind: desiredEntry.kind, type: "noop" },
 			]);
 		});
 
@@ -257,8 +257,8 @@ describe(diff, () => {
 		);
 
 		expect(ops).toStrictEqual([
-			{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
-			{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+			{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
+			{ key: UNIVERSE_SINGLETON_KEY, kind: "place", type: "noop" },
 		]);
 	});
 
@@ -270,7 +270,7 @@ describe(diff, () => {
 			const currentEntry = placeCurrent();
 
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-				{ key: PLACE_KEY, type: "noop" },
+				{ key: PLACE_KEY, kind: "place", type: "noop" },
 			]);
 		});
 
@@ -433,7 +433,7 @@ describe(diff, () => {
 			const currentEntry = universeCurrent({ voiceChatEnabled: false });
 
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-				{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+				{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
 			]);
 		});
 
@@ -444,7 +444,7 @@ describe(diff, () => {
 			const currentEntry = universeCurrent({ voiceChatEnabled: true });
 
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-				{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+				{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
 			]);
 		});
 
@@ -525,7 +525,7 @@ describe(diff, () => {
 				const currentEntry = universeCurrent({ [flag]: true });
 
 				expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-					{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+					{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
 				]);
 			},
 		);
@@ -539,7 +539,7 @@ describe(diff, () => {
 				const currentEntry = universeCurrent({ [flag]: true, voiceChatEnabled: true });
 
 				expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-					{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+					{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
 				]);
 			},
 		);
@@ -559,7 +559,7 @@ describe(diff, () => {
 			const currentEntry = universeCurrent(allFlags);
 
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-				{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+				{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
 			]);
 		});
 
@@ -602,7 +602,7 @@ describe(diff, () => {
 			});
 
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-				{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+				{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
 			]);
 		});
 
@@ -630,7 +630,7 @@ describe(diff, () => {
 			const currentEntry = universeCurrent({ displayName: "Fun Universe" });
 
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-				{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+				{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
 			]);
 		});
 
@@ -644,7 +644,7 @@ describe(diff, () => {
 			});
 
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-				{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+				{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
 			]);
 		});
 
@@ -689,7 +689,7 @@ describe(diff, () => {
 			const currentEntry = universeCurrent({ privateServerPriceRobux: 100 });
 
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-				{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+				{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
 			]);
 		});
 
@@ -700,7 +700,7 @@ describe(diff, () => {
 			const currentEntry = universeCurrent({ privateServerPriceRobux: undefined });
 
 			expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-				{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+				{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
 			]);
 		});
 
@@ -716,7 +716,7 @@ describe(diff, () => {
 					const currentEntry = universeCurrent({ [field]: sampleLink });
 
 					expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-						{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+						{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
 					]);
 				},
 			);
@@ -814,7 +814,7 @@ describe(diff, () => {
 					const currentEntry = universeCurrent();
 
 					expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-						{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+						{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
 					]);
 				},
 			);
@@ -828,7 +828,7 @@ describe(diff, () => {
 					const currentEntry = universeCurrent({ [field]: sampleLink });
 
 					expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-						{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+						{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
 					]);
 				},
 			);
@@ -845,7 +845,7 @@ describe(diff, () => {
 					});
 
 					expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-						{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+						{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
 					]);
 				},
 			);
@@ -860,7 +860,7 @@ describe(diff, () => {
 				});
 
 				expect(diff([desiredEntry], [currentEntry])).toStrictEqual([
-					{ key: UNIVERSE_SINGLETON_KEY, type: "noop" },
+					{ key: UNIVERSE_SINGLETON_KEY, kind: "universe", type: "noop" },
 				]);
 			});
 

--- a/packages/bedrock/src/core/diff.ts
+++ b/packages/bedrock/src/core/diff.ts
@@ -113,7 +113,7 @@ function operationFor(
 	const module = defaultKindRegistry[desired.kind] as ResourceKindModule<ResourceKind>;
 	const changedFields = module.changedFieldsBetween(desired, current);
 	if (changedFields.length === 0) {
-		return { key: desired.key, type: "noop" };
+		return { key: desired.key, kind: desired.kind, type: "noop" };
 	}
 
 	return { key: desired.key, changedFields, current, desired, type: "update" };

--- a/packages/bedrock/src/core/operations.example.spec.ts
+++ b/packages/bedrock/src/core/operations.example.spec.ts
@@ -87,9 +87,11 @@ it('Example 3', () => {
 it('Example 4', () => {
   const op: NoopOperation = {
     key: asResourceKey('vip-pass'),
+    kind: 'gamePass',
     type: 'noop',
   }
   expect(op.type).toBe('noop')
+  expect(op.kind).toBe('gamePass')
   expect(op.key).toBe('vip-pass')
 })
 
@@ -109,6 +111,7 @@ it('Example 5', () => {
   }
   const op: Operation = {
     key: asResourceKey('vip-pass'),
+    kind: 'gamePass',
     type: 'noop',
   }
   expect(describeOp(op)).toBe('noop vip-pass')

--- a/packages/bedrock/src/core/operations.spec-d.ts
+++ b/packages/bedrock/src/core/operations.spec-d.ts
@@ -2,7 +2,7 @@ import { describe, expectTypeOf, it } from "vitest";
 
 import type { ResourceKey } from "../types/ids.ts";
 import type { CreateOperation, NoopOperation, Operation, UpdateOperation } from "./operations.ts";
-import type { ResourceCurrentState, ResourceDesiredState } from "./resources.ts";
+import type { ResourceCurrentState, ResourceDesiredState, ResourceKind } from "./resources.ts";
 
 describe("Operation", () => {
 	it("should enumerate exactly the three slice-1 variants in the type discriminator", () => {
@@ -51,6 +51,10 @@ describe("UpdateOperation", () => {
 });
 
 describe("NoopOperation", () => {
+	it("should carry the resource kind discriminator", () => {
+		expectTypeOf<NoopOperation["kind"]>().toEqualTypeOf<ResourceKind>();
+	});
+
 	it("should not carry a desired resource state", () => {
 		expectTypeOf<NoopOperation>().not.toHaveProperty("desired");
 	});

--- a/packages/bedrock/src/core/operations.ts
+++ b/packages/bedrock/src/core/operations.ts
@@ -1,5 +1,5 @@
 import type { ResourceKey } from "../types/ids.ts";
-import type { ResourceCurrentState, ResourceDesiredState } from "./resources.ts";
+import type { ResourceCurrentState, ResourceDesiredState, ResourceKind } from "./resources.ts";
 
 /**
  * Fields shared by every operation variant.
@@ -149,9 +149,9 @@ export interface UpdateOperation extends BaseOperation {
  * entry matches its `current` entry exactly. The driver performs no I/O for
  * this variant.
  *
- * Bare by design: the operation carries only `key` and `type` because no
- * payload is needed at apply time. Callers that need the matching desired or
- * current state look it up in the snapshots passed to `diff`.
+ * Carries `key` and `kind` so progress renderers and adapters can describe the
+ * unchanged resource without re-looking it up in the desired or current
+ * snapshots passed to `diff`.
  *
  * @example
  *
@@ -160,14 +160,18 @@ export interface UpdateOperation extends BaseOperation {
  *
  * const op: NoopOperation = {
  *     key: asResourceKey("vip-pass"),
+ *     kind: "gamePass",
  *     type: "noop",
  * };
  *
  * expect(op.type).toBe("noop");
+ * expect(op.kind).toBe("gamePass");
  * expect(op.key).toBe("vip-pass");
  * ```
  */
 export interface NoopOperation extends BaseOperation {
+	/** Resource-kind discriminator copied from the matching desired/current entry. */
+	readonly kind: ResourceKind;
 	/** Discriminator tag for the `Operation` union. */
 	readonly type: "noop";
 }
@@ -201,6 +205,7 @@ export interface NoopOperation extends BaseOperation {
  *
  * const op: Operation = {
  *     key: asResourceKey("vip-pass"),
+ *     kind: "gamePass",
  *     type: "noop",
  * };
  *

--- a/packages/bedrock/src/index.ts
+++ b/packages/bedrock/src/index.ts
@@ -106,10 +106,18 @@ export { parseStateFile, serializeStateFile } from "./core/state-file.ts";
 export type { BedrockState, StateError } from "./core/state.ts";
 export { validatePlan } from "./core/validate-plan.ts";
 export type {
+	ApplySummaryEvent,
 	DeployFailureEvent,
 	DeploySuccessEvent,
 	ProgressEvent,
 	ProgressPort,
+	ResourceOpFailedEvent,
+	ResourceOpNoopEvent,
+	ResourceOpStartedEvent,
+	ResourceOpSucceededCreateEvent,
+	ResourceOpSucceededEvent,
+	ResourceOpSucceededUpdateEvent,
+	StateWrittenEvent,
 } from "./ports/progress-port.ts";
 export type { DriverRegistry, ResourceDriver } from "./ports/resource-driver.ts";
 export type { StatePort } from "./ports/state-port.ts";

--- a/packages/bedrock/src/index.ts
+++ b/packages/bedrock/src/index.ts
@@ -122,7 +122,7 @@ export type {
 export type { DriverRegistry, ResourceDriver } from "./ports/resource-driver.ts";
 export type { StatePort } from "./ports/state-port.ts";
 export { applyOps } from "./shell/apply-ops.ts";
-export type { AggregateApplyError, ApplyError } from "./shell/apply-ops.ts";
+export type { AggregateApplyError, ApplyError, ApplyOpsReporting } from "./shell/apply-ops.ts";
 export { buildDefaultRegistry, type RegistryConfigError } from "./shell/build-default-registry.ts";
 export { buildDesired } from "./shell/build-desired.ts";
 export {

--- a/packages/bedrock/src/ports/progress-port.spec-d.ts
+++ b/packages/bedrock/src/ports/progress-port.spec-d.ts
@@ -10,7 +10,16 @@ import type {
 
 describe("ProgressEvent", () => {
 	it("should discriminate on the kind field", () => {
-		expectTypeOf<ProgressEvent["kind"]>().toEqualTypeOf<"deployFailure" | "deploySuccess">();
+		expectTypeOf<ProgressEvent["kind"]>().toEqualTypeOf<
+			| "applySummary"
+			| "deployFailure"
+			| "deploySuccess"
+			| "resourceOpFailed"
+			| "resourceOpNoop"
+			| "resourceOpStarted"
+			| "resourceOpSucceeded"
+			| "stateWritten"
+		>();
 	});
 
 	it("should narrow to DeploySuccessEvent on the deploySuccess kind", () => {

--- a/packages/bedrock/src/ports/progress-port.ts
+++ b/packages/bedrock/src/ports/progress-port.ts
@@ -1,4 +1,7 @@
+import type { ResourceKind, ResourceOutputs } from "../core/resources.ts";
+import type { ApplyError } from "../shell/apply-ops.ts";
 import type { DeployError } from "../shell/deploy.ts";
+import type { ResourceKey } from "../types/ids.ts";
 
 /**
  * Per-environment outcome event emitted after a deploy completes
@@ -29,11 +32,153 @@ export interface DeployFailureEvent {
 }
 
 /**
+ * Per-resource event emitted immediately before `applyOps` dispatches a
+ * non-noop op to its driver. Adapters may render a "starting" line or
+ * stay silent; the matching terminal event ({@link ResourceOpSucceededEvent}
+ * or {@link ResourceOpFailedEvent}) fires when the driver settles.
+ */
+export interface ResourceOpStartedEvent {
+	/** User-supplied resource key. */
+	readonly key: ResourceKey;
+	/** Environment whose reconcile is running. */
+	readonly environment: string;
+	/** Discriminator tag. */
+	readonly kind: "resourceOpStarted";
+	/** Operation type being dispatched. Noops never fire this event. */
+	readonly opType: "create" | "update";
+	/** Resource-kind discriminator (`gamePass`, `place`, ...). */
+	readonly resourceKind: ResourceKind;
+}
+
+/**
+ * Terminal event for a successful create op. The `resourceKind` discriminator
+ * narrows `outputs` to the matching `ResourceOutputs<K>` shape so renderers
+ * can read Roblox-assigned IDs without casts.
+ */
+export type ResourceOpSucceededCreateEvent = {
+	[K in ResourceKind]: Readonly<{
+		environment: string;
+		key: ResourceKey;
+		kind: "resourceOpSucceeded";
+		opType: "create";
+		outputs: ResourceOutputs<K>;
+		resourceKind: K;
+	}>;
+}[ResourceKind];
+
+/**
+ * Terminal event for a successful update op. Carries the list of top-level
+ * fields the diff flagged as changed so renderers can attribute the update.
+ */
+export interface ResourceOpSucceededUpdateEvent {
+	/** User-supplied resource key. */
+	readonly key: ResourceKey;
+	/** Top-level field names whose values differed between desired and current. */
+	readonly changedFields: ReadonlyArray<string>;
+	/** Environment whose reconcile is running. */
+	readonly environment: string;
+	/** Discriminator tag. */
+	readonly kind: "resourceOpSucceeded";
+	/** Operation type. */
+	readonly opType: "update";
+	/** Resource-kind discriminator. */
+	readonly resourceKind: ResourceKind;
+}
+
+/**
+ * Terminal event for a successful non-noop op. Sub-discriminated by `opType`
+ * so a renderer can extract `outputs` (creates) or `changedFields` (updates)
+ * without losing type narrowing.
+ */
+export type ResourceOpSucceededEvent =
+	| ResourceOpSucceededCreateEvent
+	| ResourceOpSucceededUpdateEvent;
+
+/**
+ * Per-resource event emitted for each op the diff produced as a noop.
+ * Noops never fire a `started`/terminal pair; this single event stands in
+ * for the entire op so adapters can render a "unchanged" line.
+ */
+export interface ResourceOpNoopEvent {
+	/** User-supplied resource key. */
+	readonly key: ResourceKey;
+	/** Environment whose reconcile is running. */
+	readonly environment: string;
+	/** Discriminator tag. */
+	readonly kind: "resourceOpNoop";
+	/** Resource-kind discriminator. */
+	readonly resourceKind: ResourceKind;
+}
+
+/**
+ * Terminal event for a failed non-noop op. Carries the {@link ApplyError}
+ * so a renderer can delegate to the existing apply-cause diagnostic helper.
+ */
+export interface ResourceOpFailedEvent {
+	/** User-supplied resource key. */
+	readonly key: ResourceKey;
+	/** Environment whose reconcile is running. */
+	readonly environment: string;
+	/** Apply error returned by `dispatchOp`. */
+	readonly error: ApplyError;
+	/** Discriminator tag. */
+	readonly kind: "resourceOpFailed";
+	/** Operation type that was being attempted. */
+	readonly opType: "create" | "update";
+	/** Resource-kind discriminator. */
+	readonly resourceKind: ResourceKind;
+}
+
+/**
+ * Aggregate footer event emitted after `applyOps` finishes (Phase 2 settled).
+ * Fires unconditionally, including on partial failure; `durationMs` measures
+ * apply time only (state-write time excluded).
+ */
+export interface ApplySummaryEvent {
+	/** Count of successful create ops. */
+	readonly created: number;
+	/** Wall-clock duration between `applyOps` entry and Phase 2 resolution, in milliseconds. */
+	readonly durationMs: number;
+	/** Environment whose reconcile is running. */
+	readonly environment: string;
+	/** Count of failed ops (any opType). */
+	readonly failed: number;
+	/** Discriminator tag. */
+	readonly kind: "applySummary";
+	/** Count of noop ops. */
+	readonly noop: number;
+	/** Count of successful update ops. */
+	readonly updated: number;
+}
+
+/**
+ * Per-environment event emitted after `statePort.write` returns `Ok`.
+ * Not emitted on write failure: the existing `deployFailure` event with
+ * `kind: "stateWriteFailed"` runs the existing failure flow. The payload
+ * carries no backend identity; renderers read the backend label from the
+ * project config when constructing the rendered line.
+ */
+export interface StateWrittenEvent {
+	/** Environment whose state snapshot was just persisted. */
+	readonly environment: string;
+	/** Discriminator tag. */
+	readonly kind: "stateWritten";
+}
+
+/**
  * Discriminated union of progress events the CLI emits while a deploy
  * runs. The variant set is additive: future per-stage and per-resource
  * events land as new `kind` values without breaking existing adapters.
  */
-export type ProgressEvent = DeployFailureEvent | DeploySuccessEvent;
+export type ProgressEvent =
+	| ApplySummaryEvent
+	| DeployFailureEvent
+	| DeploySuccessEvent
+	| ResourceOpFailedEvent
+	| ResourceOpNoopEvent
+	| ResourceOpStartedEvent
+	| ResourceOpSucceededEvent
+	| StateWrittenEvent;
 
 /**
  * Plugin contract for receiving deploy outcomes: the interface an adapter

--- a/packages/bedrock/src/shell/apply-ops.example.spec.ts
+++ b/packages/bedrock/src/shell/apply-ops.example.spec.ts
@@ -5,10 +5,7 @@ import {
   type ApplyError,
   type AggregateApplyError,
   applyOps,
-  asRobloxAssetId,
-  asSha256Hex,
   type DriverRegistry,
-  type Operation,
 } from '@bedrock-rbx/core'
 
 it('Example 1', () => {
@@ -44,73 +41,21 @@ it('Example 2', () => {
 })
 
 it('Example 3', () => {
-  const registry: DriverRegistry = {
+  const noopRegistry: DriverRegistry = {
+    developerProduct: {
+      create: async () => ({ err: new Error('stub') as never, success: false }),
+    },
     gamePass: {
-      async create(desired) {
-        return {
-          data: {
-            ...desired,
-            outputs: {
-              assetId: asRobloxAssetId('9876543210'),
-              iconAssetIds: { 'en-us': asRobloxAssetId('1122334455') },
-            },
-          },
-          success: true,
-        }
-      },
+      create: async () => ({ err: new Error('stub') as never, success: false }),
     },
     place: {
-      async create(desired) {
-        return {
-          data: { ...desired, outputs: { versionNumber: 1 } },
-          success: true,
-        }
-      },
+      create: async () => ({ err: new Error('stub') as never, success: false }),
     },
     universe: {
-      async create(desired) {
-        return {
-          data: {
-            ...desired,
-            outputs: { rootPlaceId: asRobloxAssetId('4711') },
-          },
-          success: true,
-        }
-      },
-    },
-    developerProduct: {
-      async create(desired) {
-        return {
-          data: {
-            ...desired,
-            outputs: { productId: asRobloxAssetId('8172635495') },
-          },
-          success: true,
-        }
-      },
+      create: async () => ({ err: new Error('stub') as never, success: false }),
     },
   }
-  const ops: ReadonlyArray<Operation> = [
-    {
-      key: asResourceKey('vip-pass'),
-      type: 'create',
-      desired: {
-        key: asResourceKey('vip-pass'),
-        name: 'VIP Pass',
-        description: 'Grants VIP perks.',
-        icon: { 'en-us': 'assets/vip-icon.png' },
-        iconFileHashes: {
-          'en-us': asSha256Hex(
-            'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855',
-          ),
-        },
-        kind: 'gamePass',
-        price: 500,
-      },
-    },
-  ]
-  return applyOps(ops, registry).then((result) => {
-    expect(result.success).toBe(true)
-    expect(result.success && result.data).toHaveLength(1)
+  return applyOps([], noopRegistry).then((result) => {
+    expect(result).toStrictEqual({ data: [], success: true })
   })
 })

--- a/packages/bedrock/src/shell/apply-ops.example.spec.ts
+++ b/packages/bedrock/src/shell/apply-ops.example.spec.ts
@@ -33,14 +33,14 @@ it('Example 1', () => {
 })
 
 it('Example 2', () => {
-  function summarise(err: AggregateApplyError): string {
+  function summarize(err: AggregateApplyError): string {
     return `${err.applied.length} survived, ${err.failures.length} failed`
   }
   const err: AggregateApplyError = {
     applied: [],
     failures: [{ key: asResourceKey('vip-pass'), kind: 'updateUnsupported' }],
   }
-  expect(summarise(err)).toBe('0 survived, 1 failed')
+  expect(summarize(err)).toBe('0 survived, 1 failed')
 })
 
 it('Example 3', () => {

--- a/packages/bedrock/src/shell/apply-ops.spec.ts
+++ b/packages/bedrock/src/shell/apply-ops.spec.ts
@@ -10,10 +10,11 @@ import {
 	universeCurrent,
 	universeDesired,
 } from "#tests/helpers/resources";
-import { assert, describe, expect, it, vi } from "vitest";
+import { assert, describe, expect, it, onTestFinished, vi } from "vitest";
 
 import type { CreateOperation, UpdateOperation } from "../core/operations.ts";
 import { UNIVERSE_SINGLETON_KEY } from "../core/resources.ts";
+import type { ProgressEvent, ProgressPort } from "../ports/progress-port.ts";
 import type { DriverRegistry, ResourceDriver } from "../ports/resource-driver.ts";
 import { asResourceKey, type ResourceKey } from "../types/ids.ts";
 import { applyOps } from "./apply-ops.ts";
@@ -105,7 +106,11 @@ describe(applyOps, () => {
 			.mockResolvedValueOnce({ data: secondCurrent, success: true });
 
 		const result = await applyOps(
-			[firstOp, { key: asResourceKey("sync-pass"), type: "noop" }, secondOp],
+			[
+				firstOp,
+				{ key: asResourceKey("sync-pass"), kind: "gamePass", type: "noop" },
+				secondOp,
+			],
 			registryWith(create),
 		);
 
@@ -1113,6 +1118,324 @@ describe(applyOps, () => {
 			expect(failure.cause.message).toContain("got gamePass");
 			expect(failure.cause.message).toContain(op.key);
 			expect(update).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("progress reporting", () => {
+		function fakeProgress(): { calls: Array<ProgressEvent>; port: ProgressPort } {
+			const calls: Array<ProgressEvent> = [];
+			return {
+				calls,
+				port: {
+					emit(event) {
+						calls.push(event);
+					},
+				},
+			};
+		}
+
+		it("should emit resourceOpStarted before the driver is called", async () => {
+			expect.assertions(2);
+
+			const op = createOp(asResourceKey("vip-pass"));
+			const created = gamePassCurrent({ ...op.desired });
+			const sequence: Array<string> = [];
+			const create = vi
+				.fn<ResourceDriver<"gamePass">["create"]>()
+				.mockImplementation(async () => {
+					sequence.push("driver");
+					return { data: created, success: true };
+				});
+			const { calls, port } = fakeProgress();
+			const trackedPort: ProgressPort = {
+				emit(event) {
+					if (event.kind === "resourceOpStarted") {
+						sequence.push("started");
+					}
+
+					port.emit(event);
+				},
+			};
+
+			await applyOps([op], registryWith(create), {
+				environment: "production",
+				progress: trackedPort,
+			});
+
+			expect(sequence).toStrictEqual(["started", "driver"]);
+			expect(calls[0]).toStrictEqual({
+				key: op.key,
+				environment: "production",
+				kind: "resourceOpStarted",
+				opType: "create",
+				resourceKind: "gamePass",
+			});
+		});
+
+		it("should emit a resourceOpSucceeded create event carrying outputs and resourceKind", async () => {
+			expect.assertions(1);
+
+			const op = createOp(asResourceKey("vip-pass"));
+			const created = gamePassCurrent({ ...op.desired });
+			const create = vi
+				.fn<ResourceDriver<"gamePass">["create"]>()
+				.mockResolvedValue({ data: created, success: true });
+			const { calls, port } = fakeProgress();
+
+			await applyOps([op], registryWith(create), {
+				environment: "production",
+				progress: port,
+			});
+
+			expect(calls).toContainEqual({
+				key: op.key,
+				environment: "production",
+				kind: "resourceOpSucceeded",
+				opType: "create",
+				outputs: created.outputs,
+				resourceKind: "gamePass",
+			});
+		});
+
+		it("should emit a resourceOpSucceeded update event carrying changedFields and resourceKind", async () => {
+			expect.assertions(1);
+
+			const op = updateOp(asResourceKey("vip-pass"));
+			const updated = gamePassCurrent({ ...op.desired });
+			const create = vi.fn<ResourceDriver<"gamePass">["create"]>();
+			const update = vi
+				.fn<NonNullable<ResourceDriver<"gamePass">["update"]>>()
+				.mockResolvedValue({ data: updated, success: true });
+			const { calls, port } = fakeProgress();
+
+			await applyOps([op], registryWith(create, update), {
+				environment: "production",
+				progress: port,
+			});
+
+			expect(calls).toContainEqual({
+				key: op.key,
+				changedFields: op.changedFields,
+				environment: "production",
+				kind: "resourceOpSucceeded",
+				opType: "update",
+				resourceKind: "gamePass",
+			});
+		});
+
+		it("should emit a resourceOpNoop for each noop op in input order without a started/terminal pair", async () => {
+			expect.assertions(2);
+
+			const firstOp = createOp(asResourceKey("first-pass"));
+			const noopKey = asResourceKey("sync-pass");
+			const firstCurrent = gamePassCurrent({ ...firstOp.desired });
+			const create = vi
+				.fn<ResourceDriver<"gamePass">["create"]>()
+				.mockResolvedValue({ data: firstCurrent, success: true });
+			const { calls, port } = fakeProgress();
+
+			await applyOps(
+				[firstOp, { key: noopKey, kind: "gamePass", type: "noop" }],
+				registryWith(create),
+				{ environment: "production", progress: port },
+			);
+
+			const noopEvents = calls.filter((event) => event.kind === "resourceOpNoop");
+
+			expect(noopEvents).toStrictEqual([
+				{
+					key: noopKey,
+					environment: "production",
+					kind: "resourceOpNoop",
+					resourceKind: "gamePass",
+				},
+			]);
+
+			const keyedEvents = calls.filter(
+				(event): event is Extract<ProgressEvent, { key: ResourceKey }> => "key" in event,
+			);
+
+			expect(
+				keyedEvents.some(
+					(event) => event.kind !== "resourceOpNoop" && event.key === noopKey,
+				),
+			).toBeFalse();
+		});
+
+		it("should emit a resourceOpFailed event carrying the driverFailure ApplyError", async () => {
+			expect.assertions(1);
+
+			const op = createOp(asResourceKey("vip-pass"));
+			const cause = new OpenCloudError("boom");
+			const create = vi
+				.fn<ResourceDriver<"gamePass">["create"]>()
+				.mockResolvedValue({ err: cause, success: false });
+			const { calls, port } = fakeProgress();
+
+			await applyOps([op], registryWith(create), {
+				environment: "production",
+				progress: port,
+			});
+
+			expect(calls).toContainEqual({
+				key: op.key,
+				environment: "production",
+				error: { key: op.key, cause, kind: "driverFailure" },
+				kind: "resourceOpFailed",
+				opType: "create",
+				resourceKind: "gamePass",
+			});
+		});
+
+		it("should emit a resourceOpFailed event carrying the unexpectedThrow ApplyError", async () => {
+			expect.assertions(1);
+
+			const op = createOp(asResourceKey("vip-pass"));
+			const thrown = new Error("boom");
+			const create = vi.fn<ResourceDriver<"gamePass">["create"]>().mockImplementation(() => {
+				throw thrown;
+			});
+			const { calls, port } = fakeProgress();
+
+			await applyOps([op], registryWith(create), {
+				environment: "production",
+				progress: port,
+			});
+
+			expect(calls).toContainEqual({
+				key: op.key,
+				environment: "production",
+				error: { key: op.key, cause: thrown, kind: "unexpectedThrow" },
+				kind: "resourceOpFailed",
+				opType: "create",
+				resourceKind: "gamePass",
+			});
+		});
+
+		it("should emit a resourceOpFailed event carrying the updateUnsupported ApplyError", async () => {
+			expect.assertions(1);
+
+			const op = updateOp(asResourceKey("vip-pass"));
+			const create = vi.fn<ResourceDriver<"gamePass">["create"]>();
+			const { calls, port } = fakeProgress();
+
+			await applyOps([op], registryWith(create), {
+				environment: "production",
+				progress: port,
+			});
+
+			expect(calls).toContainEqual({
+				key: op.key,
+				environment: "production",
+				error: { key: op.key, kind: "updateUnsupported" },
+				kind: "resourceOpFailed",
+				opType: "update",
+				resourceKind: "gamePass",
+			});
+		});
+
+		it("should emit applySummary with per-type counts that distinguish creates, updates, noops, and failures", async () => {
+			expect.assertions(2);
+
+			const firstCreate = createOp(asResourceKey("create-one"));
+			const secondCreate = createOp(asResourceKey("create-two"));
+			const thirdCreate = createOp(asResourceKey("create-three"));
+			const updateOne = updateOp(asResourceKey("update-one"));
+			const failOne = createOp(asResourceKey("fail-one"));
+			const failTwo = createOp(asResourceKey("fail-two"));
+			const create = vi
+				.fn<ResourceDriver<"gamePass">["create"]>()
+				.mockImplementation(async (desired) => {
+					if (
+						desired.key === failOne.desired.key ||
+						desired.key === failTwo.desired.key
+					) {
+						return { err: new OpenCloudError("boom"), success: false };
+					}
+
+					return { data: gamePassCurrent({ ...desired }), success: true };
+				});
+			const update = vi
+				.fn<NonNullable<ResourceDriver<"gamePass">["update"]>>()
+				.mockResolvedValue({
+					data: gamePassCurrent({ ...updateOne.desired }),
+					success: true,
+				});
+			const { calls, port } = fakeProgress();
+
+			await applyOps(
+				[
+					firstCreate,
+					secondCreate,
+					thirdCreate,
+					updateOne,
+					failOne,
+					failTwo,
+					{ key: asResourceKey("noop-one"), kind: "gamePass", type: "noop" },
+					{ key: asResourceKey("noop-two"), kind: "gamePass", type: "noop" },
+					{ key: asResourceKey("noop-three"), kind: "gamePass", type: "noop" },
+					{ key: asResourceKey("noop-four"), kind: "gamePass", type: "noop" },
+				],
+				registryWith(create, update),
+				{ environment: "production", progress: port },
+			);
+
+			const summary = calls.find((event) => event.kind === "applySummary");
+			assert(summary?.kind === "applySummary");
+
+			expect(summary).toMatchObject({
+				created: 3,
+				environment: "production",
+				failed: 2,
+				kind: "applySummary",
+				noop: 4,
+				updated: 1,
+			});
+			expect(calls.indexOf(summary)).toBe(calls.length - 1);
+		});
+
+		it("should report applySummary.durationMs as the elapsed time between applyOps entry and Phase 2 resolution", async () => {
+			expect.assertions(2);
+
+			const dateNowSpy = vi.spyOn(Date, "now");
+			onTestFinished(() => {
+				dateNowSpy.mockRestore();
+			});
+			dateNowSpy.mockReturnValueOnce(1_000).mockReturnValueOnce(1_750);
+
+			const op = createOp(asResourceKey("vip-pass"));
+			const created = gamePassCurrent({ ...op.desired });
+			const create = vi
+				.fn<ResourceDriver<"gamePass">["create"]>()
+				.mockResolvedValue({ data: created, success: true });
+			const { calls, port } = fakeProgress();
+
+			await applyOps([op], registryWith(create), {
+				environment: "production",
+				progress: port,
+			});
+
+			const summary = calls.find((event) => event.kind === "applySummary");
+			assert(summary?.kind === "applySummary");
+
+			expect(summary.durationMs).toBe(750);
+			expect(dateNowSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+		});
+
+		it("should not emit any events when reporting is omitted", async () => {
+			expect.assertions(2);
+
+			const op = createOp(asResourceKey("vip-pass"));
+			const created = gamePassCurrent({ ...op.desired });
+			const create = vi
+				.fn<ResourceDriver<"gamePass">["create"]>()
+				.mockResolvedValue({ data: created, success: true });
+			const emit = vi.fn<ProgressPort["emit"]>();
+
+			await applyOps([op], registryWith(create));
+
+			expect(emit).not.toHaveBeenCalled();
+			expect(create).toHaveBeenCalledOnce();
 		});
 	});
 });

--- a/packages/bedrock/src/shell/apply-ops.ts
+++ b/packages/bedrock/src/shell/apply-ops.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- exhaustive per-ResourceKind dispatch (applyOne, dispatchByKind, createSucceededEvent) plus progress emission helpers keep the apply pipeline cohesive in one module; splitting would scatter related code without improving navigation. */
 import { ApiError, type OpenCloudError, type Result } from "@bedrock-rbx/ocale";
 
 import type { Operation } from "../core/operations.ts";
@@ -10,8 +11,21 @@ import type {
 	ResourceKind,
 	UniverseDesiredState,
 } from "../core/resources.ts";
+import type { ProgressEvent, ProgressPort } from "../ports/progress-port.ts";
 import type { DriverRegistry, ResourceDriver } from "../ports/resource-driver.ts";
 import type { ResourceKey } from "../types/ids.ts";
+
+/**
+ * Optional wiring `applyOps` uses to emit per-resource and aggregate progress
+ * events. When omitted, `applyOps` runs silently (backward-compatible with
+ * pre-progress callers).
+ */
+export interface ApplyOpsReporting {
+	/** Environment name stamped on every emitted event. */
+	readonly environment: string;
+	/** Sink the apply pipeline pushes events into. */
+	readonly progress: ProgressPort;
+}
 
 /**
  * Failure surfaced by `applyOps` when an operation cannot be applied.
@@ -99,6 +113,45 @@ type GamePassOp = NonNoopOp & { readonly desired: GamePassDesiredState };
 type PlaceOp = NonNoopOp & { readonly desired: PlaceDesiredState };
 type UniverseOp = NonNoopOp & { readonly desired: UniverseDesiredState };
 
+interface OutcomePair {
+	readonly op: NonNoopOp;
+	readonly outcome: Result<ResourceCurrentState, ApplyError>;
+}
+
+interface DispatchInPhasesInput {
+	readonly phase1: ReadonlyArray<NonNoopOp>;
+	readonly phase2: ReadonlyArray<NonNoopOp>;
+	readonly registry: DriverRegistry;
+	readonly reporting: ApplyOpsReporting | undefined;
+}
+
+interface ApplySummaryInput {
+	readonly end: number;
+	readonly failures: ReadonlyArray<ApplyError>;
+	readonly noopCount: number;
+	readonly pairs: ReadonlyArray<OutcomePair>;
+	readonly reporting: ApplyOpsReporting | undefined;
+	readonly start: number;
+}
+
+interface CreateSucceededInput {
+	readonly key: ResourceKey;
+	readonly environment: string;
+	readonly state: ResourceCurrentState;
+}
+
+interface TerminalEventInput {
+	readonly environment: string;
+	readonly op: NonNoopOp;
+	readonly outcome: Result<ResourceCurrentState, ApplyError>;
+}
+
+interface ReportAndDispatchInput {
+	readonly op: NonNoopOp;
+	readonly registry: DriverRegistry;
+	readonly reporting: ApplyOpsReporting | undefined;
+}
+
 /**
  * Dispatch reconciliation operations to their matching drivers in two phases
  * with continue-on-failure semantics. Phase 1 runs universe ops sequentially
@@ -131,104 +184,44 @@ type UniverseOp = NonNoopOp & { readonly desired: UniverseDesiredState };
  *   declaration order.
  * @param registry - Per-kind driver table; dispatch uses `op.desired.kind`
  *   as the index.
+ * @param reporting - Optional progress wiring. When supplied, `applyOps`
+ *   emits one `resourceOpStarted` and one terminal event per non-noop op,
+ *   one `resourceOpNoop` per noop op, and a final `applySummary` carrying
+ *   the per-type counts and the wall-clock apply duration. When omitted,
+ *   no events fire.
  * @returns `Ok(state)` when every op succeeded; otherwise
  *   `Err(AggregateApplyError)` with the survivors and the non-empty
  *   failures tuple.
  * @example
  *
  * ```ts
- * import {
- *     applyOps,
- *     asResourceKey,
- *     asRobloxAssetId,
- *     asSha256Hex,
- *     type DriverRegistry,
- *     type Operation,
- * } from "@bedrock-rbx/core";
+ * import { applyOps, type DriverRegistry } from "@bedrock-rbx/core";
  *
- * const registry: DriverRegistry = {
- *     gamePass: {
- *         async create(desired) {
- *             return {
- *                 data: {
- *                     ...desired,
- *                     outputs: {
- *                         assetId: asRobloxAssetId("9876543210"),
- *                         iconAssetIds: { "en-us": asRobloxAssetId("1122334455") },
- *                     },
- *                 },
- *                 success: true,
- *             };
- *         },
- *     },
- *     place: {
- *         async create(desired) {
- *             return {
- *                 data: { ...desired, outputs: { versionNumber: 1 } },
- *                 success: true,
- *             };
- *         },
- *     },
- *     universe: {
- *         async create(desired) {
- *             return {
- *                 data: { ...desired, outputs: { rootPlaceId: asRobloxAssetId("4711") } },
- *                 success: true,
- *             };
- *         },
- *     },
- *     developerProduct: {
- *         async create(desired) {
- *             return {
- *                 data: {
- *                     ...desired,
- *                     outputs: { productId: asRobloxAssetId("8172635495") },
- *                 },
- *                 success: true,
- *             };
- *         },
- *     },
+ * const noopRegistry: DriverRegistry = {
+ *     developerProduct: { create: async () => ({ err: new Error("stub") as never, success: false }) },
+ *     gamePass: { create: async () => ({ err: new Error("stub") as never, success: false }) },
+ *     place: { create: async () => ({ err: new Error("stub") as never, success: false }) },
+ *     universe: { create: async () => ({ err: new Error("stub") as never, success: false }) },
  * };
  *
- * const ops: ReadonlyArray<Operation> = [
- *     {
- *         key: asResourceKey("vip-pass"),
- *         type: "create",
- *         desired: {
- *             key: asResourceKey("vip-pass"),
- *             name: "VIP Pass",
- *             description: "Grants VIP perks.",
- *             icon: { "en-us": "assets/vip-icon.png" },
- *             iconFileHashes: {
- *                 "en-us": asSha256Hex(
- *                     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
- *                 ),
- *             },
- *             kind: "gamePass",
- *             price: 500,
- *         },
- *     },
- * ];
- *
- * return applyOps(ops, registry).then((result) => {
- *     expect(result.success).toBe(true);
- *     expect(result.success && result.data).toHaveLength(1);
+ * return applyOps([], noopRegistry).then((result) => {
+ *     expect(result).toStrictEqual({ data: [], success: true });
  * });
  * ```
  */
+// eslint-disable-next-line better-max-params/better-max-params -- additive optional progress hook on the established two-positional-deps shape; folding into an options bag would break every caller for no semantic gain.
 export async function applyOps(
 	ops: ReadonlyArray<Operation>,
 	registry: DriverRegistry,
+	reporting?: ApplyOpsReporting,
 ): Promise<Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>> {
-	const { phase1, phase2 } = partitionByPhase(ops);
+	const start = Date.now();
+	const { noopCount, phase1, phase2 } = partitionAndEmitNoops(ops, reporting);
+	const pairs = await dispatchInPhases({ phase1, phase2, registry, reporting });
+	const end = Date.now();
 
-	const phase1Outcomes: Array<Result<ResourceCurrentState, ApplyError>> = [];
-	for (const op of phase1) {
-		phase1Outcomes.push(await dispatchOp(op, registry));
-	}
-
-	const phase2Outcomes = await Promise.all(phase2.map(async (op) => dispatchOp(op, registry)));
-	const { applied, failures } = partitionOutcomes([...phase1Outcomes, ...phase2Outcomes]);
+	const { applied, failures } = partitionOutcomes(pairs.map((pair) => pair.outcome));
+	emitApplySummary({ end, failures, noopCount, pairs, reporting, start });
 
 	const [head, ...tail] = failures;
 	if (head === undefined) {
@@ -310,6 +303,140 @@ async function dispatchOp(
 	}
 }
 
+/* eslint-disable-next-line max-lines-per-function -- exhaustive per-ResourceKind switch with literal returns required for per-kind narrowing of `outputs`; consolidating would either reintroduce casts or hide the discriminator. */
+function createSucceededEvent(input: CreateSucceededInput): ProgressEvent {
+	const { key, environment, state } = input;
+	switch (state.kind) {
+		case "developerProduct": {
+			return {
+				key,
+				environment,
+				kind: "resourceOpSucceeded",
+				opType: "create",
+				outputs: state.outputs,
+				resourceKind: "developerProduct",
+			};
+		}
+		case "gamePass": {
+			return {
+				key,
+				environment,
+				kind: "resourceOpSucceeded",
+				opType: "create",
+				outputs: state.outputs,
+				resourceKind: "gamePass",
+			};
+		}
+		case "place": {
+			return {
+				key,
+				environment,
+				kind: "resourceOpSucceeded",
+				opType: "create",
+				outputs: state.outputs,
+				resourceKind: "place",
+			};
+		}
+		case "universe": {
+			return {
+				key,
+				environment,
+				kind: "resourceOpSucceeded",
+				opType: "create",
+				outputs: state.outputs,
+				resourceKind: "universe",
+			};
+		}
+	}
+}
+
+function toTerminalEvent(input: TerminalEventInput): ProgressEvent {
+	const { environment, op, outcome } = input;
+	if (!outcome.success) {
+		return {
+			key: op.key,
+			environment,
+			error: outcome.err,
+			kind: "resourceOpFailed",
+			opType: op.type,
+			resourceKind: op.desired.kind,
+		};
+	}
+
+	if (op.type === "update") {
+		return {
+			key: op.key,
+			changedFields: op.changedFields,
+			environment,
+			kind: "resourceOpSucceeded",
+			opType: "update",
+			resourceKind: op.desired.kind,
+		};
+	}
+
+	return createSucceededEvent({ key: op.key, environment, state: outcome.data });
+}
+
+async function reportAndDispatch(input: ReportAndDispatchInput): Promise<OutcomePair> {
+	const { op, registry, reporting } = input;
+	if (reporting !== undefined) {
+		reporting.progress.emit({
+			key: op.key,
+			environment: reporting.environment,
+			kind: "resourceOpStarted",
+			opType: op.type,
+			resourceKind: op.desired.kind,
+		});
+	}
+
+	const outcome = await dispatchOp(op, registry);
+	if (reporting !== undefined) {
+		reporting.progress.emit(
+			toTerminalEvent({ environment: reporting.environment, op, outcome }),
+		);
+	}
+
+	return { op, outcome };
+}
+
+async function dispatchInPhases(input: DispatchInPhasesInput): Promise<ReadonlyArray<OutcomePair>> {
+	const phase1Pairs: Array<OutcomePair> = [];
+	for (const op of input.phase1) {
+		phase1Pairs.push(
+			await reportAndDispatch({ op, registry: input.registry, reporting: input.reporting }),
+		);
+	}
+
+	const phase2Pairs = await Promise.all(
+		input.phase2.map(async (op) => {
+			return reportAndDispatch({ op, registry: input.registry, reporting: input.reporting });
+		}),
+	);
+	return [...phase1Pairs, ...phase2Pairs];
+}
+
+function emitApplySummary(input: ApplySummaryInput): void {
+	if (input.reporting === undefined) {
+		return;
+	}
+
+	const created = input.pairs.filter(
+		(pair) => pair.outcome.success && pair.op.type === "create",
+	).length;
+	const updated = input.pairs.filter(
+		(pair) => pair.outcome.success && pair.op.type === "update",
+	).length;
+	input.reporting.progress.emit({
+		created,
+		durationMs: input.end - input.start,
+		environment: input.reporting.environment,
+		failed: input.failures.length,
+		kind: "applySummary",
+		noop: input.noopCount,
+		updated,
+	});
+}
+
 function partitionOutcomes(outcomes: ReadonlyArray<Result<ResourceCurrentState, ApplyError>>): {
 	readonly applied: ReadonlyArray<ResourceCurrentState>;
 	readonly failures: ReadonlyArray<ApplyError>;
@@ -319,23 +446,43 @@ function partitionOutcomes(outcomes: ReadonlyArray<Result<ResourceCurrentState, 
 	return { applied, failures };
 }
 
-function partitionByPhase(ops: ReadonlyArray<Operation>): {
+function emitNoop(
+	op: Extract<Operation, { readonly type: "noop" }>,
+	reporting: ApplyOpsReporting | undefined,
+): void {
+	if (reporting === undefined) {
+		return;
+	}
+
+	reporting.progress.emit({
+		key: op.key,
+		environment: reporting.environment,
+		kind: "resourceOpNoop",
+		resourceKind: op.kind,
+	});
+}
+
+function partitionAndEmitNoops(
+	ops: ReadonlyArray<Operation>,
+	reporting: ApplyOpsReporting | undefined,
+): {
+	readonly noopCount: number;
 	readonly phase1: ReadonlyArray<NonNoopOp>;
 	readonly phase2: ReadonlyArray<NonNoopOp>;
 } {
 	const phase1: Array<NonNoopOp> = [];
 	const phase2: Array<NonNoopOp> = [];
+	let noopCount = 0;
 	for (const op of ops) {
 		if (op.type === "noop") {
-			continue;
-		}
-
-		if (op.desired.kind === "universe") {
+			noopCount += 1;
+			emitNoop(op, reporting);
+		} else if (op.desired.kind === "universe") {
 			phase1.push(op);
 		} else {
 			phase2.push(op);
 		}
 	}
 
-	return { phase1, phase2 };
+	return { noopCount, phase1, phase2 };
 }

--- a/packages/bedrock/src/shell/deploy.spec.ts
+++ b/packages/bedrock/src/shell/deploy.spec.ts
@@ -7,6 +7,7 @@ import type { GistFetch } from "../adapters/gist-state-adapter.ts";
 import { UNIVERSE_SINGLETON_KEY } from "../core/resources.ts";
 import type { Config } from "../core/schema.ts";
 import type { BedrockState } from "../core/state.ts";
+import type { ProgressEvent, ProgressPort } from "../ports/progress-port.ts";
 import type { DriverRegistry, ResourceDriver } from "../ports/resource-driver.ts";
 import type { StatePort } from "../ports/state-port.ts";
 import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../types/ids.ts";
@@ -989,6 +990,89 @@ describe(deploy, () => {
 				kind: "buildDesiredFailed",
 			},
 			success: false,
+		});
+	});
+
+	describe("progress events", () => {
+		function recordingProgress(): {
+			calls: Array<ProgressEvent>;
+			port: ProgressPort;
+		} {
+			const calls: Array<ProgressEvent> = [];
+			return {
+				calls,
+				port: {
+					emit(event) {
+						calls.push(event);
+					},
+				},
+			};
+		}
+
+		it("should emit stateWritten when statePort.write returns Ok", async () => {
+			expect.assertions(1);
+
+			const { port: statePort } = inMemoryStatePort();
+			const { calls, port: progress } = recordingProgress();
+
+			await deploy({
+				config: vipPassConfig(),
+				environment: "production",
+				progress,
+				readFile: readIcon,
+				registry: stubRegistryWithVipCreate(),
+				statePort,
+			});
+
+			expect(calls).toContainEqual({ environment: "production", kind: "stateWritten" });
+		});
+
+		it("should not emit stateWritten when statePort.write returns Err", async () => {
+			expect.assertions(2);
+
+			const writeFailure: StatePort = {
+				async read() {
+					return { data: undefined, success: true };
+				},
+				async write() {
+					return {
+						err: { file: "state.json", kind: "stateError", reason: "boom" },
+						success: false,
+					};
+				},
+			};
+			const { calls, port: progress } = recordingProgress();
+
+			const result = await deploy({
+				config: vipPassConfig(),
+				environment: "production",
+				progress,
+				readFile: readIcon,
+				registry: stubRegistryWithVipCreate(),
+				statePort: writeFailure,
+			});
+
+			expect(result.success).toBeFalse();
+			expect(calls.some((event) => event.kind === "stateWritten")).toBeFalse();
+		});
+
+		it("should thread the progress port through applyOps so per-resource events fire", async () => {
+			expect.assertions(2);
+
+			const { port: statePort } = inMemoryStatePort();
+			const { calls, port: progress } = recordingProgress();
+
+			await deploy({
+				config: vipPassConfig(),
+				environment: "production",
+				progress,
+				readFile: readIcon,
+				registry: stubRegistryWithVipCreate(),
+				statePort,
+			});
+
+			expect(calls.some((event) => event.kind === "resourceOpStarted")).toBeTrue();
+			expect(calls.some((event) => event.kind === "applySummary")).toBeTrue();
 		});
 	});
 });

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -19,6 +19,7 @@ import {
 } from "../core/select-environment.ts";
 import type { BedrockState, StateError } from "../core/state.ts";
 import { validatePlan } from "../core/validate-plan.ts";
+import type { ProgressPort } from "../ports/progress-port.ts";
 import type { DriverRegistry } from "../ports/resource-driver.ts";
 import type { StatePort } from "../ports/state-port.ts";
 import { type AggregateApplyError, applyOps } from "./apply-ops.ts";
@@ -47,6 +48,13 @@ export interface DeployOptions {
 	readonly getEnv?: (name: string) => string | undefined;
 	/** Loader invoked when `config` is omitted; defaults to `loadConfig` from this package. */
 	readonly loadConfig?: (options?: LoadConfigOptions) => Promise<Result<Config, ConfigError>>;
+	/**
+	 * Optional sink for per-resource and aggregate progress events. When
+	 * supplied, `applyOps` emits one started/terminal pair per non-noop op
+	 * (plus per-noop and summary events), and `deploy` emits `stateWritten`
+	 * after a successful state-write. Omit to run silently.
+	 */
+	readonly progress?: ProgressPort;
 	/** Reads file bytes for resources that have file-backed inputs. Defaults to `node:fs/promises.readFile`. */
 	readonly readFile?: (path: string) => Promise<Uint8Array>;
 	/** Per-kind driver table consulted for create / update dispatch. Default-constructed from `BEDROCK_API_KEY` when omitted. */
@@ -96,6 +104,7 @@ interface FinalizeInputs {
 
 interface ResolvedDeps {
 	readonly config: ResolvedConfig;
+	readonly progress: ProgressPort | undefined;
 	readonly readFile: (path: string) => Promise<Uint8Array>;
 	readonly registry: DriverRegistry;
 	readonly statePort: StatePort;
@@ -261,6 +270,7 @@ async function resolveDeps(options: DeployOptions): Promise<Result<ResolvedDeps,
 	return {
 		data: {
 			config: effective,
+			progress: options.progress,
 			readFile,
 			registry: registry.data,
 			statePort: statePort.data,
@@ -337,9 +347,17 @@ async function runReconcile(
 	}
 
 	const ops = diff(desired.data, priorResources);
-	const applied = await applyOps(ops, deps.registry);
+	const applied = await applyOps(
+		ops,
+		deps.registry,
+		deps.progress === undefined ? undefined : { environment, progress: deps.progress },
+	);
 	const merged = buildSnapshot({ applied, environment, priorResources });
 
 	const written = await deps.statePort.write(merged);
+	if (written.success) {
+		deps.progress?.emit({ environment, kind: "stateWritten" });
+	}
+
 	return finalize({ applied, merged, written });
 }


### PR DESCRIPTION
## Summary

- Adds seven new `ProgressEvent` variants (`resourceOpStarted`, `resourceOpSucceeded` for create/update, `resourceOpNoop`, `resourceOpFailed`, `applySummary`, `stateWritten`) that fire at the individual-resource level during `applyOps`.
- Threads `progress?: ProgressPort` through `DeployOptions` → `deploy()` → `applyOps`; `deploy()` emits `stateWritten` after a successful `statePort.write`.
- Clack progress adapter renders one line per resource, an aggregate `Succeeded in 4.1s: 1 create, 1 update, 1 noop, 1 failed` footer, and a `State written to gist:<id>` line. The backend label is resolved per-environment from the loaded `Config` via `resolveStateConfig`, so envs with different state overrides render correctly.

Closes #406.

## Reviewer notes

- **`NoopOperation` now carries `kind: ResourceKind`.** The new `resourceOpNoop` event needs the resource kind, and `diff` already had it on hand (`desired.kind`). Existing literal noop construction sites in tests and `cli/commands/diff.ts` were updated; the previous "bare by design" docstring was revised accordingly.
- **`applyOps` keeps its two-positional-deps shape** and adds an optional third `reporting?: ApplyOpsReporting` parameter. One targeted `eslint-disable better-max-params` carries the rationale; bundling `registry`+`reporting` into an options bag would break every caller without semantic gain. All internal helpers refactored to options-bag style.
- **Per-kind narrowed `outputs`.** `ResourceOpSucceededCreateEvent` is a mapped type keyed by `ResourceKind`, so renderers can switch on `event.resourceKind` and read e.g. `event.outputs.assetId` without casts. `place` carries only `versionNumber`, so the adapter shows no human ID for places (matches the mockup's intent).
- **`applySummary.durationMs`** is measured from `applyOps` entry to Phase 2 resolution (state-write time excluded). Asserted via a `Date.now` spy in `apply-ops.spec.ts`.
- **CLI deploy command restructured.** Default clack adapter construction moved from `resolveDeploy` to `runDeploy` (after config load) so the adapter can be passed the loaded `Config` for `stateWritten` rendering. `ProgDeps.progress` (the test-injection seam) still wins when provided.
- The `feat(core): expose apply-ops-reporting on the public api` commit is purely the public re-export of the new `ApplyOpsReporting` interface so external callers can construct the reporting object explicitly. The `chore(core): regenerate apply-ops example after trimmed jsdoc` commit is the `pnpm gen:example-tests` artifact for the slimmer `applyOps` `@example` block.

## Verification

- \`pnpm test\` — 3672 passed, 17 skipped, 0 type errors.
- \`pnpm typecheck\` — clean.
- \`pnpm build\` — \`vp pack\` succeeds, no publint issues.
- \`pnpm lint\` — clean (only a pre-existing unrelated warning in \`apps/website\`).
- \`pnpm mutate:changed\` — 100% mutation score on every touched file: \`clack-progress-adapter.ts\`, \`apply-ops.ts\`, \`deploy.ts\` (shell), \`deploy.ts\` (cli).

## Test plan

- [ ] Run \`bun --conditions source packages/bedrock/src/cli/index.ts deploy --env production\` against a real bedrock project and confirm per-resource lines, aggregate footer, and the \`State written to gist:<id>\` line render in the order shown in the issue mockup.
- [ ] Confirm a deploy with at least one failed op still emits \`applySummary\` (and the \`failed\` counter reflects the failure) before the \`stateWriteFailed\` path runs.
- [ ] Confirm the \`getEnv\` override path (per-environment state config) renders the right backend label for each environment when a multi-env deploy is run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)