### PR TITLE
fix(core): add jittered backoff to gist state adapter

### DIFF
--- a/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
@@ -53,6 +53,15 @@ function fakeSleep(): FakeSleep {
 	return { calls, sleep };
 }
 
+function fakeRandom(values: ReadonlyArray<number> = [0]): () => number {
+	let index = 0;
+	return () => {
+		const value = values[index] ?? values.at(-1) ?? 0;
+		index += 1;
+		return value;
+	};
+}
+
 function okJson(body: unknown): Response {
 	return new Response(JSON.stringify(body), { status: 200 });
 }
@@ -530,6 +539,7 @@ describe(createGistStateAdapter, () => {
 				const port = createGistStateAdapter({
 					fetch: fetchFn,
 					gistId: GIST_ID,
+					random: fakeRandom(),
 					sleep: sleepFake.sleep,
 					token: TOKEN,
 				});
@@ -538,7 +548,7 @@ describe(createGistStateAdapter, () => {
 
 				expect(result.success).toBeTrue();
 				expect(calls).toHaveLength(2);
-				expect(sleepFake.calls).toStrictEqual([1000]);
+				expect(sleepFake.calls).toStrictEqual([250]);
 			},
 		);
 
@@ -571,6 +581,7 @@ describe(createGistStateAdapter, () => {
 				const port = createGistStateAdapter({
 					fetch: fetchFn,
 					gistId: GIST_ID,
+					random: fakeRandom(),
 					sleep: sleepFake.sleep,
 					token: TOKEN,
 				});
@@ -579,7 +590,7 @@ describe(createGistStateAdapter, () => {
 
 				expect(result.success).toBeTrue();
 				expect(calls).toHaveLength(3);
-				expect(sleepFake.calls).toStrictEqual([1000]);
+				expect(sleepFake.calls).toStrictEqual([250]);
 			},
 		);
 	});
@@ -725,6 +736,7 @@ describe(createGistStateAdapter, () => {
 			const port = createGistStateAdapter({
 				fetch: fetchFn,
 				gistId: GIST_ID,
+				random: fakeRandom(),
 				sleep: sleepFake.sleep,
 				token: TOKEN,
 			});
@@ -737,7 +749,7 @@ describe(createGistStateAdapter, () => {
 
 			expect(result.success).toBeTrue();
 			expect(calls).toHaveLength(3);
-			expect(sleepFake.calls).toStrictEqual([1000]);
+			expect(sleepFake.calls).toStrictEqual([250]);
 		});
 
 		it("should err with the github-returned-409 reason after exhausting the retry budget", async () => {
@@ -748,11 +760,15 @@ describe(createGistStateAdapter, () => {
 				emptyResponse(409),
 				emptyResponse(409),
 				emptyResponse(409),
+				emptyResponse(409),
+				emptyResponse(409),
+				emptyResponse(409),
 			]);
 			const sleepFake = fakeSleep();
 			const port = createGistStateAdapter({
 				fetch: fetchFn,
 				gistId: GIST_ID,
+				random: fakeRandom(),
 				sleep: sleepFake.sleep,
 				token: TOKEN,
 			});
@@ -767,8 +783,41 @@ describe(createGistStateAdapter, () => {
 
 			expect(result.err.reason).toMatch(/github returned 409/u);
 			expect(result.err.file).toBe(`gist:${GIST_ID}/state.production.json`);
-			expect(calls).toHaveLength(4);
-			expect(sleepFake.calls).toStrictEqual([1000, 2000, 4000]);
+			expect(calls).toHaveLength(7);
+			expect(sleepFake.calls).toStrictEqual([250, 500, 1000, 2000, 4000, 8000]);
+		});
+
+		it("should jitter retry backoff via the injected random source", async () => {
+			expect.assertions(2);
+
+			const { fetchFn } = fakeFetchSequence([
+				emptyResponse(409),
+				emptyResponse(409),
+				emptyResponse(409),
+				emptyResponse(409),
+				emptyResponse(409),
+				emptyResponse(409),
+				emptyResponse(409),
+			]);
+			const sleepFake = fakeSleep();
+			const port = createGistStateAdapter({
+				fetch: fetchFn,
+				gistId: GIST_ID,
+				random: fakeRandom([1]),
+				sleep: sleepFake.sleep,
+				token: TOKEN,
+			});
+
+			const result = await port.write({
+				environment: "production",
+				resources: [],
+				version: 1,
+			});
+
+			assert(!result.success);
+
+			expect(result.err.reason).toMatch(/github returned 409/u);
+			expect(sleepFake.calls).toStrictEqual([500, 1000, 2000, 4000, 8000, 16_000]);
 		});
 
 		it("should sleep using setTimeout by default when sleep is not injected", async () => {
@@ -855,6 +904,7 @@ describe(createGistStateAdapter, () => {
 				const port = createGistStateAdapter({
 					fetch: fetchFn,
 					gistId: GIST_ID,
+					random: fakeRandom(),
 					sleep: sleepFake.sleep,
 					token: TOKEN,
 				});
@@ -867,7 +917,7 @@ describe(createGistStateAdapter, () => {
 
 				expect(result.success).toBeTrue();
 				expect(calls).toHaveLength(3);
-				expect(sleepFake.calls).toStrictEqual([1000]);
+				expect(sleepFake.calls).toStrictEqual([250]);
 			},
 		);
 

--- a/packages/bedrock/src/adapters/gist-state-adapter.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.ts
@@ -9,7 +9,9 @@ const GITHUB_API_BASE = "https://api.github.com";
 const GITHUB_API_VERSION = "2026-03-10";
 const USER_AGENT = "bedrock";
 const MAX_INLINE_BYTES = 10_000_000;
-const MAX_RETRIES = 3;
+const MAX_RETRIES = 6;
+const BASE_BACKOFF_MS = 500;
+const MAX_BACKOFF_MS = 16_000;
 const RETRYABLE_STATUSES: ReadonlySet<number> = new Set([409, 502, 503, 504]);
 const MAX_VISIBILITY_ATTEMPTS = 5;
 const VISIBILITY_BASE_DELAY_MS = 250;
@@ -33,6 +35,13 @@ export interface GistStateAdapterDeps {
 	/** ID of an existing GitHub Gist that holds this project's state files. */
 	readonly gistId: string;
 	/**
+	 * Injection seam for retry jitter; defaults to `Math.random`. Tests pass a
+	 * deterministic source so jittered sleep durations stay stable across runs.
+	 * Jitter prevents concurrent callers (parallel CI jobs writing to the same
+	 * gist) from retrying in lockstep and re-colliding on each backoff.
+	 */
+	readonly random?: (() => number) | undefined;
+	/**
 	 * Injection seam for retry backoff timing; defaults to a `setTimeout`-based
 	 * promise. Tests pass a fake to keep retry assertions deterministic.
 	 */
@@ -44,6 +53,7 @@ export interface GistStateAdapterDeps {
 interface AdapterContext {
 	readonly fetchFn: GistFetch;
 	readonly gistId: string;
+	readonly random: () => number;
 	readonly sleep: (ms: number) => Promise<void>;
 	readonly token: string;
 }
@@ -61,11 +71,16 @@ interface HttpFailure {
 	readonly response: Response;
 }
 
+interface RetryDeps {
+	readonly random: () => number;
+	readonly sleep: (ms: number) => Promise<void>;
+}
+
 interface ReadContentParameters {
 	readonly entry: GistFile;
 	readonly fetchFn: GistFetch;
 	readonly file: string;
-	readonly sleep: (ms: number) => Promise<void>;
+	readonly retry: RetryDeps;
 }
 
 /**
@@ -102,6 +117,7 @@ export function createGistStateAdapter(deps: GistStateAdapterDeps): StatePort {
 	const ctx: AdapterContext = {
 		fetchFn: deps.fetch ?? globalThis.fetch.bind(globalThis),
 		gistId: deps.gistId,
+		random: deps.random ?? Math.random,
 		sleep: deps.sleep ?? defaultSleep,
 		token: deps.token,
 	};
@@ -208,21 +224,20 @@ function isRetryableStatus(status: number): boolean {
 	return RETRYABLE_STATUSES.has(status);
 }
 
-function backoffMs(attempt: number): number {
-	return 1000 * 2 ** attempt;
+function backoffMs(attempt: number, random: () => number): number {
+	const cap = Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS * 2 ** attempt);
+	const half = cap / 2;
+	return half + random() * half;
 }
 
-async function withRetry(
-	sleep: (ms: number) => Promise<void>,
-	operation: () => Promise<Response>,
-): Promise<Response> {
+async function withRetry(retry: RetryDeps, operation: () => Promise<Response>): Promise<Response> {
 	let response = await operation();
 	for (let attempt = 0; attempt < MAX_RETRIES; attempt += 1) {
 		if (response.ok || !isRetryableStatus(response.status)) {
 			return response;
 		}
 
-		await sleep(backoffMs(attempt));
+		await retry.sleep(backoffMs(attempt, retry.random));
 		response = await operation();
 	}
 
@@ -235,7 +250,7 @@ async function fetchGistBody(
 ): Promise<Result<Record<string, unknown>, StateError>> {
 	let response: Response;
 	try {
-		response = await withRetry(ctx.sleep, async () => sendGet(ctx));
+		response = await withRetry(ctx, async () => sendGet(ctx));
 	} catch (err) {
 		return { err: networkError(err, file), success: false };
 	}
@@ -259,7 +274,7 @@ async function readGistContent({
 	entry,
 	fetchFn,
 	file,
-	sleep,
+	retry,
 }: ReadContentParameters): Promise<Result<BedrockState | undefined, StateError>> {
 	if (entry.size > MAX_INLINE_BYTES) {
 		return stateErr(file, `state file too large: ${entry.size} bytes`);
@@ -273,7 +288,7 @@ async function readGistContent({
 		const { rawUrl } = entry;
 		let rawResponse: Response;
 		try {
-			rawResponse = await withRetry(sleep, async () => fetchFn(rawUrl));
+			rawResponse = await withRetry(retry, async () => fetchFn(rawUrl));
 		} catch (err) {
 			return { err: networkError(err, file), success: false };
 		}
@@ -305,7 +320,7 @@ async function readPath(
 		return { data: undefined, success: true };
 	}
 
-	return readGistContent({ entry, fetchFn: ctx.fetchFn, file, sleep: ctx.sleep });
+	return readGistContent({ entry, fetchFn: ctx.fetchFn, file, retry: ctx });
 }
 
 async function sendPatch(ctx: AdapterContext, body: string): Promise<Response> {
@@ -369,7 +384,7 @@ async function writePath(
 
 	let response: Response;
 	try {
-		response = await withRetry(ctx.sleep, async () => sendPatch(ctx, body));
+		response = await withRetry(ctx, async () => sendPatch(ctx, body));
 	} catch (err) {
 		return { err: networkError(err, file), success: false };
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ catalogs:
       specifier: 5.0.0-beta.11
       version: 5.0.0-beta.11
     '@isentinel/hooks':
-      specifier: 1.4.1
-      version: 1.4.1
+      specifier: 1.5.1
+      version: 1.5.1
     '@vitest/eslint-plugin':
       specifier: 1.6.16
       version: 1.6.16
@@ -271,7 +271,7 @@ importers:
         version: 5.0.0-beta.11(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/estree@1.0.8)(@typescript-eslint/utils@8.58.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.58.1(@typescript-eslint/parser@8.58.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(@typescript/typescript6@6.0.1)(@voidzero-dev/vite-plus-test@0.1.19)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-jest-extended@3.0.1(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-n@17.24.0(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint-plugin-react-naming-convention@2.3.9(@typescript/typescript6@6.0.1)(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
       '@isentinel/hooks':
         specifier: catalog:lint
-        version: 1.4.1(@typescript/native-preview@7.0.0-dev.20260428.1)(@typescript/typescript6@6.0.1)(jiti@2.6.1)
+        version: 1.5.1(@typescript/native-preview@7.0.0-dev.20260428.1)(@typescript/typescript6@6.0.1)(jiti@2.6.1)
       '@isentinel/tsconfig':
         specifier: catalog:tsc
         version: 1.2.0(@typescript/typescript6@6.0.1)
@@ -2032,8 +2032,8 @@ packages:
     peerDependencies:
       eslint: '>=8.0.0'
 
-  '@isentinel/hooks@1.4.1':
-    resolution: {integrity: sha512-Pd4W0qbKWxBfyVRl3QtbQtmxGSFDWx/hxBu4YSwzghnpuPiw9PdYm/G+pm6S99TtvvaSSqMAAGJAY/qEERI+EQ==}
+  '@isentinel/hooks@1.5.1':
+    resolution: {integrity: sha512-kRR5i1e4lMw496T7XabGOoTEAtFQz9NgpqNLxwGO/mllsFz9RAVIW98lB05cfINqC75S7+rMbL1Fk+jKMGYi2g==}
     engines: {node: '>=24.11.0'}
     peerDependencies:
       '@typescript/native-preview': '>=7'
@@ -8672,7 +8672,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@isentinel/hooks@1.4.1(@typescript/native-preview@7.0.0-dev.20260428.1)(@typescript/typescript6@6.0.1)(jiti@2.6.1)':
+  '@isentinel/hooks@1.5.1(@typescript/native-preview@7.0.0-dev.20260428.1)(@typescript/typescript6@6.0.1)(jiti@2.6.1)':
     dependencies:
       eslint_d: 15.0.2(jiti@2.6.1)
       file-entry-cache: 11.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,7 +63,7 @@ catalogs:
     "@commitlint/types": 20.5.0
     "@eslint/config-inspector": 1.5.0
     "@isentinel/eslint-config": 5.0.0-beta.11
-    "@isentinel/hooks": 1.4.1
+    "@isentinel/hooks": 1.5.1
     "@typescript-eslint/parser": 8.58.1
     "@vitest/eslint-plugin": 1.6.16
     eslint: 9.39.2


### PR DESCRIPTION
## Summary

- Replaces the synchronized exponential retry backoff in the gist state adapter with equal-jitter (`cap/2 + random()*cap/2`) so concurrent writers don't retry in lockstep.
- Bumps `MAX_RETRIES` 3 to 6 and caps individual sleeps at 16s. Worst-case total wait ~31.5s (matches Octokit's `plugin-retry` ~30s budget); expected ~23.6s.
- Injects a `random` seam (defaults to `Math.random`) so tests can pin the jitter.

## Why

Smoke CI fails ~10% of runs with `github returned 409` on the gist state write (e.g. [run 26119104466](https://github.com/christopher-buss/bedrock/actions/runs/26119104466)). Root cause: 7 smoke spec files run in parallel against one shared gist, all collide on 409, and the prior backoff `1s · 2^n` had no jitter, so every retry attempted the conflict window simultaneously. Real users with parallel deploy jobs to the same gist hit the same failure mode.

## Notes for reviewer

- Octokit's `plugin-retry` does retry 409 on writes but uses `(n+1)²` seconds with no jitter and is missing a max-delay cap. Throttling-based serialization (`plugin-throttling`) would target the root cause but only inside a single process; our concurrent writers are separate processes. Hand-rolled retry wins here.
- The retry budget now matches Octokit's per-call total, but spread across more (smaller) attempts so transient 409s recover sooner.
- Second commit bumps `@isentinel/hooks` 1.4.1 to 1.5.1 to unblock local lint hooks.

## Test plan

- [ ] Smoke CI green on this branch
- [ ] No regressions in adapter unit tests (52 currently green locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)