### PR TITLE
chore: auto-recover stale bind mount in remote mutation offload

### DIFF
--- a/.config/cspell.config.yaml
+++ b/.config/cspell.config.yaml
@@ -15,6 +15,7 @@ words:
   - monocart
   - nonwords
   - ocale
+  - pgrep
   - pulumi
   - rbxl
   - rbxlx

--- a/scripts/mutate-remote.ts
+++ b/scripts/mutate-remote.ts
@@ -13,6 +13,13 @@
  * to its own remote staging dir (basename of cwd), so concurrent
  * agents on the same host don't clobber each other.
  *
+ * If the container is running but its bind mount has gone stale
+ * (Docker Desktop's WSL share commonly detaches after Docker Desktop
+ * restarts), the runner attempts `docker restart` once to re-establish
+ * the mount. It first checks for an in-flight mutation on the shared
+ * container and refuses to restart when one is detected so a
+ * concurrent worktree's run isn't clobbered.
+ *
  * The diff is computed locally and shipped as a file because git
  * worktrees use a `.git` file pointing at a path that only exists on
  * the local machine; the remote does not need a working `.git`.
@@ -247,6 +254,65 @@ function containerSeesWorktree(config: RemoteConfig): boolean {
 	return result.status === 0;
 }
 
+function containerHasActiveMutation(config: RemoteConfig): boolean {
+	const result = spawnSync(
+		"ssh",
+		[
+			...SSH_OPTS,
+			config.host,
+			"docker",
+			"exec",
+			config.container,
+			"pgrep",
+			"-f",
+			"bedrock-mutate.sh|stryker",
+		],
+		{ stdio: ["ignore", "ignore", "ignore"] },
+	);
+	// pgrep exits 1 when nothing matches. Treat any other non-zero
+	// status (2 syntax, 3 fatal, 127 missing binary) as "active" so
+	// we never restart on uncertainty.
+	return result.status !== 1;
+}
+
+function restartContainer(config: RemoteConfig): boolean {
+	const result = spawnSync(
+		"ssh",
+		[...SSH_OPTS, config.host, "docker", "restart", config.container],
+		{ stdio: ["ignore", "ignore", "inherit"] },
+	);
+	return result.status === 0;
+}
+
+function recoverBindMount(config: RemoteConfig): string | undefined {
+	if (containerHasActiveMutation(config)) {
+		return (
+			`${config.container} cannot see /data/worktrees/${config.worktree} after rsync, ` +
+			"but another mutation is in progress on the shared container; refusing to " +
+			"docker restart and clobber it. Retry once the other run finishes, or restart " +
+			`${config.container} by hand if you know the bind mount is stale.`
+		);
+	}
+
+	if (!restartContainer(config)) {
+		return (
+			`${config.container} cannot see /data/worktrees/${config.worktree} after rsync ` +
+			`and docker restart ${config.container} failed; run docker rm -f ${config.container} ` +
+			`and re-create with -v ${config.stage}:/data/worktrees to re-establish the WSL share.`
+		);
+	}
+
+	if (!containerSeesWorktree(config)) {
+		return (
+			`${config.container} still cannot see /data/worktrees/${config.worktree} after ` +
+			"docker restart; bind mount is severely detached. Run docker rm -f " +
+			`${config.container} and re-create with -v ${config.stage}:/data/worktrees.`
+		);
+	}
+
+	return undefined;
+}
+
 function setupRemote(config: RemoteConfig): string | undefined {
 	const upStatus = rsyncUp(config);
 	if (upStatus !== 0) {
@@ -254,11 +320,10 @@ function setupRemote(config: RemoteConfig): string | undefined {
 	}
 
 	if (!containerSeesWorktree(config)) {
-		return (
-			`${config.container} cannot see /data/worktrees/${config.worktree} after rsync; ` +
-			`bind mount may be detached. Fix: docker rm -f ${config.container}, then re-run ` +
-			`with -v ${config.stage}:/data/worktrees so Docker Desktop re-establishes the WSL share.`
-		);
+		const recoveryFailure = recoverBindMount(config);
+		if (recoveryFailure !== undefined) {
+			return recoveryFailure;
+		}
 	}
 
 	const diff = computeDiff();

--- a/scripts/mutate-remote.ts
+++ b/scripts/mutate-remote.ts
@@ -13,12 +13,13 @@
  * to its own remote staging dir (basename of cwd), so concurrent
  * agents on the same host don't clobber each other.
  *
- * If the container is running but its bind mount has gone stale
- * (Docker Desktop's WSL share commonly detaches after Docker Desktop
- * restarts), the runner attempts `docker restart` once to re-establish
- * the mount. It first checks for an in-flight mutation on the shared
- * container and refuses to restart when one is detected so a
- * concurrent worktree's run isn't clobbered.
+ * If the bind mount goes stale (common after Docker Desktop's WSL
+ * share detaches on restart), the runner attempts `docker restart`
+ * once. It skips the restart when another mutation is detected on
+ * the shared container or when the activity probe is inconclusive,
+ * so a concurrent worktree's run isn't clobbered. The probe is not
+ * atomic with the restart; on a lost race the other run falls back
+ * to local, matching the pre-recovery behavior.
  *
  * The diff is computed locally and shipped as a file because git
  * worktrees use a `.git` file pointing at a path that only exists on
@@ -68,6 +69,11 @@ interface RemoteConfig {
 	stage: string;
 	worktree: string;
 }
+
+type MutationActivity =
+	| { detail: string; kind: "unknown" }
+	| { kind: "active" }
+	| { kind: "inactive" };
 
 function readConfig(): RemoteConfig | undefined {
 	const host = process.env["BEDROCK_REMOTE_MUTATE_HOST"];
@@ -254,7 +260,7 @@ function containerSeesWorktree(config: RemoteConfig): boolean {
 	return result.status === 0;
 }
 
-function containerHasActiveMutation(config: RemoteConfig): boolean {
+function checkActiveMutation(config: RemoteConfig): MutationActivity {
 	const result = spawnSync(
 		"ssh",
 		[
@@ -267,12 +273,22 @@ function containerHasActiveMutation(config: RemoteConfig): boolean {
 			"-f",
 			"bedrock-mutate.sh|stryker",
 		],
-		{ stdio: ["ignore", "ignore", "ignore"] },
+		{ encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
 	);
-	// pgrep exits 1 when nothing matches. Treat any other non-zero
-	// status (2 syntax, 3 fatal, 127 missing binary) as "active" so
-	// we never restart on uncertainty.
-	return result.status !== 1;
+	// pgrep exits 0 when matched, 1 when nothing matched. Anything
+	// else (2 syntax, 3 fatal from pgrep; 125 docker exec error;
+	// 127 missing binary; 255 ssh failure) is an inconclusive probe.
+	if (result.status === 0) {
+		return { kind: "active" };
+	}
+
+	if (result.status === 1) {
+		return { kind: "inactive" };
+	}
+
+	const stderr = result.stderr.trim();
+	const suffix = stderr === "" ? "" : `: ${stderr}`;
+	return { detail: `pgrep probe exited ${String(result.status)}${suffix}`, kind: "unknown" };
 }
 
 function restartContainer(config: RemoteConfig): boolean {
@@ -285,29 +301,23 @@ function restartContainer(config: RemoteConfig): boolean {
 }
 
 function recoverBindMount(config: RemoteConfig): string | undefined {
-	if (containerHasActiveMutation(config)) {
-		return (
-			`${config.container} cannot see /data/worktrees/${config.worktree} after rsync, ` +
-			"but another mutation is in progress on the shared container; refusing to " +
-			"docker restart and clobber it. Retry once the other run finishes, or restart " +
-			`${config.container} by hand if you know the bind mount is stale.`
-		);
+	const activity = checkActiveMutation(config);
+	const head = `${config.container} cannot see /data/worktrees/${config.worktree} after rsync`;
+	const recreate = `run docker rm -f ${config.container} and re-create with -v ${config.stage}:/data/worktrees`;
+	if (activity.kind === "active") {
+		return `${head}, but another mutation is in progress on the shared container; refusing to docker restart and clobber it. Retry once the other run finishes.`;
+	}
+
+	if (activity.kind === "unknown") {
+		return `${head} and the active-mutation probe was inconclusive (${activity.detail}); refusing to docker restart on uncertain state. Investigate the probe failure and retry.`;
 	}
 
 	if (!restartContainer(config)) {
-		return (
-			`${config.container} cannot see /data/worktrees/${config.worktree} after rsync ` +
-			`and docker restart ${config.container} failed; run docker rm -f ${config.container} ` +
-			`and re-create with -v ${config.stage}:/data/worktrees to re-establish the WSL share.`
-		);
+		return `${head} and docker restart ${config.container} failed; ${recreate} to re-establish the WSL share.`;
 	}
 
 	if (!containerSeesWorktree(config)) {
-		return (
-			`${config.container} still cannot see /data/worktrees/${config.worktree} after ` +
-			"docker restart; bind mount is severely detached. Run docker rm -f " +
-			`${config.container} and re-create with -v ${config.stage}:/data/worktrees.`
-		);
+		return `${head}, even after docker restart; bind mount is severely detached. ${recreate}.`;
 	}
 
 	return undefined;


### PR DESCRIPTION
## Summary

When Docker Desktop on Windows restarts, the bind mount between WSL2's `bedrock-stage` and the `bedrock-mutate-server` container can come up stale: the mount is registered but does not reflect the live host filesystem. Previously the runner detected this in `containerSeesWorktree` and surfaced an error telling the user to `docker rm -f` and recreate the container. Empirically, a plain `docker restart` is enough to re-establish the WSL share in the common case.

`setupRemote` now reacts to a failed worktree probe with a one-shot recovery: check for an in-flight mutation on the shared container via `pgrep -f 'bedrock-mutate.sh|stryker'`, restart the container if no concurrent work is detected, and re-probe before continuing. The `docker rm -f` recommendation is reserved for the case where the restart itself fails or the second probe still fails.

The pgrep gate matters because the container is shared across worktrees: a naive `docker restart` triggered by one agent would terminate every active `docker exec` and kill any in-flight stryker run in another worktree. When concurrent work is detected, the runner refuses to restart and asks the user to retry once the other run finishes.

## Test plan

- [x] `pnpm lint` clean (added `pgrep` to cspell dictionary)
- [x] `pnpm typecheck` clean (root + explicit `scripts/tsconfig.json`)
- [x] `pnpm test` (3722 passing)
- [x] `pnpm build` clean
- [x] `pnpm mutate:changed` (no mutable files since changes live in `scripts/` and `.config/`, both outside `packages/*` Stryker scopes)
- [x] `bun build --no-bundle scripts/mutate-remote.ts` syntax check
- [ ] Functional: next time the bind mount goes stale, confirm `docker restart` is auto-triggered and mutation proceeds without manual intervention

## Notes

Script-level glue, not consumer-facing. Following the precedent of #344 and #371, no automated tests for this file: it sits outside the `packages/*` and `apps/*` vitest project scope. Behavior change is bounded to the recovery path; the happy path (rsync + probe succeeds) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Architecture & Code Quality Review

### Compliance with Bedrock Standards

**TDD Requirement (ADR-003)**: ⚠️ **NO TESTS ADDED**

The PR adds 70 lines of implementation without corresponding tests, violating the project's mandatory TDD requirement ("Every implementation MUST have corresponding tests"). However, this follows an **established precedent**: scripts in the `scripts/` directory are explicitly exempt per ADR-015 ("Wrapper script is a necessary evil — custom code that must be maintained") and are excluded from the 100% coverage thresholds in `vite-config`. No other scripts in the directory (`mutate-changed.ts`, `generate-example-tests.ts`, `session-start-worktree-setup.ts`) have unit tests. This exemption is intentional to minimize wrapper script overhead.

**Recommendation**: Document this exemption in the PR body or CLAUDE.md to clarify the deviation from mandatory testing for script-layer code.

### Code Quality

✅ **Type Safety**: All code is properly typed; no `any` types, no type assertions.

✅ **Error Handling**: Explicit, typed error returns with clear, actionable messages. Proper handling of pgrep exit codes (status 1 = no match; other codes treated as "active" to err safely).

✅ **Concurrency Awareness**: Correctly checks for in-flight mutations via `pgrep -f "bedrock-mutate.sh|stryker"` before attempting restart, preventing clobbering of concurrent worktree runs.

✅ **Architectural Fit**: The new functions (`containerHasActiveMutation`, `restartContainer`, `recoverBindMount`) maintain the shell-layer procedural style appropriate for orchestration scripts. No FCIS pattern violation (scripts are not subject to FCIS requirements).

✅ **Configuration Management**: Added `pgrep` to CSpell allowlist in `.config/cspell.config.yaml`.

### Functional Design

✅ **Recovery Flow**: Sensible three-step strategy when mount is stale:
  1. Detect active mutations and refuse restart if found
  2. Attempt `docker restart` once
  3. Re-probe; only recommend `docker rm -f` if restart fails or probe still fails

✅ **Documentation**: Module-level JSDoc updated to describe the recovery behavior and constraints (lines 16–21).

✅ **Failure Paths**: Three distinct recovery failure messages guide users to appropriate actions based on what went wrong (concurrent mutation, restart failed, or persistent mount detachment).

### Security & Constraints

✅ **No secrets**: All operations use public container names and paths.

✅ **External input validation**: Existing `SAFE_WORKTREE_NAME` regex already guards shell injection in `readConfig()`.

### Minor Observations

- pgrep status code logic is correct and well-commented (lines 272–275).
- New helper functions follow the established pattern of other probe/exec helpers in the file.
- No architectural concerns; script remains focused on SSH orchestration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->