### PR TITLE
feat(core): accept redacted override objects per environment

### DIFF
--- a/packages/bedrock/src/config.spec-d.ts
+++ b/packages/bedrock/src/config.spec-d.ts
@@ -10,6 +10,7 @@ import type {
 	GamePassEntry,
 	GistStateConfig,
 	PlaceEntry,
+	RedactedEnvironmentOverride,
 	RedactedGamePassOverride,
 	RedactedPlaceOverride,
 	ResolvedPlaceEntry,
@@ -25,6 +26,8 @@ import type {
 	GamePassEntry as GamePassEntrySource,
 	GistStateConfig as GistStateConfigSource,
 	PlaceEntry as PlaceEntrySource,
+	// eslint-disable-next-line id-length -- matches the symbol name; existing Source aliases use the same convention
+	RedactedEnvironmentOverride as RedactedEnvironmentOverrideSource,
 	RedactedGamePassOverride as RedactedGamePassOverrideSource,
 	RedactedPlaceOverride as RedactedPlaceOverrideSource,
 	ResolvedPlaceEntry as ResolvedPlaceEntrySource,
@@ -63,6 +66,10 @@ describe("@bedrock-rbx/core/config resource-entry re-exports", () => {
 
 	it("should re-export RedactedPlaceOverride with the same identity as core/schema", () => {
 		expectTypeOf<RedactedPlaceOverride>().toEqualTypeOf<RedactedPlaceOverrideSource>();
+	});
+
+	it("should re-export RedactedEnvironmentOverride with the same identity as core/schema", () => {
+		expectTypeOf<RedactedEnvironmentOverride>().toEqualTypeOf<RedactedEnvironmentOverrideSource>();
 	});
 
 	it("should re-export DeveloperProductEntry with the same identity as core/schema", () => {

--- a/packages/bedrock/src/config.ts
+++ b/packages/bedrock/src/config.ts
@@ -17,6 +17,7 @@ export type {
 	GistStateConfig,
 	PlaceEntry,
 	RedactedDeveloperProductOverride,
+	RedactedEnvironmentOverride,
 	RedactedGamePassOverride,
 	RedactedPlaceOverride,
 	ResolvedPlaceEntry,

--- a/packages/bedrock/src/core/redact-resources.spec.ts
+++ b/packages/bedrock/src/core/redact-resources.spec.ts
@@ -792,6 +792,214 @@ describe(applyRedaction, () => {
 			redacted: { icon: { "en-us": "assets/override-icon.png" } },
 		});
 	});
+
+	describe("env-level cross-kind override", () => {
+		it("should apply an env-level price override to every on-sale pass without per-resource repetition", () => {
+			expect.assertions(2);
+
+			const result = applyRedaction(
+				{
+					...baseConfig,
+					passes: {
+						"elite-pass": { ...vipEntry, name: "Elite Pass", price: 1500 },
+						"vip-pass": vipEntry,
+					},
+				},
+				{ price: 1 },
+			);
+
+			expect(result.passes?.["vip-pass"]?.price).toBe(1);
+			expect(result.passes?.["elite-pass"]?.price).toBe(1);
+		});
+
+		it("should apply an env-level price override to every on-sale product without per-resource repetition", () => {
+			expect.assertions(2);
+
+			const result = applyRedaction(
+				{
+					...baseConfig,
+					products: {
+						"gem-pack": gemPackEntry,
+						"gold-pack": { ...gemPackEntry, name: "Gold Pack", price: 2000 },
+					},
+				},
+				{ price: 1 },
+			);
+
+			expect(result.products?.["gem-pack"]?.price).toBe(1);
+			expect(result.products?.["gold-pack"]?.price).toBe(1);
+		});
+
+		it("should leave off-sale passes and products off-sale when an env-level price override is supplied", () => {
+			expect.assertions(2);
+
+			const offSalePass = {
+				name: "Coming Soon Pass",
+				description: "Reveal at launch.",
+				icon: { "en-us": "assets/soon.png" },
+			} as const satisfies GamePassEntry;
+			const offSaleProduct = {
+				name: "Future Pack",
+				description: "Reveal at launch.",
+			} as const satisfies DeveloperProductEntry;
+			const result = applyRedaction(
+				{
+					...baseConfig,
+					passes: { "soon-pass": offSalePass },
+					products: { "future-pack": offSaleProduct },
+				},
+				{ price: 1 },
+			);
+
+			expect(result.passes?.["soon-pass"]).not.toHaveProperty("price");
+			expect(result.products?.["future-pack"]).not.toHaveProperty("price");
+		});
+
+		it("should apply an env-level description override to every redactable kind that supports description", () => {
+			expect.assertions(3);
+
+			const result = applyRedaction(
+				{
+					...baseConfig,
+					passes: { "vip-pass": vipEntry },
+					places: { "start-place": startPlaceEntry },
+					products: { "gem-pack": gemPackEntry },
+				},
+				{ description: "Reveal at launch." },
+			);
+
+			expect(result.passes?.["vip-pass"]?.description).toBe("Reveal at launch.");
+			expect(result.places?.["start-place"]?.description).toBe("Reveal at launch.");
+			expect(result.products?.["gem-pack"]?.description).toBe("Reveal at launch.");
+		});
+
+		it("should apply an env-level displayName override only to places", () => {
+			expect.assertions(3);
+
+			const result = applyRedaction(
+				{
+					...baseConfig,
+					passes: { "vip-pass": vipEntry },
+					places: { "start-place": startPlaceEntry },
+					products: { "gem-pack": gemPackEntry },
+				},
+				{ displayName: "Hidden Project" },
+			);
+
+			expect(result.places?.["start-place"]?.displayName).toBe("Hidden Project");
+			expect(result.passes?.["vip-pass"]?.name).toBe(REDACTED_PASS_NAME);
+			expect(result.products?.["gem-pack"]?.name).toBe(
+				defaultRedactedProductName("gem-pack"),
+			);
+		});
+
+		it("should apply an env-level icon override to passes and products and silently ignore it on places", () => {
+			expect.assertions(3);
+
+			const iconOverride = { "en-us": "assets/env-icon.png" };
+			const result = applyRedaction(
+				{
+					...baseConfig,
+					passes: { "vip-pass": vipEntry },
+					places: { "start-place": startPlaceEntry },
+					products: { "gem-pack": gemPackEntry },
+				},
+				{ icon: iconOverride },
+			);
+
+			expect(result.passes?.["vip-pass"]?.icon).toStrictEqual(iconOverride);
+			expect(result.products?.["gem-pack"]?.icon).toStrictEqual(iconOverride);
+			expect(result.places?.["start-place"]).not.toHaveProperty("icon");
+		});
+
+		it("should compose a root name override with an env-level price override into one field-merged product result", () => {
+			expect.assertions(1);
+
+			const result = applyRedaction(
+				{
+					...baseConfig,
+					products: {
+						"gem-pack": { ...gemPackEntry, redacted: { name: "Hidden" } },
+					},
+				},
+				{ price: 1 },
+			);
+
+			expect(result.products?.["gem-pack"]).toStrictEqual({
+				name: "Hidden",
+				description: REDACTED_DESCRIPTION,
+				icon: { "en-us": REDACTED_ICON_PATH },
+				price: 1,
+				redacted: { name: "Hidden" },
+			});
+		});
+
+		it("should let env-level fields apply when the root layer enables redaction with bare true", () => {
+			expect.assertions(1);
+
+			const result = applyRedaction(
+				{
+					...baseConfig,
+					products: { "gem-pack": { ...gemPackEntry, redacted: true } },
+				},
+				{ price: 1 },
+			);
+
+			expect(result.products?.["gem-pack"]).toStrictEqual({
+				name: defaultRedactedProductName("gem-pack"),
+				description: REDACTED_DESCRIPTION,
+				icon: { "en-us": REDACTED_ICON_PATH },
+				price: 1,
+				redacted: true,
+			});
+		});
+
+		it("should not redact when a root false carves out despite an env-level override object", () => {
+			expect.assertions(1);
+
+			const entry = {
+				...gemPackEntry,
+				redacted: false,
+			} as const satisfies DeveloperProductEntry;
+			const result = applyRedaction(
+				{ ...baseConfig, products: { "gem-pack": entry } },
+				{ price: 1 },
+			);
+
+			expect(result.products?.["gem-pack"]).toStrictEqual(entry);
+		});
+
+		it("should let a root field override win over the env-level value for the same field", () => {
+			expect.assertions(1);
+
+			const result = applyRedaction(
+				{
+					...baseConfig,
+					products: {
+						"gem-pack": { ...gemPackEntry, redacted: { price: 500 } },
+					},
+				},
+				{ price: 1 },
+			);
+
+			expect(result.products?.["gem-pack"]?.price).toBe(500);
+		});
+
+		it("should redact a place from env-level alone when the place sets no redacted flag", () => {
+			expect.assertions(2);
+
+			const result = applyRedaction(
+				{
+					...baseConfig,
+					places: { "start-place": startPlaceEntry },
+				},
+				{ displayName: "Hidden Project" },
+			);
+
+			expect(result.places?.["start-place"]?.description).toBe(REDACTED_DESCRIPTION);
+			expect(result.places?.["start-place"]?.displayName).toBe("Hidden Project");
+		});
+	});
 });
 
 describe(collectRedactionAnnotations, () => {

--- a/packages/bedrock/src/core/redact-resources.spec.ts
+++ b/packages/bedrock/src/core/redact-resources.spec.ts
@@ -332,7 +332,7 @@ describe(applyRedaction, () => {
 			) satisfies GamePassEntry;
 			const result = applyRedaction(
 				{ ...baseConfig, passes: { "vip-pass": passEntry } },
-				envRedacted,
+				{ envLevel: envRedacted },
 			);
 			const expectedName = expectRedacted ? REDACTED_PASS_NAME : vipEntry.name;
 
@@ -425,7 +425,7 @@ describe(applyRedaction, () => {
 
 		const result = applyRedaction(
 			{ ...baseConfig, places: { "start-place": startPlaceEntry } },
-			true,
+			{ envLevel: true },
 		);
 
 		expect(result.places?.["start-place"]?.description).toBe(REDACTED_DESCRIPTION);
@@ -487,7 +487,7 @@ describe(applyRedaction, () => {
 			) satisfies ResolvedPlaceEntry;
 			const result = applyRedaction(
 				{ ...baseConfig, places: { "start-place": placeEntry } },
-				envRedacted,
+				{ envLevel: envRedacted },
 			);
 			const expectedDescription = expectRedacted
 				? REDACTED_DESCRIPTION
@@ -719,7 +719,7 @@ describe(applyRedaction, () => {
 			) satisfies DeveloperProductEntry;
 			const result = applyRedaction(
 				{ ...baseConfig, products: { "gem-pack": productEntry } },
-				envRedacted,
+				{ envLevel: envRedacted },
 			);
 			const expectedName = expectRedacted
 				? defaultRedactedProductName("gem-pack")
@@ -805,7 +805,7 @@ describe(applyRedaction, () => {
 						"vip-pass": vipEntry,
 					},
 				},
-				{ price: 1 },
+				{ envLevel: { price: 1 } },
 			);
 
 			expect(result.passes?.["vip-pass"]?.price).toBe(1);
@@ -823,7 +823,7 @@ describe(applyRedaction, () => {
 						"gold-pack": { ...gemPackEntry, name: "Gold Pack", price: 2000 },
 					},
 				},
-				{ price: 1 },
+				{ envLevel: { price: 1 } },
 			);
 
 			expect(result.products?.["gem-pack"]?.price).toBe(1);
@@ -848,7 +848,7 @@ describe(applyRedaction, () => {
 					passes: { "soon-pass": offSalePass },
 					products: { "future-pack": offSaleProduct },
 				},
-				{ price: 1 },
+				{ envLevel: { price: 1 } },
 			);
 
 			expect(result.passes?.["soon-pass"]).not.toHaveProperty("price");
@@ -865,7 +865,7 @@ describe(applyRedaction, () => {
 					places: { "start-place": startPlaceEntry },
 					products: { "gem-pack": gemPackEntry },
 				},
-				{ description: "Reveal at launch." },
+				{ envLevel: { description: "Reveal at launch." } },
 			);
 
 			expect(result.passes?.["vip-pass"]?.description).toBe("Reveal at launch.");
@@ -883,7 +883,7 @@ describe(applyRedaction, () => {
 					places: { "start-place": startPlaceEntry },
 					products: { "gem-pack": gemPackEntry },
 				},
-				{ displayName: "Hidden Project" },
+				{ envLevel: { displayName: "Hidden Project" } },
 			);
 
 			expect(result.places?.["start-place"]?.displayName).toBe("Hidden Project");
@@ -904,7 +904,7 @@ describe(applyRedaction, () => {
 					places: { "start-place": startPlaceEntry },
 					products: { "gem-pack": gemPackEntry },
 				},
-				{ icon: iconOverride },
+				{ envLevel: { icon: iconOverride } },
 			);
 
 			expect(result.passes?.["vip-pass"]?.icon).toStrictEqual(iconOverride);
@@ -922,7 +922,7 @@ describe(applyRedaction, () => {
 						"gem-pack": { ...gemPackEntry, redacted: { name: "Hidden" } },
 					},
 				},
-				{ price: 1 },
+				{ envLevel: { price: 1 } },
 			);
 
 			expect(result.products?.["gem-pack"]).toStrictEqual({
@@ -942,7 +942,7 @@ describe(applyRedaction, () => {
 					...baseConfig,
 					products: { "gem-pack": { ...gemPackEntry, redacted: true } },
 				},
-				{ price: 1 },
+				{ envLevel: { price: 1 } },
 			);
 
 			expect(result.products?.["gem-pack"]).toStrictEqual({
@@ -963,7 +963,7 @@ describe(applyRedaction, () => {
 			} as const satisfies DeveloperProductEntry;
 			const result = applyRedaction(
 				{ ...baseConfig, products: { "gem-pack": entry } },
-				{ price: 1 },
+				{ envLevel: { price: 1 } },
 			);
 
 			expect(result.products?.["gem-pack"]).toStrictEqual(entry);
@@ -979,7 +979,7 @@ describe(applyRedaction, () => {
 						"gem-pack": { ...gemPackEntry, redacted: { price: 500 } },
 					},
 				},
-				{ price: 1 },
+				{ envLevel: { price: 1 } },
 			);
 
 			expect(result.products?.["gem-pack"]?.price).toBe(500);
@@ -993,11 +993,109 @@ describe(applyRedaction, () => {
 					...baseConfig,
 					places: { "start-place": startPlaceEntry },
 				},
-				{ displayName: "Hidden Project" },
+				{ envLevel: { displayName: "Hidden Project" } },
 			);
 
 			expect(result.places?.["start-place"]?.description).toBe(REDACTED_DESCRIPTION);
 			expect(result.places?.["start-place"]?.displayName).toBe("Hidden Project");
+		});
+	});
+
+	describe("env-resource layer", () => {
+		it("should let an env-resource name override win over a root override and an env-level override for the same field", () => {
+			expect.assertions(1);
+
+			const result = applyRedaction(
+				{
+					...baseConfig,
+					products: {
+						"gem-pack": {
+							...gemPackEntry,
+							redacted: { name: "Root Name", price: 100 },
+						},
+					},
+				},
+				{
+					envLevel: { price: 1 },
+					envResource: { products: { "gem-pack": { name: "Env Resource Name" } } },
+				},
+			);
+
+			expect(result.products?.["gem-pack"]).toStrictEqual({
+				name: "Env Resource Name",
+				description: REDACTED_DESCRIPTION,
+				icon: { "en-us": REDACTED_ICON_PATH },
+				price: 100,
+				redacted: { name: "Root Name", price: 100 },
+			});
+		});
+
+		it("should treat env-resource true as enabling redaction without contributing fields, letting root and env-level fields apply", () => {
+			expect.assertions(1);
+
+			const result = applyRedaction(
+				{
+					...baseConfig,
+					products: {
+						"gem-pack": { ...gemPackEntry, redacted: { name: "Root Name" } },
+					},
+				},
+				{
+					envLevel: { price: 1 },
+					envResource: { products: { "gem-pack": true } },
+				},
+			);
+
+			expect(result.products?.["gem-pack"]).toStrictEqual({
+				name: "Root Name",
+				description: REDACTED_DESCRIPTION,
+				icon: { "en-us": REDACTED_ICON_PATH },
+				price: 1,
+				redacted: { name: "Root Name" },
+			});
+		});
+
+		it("should treat env-resource false as carving out, leaving root and env-level layers moot", () => {
+			expect.assertions(1);
+
+			const rootEntry = {
+				...gemPackEntry,
+				redacted: { name: "Root Name" },
+			} as const satisfies DeveloperProductEntry;
+			const result = applyRedaction(
+				{ ...baseConfig, products: { "gem-pack": rootEntry } },
+				{
+					envLevel: { price: 1 },
+					envResource: { products: { "gem-pack": false } },
+				},
+			);
+
+			expect(result.products?.["gem-pack"]).toStrictEqual(rootEntry);
+		});
+
+		it("should compose env-resource passes, products, and places independently against env-level", () => {
+			expect.assertions(3);
+
+			const result = applyRedaction(
+				{
+					...baseConfig,
+					passes: { "vip-pass": vipEntry },
+					places: { "start-place": startPlaceEntry },
+					products: { "gem-pack": gemPackEntry },
+				},
+				{
+					envLevel: { price: 1 },
+					envResource: {
+						passes: { "vip-pass": { name: "Hidden Pass" } },
+						places: { "start-place": { displayName: "Hidden Place" } },
+						products: { "gem-pack": { name: "Hidden Pack" } },
+					},
+				},
+			);
+
+			expect(result.passes?.["vip-pass"]?.name).toBe("Hidden Pass");
+			expect(result.places?.["start-place"]?.displayName).toBe("Hidden Place");
+			expect(result.products?.["gem-pack"]?.name).toBe("Hidden Pack");
 		});
 	});
 });

--- a/packages/bedrock/src/core/redact-resources.spec.ts
+++ b/packages/bedrock/src/core/redact-resources.spec.ts
@@ -1073,6 +1073,28 @@ describe(applyRedaction, () => {
 			expect(result.products?.["gem-pack"]).toStrictEqual(rootEntry);
 		});
 
+		it("should let an env-resource object force redaction even when the root entry sets redacted false", () => {
+			expect.assertions(1);
+
+			const result = applyRedaction(
+				{
+					...baseConfig,
+					products: { "gem-pack": { ...gemPackEntry, redacted: false } },
+				},
+				{
+					envResource: { products: { "gem-pack": { name: "Env Hidden" } } },
+				},
+			);
+
+			expect(result.products?.["gem-pack"]).toStrictEqual({
+				name: "Env Hidden",
+				description: REDACTED_DESCRIPTION,
+				icon: { "en-us": REDACTED_ICON_PATH },
+				price: REDACTED_PRICE,
+				redacted: false,
+			});
+		});
+
 		it("should compose env-resource passes, products, and places independently against env-level", () => {
 			expect.assertions(3);
 
@@ -1118,6 +1140,38 @@ describe(collectRedactionAnnotations, () => {
 		});
 
 		expect(result).toStrictEqual([]);
+	});
+
+	it("should annotate a pass whose env-overlay layer alone sets redacted: true even when the root entry omits the flag", () => {
+		expect.assertions(1);
+
+		const result = collectRedactionAnnotations(
+			{
+				...baseConfig,
+				passes: { "vip-pass": vipEntry },
+			},
+			{ passes: { "vip-pass": true } },
+		);
+
+		expect(result).toStrictEqual([
+			{ key: "vip-pass", hasRealValueEdits: true, kind: "gamePass" },
+		]);
+	});
+
+	it("should annotate a product whose env-overlay layer alone sets redacted: true even when the root entry omits the flag", () => {
+		expect.assertions(1);
+
+		const result = collectRedactionAnnotations(
+			{
+				...baseConfig,
+				products: { "gem-pack": gemPackEntry },
+			},
+			{ products: { "gem-pack": true } },
+		);
+
+		expect(result).toStrictEqual([
+			{ key: "gem-pack", hasRealValueEdits: true, kind: "developerProduct" },
+		]);
 	});
 
 	it("should emit one gamePass annotation per pass flagged redacted true with hasRealValueEdits false when the author already typed placeholder values literally", () => {

--- a/packages/bedrock/src/core/redact-resources.ts
+++ b/packages/bedrock/src/core/redact-resources.ts
@@ -7,6 +7,7 @@ import type {
 	DeveloperProductEntry,
 	GamePassEntry,
 	RedactedDeveloperProductOverride,
+	RedactedEnvironmentOverride,
 	RedactedGamePassOverride,
 	RedactedPlaceOverride,
 	ResolvedConfig,
@@ -64,6 +65,26 @@ interface ProductRedactionInputs {
 	readonly override: RedactedDeveloperProductOverride;
 }
 
+type RedactionLayer<Override> = boolean | Override | undefined;
+
+type EnvironmentLevel = boolean | RedactedEnvironmentOverride | undefined;
+
+interface ResolvedEntry<Entry, Override> {
+	readonly key: string;
+	readonly entry: Entry;
+	readonly override: Override | undefined;
+}
+
+const PASS_PRODUCT_ENV_FIELDS = ["description", "icon", "name", "price"] as const;
+
+const PLACE_ENV_FIELDS = ["description", "displayName"] as const;
+
+interface RedactCollectionInputs<Entry, Override> {
+	readonly collection: Readonly<Record<string, Entry>> | undefined;
+	readonly environmentForKind: RedactionLayer<Override>;
+	readonly redact: (item: { entry: Entry; key: string; override: Override }) => Entry;
+}
+
 /**
  * Six-character lowercase hex digest of `SHA-256(key)`, used as the
  * disambiguating suffix on a redacted developer-product's default `name`.
@@ -92,29 +113,32 @@ export function defaultRedactedProductName(key: string): string {
 
 /**
  * Pure transform that substitutes bedrock-supplied placeholder content for
- * every resource whose effective `redacted` flag is truthy. The effective
- * flag is the per-resource `redacted` value when set, otherwise the
- * `environmentRedacted` fallback. A `redacted` object form replaces
- * matching fields with the supplied values and falls back to the bedrock
- * defaults for the rest. Runs between env-overlay merge and display-name
+ * every resource whose effective redaction state is truthy. Two layers compose
+ * field-by-field: the per-resource `redacted` value on the entry and the
+ * cross-kind `environmentLevel` value passed in. The first non-undefined
+ * value sets state (`false` carves out); object layers then contribute fields
+ * with the per-resource layer winning per field, and bedrock defaults fill
+ * any field nobody set. Runs between env-overlay merge and display-name
  * prefix render so the rest of the pipeline (flatten, normalize, diff,
  * apply) operates on already-redacted values and needs no special-case
  * redaction logic.
  *
  * @param config - Post-merge `ResolvedConfig` produced by `selectEnvironment`.
- * @param environmentRedacted - Environment-level redaction toggle. Resources
- *   that omit a per-resource `redacted` flag inherit this value.
+ * @param environmentLevel - Env-level redaction layer. Accepts a boolean
+ *   toggle or a {@link RedactedEnvironmentOverride} carrying cross-kind
+ *   override fields; each redactable kind picks up only the fields its own
+ *   override type names.
  * @returns A `ResolvedConfig` whose redacted entries carry placeholder
  *   values; non-redacted entries pass through verbatim, and the input is
  *   not mutated.
  */
 export function applyRedaction(
 	config: ResolvedConfig,
-	environmentRedacted = false,
+	environmentLevel?: EnvironmentLevel,
 ): ResolvedConfig {
-	const passes = redactPasses(config.passes, environmentRedacted);
-	const places = redactPlaces(config.places, environmentRedacted);
-	const products = redactProducts(config.products, environmentRedacted);
+	const passes = redactPasses(config.passes, environmentLevel);
+	const places = redactPlaces(config.places, environmentLevel);
+	const products = redactProducts(config.products, environmentLevel);
 
 	if (passes === config.passes && places === config.places && products === config.products) {
 		return config;
@@ -168,6 +192,100 @@ export function collectRedactionAnnotations(
 	return [...passes, ...products];
 }
 
+function pickEnvironmentFields<Field extends keyof RedactedEnvironmentOverride>(
+	environmentLevel: EnvironmentLevel,
+	fields: ReadonlyArray<Field>,
+): RedactionLayer<Pick<RedactedEnvironmentOverride, Field>> {
+	if (environmentLevel === undefined || typeof environmentLevel === "boolean") {
+		return environmentLevel;
+	}
+
+	return Object.fromEntries(fields.map((field) => [field, environmentLevel[field]])) as Pick<
+		RedactedEnvironmentOverride,
+		Field
+	>;
+}
+
+/**
+ * Walk redaction layers most-specific to least-specific and produce the
+ * effective per-field override for one resource. Returns `undefined` when the
+ * resource is not redacted; returns a (possibly empty) object when it is.
+ * State step: the first non-undefined layer sets state -- `false` carves out,
+ * `true` or object enables. Fields step: walk every object layer in the same
+ * order, taking the first value per field. Callers are responsible for not
+ * passing layers with explicit `undefined` field values; the per-kind
+ * projections (see {@link pickEnvironmentFields}) drop them at the boundary.
+ *
+ * @template Override - Per-kind override type the resource accepts.
+ * @param layers - Layers ordered most-specific (index 0) to least-specific.
+ * @returns The effective override, or `undefined` when not redacted.
+ */
+function resolveEffectiveOverride<Override extends object>(
+	layers: ReadonlyArray<RedactionLayer<Override>>,
+): Override | undefined {
+	const firstNonUndefined = layers.find((layer) => layer !== undefined);
+	if (firstNonUndefined === undefined || firstNonUndefined === false) {
+		return undefined;
+	}
+
+	const effective: Record<string, unknown> = {};
+	for (const layer of layers) {
+		if (typeof layer !== "object") {
+			continue;
+		}
+
+		for (const [field, value] of Object.entries(layer)) {
+			if (!(field in effective)) {
+				effective[field] = value;
+			}
+		}
+	}
+
+	return effective as Override;
+}
+
+function resolveEntries<
+	Entry extends { readonly redacted?: RedactionLayer<Override> },
+	Override extends object,
+>(
+	entries: Readonly<Record<string, Entry>>,
+	environmentForKind: RedactionLayer<Override>,
+): ReadonlyArray<ResolvedEntry<Entry, Override>> {
+	return Object.entries(entries).map(([key, entry]) => {
+		return {
+			key,
+			entry,
+			override: resolveEffectiveOverride<Override>([entry.redacted, environmentForKind]),
+		};
+	});
+}
+
+function redactCollection<
+	Entry extends { readonly redacted?: RedactionLayer<Override> },
+	Override extends object,
+>(inputs: RedactCollectionInputs<Entry, Override>): Readonly<Record<string, Entry>> | undefined {
+	const { collection, environmentForKind, redact } = inputs;
+	if (collection === undefined) {
+		return undefined;
+	}
+
+	const resolved = resolveEntries<Entry, Override>(collection, environmentForKind);
+	if (resolved.every((item) => item.override === undefined)) {
+		return collection;
+	}
+
+	return Object.fromEntries(
+		resolved.map((item) => {
+			return item.override === undefined
+				? ([item.key, item.entry] as const)
+				: ([
+						item.key,
+						redact({ key: item.key, entry: item.entry, override: item.override }),
+					] as const);
+		}),
+	);
+}
+
 function redactPass(entry: GamePassEntry, override: RedactedGamePassOverride): GamePassEntry {
 	return {
 		...entry,
@@ -180,31 +298,13 @@ function redactPass(entry: GamePassEntry, override: RedactedGamePassOverride): G
 
 function redactPasses(
 	passes: ResolvedConfig["passes"],
-	environmentRedacted: boolean,
+	environmentLevel: EnvironmentLevel,
 ): ResolvedConfig["passes"] {
-	if (passes === undefined) {
-		return undefined;
-	}
-
-	const hasAnyRedaction = Object.values(passes).some(
-		(entry) => (entry.redacted ?? environmentRedacted) !== false,
-	);
-	if (!hasAnyRedaction) {
-		return passes;
-	}
-
-	return Object.fromEntries(
-		Object.entries(passes).map(([key, entry]) => {
-			const effective = entry.redacted ?? environmentRedacted;
-			if (effective === false) {
-				return [key, entry] as const;
-			}
-
-			const override: RedactedGamePassOverride =
-				typeof effective === "object" ? effective : {};
-			return [key, redactPass(entry, override)] as const;
-		}),
-	);
+	return redactCollection<GamePassEntry, RedactedGamePassOverride>({
+		collection: passes,
+		environmentForKind: pickEnvironmentFields(environmentLevel, PASS_PRODUCT_ENV_FIELDS),
+		redact: (item) => redactPass(item.entry, item.override),
+	});
 }
 
 function redactPlace(
@@ -220,30 +320,13 @@ function redactPlace(
 
 function redactPlaces(
 	places: ResolvedConfig["places"],
-	environmentRedacted: boolean,
+	environmentLevel: EnvironmentLevel,
 ): ResolvedConfig["places"] {
-	if (places === undefined) {
-		return undefined;
-	}
-
-	const hasAnyRedaction = Object.values(places).some(
-		(entry) => (entry.redacted ?? environmentRedacted) !== false,
-	);
-	if (!hasAnyRedaction) {
-		return places;
-	}
-
-	return Object.fromEntries(
-		Object.entries(places).map(([key, entry]) => {
-			const effective = entry.redacted ?? environmentRedacted;
-			if (effective === false) {
-				return [key, entry] as const;
-			}
-
-			const override: RedactedPlaceOverride = typeof effective === "object" ? effective : {};
-			return [key, redactPlace(entry, override)] as const;
-		}),
-	);
+	return redactCollection<ResolvedPlaceEntry, RedactedPlaceOverride>({
+		collection: places,
+		environmentForKind: pickEnvironmentFields(environmentLevel, PLACE_ENV_FIELDS),
+		redact: (item) => redactPlace(item.entry, item.override),
+	});
 }
 
 function redactProduct(inputs: ProductRedactionInputs): DeveloperProductEntry {
@@ -259,31 +342,13 @@ function redactProduct(inputs: ProductRedactionInputs): DeveloperProductEntry {
 
 function redactProducts(
 	products: ResolvedConfig["products"],
-	environmentRedacted: boolean,
+	environmentLevel: EnvironmentLevel,
 ): ResolvedConfig["products"] {
-	if (products === undefined) {
-		return undefined;
-	}
-
-	const hasAnyRedaction = Object.values(products).some(
-		(entry) => (entry.redacted ?? environmentRedacted) !== false,
-	);
-	if (!hasAnyRedaction) {
-		return products;
-	}
-
-	return Object.fromEntries(
-		Object.entries(products).map(([key, entry]) => {
-			const effective = entry.redacted ?? environmentRedacted;
-			if (effective === false) {
-				return [key, entry] as const;
-			}
-
-			const override: RedactedDeveloperProductOverride =
-				typeof effective === "object" ? effective : {};
-			return [key, redactProduct({ key, entry, override })] as const;
-		}),
-	);
+	return redactCollection<DeveloperProductEntry, RedactedDeveloperProductOverride>({
+		collection: products,
+		environmentForKind: pickEnvironmentFields(environmentLevel, PASS_PRODUCT_ENV_FIELDS),
+		redact: redactProduct,
+	});
 }
 
 function passHasRealValueEdits(entry: GamePassEntry): boolean {

--- a/packages/bedrock/src/core/redact-resources.ts
+++ b/packages/bedrock/src/core/redact-resources.ts
@@ -209,9 +209,10 @@ export function applyRedaction(config: ResolvedConfig, inputs?: RedactionInputs)
 
 /**
  * Inspect the pre-redaction merged config and produce one annotation per
- * resource flagged `redacted: true`. Callers thread the result into plan
- * output so authors can see which resources are redacted in the active
- * environment and whether their real-value edits are being suppressed.
+ * resource flagged `redacted: true` at either the root entry or its
+ * env-overlay counterpart. Callers thread the result into plan output so
+ * authors can see which resources are redacted in the active environment
+ * and whether their real-value edits are being suppressed.
  *
  * Operates on the pre-redaction view because the post-redaction config no
  * longer carries the real `name`/`description`/`icon` values needed to
@@ -219,14 +220,21 @@ export function applyRedaction(config: ResolvedConfig, inputs?: RedactionInputs)
  *
  * @param merged - `ResolvedConfig` produced by environment overlay merge,
  *   before `applyRedaction` has substituted placeholders.
+ * @param environmentResource - Per-kind env-overlay redaction layers
+ *   extracted from the active env entry. Omit when the caller has no
+ *   env-overlay layer.
  * @returns Zero or more annotations, one per redacted resource. Empty when
  *   the config declares no redacted resources.
  */
 export function collectRedactionAnnotations(
 	merged: ResolvedConfig,
+	environmentResource?: EnvironmentResourceRedaction,
 ): ReadonlyArray<RedactionAnnotation> {
 	const passes = Object.entries(merged.passes ?? {})
-		.filter(([, entry]) => entry.redacted === true)
+		.filter(
+			([key, entry]) =>
+				entry.redacted === true || environmentResource?.passes?.[key] === true,
+		)
 		.map(([key, entry]): RedactionAnnotation => {
 			return {
 				key: asResourceKey(key),
@@ -235,7 +243,10 @@ export function collectRedactionAnnotations(
 			};
 		});
 	const products = Object.entries(merged.products ?? {})
-		.filter(([, entry]) => entry.redacted === true)
+		.filter(
+			([key, entry]) =>
+				entry.redacted === true || environmentResource?.products?.[key] === true,
+		)
 		.map(([key, entry]): RedactionAnnotation => {
 			return {
 				key: asResourceKey(key),
@@ -267,9 +278,11 @@ function pickEnvironmentFields<Field extends keyof RedactedEnvironmentOverride>(
  * resource is not redacted; returns a (possibly empty) object when it is.
  * State step: the first non-undefined layer sets state -- `false` carves out,
  * `true` or object enables. Fields step: walk every object layer in the same
- * order, taking the first value per field. Callers are responsible for not
- * passing layers with explicit `undefined` field values; the per-kind
- * projections (see {@link pickEnvironmentFields}) drop them at the boundary.
+ * order, taking the first value per field. A field's value may itself be
+ * `undefined` (the env-level projection produced by {@link pickEnvironmentFields}
+ * includes every projected key, even when the env override left it absent);
+ * downstream per-kind redact functions collapse those back to bedrock
+ * placeholder defaults via `??`.
  *
  * @template Override - Per-kind override type the resource accepts.
  * @param layers - Layers ordered most-specific (index 0) to least-specific.

--- a/packages/bedrock/src/core/redact-resources.ts
+++ b/packages/bedrock/src/core/redact-resources.ts
@@ -106,9 +106,16 @@ interface ResolvedEntry<Entry, Override> {
 	readonly override: Override | undefined;
 }
 
-const PASS_PRODUCT_ENV_FIELDS = ["description", "icon", "name", "price"] as const;
+const PASS_PRODUCT_ENV_FIELDS = [
+	"description",
+	"icon",
+	"name",
+	"price",
+] as const satisfies ReadonlyArray<keyof RedactedEnvironmentOverride>;
 
-const PLACE_ENV_FIELDS = ["description", "displayName"] as const;
+const PLACE_ENV_FIELDS = ["description", "displayName"] as const satisfies ReadonlyArray<
+	keyof RedactedEnvironmentOverride
+>;
 
 interface RedactCollectionInputs<Entry, Override> {
 	readonly collection: Readonly<Record<string, Entry>> | undefined;

--- a/packages/bedrock/src/core/redact-resources.ts
+++ b/packages/bedrock/src/core/redact-resources.ts
@@ -59,15 +59,46 @@ export interface RedactionAnnotation {
 	readonly kind: ResourceKind;
 }
 
+/**
+ * Per-resource env-overlay redaction layers, keyed by kind. Each entry maps
+ * a resource key to its env-overlay `redacted` value (boolean or per-field
+ * override). `selectEnvironment` extracts these from env-overlay entries
+ * before the rest of the overlay is defu-merged onto the root, so the
+ * env-resource layer can compose field-by-field with the root layer in
+ * {@link applyRedaction}.
+ */
+export interface EnvironmentResourceRedaction {
+	/** Per-pass env-overlay redaction values keyed by resource key. */
+	readonly passes?: EnvironmentResourceLayer<RedactedGamePassOverride>;
+	/** Per-place env-overlay redaction values keyed by resource key. */
+	readonly places?: EnvironmentResourceLayer<RedactedPlaceOverride>;
+	/** Per-product env-overlay redaction values keyed by resource key. */
+	readonly products?: EnvironmentResourceLayer<RedactedDeveloperProductOverride>;
+}
+
+/**
+ * Aggregated redaction layers consumed by {@link applyRedaction}. The
+ * `envLevel` layer applies to every redactable resource in the env;
+ * `envResource` carries per-resource env-overlay overrides keyed by kind.
+ */
+export interface RedactionInputs {
+	/** Env-level redaction layer. Boolean toggle or cross-kind override object. */
+	readonly envLevel?: EnvironmentLevel;
+	/** Per-resource env-overlay redaction layers, keyed by kind. */
+	readonly envResource?: EnvironmentResourceRedaction;
+}
+
+type RedactionLayer<Override> = boolean | Override | undefined;
+
+type EnvironmentResourceLayer<Override> = Readonly<Record<string, RedactionLayer<Override>>>;
+
+type EnvironmentLevel = boolean | RedactedEnvironmentOverride | undefined;
+
 interface ProductRedactionInputs {
 	readonly key: string;
 	readonly entry: DeveloperProductEntry;
 	readonly override: RedactedDeveloperProductOverride;
 }
-
-type RedactionLayer<Override> = boolean | Override | undefined;
-
-type EnvironmentLevel = boolean | RedactedEnvironmentOverride | undefined;
 
 interface ResolvedEntry<Entry, Override> {
 	readonly key: string;
@@ -82,7 +113,14 @@ const PLACE_ENV_FIELDS = ["description", "displayName"] as const;
 interface RedactCollectionInputs<Entry, Override> {
 	readonly collection: Readonly<Record<string, Entry>> | undefined;
 	readonly environmentForKind: RedactionLayer<Override>;
+	readonly envResource: EnvironmentResourceLayer<Override> | undefined;
 	readonly redact: (item: { entry: Entry; key: string; override: Override }) => Entry;
+}
+
+interface RedactKindInputs<Entry, Override> {
+	readonly collection: Readonly<Record<string, Entry>> | undefined;
+	readonly envLevel: EnvironmentLevel;
+	readonly envResource: EnvironmentResourceLayer<Override> | undefined;
 }
 
 /**
@@ -113,32 +151,42 @@ export function defaultRedactedProductName(key: string): string {
 
 /**
  * Pure transform that substitutes bedrock-supplied placeholder content for
- * every resource whose effective redaction state is truthy. Two layers compose
- * field-by-field: the per-resource `redacted` value on the entry and the
- * cross-kind `environmentLevel` value passed in. The first non-undefined
- * value sets state (`false` carves out); object layers then contribute fields
- * with the per-resource layer winning per field, and bedrock defaults fill
- * any field nobody set. Runs between env-overlay merge and display-name
- * prefix render so the rest of the pipeline (flatten, normalize, diff,
- * apply) operates on already-redacted values and needs no special-case
- * redaction logic.
+ * every resource whose effective redaction state is truthy. Three layers
+ * compose field-by-field per resource: env-resource (most-specific, from
+ * `inputs.envResource`), root-resource (the `redacted` field on the
+ * passed-in entry), and env-level (least-specific, `inputs.envLevel`).
+ * The first non-undefined value sets state (`false` carves out); object
+ * layers then contribute fields with the most-specific layer winning per
+ * field, and bedrock defaults fill any field nobody set. Runs between
+ * env-overlay merge and display-name prefix render so the rest of the
+ * pipeline (flatten, normalize, diff, apply) operates on already-redacted
+ * values and needs no special-case redaction logic.
  *
  * @param config - Post-merge `ResolvedConfig` produced by `selectEnvironment`.
- * @param environmentLevel - Env-level redaction layer. Accepts a boolean
- *   toggle or a {@link RedactedEnvironmentOverride} carrying cross-kind
- *   override fields; each redactable kind picks up only the fields its own
- *   override type names.
+ * @param inputs - Aggregated redaction layers. Omit to skip redaction
+ *   entirely. See {@link RedactionInputs} for the shape.
  * @returns A `ResolvedConfig` whose redacted entries carry placeholder
  *   values; non-redacted entries pass through verbatim, and the input is
  *   not mutated.
  */
-export function applyRedaction(
-	config: ResolvedConfig,
-	environmentLevel?: EnvironmentLevel,
-): ResolvedConfig {
-	const passes = redactPasses(config.passes, environmentLevel);
-	const places = redactPlaces(config.places, environmentLevel);
-	const products = redactProducts(config.products, environmentLevel);
+export function applyRedaction(config: ResolvedConfig, inputs?: RedactionInputs): ResolvedConfig {
+	const environmentLevel = inputs?.envLevel;
+	const environmentResource = inputs?.envResource;
+	const passes = redactPasses({
+		collection: config.passes,
+		envLevel: environmentLevel,
+		envResource: environmentResource?.passes,
+	});
+	const places = redactPlaces({
+		collection: config.places,
+		envLevel: environmentLevel,
+		envResource: environmentResource?.places,
+	});
+	const products = redactProducts({
+		collection: config.products,
+		envLevel: environmentLevel,
+		envResource: environmentResource?.products,
+	});
 
 	if (passes === config.passes && places === config.places && products === config.products) {
 		return config;
@@ -247,15 +295,21 @@ function resolveEffectiveOverride<Override extends object>(
 function resolveEntries<
 	Entry extends { readonly redacted?: RedactionLayer<Override> },
 	Override extends object,
->(
-	entries: Readonly<Record<string, Entry>>,
-	environmentForKind: RedactionLayer<Override>,
-): ReadonlyArray<ResolvedEntry<Entry, Override>> {
-	return Object.entries(entries).map(([key, entry]) => {
+>(inputs: {
+	readonly collection: Readonly<Record<string, Entry>>;
+	readonly environmentForKind: RedactionLayer<Override>;
+	readonly envResource: EnvironmentResourceLayer<Override> | undefined;
+}): ReadonlyArray<ResolvedEntry<Entry, Override>> {
+	const { collection, environmentForKind, envResource } = inputs;
+	return Object.entries(collection).map(([key, entry]) => {
 		return {
 			key,
 			entry,
-			override: resolveEffectiveOverride<Override>([entry.redacted, environmentForKind]),
+			override: resolveEffectiveOverride<Override>([
+				envResource?.[key],
+				entry.redacted,
+				environmentForKind,
+			]),
 		};
 	});
 }
@@ -264,12 +318,17 @@ function redactCollection<
 	Entry extends { readonly redacted?: RedactionLayer<Override> },
 	Override extends object,
 >(inputs: RedactCollectionInputs<Entry, Override>): Readonly<Record<string, Entry>> | undefined {
-	const { collection, environmentForKind, redact } = inputs;
+	const { collection, environmentForKind, envResource, redact } = inputs;
 	if (collection === undefined) {
 		return undefined;
 	}
 
-	const resolved = resolveEntries<Entry, Override>(collection, environmentForKind);
+	const resolved = resolveEntries<Entry, Override>({
+		collection,
+		environmentForKind,
+		envResource,
+	});
+
 	if (resolved.every((item) => item.override === undefined)) {
 		return collection;
 	}
@@ -297,12 +356,13 @@ function redactPass(entry: GamePassEntry, override: RedactedGamePassOverride): G
 }
 
 function redactPasses(
-	passes: ResolvedConfig["passes"],
-	environmentLevel: EnvironmentLevel,
+	inputs: RedactKindInputs<GamePassEntry, RedactedGamePassOverride>,
 ): ResolvedConfig["passes"] {
+	const { collection, envLevel, envResource } = inputs;
 	return redactCollection<GamePassEntry, RedactedGamePassOverride>({
-		collection: passes,
-		environmentForKind: pickEnvironmentFields(environmentLevel, PASS_PRODUCT_ENV_FIELDS),
+		collection,
+		environmentForKind: pickEnvironmentFields(envLevel, PASS_PRODUCT_ENV_FIELDS),
+		envResource,
 		redact: (item) => redactPass(item.entry, item.override),
 	});
 }
@@ -319,12 +379,13 @@ function redactPlace(
 }
 
 function redactPlaces(
-	places: ResolvedConfig["places"],
-	environmentLevel: EnvironmentLevel,
+	inputs: RedactKindInputs<ResolvedPlaceEntry, RedactedPlaceOverride>,
 ): ResolvedConfig["places"] {
+	const { collection, envLevel, envResource } = inputs;
 	return redactCollection<ResolvedPlaceEntry, RedactedPlaceOverride>({
-		collection: places,
-		environmentForKind: pickEnvironmentFields(environmentLevel, PLACE_ENV_FIELDS),
+		collection,
+		environmentForKind: pickEnvironmentFields(envLevel, PLACE_ENV_FIELDS),
+		envResource,
 		redact: (item) => redactPlace(item.entry, item.override),
 	});
 }
@@ -341,12 +402,13 @@ function redactProduct(inputs: ProductRedactionInputs): DeveloperProductEntry {
 }
 
 function redactProducts(
-	products: ResolvedConfig["products"],
-	environmentLevel: EnvironmentLevel,
+	inputs: RedactKindInputs<DeveloperProductEntry, RedactedDeveloperProductOverride>,
 ): ResolvedConfig["products"] {
+	const { collection, envLevel, envResource } = inputs;
 	return redactCollection<DeveloperProductEntry, RedactedDeveloperProductOverride>({
-		collection: products,
-		environmentForKind: pickEnvironmentFields(environmentLevel, PASS_PRODUCT_ENV_FIELDS),
+		collection,
+		environmentForKind: pickEnvironmentFields(envLevel, PASS_PRODUCT_ENV_FIELDS),
+		envResource,
 		redact: redactProduct,
 	});
 }

--- a/packages/bedrock/src/core/redact-resources.ts
+++ b/packages/bedrock/src/core/redact-resources.ts
@@ -76,23 +76,23 @@ export interface EnvironmentResourceRedaction {
 	readonly products?: EnvironmentResourceLayer<RedactedDeveloperProductOverride>;
 }
 
-/**
- * Aggregated redaction layers consumed by {@link applyRedaction}. The
- * `envLevel` layer applies to every redactable resource in the env;
- * `envResource` carries per-resource env-overlay overrides keyed by kind.
- */
-export interface RedactionInputs {
-	/** Env-level redaction layer. Boolean toggle or cross-kind override object. */
-	readonly envLevel?: EnvironmentLevel;
-	/** Per-resource env-overlay redaction layers, keyed by kind. */
-	readonly envResource?: EnvironmentResourceRedaction;
-}
-
 type RedactionLayer<Override> = boolean | Override | undefined;
 
 type EnvironmentResourceLayer<Override> = Readonly<Record<string, RedactionLayer<Override>>>;
 
 type EnvironmentLevel = boolean | RedactedEnvironmentOverride | undefined;
+
+/**
+ * Aggregated redaction layers consumed by {@link applyRedaction}. The
+ * `envLevel` layer applies to every redactable resource in the env;
+ * `envResource` carries per-resource env-overlay overrides keyed by kind.
+ */
+interface RedactionInputs {
+	/** Env-level redaction layer. Boolean toggle or cross-kind override object. */
+	readonly envLevel?: EnvironmentLevel;
+	/** Per-resource env-overlay redaction layers, keyed by kind. */
+	readonly envResource?: EnvironmentResourceRedaction;
+}
 
 interface ProductRedactionInputs {
 	readonly key: string;

--- a/packages/bedrock/src/core/schema.example.spec.ts
+++ b/packages/bedrock/src/core/schema.example.spec.ts
@@ -5,10 +5,11 @@ import type {
   RedactedGamePassOverride,
   PlaceEntry,
   RedactedPlaceOverride,
+  Config,
+  RedactedEnvironmentOverride,
   DeveloperProductEntry,
   RedactedDeveloperProductOverride,
   ResourceEntryByKind,
-  Config,
   StateConfig,
 } from '@bedrock-rbx/core/config'
 import {
@@ -42,6 +43,23 @@ it('Example 2', () => {
 })
 
 it('Example 3', () => {
+  const devRedaction: RedactedEnvironmentOverride = { price: 1 }
+  const config: Config = {
+    environments: { dev: { redacted: devRedaction } },
+    passes: {
+      'vip-pass': {
+        name: 'VIP Pass',
+        description: 'Grants VIP perks.',
+        icon: { 'en-us': 'assets/vip.png' },
+        price: 500,
+      },
+    },
+    state: { backend: 'gist', gistId: 'abc123' },
+  }
+  expect(config.environments['dev']?.redacted).toStrictEqual({ price: 1 })
+})
+
+it('Example 4', () => {
   const override: RedactedDeveloperProductOverride = {
     name: 'Closed Beta Pack',
     price: 500,
@@ -55,7 +73,7 @@ it('Example 3', () => {
   expect(entry.redacted).toStrictEqual({ name: 'Closed Beta Pack', price: 500 })
 })
 
-it('Example 4', () => {
+it('Example 5', () => {
   const entry: ResourceEntryByKind['gamePass'] = {
     description: 'Grants VIP perks.',
     icon: { 'en-us': 'assets/vip-icon.png' },
@@ -65,7 +83,7 @@ it('Example 4', () => {
   expect(entry.name).toBe('VIP Pass')
 })
 
-it('Example 5', () => {
+it('Example 6', () => {
   const config: Config = {
     environments: { production: {} },
     state: { backend: 'gist', gistId: 'abc123def456' },
@@ -81,7 +99,7 @@ it('Example 5', () => {
   expect(config.passes!['vip-pass']!.name).toBe('VIP Pass')
 })
 
-it('Example 6', () => {
+it('Example 7', () => {
   const config: Config = {
     environments: {
       production: { places: { 'start-place': { placeId: '4711' } } },
@@ -97,7 +115,7 @@ it('Example 6', () => {
   }
 })
 
-it('Example 7', () => {
+it('Example 8', () => {
   const config: StateConfig = { backend: 'gist', gistId: 'abc' }
   expect(isGistStateConfig(config)).toBeTrue()
   if (isGistStateConfig(config)) {
@@ -105,7 +123,7 @@ it('Example 7', () => {
   }
 })
 
-it('Example 8', () => {
+it('Example 9', () => {
   const ok = validateConfig(
     {
       environments: { production: {} },

--- a/packages/bedrock/src/core/schema.spec-d.ts
+++ b/packages/bedrock/src/core/schema.spec-d.ts
@@ -5,6 +5,7 @@ import type {
 	EnvironmentEntry,
 	GamePassEntry,
 	PlaceEntry,
+	RedactedGamePassOverride,
 	ResolvedPlaceEntry,
 	ResolvedUniverseEntry,
 	StateConfig,
@@ -84,15 +85,17 @@ describe("EnvironmentEntry overlay shapes", () => {
 	});
 });
 
-describe("EnvironmentEntry passes overlay redacted narrowing", () => {
-	it("should narrow the passes overlay redacted field to boolean so per-field overrides stay root-only", () => {
-		expectTypeOf<PassesOverlayEntry["redacted"]>().toEqualTypeOf<boolean | undefined>();
+describe("EnvironmentEntry passes overlay redacted shape", () => {
+	it("should accept boolean and the per-field RedactedGamePassOverride object alike", () => {
+		expectTypeOf<PassesOverlayEntry["redacted"]>().toEqualTypeOf<
+			boolean | RedactedGamePassOverride | undefined
+		>();
 	});
 
-	it("should reject a passes overlay entry that declares the redacted object override form", () => {
-		// @ts-expect-error per-field redaction overrides are valid only on the
-		// root passes entry.
-		const overlay: PassesOverlayEntry = { redacted: { name: "Closed Beta" } };
+	it("should accept a passes overlay entry that declares the redacted object override form", () => {
+		const overlay = {
+			redacted: { name: "Closed Beta" },
+		} as const satisfies PassesOverlayEntry;
 		expectTypeOf(overlay).toExtend<PassesOverlayEntry>();
 	});
 

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -2081,14 +2081,15 @@ describe(validateConfig, () => {
 		},
 	);
 
-	it("should reject an object override form on a per-environment passes overlay redacted field", () => {
+	it("should accept an object override form on a per-environment passes overlay redacted field", () => {
 		expect.assertions(1);
 
+		const override = { name: "Closed Beta", price: 1 };
 		const result = validateConfig(
 			{
 				environments: {
 					staging: {
-						passes: { "vip-pass": { redacted: { name: "Closed Beta" } } },
+						passes: { "vip-pass": { redacted: override } },
 					},
 				},
 				passes: {
@@ -2097,6 +2098,26 @@ describe(validateConfig, () => {
 						description: "Grants VIP perks.",
 						icon: { "en-us": "assets/vip.png" },
 					},
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.environments["staging"]?.passes?.["vip-pass"]?.redacted).toStrictEqual(
+			override,
+		);
+	});
+
+	it("should reject an empty object on a per-environment passes overlay redacted field", () => {
+		expect.assertions(2);
+
+		const result = validateConfig(
+			{
+				environments: {
+					staging: { passes: { "vip-pass": { redacted: {} } } },
 				},
 				state: { backend: "gist", gistId: "root-gist" },
 			},
@@ -2113,6 +2134,7 @@ describe(validateConfig, () => {
 			"vip-pass",
 			"redacted",
 		]);
+		expect(result.err.issues[0]!.message).toContain("redacted: true");
 	});
 
 	it.for([
@@ -2142,9 +2164,10 @@ describe(validateConfig, () => {
 		},
 	);
 
-	it("should reject an object override form on a per-environment places overlay redacted field", () => {
+	it("should accept an object override form on a per-environment places overlay redacted field", () => {
 		expect.assertions(1);
 
+		const override = { displayName: "Hidden Project" };
 		const result = validateConfig(
 			{
 				environments: {
@@ -2152,9 +2175,32 @@ describe(validateConfig, () => {
 						places: {
 							"start-place": {
 								placeId: "5555",
-								redacted: { displayName: "Hidden" },
+								redacted: override,
 							},
 						},
+					},
+				},
+				places: { "start-place": { filePath: "places/start.rbxl" } },
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(
+			result.data.environments["staging"]?.places?.["start-place"]?.redacted,
+		).toStrictEqual(override);
+	});
+
+	it("should reject an empty object on a per-environment places overlay redacted field", () => {
+		expect.assertions(2);
+
+		const result = validateConfig(
+			{
+				environments: {
+					staging: {
+						places: { "start-place": { placeId: "5555", redacted: {} } },
 					},
 				},
 				places: { "start-place": { filePath: "places/start.rbxl" } },
@@ -2173,6 +2219,7 @@ describe(validateConfig, () => {
 			"start-place",
 			"redacted",
 		]);
+		expect(result.err.issues[0]!.message).toContain("redacted: true");
 	});
 
 	it("should accept a per-environment products overlay that supplies a partial subset of fields", () => {
@@ -2368,14 +2415,43 @@ describe(validateConfig, () => {
 		},
 	);
 
-	it("should reject an object override form on a per-environment products overlay redacted field", () => {
+	it("should accept an object override form on a per-environment products overlay redacted field", () => {
 		expect.assertions(1);
+
+		const override = { name: "Closed Beta Pack", price: 1 };
+		const result = validateConfig(
+			{
+				environments: {
+					staging: {
+						products: { "gem-pack": { redacted: override } },
+					},
+				},
+				products: {
+					"gem-pack": {
+						name: "Gem Pack",
+						description: "Stocks the player up with 1,000 premium gems.",
+					},
+				},
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.environments["staging"]?.products?.["gem-pack"]?.redacted).toStrictEqual(
+			override,
+		);
+	});
+
+	it("should reject an empty object on a per-environment products overlay redacted field", () => {
+		expect.assertions(2);
 
 		const result = validateConfig(
 			{
 				environments: {
 					staging: {
-						products: { "gem-pack": { redacted: { name: "Closed Beta Pack" } } },
+						products: { "gem-pack": { redacted: {} } },
 					},
 				},
 				products: {
@@ -2399,6 +2475,7 @@ describe(validateConfig, () => {
 			"gem-pack",
 			"redacted",
 		]);
+		expect(result.err.issues[0]!.message).toContain("redacted: true");
 	});
 
 	it.for(INVALID_ROBUX_PRICES)(

--- a/packages/bedrock/src/core/schema.spec.ts
+++ b/packages/bedrock/src/core/schema.spec.ts
@@ -2524,12 +2524,36 @@ describe(validateConfig, () => {
 		expect(result.data.environments["production"]?.redacted).toBe(redacted);
 	});
 
-	it("should reject an object-form redacted on an environments entry", () => {
+	it("should accept an object-form redacted on an environments entry that carries the cross-kind union of override fields", () => {
 		expect.assertions(1);
+
+		const override = {
+			name: "Closed Beta",
+			description: "Reveal at launch.",
+			displayName: "Hidden Project",
+			icon: { "en-us": "assets/redacted.png" },
+			price: 1,
+		};
 
 		const result = validateConfig(
 			{
-				environments: { production: { redacted: { name: "Closed Beta" } } },
+				environments: { production: { redacted: override } },
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(result.success);
+
+		expect(result.data.environments["production"]?.redacted).toStrictEqual(override);
+	});
+
+	it("should reject an empty redacted override on an environments entry and recommend redacted: true for default placeholders", () => {
+		expect.assertions(2);
+
+		const result = validateConfig(
+			{
+				environments: { production: { redacted: {} } },
 				state: { backend: "gist", gistId: "root-gist" },
 			},
 			SOURCE,
@@ -2542,6 +2566,29 @@ describe(validateConfig, () => {
 			"environments",
 			"production",
 			"redacted",
+		]);
+		expect(result.err.issues[0]!.message).toContain("redacted: true");
+	});
+
+	it("should reject an unknown key on an env-level redacted override and attribute the issue to the offending key", () => {
+		expect.assertions(1);
+
+		const result = validateConfig(
+			{
+				environments: { production: { redacted: { bogus: "value" } } },
+				state: { backend: "gist", gistId: "root-gist" },
+			},
+			SOURCE,
+		);
+
+		assert(!result.success);
+		assert(result.err.kind === "validationFailed");
+
+		expect(result.err.issues[0]!.path).toStrictEqual([
+			"environments",
+			"production",
+			"redacted",
+			"bogus",
 		]);
 	});
 

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -85,6 +85,54 @@ export interface RedactedPlaceOverride {
 }
 
 /**
+ * Env-scoped redaction override that applies across every redactable kind in
+ * a single environment. Each field is projected onto the kinds whose own
+ * override type names it: `price`, `name`, and `icon` reach passes and
+ * products; `description` reaches passes, products, and places; `displayName`
+ * reaches places. Fields a kind does not recognize are silently ignored for
+ * that kind.
+ *
+ * Composes field-by-field with per-resource overrides at the root and inside
+ * an env overlay; the most-specific layer wins per field. Boolean `true`
+ * contributes no fields; `false` carves the resource out at its layer.
+ *
+ * @example
+ *
+ * ```ts
+ * import type { Config, RedactedEnvironmentOverride } from "@bedrock-rbx/core/config";
+ *
+ * const devRedaction: RedactedEnvironmentOverride = { price: 1 };
+ *
+ * const config: Config = {
+ *     environments: { dev: { redacted: devRedaction } },
+ *     passes: {
+ *         "vip-pass": {
+ *             name: "VIP Pass",
+ *             description: "Grants VIP perks.",
+ *             icon: { "en-us": "assets/vip.png" },
+ *             price: 500,
+ *         },
+ *     },
+ *     state: { backend: "gist", gistId: "abc123" },
+ * };
+ *
+ * expect(config.environments["dev"]?.redacted).toStrictEqual({ price: 1 });
+ * ```
+ */
+export interface RedactedEnvironmentOverride {
+	/** Override name applied to every passes and products entry the env redacts. */
+	name?: string | undefined;
+	/** Override description applied to every passes, products, and places entry the env redacts. */
+	description?: string | undefined;
+	/** Override display name applied only to places (and universes, when their redaction lands). */
+	displayName?: string | undefined;
+	/** Override icon path applied to every passes and products entry the env redacts. */
+	icon?: Record<"en-us", string> | undefined;
+	/** Override Robux price applied to every on-sale passes and products entry the env redacts. */
+	price?: number | undefined;
+}
+
+/**
  * Body of a single entry in the `passes` collection. Keys in the parent
  * record are `ResourceKey`-shaped strings enforced at schema validation.
  */
@@ -428,8 +476,14 @@ export interface EnvironmentEntry {
 		string,
 		Partial<WithoutKey<DeveloperProductEntry, "redacted">> & { redacted?: boolean | undefined }
 	>;
-	/** Per-environment redaction toggle. Per-resource `redacted` flags on the merged config take precedence; `false` carves out exceptions. */
-	redacted?: boolean | undefined;
+	/**
+	 * Per-environment redaction layer. Accepts a boolean toggle or a
+	 * {@link RedactedEnvironmentOverride} carrying cross-kind override
+	 * fields. Per-resource `redacted` flags on the merged config take
+	 * precedence per field; `false` at any layer carves out at that
+	 * layer.
+	 */
+	redacted?: boolean | RedactedEnvironmentOverride | undefined;
 	/** Per-environment state override; takes precedence over root `state`. */
 	state?: StateConfig;
 	/**
@@ -838,6 +892,24 @@ const productRedactedOverride = type({
 
 const productRedacted = productRedactedOverride.or(OPTIONAL_BOOLEAN);
 
+const environmentRedactedOverride = type({
+	"description?": "string",
+	"displayName?": "string",
+	"icon?": iconMap,
+	"name?": "string",
+	"price?": OPTIONAL_ROBUX_PRICE,
+})
+	.onUndeclaredKey("reject")
+	.narrow((value, ctx) => {
+		if (Object.keys(value).length === 0) {
+			return ctx.mustBe(NON_EMPTY_OVERRIDE_MESSAGE);
+		}
+
+		return true;
+	});
+
+const environmentRedacted = environmentRedactedOverride.or(OPTIONAL_BOOLEAN);
+
 // Resource-kind entry schemas. Adding a new kind is two additions:
 // 1. Declare its entry schema and keyed-map collection below.
 // 2. Reference that collection as an optional property on `rootSchema`.
@@ -971,7 +1043,7 @@ const environmentEntry: Type<EnvironmentEntry> = type({
 	"passes?": passesOverlayCollection,
 	"places?": placesOverlayCollection,
 	"products?": productsOverlayCollection,
-	[REDACTED_KEY]: OPTIONAL_BOOLEAN,
+	[REDACTED_KEY]: environmentRedacted,
 	"state?": stateConfig,
 	"universe?": universeOverlay,
 }).onUndeclaredKey("reject");

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -551,6 +551,16 @@ export interface DisplayNamePrefixConfig {
 }
 
 /**
+ * Helper that produces a shallow `Omit<T, K>` without using TypeScript's
+ * built-in `Omit` (deprecated under the project's lint rules because of
+ * its lossy interaction with mapped types).
+ *
+ * @template T - Source type to project keys away from.
+ * @template Key - Key (or union of keys) on `T` to remove.
+ */
+export type WithoutKey<T, Key extends keyof T> = Pick<T, Exclude<keyof T, Key>>;
+
+/**
  * Per-environment universe overlay shape that prevents `universeId` from
  * being redeclared alongside a root-authoritative `universeId`.
  * Used by {@link ConfigRootUniverseId}: when the root universe block
@@ -747,16 +757,6 @@ export interface ResolvedConfig extends Pick<ConfigBase, Exclude<keyof ConfigBas
  * still declare (for example `"placeId"` or `"universeId"`).
  */
 type Overlay<T, RequiredKey extends keyof T> = SetRequired<Partial<T>, RequiredKey>;
-
-/**
- * Helper that produces a shallow `Omit<T, K>` without using TypeScript's
- * built-in `Omit` (deprecated under the project's lint rules because of
- * its lossy interaction with mapped types).
- *
- * @template T - Source type to project keys away from.
- * @template Key - Key (or union of keys) on `T` to remove.
- */
-type WithoutKey<T, Key extends keyof T> = Pick<T, Exclude<keyof T, Key>>;
 
 /**
  * Fields shared by every {@link Config} variant. The discriminated

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -158,7 +158,7 @@ export interface GamePassEntry {
 	 * placeholders with custom values while leaving the rest at bedrock
 	 * defaults; the object form implies redaction is enabled. Omit or set
 	 * `false` to push the real values unchanged. Environment overlays accept
-	 * only the boolean form.
+	 * the same shape and compose field-by-field with this layer.
 	 */
 	redacted?: boolean | RedactedGamePassOverride | undefined;
 }
@@ -243,7 +243,8 @@ export interface DeveloperProductEntry {
 	 * substitute selected placeholders with custom values while leaving the
 	 * rest at bedrock defaults; the object form implies redaction is enabled.
 	 * Omit or set `false` to push the real values unchanged. Environment
-	 * overlays accept only the boolean form.
+	 * overlays accept the same shape and compose field-by-field with this
+	 * layer.
 	 */
 	redacted?: boolean | RedactedDeveloperProductOverride | undefined;
 	/**
@@ -278,7 +279,8 @@ export interface PlaceEntry {
 	 * {@link RedactedPlaceOverride} to substitute selected placeholders
 	 * with custom values, including `displayName`. The object form
 	 * implies redaction is enabled. Omit or set `false` to push the real
-	 * values unchanged. Environment overlays accept only the boolean form.
+	 * values unchanged. Environment overlays accept the same shape and
+	 * compose field-by-field with this layer.
 	 */
 	redacted?: boolean | RedactedPlaceOverride | undefined;
 	/** Maximum players per server; positive integer. */

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -307,8 +307,8 @@ export interface ResolvedPlaceEntry {
 	placeId: string;
 	/**
 	 * Resolved redaction setting after merging the per-environment overlay
-	 * (boolean only at the overlay level) onto the root entry. See
-	 * {@link PlaceEntry.redacted} for the authored shape.
+	 * onto the root entry. See {@link PlaceEntry.redacted} for the
+	 * authored shape.
 	 */
 	redacted?: boolean | RedactedPlaceOverride | undefined;
 	/** Maximum players per server; positive integer. */
@@ -449,14 +449,11 @@ export interface EnvironmentEntry {
 	 *
 	 * Uses a partial `GamePassEntry` directly rather than `Overlay<T, K>`
 	 * because game passes have no user-supplied identity key (Open Cloud
-	 * mints the asset ID). The `redacted` field narrows to a boolean here:
-	 * per-field overrides (the {@link RedactedGamePassOverride} object form)
-	 * are valid only on the root resource entry.
+	 * mints the asset ID). The `redacted` field accepts the same shape it
+	 * does at the root entry: a boolean toggle or a {@link RedactedGamePassOverride}
+	 * carrying per-field overrides for this resource in this environment.
 	 */
-	passes?: Record<
-		string,
-		Partial<WithoutKey<GamePassEntry, "redacted">> & { redacted?: boolean | undefined }
-	>;
+	passes?: Record<string, Partial<GamePassEntry>>;
 	/**
 	 * Per-environment places overlay. `placeId` is required on every
 	 * declared entry; `filePath` is optional and falls through to the
@@ -468,14 +465,12 @@ export interface EnvironmentEntry {
 	 * missing fields fall through to the matching root `products` entry at
 	 * merge time. Mirrors the `passes` shape because developer products
 	 * also have no user-supplied identity key (Open Cloud mints the
-	 * `productId`). The `redacted` field narrows to a boolean here:
-	 * per-field overrides (the {@link RedactedDeveloperProductOverride}
-	 * object form) are valid only on the root resource entry.
+	 * `productId`). The `redacted` field accepts the same shape it does
+	 * at the root entry: a boolean toggle or a
+	 * {@link RedactedDeveloperProductOverride} carrying per-field
+	 * overrides for this resource in this environment.
 	 */
-	products?: Record<
-		string,
-		Partial<WithoutKey<DeveloperProductEntry, "redacted">> & { redacted?: boolean | undefined }
-	>;
+	products?: Record<string, Partial<DeveloperProductEntry>>;
 	/**
 	 * Per-environment redaction layer. Accepts a boolean toggle or a
 	 * {@link RedactedEnvironmentOverride} carrying cross-kind override
@@ -996,7 +991,7 @@ const gamePassOverlay = type({
 	"icon?": iconMap,
 	"name?": "string",
 	"price?": OPTIONAL_ROBUX_PRICE,
-	[REDACTED_KEY]: OPTIONAL_BOOLEAN,
+	[REDACTED_KEY]: gamePassRedacted,
 }).onUndeclaredKey("reject");
 
 const passesOverlayCollection = type({
@@ -1009,7 +1004,7 @@ const developerProductOverlay = type({
 	"isRegionalPricingEnabled?": OPTIONAL_BOOLEAN,
 	"name?": "string",
 	"price?": OPTIONAL_ROBUX_PRICE,
-	[REDACTED_KEY]: OPTIONAL_BOOLEAN,
+	[REDACTED_KEY]: productRedacted,
 	"storePageEnabled?": OPTIONAL_BOOLEAN,
 }).onUndeclaredKey("reject");
 
@@ -1022,7 +1017,7 @@ const placeOverlay = type({
 	"displayName?": OPTIONAL_STRING,
 	"filePath?": "string",
 	"placeId": ROBLOX_ID_DIGITS,
-	[REDACTED_KEY]: OPTIONAL_BOOLEAN,
+	[REDACTED_KEY]: placeRedacted,
 	"serverSize?": OPTIONAL_POSITIVE_INTEGER,
 }).onUndeclaredKey("reject");
 

--- a/packages/bedrock/src/core/select-environment.spec.ts
+++ b/packages/bedrock/src/core/select-environment.spec.ts
@@ -917,6 +917,38 @@ describe(selectEnvironment, () => {
 		expect(result.data.places?.["start-place"]?.description).toBe(REDACTED_DESCRIPTION);
 		expect(result.data.places?.["start-place"]?.displayName).toBe("[STAGING] Start Place");
 	});
+
+	it("should compose env-resource, root-resource, and env-level redaction overrides field-by-field", () => {
+		expect.assertions(4);
+
+		const config: Config = {
+			environments: {
+				dev: {
+					products: {
+						"gem-pack": {
+							redacted: { icon: { "en-us": "assets/dev-override.png" } },
+						},
+					},
+					redacted: { price: 1 },
+				},
+			},
+			products: {
+				"gem-pack": { ...GEM_PACK, redacted: { name: "Hidden Pack" } },
+			},
+			state: ROOT_STATE,
+		};
+
+		const result = selectEnvironment(config, "dev");
+
+		assert(result.success);
+
+		const gemPack = result.data.products?.["gem-pack"];
+
+		expect(gemPack?.name).toBe("Hidden Pack");
+		expect(gemPack?.icon).toStrictEqual({ "en-us": "assets/dev-override.png" });
+		expect(gemPack?.price).toBe(1);
+		expect(gemPack?.description).toBe(REDACTED_DESCRIPTION);
+	});
 });
 
 describe(selectMergedEnvironment, () => {

--- a/packages/bedrock/src/core/select-environment.ts
+++ b/packages/bedrock/src/core/select-environment.ts
@@ -3,7 +3,7 @@ import type { Result } from "@bedrock-rbx/ocale";
 import { defu } from "defu";
 
 import { renderDisplayNamePrefix } from "./display-name-prefix.ts";
-import { applyRedaction } from "./redact-resources.ts";
+import { applyRedaction, type EnvironmentResourceRedaction } from "./redact-resources.ts";
 import type {
 	Config,
 	DeveloperProductEntry,
@@ -107,6 +107,8 @@ interface MergedEnvironment {
 	 */
 	readonly merged: ResolvedConfig;
 }
+
+type WithoutRedacted<T> = Pick<T, Exclude<keyof T, "redacted">>;
 
 /**
  * Project a `Config` onto a single environment up to the pre-redaction
@@ -330,10 +332,28 @@ function mergeUniverse(
 	return defu(overlay ?? {}, base ?? {}) as ResolvedUniverseEntry;
 }
 
+function stripRedacted<T extends { readonly redacted?: unknown }>(
+	overlay: Readonly<Record<string, T>> | undefined,
+): Record<string, WithoutRedacted<T>> | undefined {
+	if (overlay === undefined) {
+		return undefined;
+	}
+
+	return Object.fromEntries(
+		Object.entries(overlay).map(([key, entryValue]) => {
+			const { redacted: _redacted, ...rest } = entryValue;
+			return [key, rest];
+		}),
+	);
+}
+
 function mergeOverlays(config: Config, entry: EnvironmentEntry): ResolvedConfig {
-	const passes = mergeKeyedRecord<GamePassEntry>(entry.passes, config.passes);
-	const places = mergeKeyedRecord<ResolvedPlaceEntry>(entry.places, config.places);
-	const products = mergeKeyedRecord<DeveloperProductEntry>(entry.products, config.products);
+	const passes = mergeKeyedRecord<GamePassEntry>(stripRedacted(entry.passes), config.passes);
+	const places = mergeKeyedRecord<ResolvedPlaceEntry>(stripRedacted(entry.places), config.places);
+	const products = mergeKeyedRecord<DeveloperProductEntry>(
+		stripRedacted(entry.products),
+		config.products,
+	);
 	const universe = mergeUniverse(entry.universe, config.universe);
 	const state = entry.state ?? config.state;
 
@@ -463,13 +483,34 @@ function applyPlacesPrefix(
 	);
 }
 
+function extractRedactionLayer<Value>(
+	overlay: Readonly<Record<string, { readonly redacted?: Value }>>,
+): Readonly<Record<string, Value>> {
+	const layer: Record<string, Value> = {};
+	for (const [key, entryValue] of Object.entries(overlay)) {
+		if (entryValue.redacted !== undefined) {
+			layer[key] = entryValue.redacted;
+		}
+	}
+
+	return layer;
+}
+
 function redactAndPrefix(inputs: {
 	readonly config: Config;
 	readonly entry: EnvironmentEntry;
 	readonly merged: ResolvedConfig;
 }): ResolvedConfig {
 	const { config, entry, merged } = inputs;
-	const redacted = applyRedaction(merged, entry.redacted);
+	const environmentResource: EnvironmentResourceRedaction = {
+		...(entry.passes ? { passes: extractRedactionLayer(entry.passes) } : {}),
+		...(entry.places ? { places: extractRedactionLayer(entry.places) } : {}),
+		...(entry.products ? { products: extractRedactionLayer(entry.products) } : {}),
+	};
+	const redacted = applyRedaction(merged, {
+		envLevel: entry.redacted,
+		envResource: environmentResource,
+	});
 	const prefix = resolvePrefix(config, entry);
 	const places = applyPlacesPrefix(redacted.places, prefix);
 	const universe = applyUniversePrefix(redacted.universe, prefix);

--- a/packages/bedrock/src/core/select-environment.ts
+++ b/packages/bedrock/src/core/select-environment.ts
@@ -153,6 +153,23 @@ export function selectMergedEnvironment(
 }
 
 /**
+ * Build the per-resource env-overlay redaction layer that `applyRedaction`
+ * and `collectRedactionAnnotations` consume. Reads each redactable kind off
+ * the environment entry and projects every entry's `redacted` field into
+ * the layer; omits kinds the env entry does not declare.
+ *
+ * @param entry - Environment entry whose overlay redaction values to extract.
+ * @returns A `EnvironmentResourceRedaction` ready to pass downstream.
+ */
+export function extractResourceRedaction(entry: EnvironmentEntry): EnvironmentResourceRedaction {
+	return {
+		...(entry.passes ? { passes: extractRedactionLayer(entry.passes) } : {}),
+		...(entry.places ? { places: extractRedactionLayer(entry.places) } : {}),
+		...(entry.products ? { products: extractRedactionLayer(entry.products) } : {}),
+	};
+}
+
+/**
  * Project a validated `Config` onto a single environment. Looks up the
  * matching `environments[environment]` entry, deep-merges its resource
  * overlay (`passes`, `places`, `universe`) over the root config via defu,
@@ -439,6 +456,19 @@ function findIncompletePlace(
 	return undefined;
 }
 
+function extractRedactionLayer<Value>(
+	overlay: Readonly<Record<string, { readonly redacted?: Value }>>,
+): Readonly<Record<string, Value>> {
+	const layer: Record<string, Value> = {};
+	for (const [key, entryValue] of Object.entries(overlay)) {
+		if (entryValue.redacted !== undefined) {
+			layer[key] = entryValue.redacted;
+		}
+	}
+
+	return layer;
+}
+
 function resolvePrefix(config: Config, entry: EnvironmentEntry): string | undefined {
 	if (config.displayNamePrefix?.enabled === false) {
 		return undefined;
@@ -482,33 +512,15 @@ function applyPlacesPrefix(
 	);
 }
 
-function extractRedactionLayer<Value>(
-	overlay: Readonly<Record<string, { readonly redacted?: Value }>>,
-): Readonly<Record<string, Value>> {
-	const layer: Record<string, Value> = {};
-	for (const [key, entryValue] of Object.entries(overlay)) {
-		if (entryValue.redacted !== undefined) {
-			layer[key] = entryValue.redacted;
-		}
-	}
-
-	return layer;
-}
-
 function redactAndPrefix(inputs: {
 	readonly config: Config;
 	readonly entry: EnvironmentEntry;
 	readonly merged: ResolvedConfig;
 }): ResolvedConfig {
 	const { config, entry, merged } = inputs;
-	const environmentResource: EnvironmentResourceRedaction = {
-		...(entry.passes ? { passes: extractRedactionLayer(entry.passes) } : {}),
-		...(entry.places ? { places: extractRedactionLayer(entry.places) } : {}),
-		...(entry.products ? { products: extractRedactionLayer(entry.products) } : {}),
-	};
 	const redacted = applyRedaction(merged, {
 		envLevel: entry.redacted,
-		envResource: environmentResource,
+		envResource: extractResourceRedaction(entry),
 	});
 	const prefix = resolvePrefix(config, entry);
 	const places = applyPlacesPrefix(redacted.places, prefix);

--- a/packages/bedrock/src/core/select-environment.ts
+++ b/packages/bedrock/src/core/select-environment.ts
@@ -13,6 +13,7 @@ import type {
 	ResolvedPlaceEntry,
 	ResolvedUniverseEntry,
 	UniverseEntry,
+	WithoutKey,
 } from "./schema.ts";
 
 /**
@@ -107,8 +108,6 @@ interface MergedEnvironment {
 	 */
 	readonly merged: ResolvedConfig;
 }
-
-type WithoutRedacted<T> = Pick<T, Exclude<keyof T, "redacted">>;
 
 /**
  * Project a `Config` onto a single environment up to the pre-redaction
@@ -334,7 +333,7 @@ function mergeUniverse(
 
 function stripRedacted<T extends { readonly redacted?: unknown }>(
 	overlay: Readonly<Record<string, T>> | undefined,
-): Record<string, WithoutRedacted<T>> | undefined {
+): Record<string, WithoutKey<T, "redacted">> | undefined {
 	if (overlay === undefined) {
 		return undefined;
 	}

--- a/packages/bedrock/src/index.ts
+++ b/packages/bedrock/src/index.ts
@@ -84,6 +84,7 @@ export {
 	type GistStateConfig,
 	type PlaceEntry,
 	type RedactedDeveloperProductOverride,
+	type RedactedEnvironmentOverride,
 	type RedactedGamePassOverride,
 	type RedactedPlaceOverride,
 	type ResolvedConfig,

--- a/packages/bedrock/src/shell/preview-diff.ts
+++ b/packages/bedrock/src/shell/preview-diff.ts
@@ -12,6 +12,7 @@ import { collectRedactionAnnotations, type RedactionAnnotation } from "../core/r
 import { resolveStateConfig, type StateNotConfiguredError } from "../core/resolve-state-config.ts";
 import type { Config, ResolvedConfig } from "../core/schema.ts";
 import {
+	extractResourceRedaction,
 	type IncompletePassEntryError,
 	type IncompletePlaceEntryError,
 	type IncompleteUniverseEntryError,
@@ -172,10 +173,11 @@ function resolveEnvironmentView(
 		return { err: selected.err, success: false };
 	}
 
+	const environmentResource = extractResourceRedaction(merged.data.entry);
 	return {
 		data: {
 			effective: selected.data,
-			redactions: collectRedactionAnnotations(merged.data.merged),
+			redactions: collectRedactionAnnotations(merged.data.merged, environmentResource),
 		},
 		success: true,
 	};


### PR DESCRIPTION
## Summary

- `environments.<env>.redacted` accepts a `RedactedEnvironmentOverride` object alongside `boolean`. The override carries the cross-kind union of redactable fields (`name`, `description`, `icon`, `price`, `displayName`) and projects onto each kind for the fields that kind recognises.
- `environments.<env>.{passes,places,products}.<key>.redacted` accepts the kind's existing per-field override object alongside `boolean`, removing the public-API asymmetry the exported `Redacted{GamePass,DeveloperProduct,Place}Override` types previously suggested.
- Redaction layers compose field-by-field per resource, most-specific to least-specific: env-resource > root-resource > env-level. The first non-undefined `redacted` value sets state (`false` carves out); object layers contribute fields with the most-specific layer winning per field; boolean `true` contributes no fields; bedrock kind defaults fill any field nobody set.

Realises the env-scope-override and field-level-merging sections of the 2026-05-19 amendment to [docs/adr/024-resource-redaction.md](https://github.com/christopher-buss/bedrock/blob/main/docs/adr/024-resource-redaction.md) ([#435](https://github.com/christopher-buss/bedrock/pull/435)). Covers user story 17 from the PRD ([#408](https://github.com/christopher-buss/bedrock/issues/408)).

Closes #434.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm build` succeeds
- [x] `pnpm test` (2139 passed, 0 failed, type checks clean)
- [x] `pnpm typecheck` clean
- [x] `pnpm mutate:changed` reports 100% on `packages/bedrock/src/core/redact-resources.ts`, `schema.ts`, and `select-environment.ts`
- [x] Three rejection tests in `schema.spec.ts` flipped to acceptance; empty-object rejection siblings added for each env-overlay kind
- [x] `select-environment.spec.ts` integration test exercises root override `{ name }` + env-level override `{ price }` + env-resource override `{ icon }` field-merging end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)