### PR TITLE
docs: amend adr-024 for env-scope redaction overrides

### DIFF
--- a/docs/adr/024-resource-redaction.md
+++ b/docs/adr/024-resource-redaction.md
@@ -364,3 +364,63 @@ tracked in [issue #431](https://github.com/christopher-buss/bedrock/issues/431).
 | `developerProduct` | `name` | `` `Hidden Product ${suffix}` `` |
 
 Other rows are unchanged from the 2026-05-16 table above.
+
+## Amendment -- 2026-05-19 (env-scope overrides and field-level merging)
+
+Three changes lift restrictions the original Decision placed on the redaction surface, plus a default-value bump for the price field added in [#427](https://github.com/christopher-buss/bedrock/pull/427).
+
+### Default redacted price for game-pass and developer-product
+
+`REDACTED_PRICE` becomes `99999`. The original Decision's Placeholder defaults table did not cover `price`; [#427](https://github.com/christopher-buss/bedrock/pull/427) introduced `price` as a redactable field with an implicit default of `1`. The bump is a fail-safe shift. A misconfigured redacted resource erring on "unbuyable" is preferable to one erring on "accidentally cheap": the former is embarrassing, the latter risks revenue loss and premature reveal of monetization metadata.
+
+Off-sale resources (`price: undefined`) continue to stay off-sale through redaction; the default applies only when a real price is set.
+
+### Placeholder defaults (price-aware)
+
+| Kind               | Field   | Default                  |
+| ------------------ | ------- | ------------------------ |
+| `gamePass`         | `price` | `99999` (when on-sale)   |
+| `developerProduct` | `price` | `99999` (when on-sale)   |
+
+Other rows are unchanged from earlier tables.
+
+### Env-level cross-kind override object accepted
+
+The "Env-level override object" alternative is no longer deferred. A concrete use case has surfaced: an author needs every redactable product and pass in an env to ship with `{ price: 1 }` (or another uniform override) without repeating the override per resource.
+
+`environments.<env>.redacted` accepts `boolean | RedactedEnvironmentOverride | undefined`, where `RedactedEnvironmentOverride` carries the union of redactable fields across kinds:
+
+| Field         | Applies to                                                  |
+| ------------- | ----------------------------------------------------------- |
+| `name`        | `gamePass`, `developerProduct`                              |
+| `description` | `gamePass`, `developerProduct`, `place`                     |
+| `icon`        | `gamePass`, `developerProduct`                              |
+| `price`       | `gamePass`, `developerProduct`                              |
+| `displayName` | `place`, `universe` (when explicitly redacted via override) |
+
+Per-kind application: each redactable kind picks up only the fields its own override type supports. Fields a kind does not recognize are silently ignored for that kind. The "kind-specific field eligibility" concern raised in the original Alternatives Considered section is resolved by this rule.
+
+### Per-resource env-overlay object form accepted
+
+Each per-resource entry inside an env overlay (`environments.<env>.passes.<key>`, `.products.<key>`, `.places.<key>`) accepts the kind's existing override object form alongside `boolean`. The env-overlay surface aligns with the root resource entry, removing the public-API asymmetry where the exported `RedactedGamePassOverride`, `RedactedDeveloperProductOverride`, and `RedactedPlaceOverride` types appeared usable wherever `redacted` was mentioned but were rejected at env scope. Covers user story 17 from the PRD ([#408](https://github.com/christopher-buss/bedrock/issues/408)).
+
+### Field-level merging precedence
+
+Layers compose field-by-field rather than whole-object. The original Precedence section's "most-specific layer wins" reading was consistent with both whole-object and field-level merging because only one layer (root-resource) carried object form; the question had no observable answer. With object form at every layer the choice is explicit.
+
+Layer order remains most-specific to least-specific. Short forms below are convenient nicknames used through the rest of this amendment:
+
+```text
+env-resource (per-resource inside an env overlay)
+  > root-resource (per-resource at root)
+  > env-level (cross-kind on the env entry)
+```
+
+Resolution is two-step:
+
+1. **State.** The first non-undefined `redacted` value sets the redaction state. `false` carves out: the resource is not redacted and lower layers are moot. `true` or object form enables redaction; proceed to step 2.
+2. **Fields.** Walk every object-form layer encountered (most-specific to least-specific). Merge fields with the most-specific layer's value winning per field. Boolean `true` contributes no fields. Bedrock kind defaults fill any field still unset.
+
+Canonical example: `products.myProduct.redacted = { name: "Hidden" }` at root combined with `environments.dev.redacted = { price: 1 }` at env-level resolves, for dev's `myProduct`, to `{ name: "Hidden", price: 1 }` plus kind defaults for `description` and `icon`.
+
+The Negative section clause about authors needing to "repeat the override on each env overlay's entry" is superseded: root-level overrides now compose with env-level and env-resource overrides automatically.

--- a/docs/adr/024-resource-redaction.md
+++ b/docs/adr/024-resource-redaction.md
@@ -367,7 +367,7 @@ Other rows are unchanged from the 2026-05-16 table above.
 
 ## Amendment -- 2026-05-19 (env-scope overrides and field-level merging)
 
-Three changes lift restrictions the original Decision placed on the redaction surface, plus a default-value bump for the price field added in [#427](https://github.com/christopher-buss/bedrock/pull/427).
+Four coupled changes: three lift restrictions the original Decision placed on the redaction surface, and one bumps the default for the price field added in [#427](https://github.com/christopher-buss/bedrock/pull/427).
 
 ### Default redacted price for game-pass and developer-product
 


### PR DESCRIPTION
## Summary

Appends a 2026-05-19 amendment block to ADR-024 covering four coupled changes to the redaction surface, locked in via a grilling session.

- **Default redacted price bump.** `REDACTED_PRICE` becomes `99999` for both `gamePass` and `developerProduct`. Fail-safe shift: a misconfigured redacted resource erring on "unbuyable" is preferable to one erring on "accidentally cheap". Fills the gap left by [#427](https://github.com/christopher-buss/bedrock/pull/427), which added `price` to the redactable field set without amending the Placeholder defaults table.
- **Env-level cross-kind override accepted.** Reverses the original Alternatives Considered rejection of the env-level override object form. The concrete use case driving the reversal: an author wants every redactable product and pass in `dev` to ship with `{ price: 1 }` without per-resource repetition. New public type `RedactedEnvironmentOverride` carries the union of redactable fields with per-kind application semantics (each kind picks up only fields its override type supports).
- **Per-resource env-overlay object form accepted.** Brings env-overlay entries into line with root resource entries. Removes the public-API asymmetry where the exported per-kind override types appeared usable wherever `redacted` was mentioned but were rejected at env scope. Covers user story 17 from PRD [#408](https://github.com/christopher-buss/bedrock/issues/408).
- **Field-level merging precedence.** Layers compose field-by-field rather than whole-object. The original "most-specific layer wins" framing was vacuously consistent with both readings because object form lived only at root-resource; with object form now at every layer the choice is explicit. Two-step resolution: state (first non-undefined wins; `false` carves out) then field merge (most-specific layer's value wins per field; boolean `true` contributes no fields).

The Negative section clause about authors needing to "repeat the override on each env overlay's entry" is superseded by the new precedence rule.

## Implementation tracked separately

- [#433](https://github.com/christopher-buss/bedrock/issues/433): price default bump
- [#434](https://github.com/christopher-buss/bedrock/issues/434): env-scope override surface

Both AFK-ready, independent, parallelizable. They now work against an authoritative spec rather than carrying ADR work in their own bodies.

## Test plan

- [x] `git diff` confirms a single docs-only file change scoped to the ADR amendment.
- [x] Pre-commit `hk` gates passed (no-commit-to-branch, check-merge-conflict, detect-private-key, lint, gen-example-tests, commitlint).
- [ ] Reviewer cross-checks the precedence rule reads coherently against the original Decision / Precedence section.
- [ ] Reviewer cross-checks the per-kind application table matches each kind's existing redacted-override type surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# ADR-024 Amendment: Env-Scope Redaction Overrides and Field-Level Merging

## Summary

This documentation-only amendment to ADR-024 (Resource Redaction) appends three coupled design decisions that broaden the redaction configuration surface and clarify merging semantics. No code changes; all implementation work is tracked separately.

## Changes

**docs/adr/024-resource-redaction.md** — Added three subsections (2026-05-19 amendment block):

### 1. Default Redacted Price Bump
- Establishes `REDACTED_PRICE = 99999` for on-sale `gamePass` and `developerProduct` 
- Rationale: fail-safe preference for "unbuyable" over "accidentally cheap" (avoids accidental revenue loss and metadata leakage from misconfiguration)
- Off-sale resources remain off-sale through redaction
- Backfill for PR `#427`, which added `price` as a redactable field without updating placeholder defaults

### 2. Env-Level Cross-Kind Override Object
- Reverses the original "Env-level override object" alternative rejection (originally deferred for lack of concrete use case)
- `environments.<env>.redacted` now accepts `boolean | RedactedEnvironmentOverride | undefined`
- `RedactedEnvironmentOverride` carries the union of redactable fields with per-kind application: each kind silently ignores unsupported fields
- Resolves "kind-specific field eligibility" concern by applying fields only to kinds that recognize them

### 3. Per-Resource Env-Overlay Object Form
- Permits `environments.<env>.passes|products|places.<key>.redacted` to accept kind-specific override object form (alongside boolean)
- Removes public-API asymmetry: exported override types (`RedactedGamePassOverride`, etc.) were syntactically valid but rejected at env scope
- Addresses PRD user story 17 (issue `#408`)

### 4. Field-Level Merging Precedence (Two-Step Resolution)
- Clarifies that layers compose **field-by-field**, not whole-object ("most-specific layer wins per field")
- **Step 1 (State):** First non-undefined `redacted` value wins; `false` carves out (no redaction, lower layers moot); `true` or object form enables redaction
- **Step 2 (Fields):** For enabled redaction, walk object-form layers (env-resource > root-resource > env-level), merge field-by-field with most-specific value winning per field; boolean `true` contributes zero fields; bedrock kind defaults fill remaining gaps
- Example: `products.myProduct.redacted = { name: "Hidden" }` + `environments.dev.redacted = { price: 1 }` → `{ name: "Hidden", price: 1 }` + kind defaults for `description`, `icon`
- Supersedes original Negative clause requiring authors to repeat overrides per env-overlay entry

## Architectural Assessment

**FCIS Compliance:** No implementation changes in this commit; the amendment is purely design documentation. Existing `applyRedaction` and related core functions remain pure (no I/O, no side effects).

**Testing & Coverage:** Implementation of the three lifted restrictions (env-level override object, per-resource env-overlay object form, field-level merging) is tracked separately in issues `#433` (price default bump) and `#434` (env-scope override surface). This amendment documents the design; test/implementation work is gated independently.

**Public API Impact:** Amendment impacts the public config schema (`RedactedEnvironmentOverride` type, expanded `environments.<env>.redacted` shape, expanded env-overlay entry shapes). Per ADR-017, these are backward-compatible additive changes (authors who do not use the new forms see current behavior unchanged).

**Security & Constraints:** No deviation from existing open-cloud-only, no-secrets-in-state constraints. Redaction strategy remains unchanged.

## References

- Related PRs: `#427` (price as redactable field), `#426` (developer-product name suffix), `#432` (moderation-safe defaults)
- Implementation tracking: issues `#433`, `#434`
- User story: PRD `#408` (per-resource env-overlay object form)
- Moderation filter workarounds: issue `#431`

## Review Status

Documentation-only; pre-commit gates (markdownlint, docs build) passed. Two reviewer cross-checks remain per PR status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->