### PR TITLE
docs: add package readmes for core and ocale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ See `docs/adr/` for full Architecture Decision Records.
 - **TypeScript over Rust**: Community contribution accessibility
 - **Open Cloud only**: ROBLOSECURITY is deprecated, Open Cloud is the future
 - **GitHub Gists for state**: Zero external service, works with GITHUB_TOKEN
-- **Multi-format config**: Support TS, JS, YAML, JSON via c12
+- **Multi-format config**: Support TS, JS, YAML, JSON, Luau via c12
 
 ## Common Commands
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It is a spiritual successor to [Mantle](https://github.com/blake-mealey/mantle)
   [ADR-017](./docs/adr/017-product-framing-programmatic-iac-with-cli.md).
 - **State in a GitHub Gist.** Zero external services to stand up; a
   `GITHUB_TOKEN` is enough. Extensible to other backends.
-- **Multi-format config.** TypeScript, JavaScript, YAML, or JSON via c12.
+- **Multi-format config.** TypeScript, JavaScript, YAML, JSON, or Luau via c12.
 
 ## Packages
 

--- a/packages/bedrock/README.md
+++ b/packages/bedrock/README.md
@@ -1,0 +1,180 @@
+# @bedrock-rbx/core
+
+Infrastructure-as-Code for Roblox, with a bundled `bedrock` CLI.
+
+[![npm version](https://img.shields.io/npm/v/@bedrock-rbx/core.svg)](https://npmx.dev/package/@bedrock-rbx/core)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/christopher-buss/bedrock/blob/main/LICENSE)
+[![CI](https://github.com/christopher-buss/bedrock/actions/workflows/ci.yaml/badge.svg)](https://github.com/christopher-buss/bedrock/actions/workflows/ci.yaml)
+
+> **Status: 0.1 beta.** The public API is stabilizing. Breaking changes may land in minor releases (0.1 to 0.2) until 1.0.
+
+## What is `@bedrock-rbx/core`?
+
+Bedrock defines a Roblox experience's setup, including the universe, places, game passes, and developer products, in a single config file you keep alongside your game code. Each deploy diffs that config against the live state in Roblox and applies the create or update operations needed to bring them into sync. Adding a new place (lobby, mini-game, hub world) means editing the config instead of clicking through Creator Hub.
+
+It is a spiritual successor to [Mantle](https://github.com/blake-mealey/mantle) (no longer maintained), rebuilt on top of [Roblox Open Cloud](https://create.roblox.com/docs/cloud). That means API-key authentication only, no `ROBLOSECURITY` cookies or legacy endpoints.
+
+Bedrock ships two paths to the same engine. The `bedrock` CLI reconciles a config file (TypeScript, JavaScript, YAML, JSON, or Luau) against live Roblox state. The programmatic API exposes the same `deploy()`, `diff()`, and `applyOps()` functions for direct use in TypeScript, so deploys can be triggered from a webhook handler, a chat bot, or any other service in your stack. Both surfaces run identical code below the entry point.
+
+## Install
+
+```bash
+pnpm add -D @bedrock-rbx/core
+# or: npm install --save-dev @bedrock-rbx/core
+# or: bun add -d @bedrock-rbx/core
+```
+
+The `bedrock` binary is then available via your package manager (`pnpm bedrock`, `npx bedrock`, `bunx bedrock`).
+
+**Runtime:** Node >= 24.12 or Bun >= 1.3.
+
+**Authentication:** bedrock reads two environment variables.
+
+| Variable | Purpose | Where to get it |
+|---|---|---|
+| `BEDROCK_API_KEY` | Authenticates Open Cloud calls. | [Creator Hub > Credentials > API Keys](https://create.roblox.com/dashboard/credentials). Needs the scopes for the resources you manage (universe-place, universe-place-config, universe-passes, universe-developer-products, asset-create). |
+| `BEDROCK_GITHUB_TOKEN` | Reads and writes the state gist (the default state backend). | A GitHub personal access token with the `gist` scope. The gist itself starts empty: create one at [gist.github.com](https://gist.github.com), then put its ID in your config's `state.gistId`. |
+
+Both can be overridden per environment in your config (or via `--api-key` / `--github-token` flags on the CLI).
+
+## Quick start (programmatic)
+
+A bedrock config is a plain `Config` object. The `defineConfig` helper is identity at runtime; it exists only to give TypeScript users full type inference and autocomplete.
+
+```ts
+// bedrock.config.ts
+import { defineConfig } from "@bedrock-rbx/core/config";
+
+export default defineConfig({
+	environments: {
+		production: { universe: { universeId: 1234567890 } },
+	},
+	passes: {
+		"vip-pass": {
+			name: "VIP Pass",
+			description: "Grants VIP perks.",
+			icon: { "en-us": "assets/vip-icon.png" },
+			price: 500,
+		},
+	},
+	places: {
+		"start-place": {
+			name: "Start Place",
+			file: "places/start.rbxl",
+		},
+	},
+	state: { backend: "gist", gistId: "abc123def456" },
+	universe: {
+		name: "My Game",
+		description: "An adventure.",
+	},
+});
+```
+
+Place your custom deploy orchestration at `.bedrock/deploy.ts`. The `bedrock deploy` CLI auto-discovers and invokes this file when present, and the same exports can be imported from a webhook handler, chat bot, or other service that wants to trigger deploys directly.
+
+```ts
+// .bedrock/deploy.ts
+import { deploy } from "@bedrock-rbx/core";
+
+/**
+ * Triggered from a webhook handler whenever a release tag is pushed.
+ * Wraps `deploy` with custom orchestration: structured logging on
+ * failure, success reporting back to the caller.
+ *
+ * @param environment - Target environment from the webhook payload.
+ * @returns Whether the deploy completed successfully.
+ */
+export async function deployFromWebhook(environment: string): Promise<boolean> {
+	const result = await deploy({ environment });
+	if (!result.success) {
+		console.error("bedrock deploy failed", { environment, err: result.err });
+		return false;
+	}
+
+	console.log("bedrock deploy succeeded", { environment });
+	return true;
+}
+```
+
+`deploy()` returns a `Result<BedrockState, DeployError>` rather than throwing on failure. `Result` is a discriminated union: `result.success` is `true` with the value on `result.data`, or `false` with the error on `result.err`. `DeployError` is itself stage-tagged (`configLoadFailed`, `stateReadFailed`, `applyFailed`, and similar) so callers can branch on `kind` to distinguish what went wrong without parsing error messages.
+
+## Quick start (CLI)
+
+Using the same `bedrock.config.ts` from above:
+
+```bash
+export BEDROCK_API_KEY=...
+export BEDROCK_GITHUB_TOKEN=...
+
+pnpm bedrock deploy --env production
+```
+
+`bedrock deploy` discovers `bedrock.config.{ts,js,mjs,yaml,yml,json,luau}` in the current directory, loads it, and runs the same reconcile as the programmatic path. Output is rendered via `@clack/prompts` (interactive progress, summary, and error reporting).
+
+`--env` may be repeated to deploy to multiple environments in one invocation; each environment is reconciled with its own merged config and its own state slot.
+
+## What bedrock manages today
+
+| Kind | Key example | What bedrock manages | Notes |
+|---|---|---|---|
+| `universe` | `"main"` (singleton) | Name, description, social links, age guidelines, opt-in studio access. | Adopted by ID. Bedrock does not create new universes. |
+| `place` | `"start-place"` | Place metadata (name, description, server-fill mode, max-player count), `.rbxl` file uploads. | The root place is adopted; secondary places are provisioned by bedrock. |
+| `gamePass` | `"vip-pass"` | Name, description, icon upload, price, on-sale state. | Provisioned by bedrock; the asset ID is recorded in outputs. |
+| `developerProduct` | `"gem-pack-100"` | Name, description, icon upload, price. | Provisioned by bedrock; the asset ID is recorded in outputs. |
+
+Bedrock does not delete resources. Removing an entry from your config leaves the upstream entity in place; delete it from Creator Hub directly if you want it gone. Additional kinds (badges, place settings, more) are on the [roadmap](https://github.com/christopher-buss/bedrock/projects).
+
+## CLI reference
+
+```text
+bedrock <command> [options]
+```
+
+**`bedrock deploy`** - reconciles every configured environment (or only those passed via `--env`) against live Roblox state, writing the new state snapshot on success.
+
+Options: `--env <name>` (repeatable), `--config <path>`, `--api-key <value>`, `--github-token <value>`.
+
+**`bedrock diff`** - previews the operations a deploy *would* apply, without writing state or hitting any mutating Roblox endpoints. Suitable for code review and CI.
+
+Options: same as `deploy`.
+
+**`bedrock migrate [stateFilePath]`** - translates a state file from another deployment tool into a bedrock project. Currently supports Mantle (`--from mantle`); other sources will be added as needed. The maintainer-prompt UI walks through naming the project, choosing a backend, and resolving any unrecognized fields.
+
+Options: `--from <tool>`.
+
+Pass `--help` to any command for the full option list at the version you have installed.
+
+## Programmatic API surface
+
+The most commonly imported entry points:
+
+| Symbol | Module | Role |
+|---|---|---|
+| `deploy()` | `@bedrock-rbx/core` | Full reconcile end-to-end. |
+| `diff()` | `@bedrock-rbx/core` | Pure function from desired and current state to an operation list. |
+| `applyOps()` | `@bedrock-rbx/core` | Dispatch an operation list to its drivers and collect outputs. |
+| `loadConfig()` | `@bedrock-rbx/core` | Discover and load a `bedrock.config.*` file. |
+| `buildDesired()` | `@bedrock-rbx/core` | Compute the desired-state list from a resolved config. |
+| `defineConfig()` | `@bedrock-rbx/core/config` | Type-helper for `bedrock.config.ts`. |
+| `ResourceDriver<K>` | `@bedrock-rbx/core` | Plugin contract for resource kinds. |
+| `StatePort` | `@bedrock-rbx/core` | Plugin contract for state backends. |
+| `ProgressPort` | `@bedrock-rbx/core` | Listener interface for per-resource and aggregate deploy events. |
+
+`ResourceDriver<K>`, `StatePort`, and `ProgressPort` are published contracts today; the plugin runtime that lets you register custom implementations against a real deploy ships in v0.3.
+
+See the [full reference on the docs site](https://bedrock-livid.vercel.app/) for the complete list of exports.
+
+## Status, docs, and contributing
+
+Bedrock is in active development ahead of a first public release. Track scope and timing on the [project board](https://github.com/christopher-buss/bedrock/projects).
+
+- [Documentation site](https://bedrock-livid.vercel.app/) (work in progress)
+- [Source repository](https://github.com/christopher-buss/bedrock)
+- [Issues](https://github.com/christopher-buss/bedrock/issues) (maintainer-only; external feedback runs through [Discussions](https://github.com/christopher-buss/bedrock/discussions) as prompt requests)
+- [Contributing guide](https://github.com/christopher-buss/bedrock/blob/main/CONTRIBUTING.md)
+- [Security policy](https://github.com/christopher-buss/bedrock/blob/main/SECURITY.md)
+
+## License
+
+[MIT](https://github.com/christopher-buss/bedrock/blob/main/LICENSE) (c) Christopher Buss.

--- a/packages/open-cloud/README.md
+++ b/packages/open-cloud/README.md
@@ -1,0 +1,128 @@
+# @bedrock-rbx/ocale
+
+Zero-dependency TypeScript SDK for Roblox Open Cloud.
+
+[![npm version](https://img.shields.io/npm/v/@bedrock-rbx/ocale.svg)](https://npmx.dev/package/@bedrock-rbx/ocale)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/christopher-buss/bedrock/blob/main/LICENSE)
+[![CI](https://github.com/christopher-buss/bedrock/actions/workflows/ci.yaml/badge.svg)](https://github.com/christopher-buss/bedrock/actions/workflows/ci.yaml)
+
+> **Status: 0.1 beta.** The public API is stabilizing. Breaking changes may land in minor releases (0.1 to 0.2) until 1.0.
+
+## What is `@bedrock-rbx/ocale`?
+
+A typed HTTP client for [Roblox Open Cloud](https://create.roblox.com/docs/cloud). Each Roblox feature (universes, places, game passes, developer products, badges, storage, Luau execution) is exposed as its own client class with the methods, request types, and response types you would otherwise build by hand against the raw REST endpoints.
+
+The SDK has zero runtime dependencies and runs on Node >= 24.12 or Bun >= 1.3 using the standard `fetch`, `FormData`, and `TextEncoder` web APIs. Rate-limit queueing and retry handling are built in: requests are queued per-operation against Roblox's published limits, and idempotent calls automatically retry on 429 and 5xx responses without consumer code reaching for `try`/`catch` or `setTimeout`.
+
+`@bedrock-rbx/ocale` is the foundation that [`@bedrock-rbx/core`](https://github.com/christopher-buss/bedrock/tree/main/packages/bedrock) uses internally to talk to Roblox, and it is publishable as a standalone package for anyone building tooling, scripts, or services that need typed Open Cloud calls without bedrock's full IaC engine. If you already depend on `@bedrock-rbx/core`, ocale is installed transitively; reach for it directly when you need HTTP-level control that core's IaC engine does not expose.
+
+## Install
+
+```bash
+pnpm add @bedrock-rbx/ocale
+# or: npm install @bedrock-rbx/ocale
+# or: bun add @bedrock-rbx/ocale
+```
+
+**Runtime:** Node >= 24.12 or Bun >= 1.3.
+
+**Authentication:** every client takes an `apiKey` at construction. Generate one at [Creator Hub > Credentials > API Keys](https://create.roblox.com/dashboard/credentials) and grant it the scopes for the operations you plan to call (each method's JSDoc lists its required scopes).
+
+## Quick start
+
+```ts
+import { GamePassesClient } from "@bedrock-rbx/ocale/game-passes";
+
+const client = new GamePassesClient({ apiKey: "your-open-cloud-api-key" });
+
+const result = await client.get({
+	gamePassId: "9876543210",
+	universeId: "1234567890", // from your experience URL in Creator Hub
+});
+
+if (!result.success) {
+	console.error(`Open Cloud call failed: ${result.err.message}`);
+	process.exit(1);
+}
+
+console.log(`${result.data.name}: ${result.data.priceInRobux} Robux`);
+```
+
+Every method returns `Promise<Result<T, OpenCloudError>>`. `Result` is a discriminated union: `result.success` is `true` with the parsed response on `result.data`, or `false` with a structured error on `result.err`. No exception ever escapes a client method.
+
+## Available clients
+
+Resource clients live on subpaths so unused features tree-shake out of your bundle.
+
+| Subpath | Client | What it covers |
+|---|---|---|
+| `@bedrock-rbx/ocale/universes` | `UniversesClient` | Universe metadata, social links, icon and thumbnail uploads, badges and game-passes scoped to a universe. |
+| `@bedrock-rbx/ocale/places` | `PlacesClient` | Place metadata, `.rbxl` publishing, Luau execution tasks scoped to a place. |
+| `@bedrock-rbx/ocale/game-passes` | `GamePassesClient` | Game pass CRUD, icon upload, localized name and description updates. |
+| `@bedrock-rbx/ocale/developer-products` | `DeveloperProductsClient` | Developer product CRUD, icon upload, localized name and description updates. |
+| `@bedrock-rbx/ocale/badges` | `BadgesClient` | Badge CRUD and localized icon uploads. |
+| `@bedrock-rbx/ocale/storage` | `StorageClient` | Memory stores (sorted maps, queues) for live game state. |
+| `@bedrock-rbx/ocale/luau-execution` | `LuauExecutionClient` | Standalone Luau execution tasks with binary inputs and log streaming. |
+| `@bedrock-rbx/ocale/locales` | `ROBLOX_CREATOR_LOCALES` (data) | Reference list of locales Roblox supports for localized fields. |
+
+Additional Open Cloud features (messaging, data stores, OAuth, groups, analytics) are not yet wrapped; they are tracked on the [roadmap](https://github.com/christopher-buss/bedrock/projects).
+
+The package root (`@bedrock-rbx/ocale`) deliberately re-exports only shared utilities: `Result`, `Page`, `OpenCloudError` and its subclasses (`ApiError`, `RateLimitError`, `NetworkError`, `ValidationError`, and similar), and the `OpenCloudClientOptions` type. Resource clients are not on the root barrel.
+
+## Rate limiting and retries
+
+The SDK queues every request behind a per-operation rate-limit bucket sourced from Roblox's published OpenAPI schema. You fire calls at whatever rate your code needs; the SDK paces them.
+
+Retry behavior is idempotency-aware:
+
+| Method kind | 429 (rate limit) | 5xx (server error) |
+|---|---|---|
+| Create | Retry | Do not retry |
+| Read / List | Retry | Retry |
+| Update | Retry | Retry |
+| Delete | Retry | Retry |
+
+Create operations skip 5xx retries because Roblox does not support idempotency keys and a duplicate retry would silently produce a second resource. If you can detect duplicates externally, opt back into 5xx retry on a per-call basis via `retryableStatuses` on the request options argument.
+
+After retry attempts are exhausted, the final failure surfaces on `result.err` as the typed error that caused it (`RateLimitError` for 429s, `ApiError` for 5xx, `NetworkError` for transport-level faults, and so on).
+
+Observability hooks (`onRequest`, `onRetry`, `onRateLimit`) accept callbacks on the client constructor for logging, metrics, or tracing integration.
+
+## Per-request configuration overrides
+
+Client-level config is frozen on construction. Every method accepts an optional second `RequestOptions` argument that overrides config for a single call:
+
+```ts
+const client = new GamePassesClient({ apiKey: "main-key" });
+
+const result = await client.create(parameters, {
+	apiKey: "asset-upload-key", // different key for moderation safety
+	timeout: 60_000,
+});
+```
+
+This pattern fits multi-tenant tooling (different API keys per workspace), credential rotation (swap mid-batch), and isolating retry / timeout policies to specific calls.
+
+## Testing helpers
+
+A `@bedrock-rbx/ocale/testing` subpath exports the same fakes the SDK's own integration tests use:
+
+- `createFakeHttpClient(...)` and `createFakeSend(...)` for swapping the HTTP transport with a recorded fake that validates request bodies against the vendored OpenAPI schema.
+- `createFakeSleep(...)` for deterministic retry and rate-limit timing.
+- `valid*Body` fixtures (`validGamePassBody`, `validPlaceBody`, `validUniverseBody`, and similar) for synthesising realistic response payloads.
+
+Pass the fake into any client via the `httpClient` and `sleep` parameters on `OpenCloudClientOptions` and assert against the captured requests.
+
+## Status, docs, and contributing
+
+This package is in active development ahead of a first public release. Track scope and timing on the [project board](https://github.com/christopher-buss/bedrock/projects).
+
+- [Documentation site](https://bedrock-livid.vercel.app/) (work in progress)
+- [Source repository](https://github.com/christopher-buss/bedrock/tree/main/packages/open-cloud)
+- [Issues](https://github.com/christopher-buss/bedrock/issues) (maintainer-only; external feedback runs through [Discussions](https://github.com/christopher-buss/bedrock/discussions) as prompt requests)
+- [Contributing guide](https://github.com/christopher-buss/bedrock/blob/main/CONTRIBUTING.md)
+- [Security policy](https://github.com/christopher-buss/bedrock/blob/main/SECURITY.md)
+
+## License
+
+[MIT](https://github.com/christopher-buss/bedrock/blob/main/LICENSE) (c) Christopher Buss.


### PR DESCRIPTION
## Summary

- Add `packages/bedrock/README.md` for `@bedrock-rbx/core`: install, auth, programmatic and CLI quick starts, supported resource kinds, CLI reference, public API surface.
- Add `packages/open-cloud/README.md` for `@bedrock-rbx/ocale`: install, quick start, available resource clients table, rate-limiting and retry semantics, per-request overrides, testing-helper subpath.
- Update root `CLAUDE.md` and root `README.md` to list Luau among the multi-format config bullets (ADR-025 was missing from both).

Both READMEs were drafted via the `doc-coauthoring` workflow and validated against a fresh-Claude reader-test sub-agent before commit. Voice and framing decisions captured in `feedback_bedrock_readme_framing.md` memory (no casual filler, no cross-ecosystem analogies, equal billing for CLI and programmatic surfaces).

## Documented as planned (not yet shipped)

The core README documents two near-term features that don't exist on `main` yet, by request:

- `BEDROCK_GITHUB_TOKEN` env var (rename from `GITHUB_TOKEN`).
- `.bedrock/deploy.ts` CLI auto-discovery (planned per #246).

Update the README when these land, or revert these specific sentences if the plan slips.

## Test plan

- [ ] Skim each README on GitHub for table/code-block rendering.
- [ ] Confirm all links resolve (absolute URLs only, since READMEs render on npm).
- [ ] Cross-check the core Quick-start config against `core/schema.ts` for field accuracy.
- [ ] Cross-check the ocale API key scope list against current Open Cloud docs (the README cites `universe-place`, `universe-place-config`, `universe-passes`, `universe-developer-products`, `asset-create`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Architecture Compliance Review

### 1. FCIS Pattern & Ports Representation ✅
Both package READMEs correctly represent the FCIS + Ports architecture indirectly:

- **`@bedrock-rbx/core` README**: Distinguishes between the CLI shell (I/O, orchestration) and programmatic core functions (pure business logic). The `deploy()` return pattern (`Result<BedrockState, DeployError>`) correctly documents the error-handling contract from ADR-009.
- **`@bedrock-rbx/ocale` README**: Presents class-based clients as driven adapters (secondary ports) with pure `Result` types, no exceptions. Subpath exports prevent barrel-file coupling.

### 2. Security & Open Cloud Constraint Compliance ✅
- Both READMEs enforce Open Cloud only; `BEDROCK_API_KEY` is the sole authentication method.
- State model correctly documented: GitHub Gist stores resource IDs only (public data), no secrets in state.
- No ROBLOSECURITY or legacy API references.

### 3. Testing & Error Handling Contracts ✅
- Correctly documents `Result<T, Error>` discriminated union pattern with `result.success` branching (ADR-009).
- `@bedrock-rbx/ocale` correctly documents idempotency-aware retry semantics (Create ops skip 5xx retries; Read/Update/Delete retry all failures).
- Testing helpers documented for `@bedrock-rbx/ocale/testing` subpath (fake HTTP client, fake sleep, valid*Body fixtures).

### 4. Public API Surface Accuracy ✅
**`@bedrock-rbx/core`** correctly lists entry points:
- `deploy()`, `diff()`, `applyOps()`, `loadConfig()`, `buildDesired()`, `defineConfig()`
- Port contracts: `ResourceDriver<K>`, `StatePort`, `ProgressPort`

**`@bedrock-rbx/ocale`** correctly documents:
- Client subpaths (universes, places, game-passes, developer-products, badges, storage, luau-execution, locales)
- Root barrel exports only shared utilities (`Result`, `OpenCloudError` and subclasses, `OpenCloudClientOptions`)

### 5. Configuration Format Updates ✅
CLAUDE.md and README.md additions of "Luau" to multi-format config list align with ADR-025 (Luau type definitions).

---

## Notes

**Two near-term features documented as current:**

The PR objectives flag that the `@bedrock-rbx/core` README documents two features not yet on main:

1. **`BEDROCK_GITHUB_TOKEN`** (line 36): Noted as a rename from `GITHUB_TOKEN`. The instructions should reference this as "upcoming" or include a note if implementation timing is uncertain.
2. **`.bedrock/deploy.ts` CLI auto-discovery** (line 74): Documented as if available; per issue `#246`, this is planned but not yet shipped. Should clarify timeline or mark as future feature.

Both sentences are flagged in the PR objectives as items to "update or reverted if plans change"—consider adding a version-bounded note (e.g., "v0.2 roadmap") to prevent surprise on release.

**Documentation Validation:**

- Rendering, link resolution, and cross-checking of config and API scope accuracy are covered in the test plan.
- Both READMEs follow the established voice/framing from the doc-coauthoring workflow (validated with reader-test).
- No broken links to internal docs (bedrock-livid.vercel.app, GitHub org paths).

---

## Summary

This is a compliance-clean documentation PR. The READMEs accurately represent the FCIS + Ports architecture, enforce Bedrock's security constraints (Open Cloud only, no secrets in state), document correct error-handling and retry contracts, and list the public API surface correctly. The only action item is clarifying the versioning/readiness status of the two near-term features before or on release to avoid confusion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/451?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->