### PR TITLE
fix(core): distinguish rate-limit from auth in gist state adapter

### DIFF
--- a/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
@@ -182,6 +182,62 @@ describe(createGistStateAdapter, () => {
 			},
 		);
 
+		it("should err with a rate-limited reason on 403 carrying a Retry-After header", async () => {
+			expect.assertions(4);
+
+			const { fetchFn } = fakeFetch(
+				() => new Response("", { headers: { "Retry-After": "60" }, status: 403 }),
+			);
+			const port = createGistStateAdapter({ fetch: fetchFn, gistId: GIST_ID, token: TOKEN });
+
+			const result = await port.read("production");
+
+			expect(result.success).toBeFalse();
+
+			assert(!result.success);
+
+			expect(result.err.reason).toMatch(/rate limit/u);
+			expect(result.err.reason).not.toMatch(/auth failed/u);
+			expect(result.err.reason).toContain("60");
+		});
+
+		it("should err with a rate-limited reason on 403 carrying X-RateLimit-Remaining: 0", async () => {
+			expect.assertions(4);
+
+			const { fetchFn } = fakeFetch(
+				() => new Response("", { headers: { "X-RateLimit-Remaining": "0" }, status: 403 }),
+			);
+			const port = createGistStateAdapter({ fetch: fetchFn, gistId: GIST_ID, token: TOKEN });
+
+			const result = await port.read("production");
+
+			expect(result.success).toBeFalse();
+
+			assert(!result.success);
+
+			expect(result.err.reason).toMatch(/rate limit/u);
+			expect(result.err.reason).not.toMatch(/auth failed/u);
+			expect(result.err.reason).not.toMatch(/retry after/u);
+		});
+
+		it("should err with an auth reason on 401 even when rate-limit headers are present", async () => {
+			expect.assertions(3);
+
+			const { fetchFn } = fakeFetch(
+				() => new Response("", { headers: { "Retry-After": "60" }, status: 401 }),
+			);
+			const port = createGistStateAdapter({ fetch: fetchFn, gistId: GIST_ID, token: TOKEN });
+
+			const result = await port.read("production");
+
+			expect(result.success).toBeFalse();
+
+			assert(!result.success);
+
+			expect(result.err.reason).toMatch(/auth failed/u);
+			expect(result.err.reason).not.toMatch(/rate limit/u);
+		});
+
 		it("should err with a network-error reason when fetch throws", async () => {
 			expect.assertions(2);
 

--- a/packages/bedrock/src/adapters/gist-state-adapter.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.ts
@@ -58,7 +58,7 @@ interface GistFile {
 interface HttpFailure {
 	readonly file: string;
 	readonly gistId: string;
-	readonly status: number;
+	readonly response: Response;
 }
 
 interface ReadContentParameters {
@@ -153,9 +153,27 @@ function toGistFile(entry: unknown): GistFile | undefined {
 	return { content, isTruncated, rawUrl, size };
 }
 
-function mapHttpError({ file, gistId, status }: HttpFailure): StateError {
+function isRateLimited(headers: Headers): boolean {
+	return headers.get("retry-after") !== null || headers.get("x-ratelimit-remaining") === "0";
+}
+
+function rateLimitReason(status: number, headers: Headers): string {
+	const retryAfter = headers.get("retry-after");
+	if (retryAfter !== null) {
+		return `rate limited (${status}): retry after ${retryAfter}s`;
+	}
+
+	return `rate limited (${status})`;
+}
+
+function mapHttpError({ file, gistId, response }: HttpFailure): StateError {
+	const { headers, status } = response;
 	if (status === 404) {
 		return { file, kind: "stateError", reason: `gist ${gistId} not found: check gistId` };
+	}
+
+	if (status === 403 && isRateLimited(headers)) {
+		return { file, kind: "stateError", reason: rateLimitReason(status, headers) };
 	}
 
 	if (status === 401 || status === 403) {
@@ -224,7 +242,7 @@ async function fetchGistBody(
 
 	if (!response.ok) {
 		return {
-			err: mapHttpError({ file, gistId: ctx.gistId, status: response.status }),
+			err: mapHttpError({ file, gistId: ctx.gistId, response }),
 			success: false,
 		};
 	}
@@ -371,7 +389,7 @@ async function writePath(
 	}
 
 	return {
-		err: mapHttpError({ file, gistId: ctx.gistId, status: response.status }),
+		err: mapHttpError({ file, gistId: ctx.gistId, response }),
 		success: false,
 	};
 }


### PR DESCRIPTION
## Summary

A 403 from GitHub's gist API previously surfaced as `auth failed (403): check token scopes` regardless of whether the underlying cause was a real auth failure or a primary/secondary rate-limit. We hit this firsthand while triaging the smoke-test failure across PR #426: every test failed with the misleading "check token scopes" message, sending the investigation toward token configuration when the actual cause was GitHub's secondary rate-limit kicking in after a burst of CI runs.

`mapHttpError` now receives the full `Response` and, on a 403, looks for `Retry-After` or `X-RateLimit-Remaining: 0` headers. When present, it emits `rate limited (403): retry after Ns` (with the `Retry-After` value if available) instead of the auth message. 401 is unchanged — GitHub does not 401 on rate-limit, so even with rate-limit-looking headers the response is still treated as auth.

The two helpers (`isRateLimited`, `rateLimitReason`) are local to the adapter; no public API change. `StateError.reason` is still a plain string; only its content shifts for the rate-limit case.

## Test plan

- [x] `pnpm vp test run src/adapters/gist-state-adapter.spec.ts` — 51/51, including three new tests covering Retry-After, X-RateLimit-Remaining:0, and the 401-still-auth case
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm mutate:changed` — 100% (23/23 mutants killed, including the `if (retryAfter !== null)` conditional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Bedrock Code Review: PR `#430`

### ✅ ARCHITECTURE COMPLIANCE

**FCIS Pattern:** Fully compliant.
- Changes isolated to the **Adapter** layer (gist-state-adapter), the correct location for HTTP error handling.
- Two new helper functions (`isRateLimited`, `rateLimitReason`) are **local to the adapter** — no public API surface expanded.
- No I/O in Core, no business logic in Shell.
- StatePort interface signature unchanged; no public contract breakage.

**Error Handling Boundary:** Proper placement.
- The adapter now inspects response **headers** at the I/O boundary before returning errors to the shell — defensive design at the right layer.
- Checks are case-insensitive and defensive: `headers.get("retry-after")` and `headers.get("x-ratelimit-remaining") === "0"`.

---

### ✅ TESTING COMPLIANCE (100% Coverage + Mutation Testing)

**TDD Observed:**
- Three new test cases cover the conditional branches:
  1. `should err with a rate-limited reason on 403 carrying a Retry-After header` — verifies retry-after message and excludes "auth failed"
  2. `should err with a rate-limited reason on 403 carrying X-RateLimit-Remaining: 0` — verifies rate-limit detection without retry-after
  3. `should err with an auth reason on 401 even when rate-limit headers are present` — ensures 401 always means auth failure, not rate-limit

**Test Quality:**
- All tests follow `it("should <behavior>")` naming convention (36 tests in file, all compliant).
- Explicit `expect.assertions(N)` counts on every test — enforced TDD discipline.
- Use of `fakeFetch` callback responder ensures **test isolation** (no real HTTP).
- Assertions use `.toMatch()` regex and `.toContain()` for semantic error message validation.
- **Mutation testing:** PR claims "pnpm mutate:changed — 100% (23/23 mutants killed)" — the new conditional is properly testable.
- **Test suite:** "51/51" passing including the new tests.

---

### ✅ TEST ISOLATION

Adapter test pattern is correct:
- Injected `fakeFetch` callback-based fake transport (no mocking framework cruft).
- Tests verify error **reasons** (string content) not status codes — testing the adapter's interpretation, not parroting the HTTP layer.
- Read/write paths both tested.

---

### ✅ SECURITY & CONSTRAINTS

- Open Cloud compatible (GitHub Gist API via PAT token).
- State files remain resource-ID-only (no secrets stored); token is config-time injection, not persisted.
- External input (HTTP response, headers) validated at adapter boundary before reaching Core.

---

### ✅ CODE QUALITY

- **TypeScript strict mode:** No `any` types in diffs.
- **Error typing:** Proper `Result<T, StateError>` return types throughout.
- **Defensive headers:** Checks both `retry-after` and `x-ratelimit-remaining: 0` for robustness.
- **Error message clarity:** Distinguishes "rate limited (403): retry after 60s" (new) from "auth failed (403): check token scopes" (unchanged).
- **Logic priority:** 403+rate-limit-header → rate-limit error; 401 → always auth (correct, GitHub never uses 401 for rate-limits).

---

### 📊 CHANGE SUMMARY

| Aspect | Status |
|--------|--------|
| Architecture | ✅ Adapter-only, no Core/Shell changes |
| Public API | ✅ No exports changed |
| Tests | ✅ 3 new, 51/51 passing, 100% mutation coverage |
| Coverage | ✅ Stated as 100% (no coverage report attached; assume pre-commit gate passed) |
| Code quality | ✅ Strict TypeScript, proper error typing |
| Test isolation | ✅ Injected fakes, no real HTTP |
| Security | ✅ No secrets in state, token config-time injection |

**Minor Observation (non-blocking):** The refactor from `status: number` to `response: Response` in the internal `HttpFailure` struct is internal-only and necessary for the feature. No revision required.

---

### ✅ READY TO MERGE

PR meets all Bedrock standards. Changes are minimal, focused, well-tested, and properly isolated to the adapter layer. Mutation testing confirmation provides strong confidence in branch coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/430?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->