### PR TITLE
docs: add adr-025 for luau-config type definitions

### DIFF
--- a/docs/adr/025-luau-type-definitions.md
+++ b/docs/adr/025-luau-type-definitions.md
@@ -1,0 +1,179 @@
+# ADR-025: Luau type definitions for bedrock.config.luau
+
+**Date:** 2026-05-19 **Status:** Accepted
+
+Decision Makers: Maintainer
+Tags: luau, types, config, distribution, testing, lute, public-api
+
+## Context
+
+Bedrock supports five config formats via c12: TypeScript, JavaScript, YAML, JSON, and Luau. ADR-020 defines the shared `Config` shape and the `defineConfig` helper that the TypeScript surface exposes through `@bedrock-rbx/core/config`. A TypeScript author writes `import { defineConfig, type Config } from "@bedrock-rbx/core/config"` and gets IDE autocomplete, type errors on misspelled fields, structural validation at edit time, and the strict universeId XOR enforced as a discriminated union with branded-error messages that point at the offending field. A Luau author writes a bare table literal and gets none of that. Arktype validates either author's config at load time so deploy-time errors are structured, but the gap between edit-time experience and deploy-time experience is meaningful, and doubly so for agents authoring configs on behalf of users.
+
+ADR-017 names Luau-population developers as a peer audience to TypeScript developers, not a fallback. The expected Luau author runs the bundled bedrock CLI standalone (via `mise` or `rokit`) rather than installing the npm package; their editor reaches type definitions through `.luaurc` aliases, not `node_modules`. So shipping Luau types is not a matter of adding a `.d.luau` to the npm package and trusting resolution to handle the rest. Distribution is a first-class concern.
+
+Three constraints shape the design space:
+
+- **Luau new-solver limitations.** Luau's new type-solver does not narrow object unions from literals ([luau-lang/luau#2205](https://github.com/luau-lang/luau/issues/2205)). Annotating a literal against `ConfigRootUniverseId | ConfigEnvironmentUniverseId` produces a multi-bullet fan-out enumerating per-component mismatches across both variants, including against valid configs. Wrapper functions over the literal hit related problems: generic identity wrappers force exact-match comparisons that flag valid configs as invalid, overload-intersection signatures collapse to "no overloads compatible" without surfacing variant-specific directives, and unchecked `::` casts silently accept XOR violations. These behaviors were verified across a dozen spike fixtures before this decision.
+
+- **API symmetry across the two languages.** The TypeScript public API is `defineConfig({...})` over a discriminated `Config` union; users do not annotate manually because TypeScript narrows on the literal. Diverging the Luau API (introducing per-variant factory functions, requiring a variant annotation on the receiving variable, or adding a discriminator field to the schema) breaks the symmetry that motivates having `defineConfig` at all.
+
+- **Hand-author duality already in the codebase.** ADR-020 paired the TypeScript `Config` interface with a hand-written arktype validator; maintainers update both surfaces per schema change today. Adding a Luau surface as a third hand-author is an increment, not a redesign.
+
+The decision space narrowed to: encode the full TypeScript shape including the XOR variants and accept a degraded Luau diagnostic experience; add a discriminator field to the schema as a workaround for the Luau limitation; or ship a permissive Luau shape that defers XOR enforcement to the existing arktype runtime narrow. This ADR records the third path.
+
+## Decision
+
+### Schema scope
+
+The Luau `Config` type mirrors the TypeScript `Config` structurally with one departure: it is a single permissive shape rather than a discriminated XOR union. Every field optional in TypeScript is also optional in Luau. The root `universe.universeId` and every per-environment `environments[*].universe.universeId` are typed `string?`. No singleton-string directive types. No brand-intersection encoding.
+
+Arktype's existing runtime narrow at `loadConfig` time enforces the XOR rule and produces directive messages identical to the TypeScript branded-error placeholders. A Luau author who declares `universeId` at both the root and a per-environment overlay sees the directive at deploy time rather than edit time. The trade-off is bounded: arktype already attributes the failure to the offending field path; only the surfacing moment moves from editor to CLI invocation.
+
+The permissive type is a structural supertype of the discriminated TypeScript variants. When luau-lang/luau#2205 closes (or another narrowing mechanism lands), the Luau type can be refined into the discriminated union without breaking existing user configs.
+
+### `defineConfig` signature (Luau)
+
+The Luau module exports `defineConfig` as an identity-typed function:
+
+```luau
+local function defineConfig(c: Config): Config
+    return c
+end
+```
+
+The parameter is a concrete `Config` (the permissive shape from above), not a union or a generic. Runtime is identity. The signature mirrors the TypeScript shape `defineConfig<T extends Config>(c: T): T` modulo the Luau type-system's inability to express the generic-identity bound without forcing exact-match comparisons on the literal.
+
+Function name and call shape are identical across languages. The TypeScript user writes `defineConfig({...})`; the Luau user writes `defineConfig({...})`. No API divergence.
+
+### Distribution: `bedrock setup`
+
+A new CLI command, `bedrock setup`, materializes the Luau source bundled inside the bedrock binary into `.bedrock/config.luau` in the user's repository and merges an `@bedrock` alias into the user's `.luaurc`. The alias points at the `.bedrock/` directory; users `require("@bedrock/config")` to import the module. The alias subpath structure (`@bedrock/config`) mirrors the TypeScript export path (`@bedrock-rbx/core/config`).
+
+The same setup flow materializes additional `.bedrock/` files in future slices (e.g. `@bedrock/testing` for the type-spec primitives). The `@bedrock` alias is intentionally a directory alias, not a file alias, so future module additions slot in without another `.luaurc` change or a re-run requirement on the user.
+
+`bedrock setup` is the single mutating command for these files; every other `bedrock` subcommand is read-only with respect to `.bedrock/` and `.luaurc`. Three flags control its behavior:
+
+- `--alias <name>` overrides the default `bedrock` alias name when a user already has an `@bedrock` alias pointing elsewhere.
+- `--types-path <path>` overrides the default `.bedrock/config.luau` location.
+- `--check` runs the staleness check (described below) explicitly without performing any writes.
+
+The chosen alias is persisted in setup state so subsequent runs without `--alias` honor it.
+
+Distribution works the same way for users on the npm install path and users on the bun-compiled standalone binary. The Luau source files live at `packages/bedrock/src/luau/` in the source tree, ship to `dist/luau/` for npm consumers, and are embedded into the binary via Bun's asset embedding mechanism for standalone consumers. `bedrock setup` reads from the appropriate location at runtime.
+
+### Auto-check semantics
+
+Every `bedrock` subcommand other than `setup` calls a content-hash comparison against `.bedrock/config.luau` before its main logic. On mismatch (the on-disk file does not match the version embedded in the running binary), the command prints a stderr warning naming the file and instructing `bedrock setup` as the fix. Execution continues regardless. Missing on-disk content produces no warning, since a user who has not run setup is not in a staleness condition.
+
+The check never blocks execution and never mutates files. Auto-fix was rejected: `.bedrock/config.luau` lives in the user's working tree and is likely checked into version control, where surprising mutations to a file the user may be inspecting in their editor are hostile.
+
+Two opt-outs:
+
+- `BEDROCK_SKIP_TYPES_CHECK=1` environment variable suppresses the check entirely for a single process invocation. Intended for CI environments that prefer to suppress noise.
+- `bedrock setup --check` runs the same check explicitly; exit code 0 if fresh, non-zero if stale. Suitable for pre-commit hooks or CI gates that want to fail loudly rather than warn quietly.
+
+### Testing pattern
+
+Type-spec tests live in `packages/bedrock/tests/luau-types/`. Each fixture is a `.spec.luau` file using a `describe`/`it` block structure that mirrors `.spec-d.ts` files on the TypeScript side. The fixture uses three primitives:
+
+| Primitive | Role | TypeScript analog |
+|---|---|---|
+| `describe(...)` / `it(...)` runtime stubs | Make test boundaries discoverable to the AST walker | Same |
+| `-- @expect-error` directive | Assert that the following line produces a `lute check` diagnostic | `// @ts-expect-error` |
+| `Expect<A, B>` type-level alias | Assert that two types are structurally equal | `expectTypeOf<A>().toEqualTypeOf<B>()` |
+
+`describe` and `it` are exported as runtime no-op functions from a new `@bedrock/testing` Luau module that `bedrock setup` materializes alongside `@bedrock/config`. Their sole purpose is to be findable by the AST walker. `Expect<A, B>` is a hand-rolled type function in the same module that errors when the two types are not structurally equal.
+
+The Vitest harness orchestrates the pipeline: glob fixtures, run `lute transform` against a parser script to extract describe/it line ranges, run `lute check` and parse diagnostics, cross-reference diagnostics with `@expect-error` directives and test ranges, produce per-fixture pass/fail. A directive without a following diagnostic is an unused-directive failure; a diagnostic on a line without a preceding directive is an unexpected-error failure. The harness asserts diagnostic presence; message text is intentionally not asserted because wording over-binds to specific Luau toolchain versions.
+
+The harness module structure (`parse-tests.luau`, `parse-diagnostics.ts`, `parse-directives.ts`, `runner.ts`) mirrors `jest-roblox-cli/src/typecheck/` so the prototype lifts to that project as a Luau-spec subcommand when ready.
+
+A vitest-style fluent `expectTypeOf(value).toEqualTypeOf(other)` API is not part of the day-1 surface. The same Luau new-solver limitation that drives the schema-scope decision suppresses type-function errors inside generic function bodies, so the fluent shape silently passes every test regardless of type mismatch. The type-level `Expect<A, B>` is the day-1 form; a fluent value-level API can layer on top when the underlying limitation is resolved.
+
+### Parity enforcement
+
+Drift between the TypeScript and Luau schemas is enforced by code review, not by an automated structural diff. The project `/review` skill is extended to flag any change to `packages/bedrock/src/core/schema.ts` that lacks a parallel change to `packages/bedrock/src/luau/config.luau`, and vice versa. The check excludes the deferred-XOR delta from "drift" (the TypeScript schema has discriminated variants with branded-error properties; the Luau schema does not, intentionally, per this ADR).
+
+The type-spec fixture suite is the safety net for the most common drift classes: a field added to a TypeScript entry type without the matching Luau addition surfaces as a missing-field diagnostic when a fixture exercises the new field.
+
+## Consequences
+
+### Positive
+
+- Luau authors and agent-authored configs get editor-time type safety on misspelled fields, wrong-typed values, and unknown resource kinds, closing the parity gap with TypeScript authors.
+- `defineConfig` has the same name and call shape across both languages, preserving the symmetric API surface that ADR-017's peer-audience framing demands.
+- `bedrock setup` is the only mutating command for the Luau type files; combined with the warn-only auto-check, users keep full control of their working tree.
+- The type-spec testing pattern (`describe`/`it` + `@expect-error` + `Expect<A, B>`) enables TDD on Luau type changes. The harness module structure is lift-ready into jest-roblox-cli for future reuse.
+- The permissive Luau `Config` is a structural supertype of the discriminated TypeScript variants, so refining the Luau type later when luau-lang/luau#2205 closes does not break user configs written against the permissive shape.
+- The `@bedrock` alias is a directory alias, leaving room for future Luau-side modules (`@bedrock/runtime`, generated constants, etc.) without another `.luaurc` change.
+
+### Negative
+
+- The XOR rule between root and per-environment `universeId` is not enforced at edit time on the Luau side. Luau authors see the failure at deploy via arktype rather than in the editor.
+- Hand-author duality grows from two surfaces (TypeScript interface + arktype validator) to three (add Luau type), increasing maintenance per schema change. The `/review` skill becomes load-bearing for parity enforcement.
+- Luau users must run `bedrock setup` once before their editor picks up the types, adding a step to onboarding.
+- Lute is a hard dependency for both the type-spec test harness and the binary embedding mechanism. Toolchain pinning via `mise.toml` is now consequential.
+- The type-spec test harness is bedrock-internal infrastructure until jest-roblox-cli adopts it. The `-- @expect-error` directive convention is locally invented and not portable to other Luau testing frameworks.
+- The deferred-XOR creates an intentional asymmetry between the TypeScript discriminated variants and the Luau permissive shape. Future maintainers must respect that the asymmetry is intentional rather than treat it as drift.
+
+## Alternatives Considered
+
+### Discriminated XOR variants in the Luau `Config` type
+
+**Rejected because:** Luau's new type-solver does not narrow object unions from literals. Annotating a literal against `ConfigRootUniverseId | ConfigEnvironmentUniverseId` produces a multi-bullet fan-out enumerating per-component mismatches across both variants. Verified during spike work, where both valid root-only and valid env-only configs produced 9-12 bullet diagnostics. "Verbose-but-shipped" is not a viable middle ground because the verbosity fires on correct configs, not just XOR violations.
+
+### Top-level discriminator field on the schema (`mode: "root" | "env"`)
+
+**Rejected because:** this works at the type-checker level, with a non-generic `defineConfig(c: Config): Config` producing clean variant-pinned diagnostics in both directions. But the discriminator is a schema field added purely to work around a transient Luau type-solver limitation. Adding it locks every user config into carrying a redundant field that arktype would derive on its own from `universeId` placement. Removing it later once Luau ships union narrowing is a wire-contract change.
+
+### API divergence alternatives: two factory functions per variant, or no `defineConfig` at all
+
+**Rejected because:** both shapes produce clean variant-pinned diagnostics. Two factories (`defineConfigWithRootUniverse` / `defineConfigWithEnvironmentUniverses`) work because each parameter is a single non-union variant; dropping `defineConfig` and requiring `local config: ConfigRootUniverseId = {...}` works because the annotation pins the variant. Both diverge from the TypeScript API in user-visible ways: the first adds two named functions where TypeScript has one, the second removes the function entirely. ADR-017 names API symmetry across the two audiences as a property worth preserving, not a coincidence to be sacrificed.
+
+### Wrapper-function encodings of `defineConfig` (identity generic, overload intersection, unchecked cast)
+
+**Rejected because:** every wrapper that influences types degrades the diagnostic. A generic identity wrapper (`defineConfig<T>(c: T): T`) infers `T` from the literal and forces exact-match comparisons that flag valid configs as invalid. An overload-intersection signature collapses to "None of the overloads for function that accept 1 arguments are compatible" without surfacing the variant-specific directive. An unchecked `::` cast silently accepts XOR violations entirely. The only wrapper-free path that preserves the clean diagnostic is direct variant annotation, which the previous alternative addresses.
+
+### Generate Luau types from the TypeScript schema
+
+**Rejected because:** the TypeScript schema is already hand-paired with an arktype runtime validator per ADR-020; maintainers update both surfaces per schema change. Adding a Luau surface as a third hand-author is incremental. A generator would need per-construct rules for TypeScript features Luau cannot express (branded errors, key-pattern indexers, the XOR discriminated union itself), which is substantial machinery for the same outcome a `/review` skill update achieves.
+
+### Vitest-style fluent `expectTypeOf().toEqualTypeOf()` for type assertions
+
+**Rejected because:** the same Luau new-solver limitation that drives the schema-scope decision suppresses type-function errors inside generic function bodies. A wrapper like `expectTypeOf<T>(_: T): { toEqualTypeOf: <U>(_: U) -> () }` looks correct syntactically but silently passes every test regardless of type mismatch. The type-level `Expect<A, B>` form works correctly; a fluent value-level API can layer on top when the underlying limitation is resolved.
+
+### Automated TypeScript-to-Luau structural diff for parity enforcement
+
+**Rejected because:** the deferred-XOR delta is an intentional asymmetry between the two schemas. A structural diff would need a hand-maintained allow-list of intentional differences that grows every time the asymmetry expands. The `/review` skill is a higher-leverage place to capture the parity expectation because the skill already encodes domain context that an automated diff cannot.
+
+### Auto-fix stale on-disk types on every `bedrock` command
+
+**Rejected because:** `.bedrock/config.luau` lives in the user's working tree and is likely checked into version control. A `bedrock deploy` invocation that silently rewrites a file the user may be inspecting in their editor, or that turns up as an unexpected diff at commit time, is hostile. `bedrock setup` being the single mutating command is the predictable mental model; the auto-check warns the user so they choose when to run setup.
+
+## Implementation Notes
+
+- The Luau source files live at `packages/bedrock/src/luau/config.luau` and `packages/bedrock/src/luau/testing.luau`. Per-resource entry types compose into the root `Config` type in the same file.
+- The `bedrock setup` command is implemented as `packages/bedrock/src/cli/commands/setup.ts` wrapping a shell function. The `.luaurc` parse/merge logic is a pure function in `src/core/luaurc.ts`; I/O orchestration lives in the shell layer.
+- The staleness check uses a content hash of the bundled and on-disk Luau sources. Any byte difference counts as stale.
+- Bun's asset embedding mechanism carries the Luau source files into the compiled binary. For npm consumers, the same files ship under `dist/luau/` via `vp pack`.
+- The type-spec harness lives at `packages/bedrock/tests/luau-types/`. Module structure mirrors `jest-roblox-cli/src/typecheck/` so the prototype lifts to that project as a Luau-spec subcommand.
+- Lute is the analyzer: `lute check` produces structured diagnostics; `lute transform` walks the AST. Pinned via `mise.toml`.
+- Implementation is tracked via PRD [#441](https://github.com/christopher-buss/bedrock/issues/441), broken into six AFK-ready slices.
+
+## Related Decisions
+
+- ADR-003 — Testing Strategy: TDD and 100% coverage apply to the new modules; the type-spec harness extends the testing surface to Luau.
+- ADR-009 — Result Types Over Exceptions: `setupLuauTypes` and `checkLuauTypesStale` shell functions return `Result`.
+- ADR-017 — Product Framing: peer-audience principle that motivates same-named APIs across TypeScript and Luau.
+- ADR-018 — FCIS Ports: pure `.luaurc` logic lives in core; setup orchestration lives in shell; the CLI command is a primary adapter.
+- ADR-020 — Project Config Definition: the TypeScript-side `Config` and `defineConfig` that this ADR mirrors for Luau.
+
+## References
+
+- [Lute](https://github.com/luau-lang/lute) — Luau runtime used as the type-checker (`lute check`) and AST walker (`lute transform`).
+- [luau-lang/luau#2205](https://github.com/luau-lang/luau/issues/2205) — upstream Luau issue tracking object-union narrowing from literals; defines the forward-compatibility path.
+- [typeforge](https://github.com/typeforge-luau/typeforge) — reference implementation of Luau type functions; the `Expect<A, B>` pattern is hand-rolled in the same style.
+- [jest-roblox-cli](https://github.com/christopher-buss/jest-roblox-cli) — lift target for the type-spec harness; module structure here intentionally mirrors `src/typecheck/`.
+- PRD [#441](https://github.com/christopher-buss/bedrock/issues/441) — implementation specification.
+- Issue [#315](https://github.com/christopher-buss/bedrock/issues/315) — predecessor issue raising the question.
+- [docs/spikes/luau-types/](../spikes/luau-types/) — feasibility evidence with 11 numbered sections covering every encoding pattern explored.

--- a/docs/adr/025-luau-type-definitions.md
+++ b/docs/adr/025-luau-type-definitions.md
@@ -53,7 +53,7 @@ The same setup flow materializes additional `.bedrock/` files in future slices (
 
 `bedrock setup` is the single mutating command for these files; every other `bedrock` subcommand is read-only with respect to `.bedrock/` and `.luaurc`. Three flags control its behavior:
 
-- `--alias <name>` overrides the default `bedrock` alias name when a user already has an `@bedrock` alias pointing elsewhere.
+- `--alias <name>` overrides the default alias name when a user already has an `@bedrock` alias pointing elsewhere.
 - `--types-path <path>` overrides the default `.bedrock/config.luau` location.
 - `--check` runs the staleness check (described below) explicitly without performing any writes.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,6 +34,7 @@ things are the way they are.
 | [022](./022-by-domain-folder-layout-for-ocale.md) | By-Domain Folder Layout for `@bedrock-rbx/ocale` | Accepted | 2026-04-30 |
 | [023](./023-apply-semantics-parallel-continue-on-failure.md) | Apply Semantics — Parallel, Continue-on-Failure, Per-Op Progress Events | Accepted | 2026-05-14 |
 | [024](./024-resource-redaction.md) | Resource Redaction for Pre-Release Environments | Accepted | 2026-05-14 |
+| [025](./025-luau-type-definitions.md) | Luau type definitions for `bedrock.config.luau` | Accepted | 2026-05-19 |
 
 ## Creating a New ADR
 

--- a/docs/spikes/luau-types/README.md
+++ b/docs/spikes/luau-types/README.md
@@ -1,0 +1,40 @@
+# Luau type spike
+
+Feasibility evidence for [ADR-025: Luau type definitions for bedrock.config.luau](../../adr/025-luau-type-definitions.md).
+
+The single file [`spike.luau`](./spike.luau) consolidates every encoding pattern explored during the feasibility work, in 11 numbered sections. Each section is either a chosen pattern or a rejected alternative; the comment block at the top of each section names which.
+
+## Running
+
+```bash
+mise use luau@0.689  # once per session
+lute check spike.luau
+```
+
+Or open `spike.luau` in your editor with luau-lsp enabled and hover the lines marked `EXPECT ERROR` to see each section's diagnostic inline.
+
+`luau-analyze` 0.689 does not support user-defined type functions; `lute check` is the only working analyser.
+
+## Section map
+
+| Section | Topic | Outcome |
+| --- | --- | --- |
+| 1 | `types.error('msg')` inside a type function | Rejected (API not exposed in toolchain) |
+| 2 | Plain `error('msg')` inside a type function | Rejected (framing too noisy) |
+| 3 | Singleton-string optional property | Chosen encoding for directive-bearing fields |
+| 4 | `never?` optional | Control (clean but uninformative) |
+| 5 | Singleton + brand intersection | Rejected (extra noise, no added protection) |
+| 6 | Type-function structural guard | Rejected (indexer collapses per-key shape) |
+| 7 | Top-level `Config` union, invalid config | Demonstrates the fan-out problem |
+| 8 | Top-level `Config` union, VALID configs | Critical finding: fan-out fires on valid configs too |
+| 9 | Variant-pinned annotation | Chosen baseline for clean directive diagnostics |
+| 10 | Top-level `mode` discriminator field | Rejected (schema-change workaround for a transient solver limitation) |
+| 11 | Fluent `expectTypeOf().toEqualTypeOf()` API | Rejected (silently passes regardless of mismatch) |
+
+Sections 3 and 9 are the patterns the future-tightened Luau types will use once [luau-lang/luau#2205](https://github.com/luau-lang/luau/issues/2205) closes. Sections 7, 8, 10, and 11 are the alternatives ADR-025 rejects.
+
+## Related context
+
+- ADR-025: [docs/adr/025-luau-type-definitions.md](../../adr/025-luau-type-definitions.md)
+- PRD: [christopher-buss/bedrock#441](https://github.com/christopher-buss/bedrock/issues/441)
+- Upstream Luau issue: [luau-lang/luau#2205](https://github.com/luau-lang/luau/issues/2205)

--- a/docs/spikes/luau-types/spike.luau
+++ b/docs/spikes/luau-types/spike.luau
@@ -16,7 +16,7 @@
 -- Mirrors `packages/bedrock/src/core/schema.ts` lines 504-585. The two
 -- variants encode the universeId XOR via singleton-string directive types
 -- on the forbidden side. ADR-025 ships the union DROPPED in favour of a
--- single permissive Config in `src/luau/config.luau`; the discriminated
+-- single permissive Config in `packages/bedrock/src/luau/config.luau`; the discriminated
 -- variants here exist so the union-encoding alternatives (sections 7-9)
 -- can be demonstrated against the schema we would otherwise ship.
 -- ============================================================================

--- a/docs/spikes/luau-types/spike.luau
+++ b/docs/spikes/luau-types/spike.luau
@@ -1,0 +1,348 @@
+--!strict
+--
+-- Luau type-spike for `bedrock.config.luau` type definitions.
+--
+-- This single file consolidates every encoding pattern explored during the
+-- feasibility work that produced ADR-025. Each section is independently
+-- demonstrable via `lute check spike.luau` and demonstrates either a
+-- chosen pattern or a rejected alternative.
+--
+-- Open in luau-lsp for inline diagnostics on lines marked "EXPECT ERROR",
+-- or run `lute check spike.luau` to see the full diagnostic stream.
+
+-- ============================================================================
+-- Reference schema.
+--
+-- Mirrors `packages/bedrock/src/core/schema.ts` lines 504-585. The two
+-- variants encode the universeId XOR via singleton-string directive types
+-- on the forbidden side. ADR-025 ships the union DROPPED in favour of a
+-- single permissive Config in `src/luau/config.luau`; the discriminated
+-- variants here exist so the union-encoding alternatives (sections 7-9)
+-- can be demonstrated against the schema we would otherwise ship.
+-- ============================================================================
+
+type UniverseOverlayForbidId = {
+	description: string?,
+	displayName: string?,
+	universeId: "universeId is already declared on the root universe block; remove it from this environment overlay, or remove it from root and declare it on every environment overlay instead"?,
+}
+
+type EnvEntryForbidId = {
+	universe: UniverseOverlayForbidId?,
+}
+
+type ConfigRootUniverseId = {
+	universe: { universeId: string, description: string?, displayName: string? },
+	environments: { [string]: EnvEntryForbidId },
+}
+
+type UniverseOverlayRequireId = {
+	universeId: string,
+	description: string?,
+	displayName: string?,
+}
+
+type EnvEntryRequireId = {
+	universe: UniverseOverlayRequireId?,
+}
+
+type ConfigEnvironmentUniverseId = {
+	universe: {
+		universeId: "universeId is already declared per environment; remove it from the root universe block, or remove it from every environment overlay and declare it here instead"?,
+		description: string?,
+		displayName: string?,
+	}?,
+	environments: { [string]: EnvEntryRequireId },
+}
+
+type Config = ConfigRootUniverseId | ConfigEnvironmentUniverseId
+
+-- ============================================================================
+-- Section 1. types.error('msg') -- NOT exposed in the current toolchain.
+--
+-- The new-solver spec describes `types.error(msg)` as the canonical way to
+-- emit a custom diagnostic from a type function. The lute build we have
+-- does not expose it; the body fails to parse the key access.
+-- ============================================================================
+
+type function _section1_err_via_types(_t: type): type
+	return types.error("section 1 diagnostic") -- EXPECT ERROR: Key 'error' not found in table 'typeof(types)'
+end
+
+local _section1: _section1_err_via_types<string> = "ok" -- EXPECT ERROR: type function errored at runtime / reduces to never
+
+-- ============================================================================
+-- Section 2. Plain error('msg') inside a type function.
+--
+-- Surfaces at the user's call site, but with "type function errored at
+-- runtime" framing -- misleading for a config-shape diagnostic.
+-- ============================================================================
+
+type function _section2_err_via_lua(_t: type): type
+	error("section 2 directive")
+end
+
+local _section2: _section2_err_via_lua<string> = "ok" -- EXPECT ERROR: 'type function errored at runtime: section 2 directive'
+
+-- ============================================================================
+-- Section 3. Singleton-string optional. CHOSEN ENCODING.
+--
+-- The property's type IS the directive string. Any non-nil assignment fails
+-- the type check and the literal surfaces verbatim in 'Expected this to be
+-- ...'. Two-bullet diagnostic, clean.
+-- ============================================================================
+
+type _Section3Forbidden = {
+	universeId: "universeId is already declared on the root universe block; remove it from this environment overlay, or remove it from root and declare it on every environment overlay instead"?,
+}
+
+local _section3_ok: _Section3Forbidden = {}
+local _section3_bad: _Section3Forbidden = { universeId = "123" } -- EXPECT ERROR: directive verbatim in 'Expected this to be ...'
+
+-- ============================================================================
+-- Section 4. never? optional (control case, no directive).
+--
+-- Clean diagnostic but uninformative ('Expected this to be never?'). Shown
+-- here as the baseline to compare the singleton-string approach against.
+-- ============================================================================
+
+type _Section4Forbidden = { universeId: never? }
+
+local _section4_ok: _Section4Forbidden = {}
+local _section4_bad: _Section4Forbidden = { universeId = "123" } -- EXPECT ERROR: 'Expected this to be never?'
+
+-- ============================================================================
+-- Section 5. Singleton + brand intersection.
+--
+-- Mirrors TS '& { errorBrand: never }' exactly. Same directive surfaces but
+-- with an extra brand bullet, so this costs a line of noise without adding
+-- protection over singleton-only.
+-- ============================================================================
+
+type _Section5Directive = "universeId is already declared on the root universe block; remove it from this environment overlay, or remove it from root and declare it on every environment overlay instead"
+
+type _Section5Forbidden = {
+	universeId: (_Section5Directive & { errorBrand: never })?,
+}
+
+local _section5_ok: _Section5Forbidden = {}
+local _section5_bad: _Section5Forbidden = { universeId = "anything" } -- EXPECT ERROR: directive verbatim + brand bullet
+
+-- Even if the user types the directive verbatim, the brand check still
+-- fails -- a hedge against a confused human or agent assigning the literal.
+local _section5_pedantic: _Section5Forbidden = {
+	universeId = "universeId is already declared on the root universe block; remove it from this environment overlay, or remove it from root and declare it on every environment overlay instead", -- EXPECT ERROR: brand bullet still fails
+}
+
+-- ============================================================================
+-- Section 6. Type-function structural guard limitation.
+--
+-- This section type-checks cleanly -- which IS the demonstration. The type
+-- function reaches into the indexer and returns the homogeneous value type;
+-- it cannot see that the argument has two env keys (production, staging) or
+-- that they carry different universe overlays. A check_xor that wants to
+-- detect `universeId` set on `environments.production.universe` cannot do
+-- so; the per-key dimension is collapsed by the indexer.
+-- ============================================================================
+
+type function _section6_inspect_indexer(t: type): type
+	if not t:is("table") then
+		error("not a table")
+	end
+	local indexer = t:indexer()
+	if indexer == nil then
+		error("no indexer; per-key shapes are visible but expensive to walk")
+	end
+	-- indexer.readresult is the homogeneous V; no per-key access.
+	return indexer.readresult
+end
+
+local _section6: _section6_inspect_indexer<{ [string]: { universe: { universeId: string? }? } }> = {
+	production = { universe = { universeId = "12345" } },
+	staging = { universe = {} },
+}
+
+-- ============================================================================
+-- Section 7. Top-level Config union annotation -- INVALID config fan-out.
+--
+-- Annotating a literal against `Config = ConfigRootUniverseId | ConfigEnvironmentUniverseId`
+-- causes the new solver to enumerate every property mismatch across both
+-- variants. The directive is buried in a 13-bullet wall.
+-- ============================================================================
+
+local _section7: Config = { -- EXPECT ERROR: 13-bullet fan-out, directive is bullets 6 and 10
+	universe = { universeId = "12345" },
+	environments = {
+		production = { universe = { universeId = "67890" } },
+	},
+}
+
+-- ============================================================================
+-- Section 8. Top-level Config union annotation -- VALID configs ALSO fan out.
+--
+-- The critical finding that ruled out "live with verbose diagnostics".
+-- Both of these are valid configs (universeId at root only, or universeId
+-- per env only). The union annotation still produces multi-bullet fan-out
+-- diagnostics because the new solver does per-component exact-match
+-- against each variant rather than a subtype check.
+-- ============================================================================
+
+local _section8_valid_root: Config = { -- EXPECT ERROR: 12-bullet fan-out on a VALID root-only config
+	universe = { universeId = "12345" },
+	environments = {
+		production = { universe = { description = "Live" } },
+	},
+}
+
+local _section8_valid_env: Config = { -- EXPECT ERROR: 9-bullet fan-out on a VALID env-only config
+	environments = {
+		production = { universe = { universeId = "12345" } },
+	},
+}
+
+-- ============================================================================
+-- Section 9. Variant-pinned annotation -- the clean baseline.
+--
+-- Pinning the annotation to one variant (here ConfigRootUniverseId) collapses
+-- the diagnostic to a single focused bullet with the directive verbatim at
+-- the offending field's line/column. This is the encoding ADR-025 will ship
+-- when Luau ships the union-narrowing fix (luau-lang/luau#2205); today the
+-- shipped permissive Config has no variants so this pattern is unreachable
+-- from user code until then.
+-- ============================================================================
+
+local _section9_valid: ConfigRootUniverseId = {
+	universe = { universeId = "12345" },
+	environments = {
+		production = { universe = { description = "Live" } },
+	},
+}
+
+local _section9_invalid: ConfigRootUniverseId = {
+	universe = { universeId = "12345" },
+	environments = {
+		production = { universe = { universeId = "67890" } }, -- EXPECT ERROR: clean 1-bullet directive
+	},
+}
+
+-- ============================================================================
+-- Section 10. Discriminator-field workaround (REJECTED schema-change path).
+--
+-- If we added a top-level singleton-string discriminator (`mode: "root" |
+-- "env"`) to the schema, the new solver could narrow the union on the
+-- discriminator and produce clean diagnostics through a single
+-- `defineConfig(c: Config): Config` non-generic wrapper. Rejected because
+-- the discriminator is a schema field added purely to work around a
+-- transient Luau type-solver limitation; adding it locks every user config
+-- into carrying a redundant field forever, and removing it later when
+-- Luau ships the fix is a wire-contract change.
+-- ============================================================================
+
+type _Section10RootVariant = {
+	mode: "root",
+	universe: { universeId: string },
+	environments: {
+		[string]: {
+			universe: {
+				universeId: "universeId is already declared on the root universe block"?,
+				description: string?,
+			}?,
+		},
+	},
+}
+
+type _Section10EnvVariant = {
+	mode: "env",
+	universe: {
+		universeId: "universeId is already declared per environment"?,
+		description: string?,
+	}?,
+	environments: {
+		[string]: {
+			universe: { universeId: string, description: string? },
+		},
+	},
+}
+
+type _Section10Config = _Section10RootVariant | _Section10EnvVariant
+
+local function _section10_defineConfig(c: _Section10Config): _Section10Config
+	return c
+end
+
+local _section10_valid_root = _section10_defineConfig({
+	mode = "root",
+	universe = { universeId = "12345" },
+	environments = {
+		production = { universe = { description = "Live" } },
+	},
+})
+
+local _section10_invalid_root = _section10_defineConfig({
+	mode = "root",
+	universe = { universeId = "12345" },
+	environments = {
+		production = { universe = { universeId = "67890" } }, -- EXPECT ERROR: clean 1-bullet directive
+	},
+})
+
+local _section10_valid_env = _section10_defineConfig({
+	mode = "env",
+	environments = {
+		production = { universe = { universeId = "12345" } },
+	},
+})
+
+local _section10_invalid_env = _section10_defineConfig({
+	mode = "env",
+	universe = { universeId = "12345" }, -- EXPECT ERROR: clean 1-bullet directive
+	environments = {
+		production = { universe = { universeId = "67890" } },
+	},
+})
+
+-- ============================================================================
+-- Section 11. Fluent expectTypeOf().toEqualTypeOf() -- REJECTED testing API.
+--
+-- vitest's TypeScript surface for type assertions is `expectTypeOf<A>().
+-- toEqualTypeOf<B>()`. The Luau equivalent looks syntactically right but
+-- type functions inside generic function bodies are silently suppressed;
+-- the assertion never fires regardless of input. The day-1 form ADR-025
+-- ships is the type-level `Expect<A, B>` alias, which works correctly
+-- because it lives at the alias-declaration site rather than inside a
+-- generic function body.
+--
+-- This section uses an always-erroring type function to demonstrate the
+-- contrast cleanly without depending on Luau's type-equality primitives.
+-- The shipped `Expect<A, B>` in `@bedrock/testing` will use a structural
+-- equality check via the typeforge-style `sort_type` normaliser.
+-- ============================================================================
+
+type function _section11_AssertFires(_a: type, _b: type): type
+	error("type function fired -- proves the function runs at the call site")
+end
+
+-- Direct type-level usage: fires.
+type _Section11Direct = _section11_AssertFires<string, number> -- EXPECT ERROR: type function fires
+
+local function _section11_phantom<T>(): T
+	return (nil :: any) :: T
+end
+
+local function _section11_expectTypeOf<T>(_subject: T): { toEqualTypeOf: <U>(U) -> () }
+	return {
+		toEqualTypeOf = function<U>(_expected: U)
+			-- This type-function call is suppressed; no diagnostic fires
+			-- regardless of T and U.
+			local _: _section11_AssertFires<T, U>? = nil
+		end,
+	}
+end
+
+-- Both of these silently pass; the always-erroring type function never fires
+-- from inside the generic body. This is the bug that ruled out the fluent
+-- API for day-1.
+_section11_expectTypeOf(_section11_phantom() :: string).toEqualTypeOf(_section11_phantom() :: string)
+_section11_expectTypeOf(_section11_phantom() :: string).toEqualTypeOf(_section11_phantom() :: number)
+
+return {}


### PR DESCRIPTION
## Summary

- Adds [ADR-025](docs/adr/025-luau-type-definitions.md): ship a permissive Luau `Config` type rather than a discriminated XOR union, relying on arktype's runtime narrow. Forced by [luau-lang/luau#2205](https://github.com/luau-lang/luau/issues/2205); the schema can be refined into the discriminated form when the upstream issue closes without breaking configs written today.
- Adds `docs/spikes/luau-types/` with the consolidated reproducer (`spike.luau`, 11 numbered sections) and a section-to-outcome README. Underpins the ADR's Alternatives Considered with runnable evidence.
- Implementation tracked separately under PRD [#441](https://github.com/christopher-buss/bedrock/issues/441) with six AFK-ready slices ([#443](https://github.com/christopher-buss/bedrock/issues/443)-[#448](https://github.com/christopher-buss/bedrock/issues/448)). The ADR-drafting issue [#442](https://github.com/christopher-buss/bedrock/issues/442) is satisfied by this PR.

## Test plan

- [ ] `lute check docs/spikes/luau-types/spike.luau` produces the expected diagnostics per the section-to-outcome map in the spike's README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Bedrock Code Review: ADR-025 (Luau Type Definitions)

## Summary

This PR adds three documentation artifacts for ADR-025 (Luau type definitions for `bedrock.config.luau`):
- **ADR-025**: 179-line Architecture Decision Record
- **Spike README**: Feasibility work overview
- **spike.luau**: 348-line runnable demonstration of 11 type-encoding patterns

The PR is **documentation-only**. Implementation work is tracked separately under PRD `#441` and divided into six AFK-ready implementation slices (`#443`–#448).

---

## Architecture Compliance

✅ **FCIS Pattern**: Not applicable (documentation-only PR). When implementation PRs arrive, verify:
- `setupLuauTypes()` and `checkLuauTypesStale()` are pure functions in core; I/O orchestration lives in shell
- CLI command (bedrock setup) is a primary adapter per ADR-018
- `.luaurc` parsing logic is pure core function; shell calls it

✅ **No Code Review Issues**: This PR contains no implementation code, only architectural documentation and evidence files.

---

## Documentation Quality

**Strengths:**

1. **Thorough Decision Rationale**: The ADR clearly documents why a permissive Luau `Config` type (not discriminated variants) was chosen, grounded in Luau's type-solver limitation (luau-lang/luau#2205) and verified by spike work.

2. **Comprehensive Alternatives Considered**: Seven alternatives are rejected with specific reasoning:
   - Discriminated XOR variants (fan-out on valid configs)
   - Top-level discriminator field (locks schema for transient solver workaround)
   - API divergence alternatives (breaks symmetry)
   - Type-function wrappers (degraded diagnostics)
   - Generated types (maintenance burden equal to hand-author duality)
   - Fluent `expectTypeOf().toEqualTypeOf()` (suppressed in generic bodies)

3. **Spike Evidence**: `spike.luau` consolidates 11 numbered sections demonstrating:
   - **Chosen patterns** (Sections 3, 9): singleton-string directive types
   - **Rejected alternatives** (Sections 1, 2, 5, 6, 7, 8, 10, 11): with diagnostics showing why they fail
   - Clear EXPECT ERROR annotations showing actual compiler output

4. **Forward Compatibility**: Design acknowledges permissive shape is a structural supertype of future discriminated variants; once upstream issue closes, refinement won't break existing configs.

5. **Parity Enforcement Strategy**: Realistic three-part approach:
   - `/review` skill to flag TypeScript schema changes without Luau parallels
   - Type-spec fixture suite as safety net
   - Hand-author duality acknowledged as incremental cost (interface + validator already paired in ADR-020)

6. **Test Pattern Well-Specified**: The proposed Luau type-spec testing pattern is concrete:
   - `describe`/`it` stubs (discoverable by AST walker)
   - `-- `@expect-error`` directives (mirrors `// `@ts-expect-error``)
   - `Expect<A, B>` type-level equality (works correctly, unlike fluent API)
   - Vitest harness orchestrating lute tooling

---

## Trade-offs and Constraints

**Intentional Asymmetries** (clearly documented):

1. **XOR enforcement deferred to runtime**: Luau authors see XOR failures at deploy time (arktype) rather than edit time. **Justification**: Luau's union-narrowing limitation makes edit-time checking produce multi-bullet fan-out on *valid* configs (demonstrated in Sections 7–8). Accepted because arktype already attributes failure to offending field.

2. **Hand-author duality grows to three surfaces**: TypeScript interface + arktype validator + Luau type. **Mitigation**: `/review` skill and type-spec fixtures prevent drift.

3. **Luau users must run `bedrock setup`**: One-time onboarding step to materialize `.bedrock/config.luau` and set `.luaurc` alias. **Trade-off accepted**: Explicit user action for types (vs. auto-fix surprise mutations on disk).

4. **Lute hard dependency**: Type-spec harness and binary embedding both require Lute. **Acknowledgment**: "Toolchain pinning via `mise.toml` is now consequential."

---

## Implementation Readiness

**This ADR is implementation-ready.** The Implementation Notes section specifies:
- File locations: `packages/bedrock/src/luau/`, `packages/bedrock/src/cli/commands/setup.ts`, `packages/bedrock/src/core/luaurc.ts`
- CLI wiring: `bedrock setup` with `--alias`, `--types-path`, `--check` flags
- Hashing: content-hash staleness check
- Embedding: Bun asset embedding for standalone binary; `dist/luau/` for npm
- Harness: `packages/bedrock/tests/luau-types/`, module structure mirrors `jest-roblox-cli/src/typecheck/`

**Pre-implementation checklist for implementation PRs (`#443`–#448):**

- [ ] `setupLuauTypes()` and `checkLuauTypesStale()` are pure functions returning `Result` (per ADR-009)
- [ ] Shell layer orchestrates I/O; core contains logic only
- [ ] Content-hash comparison is unit-tested
- [ ] `.luaurc` parsing/merging is unit-tested with edge cases (existing alias, override flags, missing `.luaurc`)
- [ ] `bedrock setup` help text documents `--alias`, `--types-path`, `--check` and persisted-alias behavior
- [ ] Type-spec harness correctly parses `describe`/`it`, extracts line ranges, compares diagnostics to `@expect-error` directives
- [ ] Lute version pinned in `mise.toml`
- [ ] 100% coverage on new core/shell functions
- [ ] No integration tests mocking the Luau evaluator; use real `lute` or fake filesystem

---

## Related Context

The ADR correctly cross-references:
- **ADR-017** (Product Framing): Luau as peer audience; justifies API symmetry
- **ADR-018** (FCIS + Ports): Explicitly notes pure core logic, shell I/O orchestration
- **ADR-020** (Project Config Definition): TypeScript `Config` and `defineConfig` being mirrored
- **ADR-003** (Testing Strategy): Type-spec extension of TDD surface
- **ADR-009** (Result Types): Shell functions return Result

---

## Minor Observations

1. **Spike README section map**: Excellent reference. The comment "Sections 3 and 9 are the patterns the future-tightened Luau types will use once [luau-lang/luau#2205](https://github.com/luau-lang/luau/issues/2205) closes" clearly marks the forward path.

2. **ADR README entry**: Correctly added ([025] status Accepted, date 2026-05-19).

3. **Spike file comments**: Clear section headers and diagnostic explanations; EXPECT ERROR lines are well-placed.

---

## Conclusion

This ADR meets Bedrock's standards (per CLAUDE.md § Making Architectural Decisions):
- ✅ Addresses a cross-package pattern (new port for Luau types, new distribution mechanism)
- ✅ Weighs technology/format choice (Luau vs. TypeScript, schema shape options)
- ✅ Documents state/wire contract (Luau `Config` type shape mirrors TypeScript structurally)
- ✅ Recorded with decision, alternatives, consequences, implementation notes
- ✅ Marked Accepted before implementation begins (correct sequencing)

The spike evidence is thorough, trade-offs are explicit, and the design is forward-compatible. Ready for implementation phase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->