### PR TITLE
feat(core): support bedrock-github-token env var

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ See `docs/adr/` for full Architecture Decision Records.
 
 - **TypeScript over Rust**: Community contribution accessibility
 - **Open Cloud only**: ROBLOSECURITY is deprecated, Open Cloud is the future
-- **GitHub Gists for state**: Zero external service, works with GITHUB_TOKEN
+- **GitHub Gists for state**: Zero external service, works with BEDROCK_GITHUB_TOKEN
 - **Multi-format config**: Support TS, JS, YAML, JSON via c12
 
 ## Common Commands

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It is a spiritual successor to [Mantle](https://github.com/blake-mealey/mantle)
   your own tooling, or reach for the CLI for day-to-day deploys. See
   [ADR-017](./docs/adr/017-product-framing-programmatic-iac-with-cli.md).
 - **State in a GitHub Gist.** Zero external services to stand up; a
-  `GITHUB_TOKEN` is enough. Extensible to other backends.
+  `BEDROCK_GITHUB_TOKEN` is enough. Extensible to other backends.
 - **Multi-format config.** TypeScript, JavaScript, YAML, or JSON via c12.
 
 ## Packages

--- a/apps/website/.vitepress/theme/home-landing.vue
+++ b/apps/website/.vitepress/theme/home-landing.vue
@@ -341,8 +341,8 @@ function toggleTheme(): void {
 						<div class="feature-num">&rarr; 03</div>
 						<h3>State on your terms</h3>
 						<p>
-							Store state in a GitHub Gist with just a <code>GITHUB_TOKEN</code>. S3
-							is on the way.
+							Store state in a GitHub Gist with just a
+							<code>BEDROCK_GITHUB_TOKEN</code>. S3 is on the way.
 						</p>
 					</div>
 					<div class="feature">

--- a/packages/bedrock/src/cli/commands/deploy.spec.ts
+++ b/packages/bedrock/src/cli/commands/deploy.spec.ts
@@ -242,7 +242,7 @@ describe(deployCommand, () => {
 			const [call] = firstCall;
 
 			expect(call.getEnv?.("BEDROCK_API_KEY")).toBe("BEDROCK_OVERRIDE");
-			expect(call.getEnv?.("GITHUB_TOKEN")).toBe("GH_OVERRIDE");
+			expect(call.getEnv?.("BEDROCK_GITHUB_TOKEN")).toBe("GH_OVERRIDE");
 			expect(call.getEnv?.("UNRELATED_VAR")).toBe("from-process-unrelated");
 		} finally {
 			vi.unstubAllEnvs();
@@ -253,7 +253,7 @@ describe(deployCommand, () => {
 		expect.assertions(3);
 
 		vi.stubEnv("BEDROCK_API_KEY", "from-process-bedrock");
-		vi.stubEnv("GITHUB_TOKEN", "from-process-github");
+		vi.stubEnv("BEDROCK_GITHUB_TOKEN", "from-process-github");
 
 		try {
 			const loadConfig = fakeLoad({ data: sampleConfig, success: true });
@@ -268,7 +268,7 @@ describe(deployCommand, () => {
 			const [call] = firstCall;
 
 			expect(call.getEnv?.("BEDROCK_API_KEY")).toBe("FLAG_BEDROCK");
-			expect(call.getEnv?.("GITHUB_TOKEN")).toBe("from-process-github");
+			expect(call.getEnv?.("BEDROCK_GITHUB_TOKEN")).toBe("from-process-github");
 			expect(call.getEnv?.("UNRELATED_VAR")).toBeUndefined();
 		} finally {
 			vi.unstubAllEnvs();
@@ -279,7 +279,7 @@ describe(deployCommand, () => {
 		expect.assertions(2);
 
 		vi.stubEnv("BEDROCK_API_KEY", "process-bedrock");
-		vi.stubEnv("GITHUB_TOKEN", "process-github");
+		vi.stubEnv("BEDROCK_GITHUB_TOKEN", "process-github");
 
 		try {
 			const loadConfig = fakeLoad({ data: sampleConfig, success: true });
@@ -294,7 +294,7 @@ describe(deployCommand, () => {
 			const [call] = firstCall;
 
 			expect(call.getEnv?.("BEDROCK_API_KEY")).toBe("process-bedrock");
-			expect(call.getEnv?.("GITHUB_TOKEN")).toBe("process-github");
+			expect(call.getEnv?.("BEDROCK_GITHUB_TOKEN")).toBe("process-github");
 		} finally {
 			vi.unstubAllEnvs();
 		}

--- a/packages/bedrock/src/cli/commands/diff.spec.ts
+++ b/packages/bedrock/src/cli/commands/diff.spec.ts
@@ -535,7 +535,7 @@ describe(diffCommand, () => {
 			const [call] = firstCall;
 
 			expect(call.getEnv?.("BEDROCK_API_KEY")).toBe("BEDROCK_OVERRIDE");
-			expect(call.getEnv?.("GITHUB_TOKEN")).toBe("GH_OVERRIDE");
+			expect(call.getEnv?.("BEDROCK_GITHUB_TOKEN")).toBe("GH_OVERRIDE");
 			expect(call.getEnv?.("UNRELATED_VAR")).toBe("from-process-unrelated");
 		} finally {
 			vi.unstubAllEnvs();
@@ -546,7 +546,7 @@ describe(diffCommand, () => {
 		expect.assertions(3);
 
 		vi.stubEnv("BEDROCK_API_KEY", "from-process-bedrock");
-		vi.stubEnv("GITHUB_TOKEN", "from-process-github");
+		vi.stubEnv("BEDROCK_GITHUB_TOKEN", "from-process-github");
 
 		try {
 			const loadConfig = fakeLoad({ data: sampleConfig, success: true });
@@ -561,7 +561,7 @@ describe(diffCommand, () => {
 			const [call] = firstCall;
 
 			expect(call.getEnv?.("BEDROCK_API_KEY")).toBe("FLAG_BEDROCK");
-			expect(call.getEnv?.("GITHUB_TOKEN")).toBe("from-process-github");
+			expect(call.getEnv?.("BEDROCK_GITHUB_TOKEN")).toBe("from-process-github");
 			expect(call.getEnv?.("UNRELATED_VAR")).toBeUndefined();
 		} finally {
 			vi.unstubAllEnvs();
@@ -572,7 +572,7 @@ describe(diffCommand, () => {
 		expect.assertions(2);
 
 		vi.stubEnv("BEDROCK_API_KEY", "process-bedrock");
-		vi.stubEnv("GITHUB_TOKEN", "process-github");
+		vi.stubEnv("BEDROCK_GITHUB_TOKEN", "process-github");
 
 		try {
 			const loadConfig = fakeLoad({ data: sampleConfig, success: true });
@@ -587,7 +587,7 @@ describe(diffCommand, () => {
 			const [call] = firstCall;
 
 			expect(call.getEnv?.("BEDROCK_API_KEY")).toBe("process-bedrock");
-			expect(call.getEnv?.("GITHUB_TOKEN")).toBe("process-github");
+			expect(call.getEnv?.("BEDROCK_GITHUB_TOKEN")).toBe("process-github");
 		} finally {
 			vi.unstubAllEnvs();
 		}

--- a/packages/bedrock/src/cli/commands/migrate.spec.ts
+++ b/packages/bedrock/src/cli/commands/migrate.spec.ts
@@ -286,7 +286,7 @@ describe(migrateCommand, () => {
 		onTestFinished(() => {
 			vi.unstubAllEnvs();
 		});
-		vi.stubEnv("GITHUB_TOKEN", "from-process");
+		vi.stubEnv("BEDROCK_GITHUB_TOKEN", "from-process");
 
 		const buildStatePort = vi.fn<BuildStatePortFunc>(() => happyPortResult());
 		const deps = makeDeps({ buildStatePort });
@@ -296,7 +296,7 @@ describe(migrateCommand, () => {
 
 		const firstCall = vi.mocked(buildStatePort).mock.calls[0]?.[0];
 
-		expect(firstCall?.getEnv("GITHUB_TOKEN")).toBe("from-process");
+		expect(firstCall?.getEnv("BEDROCK_GITHUB_TOKEN")).toBe("from-process");
 	});
 
 	it("should render an io error and exit 1 when the migrator throws (e.g. EACCES)", async () => {
@@ -473,7 +473,7 @@ describe(migrateCommand, () => {
 				err: {
 					kind: "missingCredential",
 					purpose: "stateBackend",
-					variable: "GITHUB_TOKEN",
+					variable: "BEDROCK_GITHUB_TOKEN",
 				},
 				success: false,
 			};
@@ -484,7 +484,7 @@ describe(migrateCommand, () => {
 		await migrateCommand(deps)("./.mantle-state.yml", { from: "mantle" });
 
 		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
-			"missing credential: environment variable GITHUB_TOKEN is not set",
+			"missing credential: environment variable BEDROCK_GITHUB_TOKEN is not set",
 		);
 		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
 	});

--- a/packages/bedrock/src/cli/credential-environment-overrides.spec.ts
+++ b/packages/bedrock/src/cli/credential-environment-overrides.spec.ts
@@ -11,12 +11,12 @@ describe(buildCredentialOverrides, () => {
 		expect(result).toStrictEqual({ BEDROCK_API_KEY: "rbx-123" });
 	});
 
-	it("should map githubToken to GITHUB_TOKEN when supplied", () => {
+	it("should map githubToken to BEDROCK_GITHUB_TOKEN when supplied", () => {
 		expect.assertions(1);
 
 		const result = buildCredentialOverrides({ githubToken: "ghp_456" });
 
-		expect(result).toStrictEqual({ GITHUB_TOKEN: "ghp_456" });
+		expect(result).toStrictEqual({ BEDROCK_GITHUB_TOKEN: "ghp_456" });
 	});
 
 	it("should include both env vars when both flags are supplied", () => {
@@ -24,7 +24,10 @@ describe(buildCredentialOverrides, () => {
 
 		const result = buildCredentialOverrides({ apiKey: "rbx-123", githubToken: "ghp_456" });
 
-		expect(result).toStrictEqual({ BEDROCK_API_KEY: "rbx-123", GITHUB_TOKEN: "ghp_456" });
+		expect(result).toStrictEqual({
+			BEDROCK_API_KEY: "rbx-123",
+			BEDROCK_GITHUB_TOKEN: "ghp_456",
+		});
 	});
 
 	it("should return an empty record when neither flag is supplied", () => {

--- a/packages/bedrock/src/cli/credential-environment-overrides.ts
+++ b/packages/bedrock/src/cli/credential-environment-overrides.ts
@@ -2,7 +2,7 @@
 interface CredentialFlags {
 	/** Roblox Open Cloud API key override; translates to BEDROCK_API_KEY when defined. */
 	readonly apiKey?: string;
-	/** GitHub token override; translates to GITHUB_TOKEN when defined. */
+	/** GitHub token override; translates to BEDROCK_GITHUB_TOKEN when defined. */
 	readonly githubToken?: string;
 }
 
@@ -19,7 +19,7 @@ export function buildCredentialOverrides(flags: CredentialFlags): Readonly<Recor
 	}
 
 	if (flags.githubToken !== undefined) {
-		overrides["GITHUB_TOKEN"] = flags.githubToken;
+		overrides["BEDROCK_GITHUB_TOKEN"] = flags.githubToken;
 	}
 
 	return overrides;

--- a/packages/bedrock/src/cli/index.ts
+++ b/packages/bedrock/src/cli/index.ts
@@ -66,7 +66,7 @@ export function createProg(deps: ProgDeps = {}): Sade {
 		.option("--env", "Target environment (repeat for multiple)")
 		.option("--config", "Config file path (overrides discovery)")
 		.option("--api-key", "Override the BEDROCK_API_KEY environment variable")
-		.option("--github-token", "Override the GITHUB_TOKEN environment variable")
+		.option("--github-token", "Override the BEDROCK_GITHUB_TOKEN environment variable")
 		.action(deployCommand(deps));
 
 	prog.command("diff")
@@ -74,7 +74,7 @@ export function createProg(deps: ProgDeps = {}): Sade {
 		.option("--env", "Target environment (repeat for multiple)")
 		.option("--config", "Config file path (overrides discovery)")
 		.option("--api-key", "Override the BEDROCK_API_KEY environment variable")
-		.option("--github-token", "Override the GITHUB_TOKEN environment variable")
+		.option("--github-token", "Override the BEDROCK_GITHUB_TOKEN environment variable")
 		.action(diffCommand(deps));
 
 	prog.command("migrate [stateFilePath]")

--- a/packages/bedrock/src/cli/parse-options.ts
+++ b/packages/bedrock/src/cli/parse-options.ts
@@ -13,7 +13,7 @@ export interface CommonOptions {
 	readonly configFile?: string;
 	/** Target environment names. Sade collects `--env` repeatedly into this list. */
 	readonly environments: ReadonlyArray<string>;
-	/** GitHub token override; falls back to GITHUB_TOKEN when undefined. */
+	/** GitHub token override; falls back to BEDROCK_GITHUB_TOKEN when undefined. */
 	readonly githubToken?: string;
 }
 

--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -37,9 +37,9 @@ describe(renderDeployError, () => {
 			err: {
 				kind: "missingCredential",
 				purpose: "stateBackend",
-				variable: "GITHUB_TOKEN",
+				variable: "BEDROCK_GITHUB_TOKEN",
 			},
-			expected: "missing credential: environment variable GITHUB_TOKEN is not set",
+			expected: "missing credential: environment variable BEDROCK_GITHUB_TOKEN is not set",
 		},
 		{
 			err: {
@@ -494,8 +494,12 @@ describe(renderMigrateError, () => {
 describe(renderBuildStatePortError, () => {
 	it.for<{ err: MissingCredentialError | UnsupportedBackendError; expected: string }>([
 		{
-			err: { kind: "missingCredential", purpose: "stateBackend", variable: "GITHUB_TOKEN" },
-			expected: "missing credential: environment variable GITHUB_TOKEN is not set",
+			err: {
+				kind: "missingCredential",
+				purpose: "stateBackend",
+				variable: "BEDROCK_GITHUB_TOKEN",
+			},
+			expected: "missing credential: environment variable BEDROCK_GITHUB_TOKEN is not set",
 		},
 		{
 			err: { backend: "s3", hint: "pass a custom statePort", kind: "unsupportedBackend" },

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -403,8 +403,8 @@ export interface UniverseEntry {
 
 /**
  * State configuration for the GitHub Gist backend. Holds the public gist
- * ID; the GitHub token is read from `BEDROCK_GITHUB_TOKEN` only when the
- * library default-constructs the adapter.
+ * ID; the library reads the GitHub token from `BEDROCK_GITHUB_TOKEN` when
+ * it default-constructs the adapter.
  */
 export interface GistStateConfig {
 	/** Discriminator selecting the gist adapter. */

--- a/packages/bedrock/src/core/schema.ts
+++ b/packages/bedrock/src/core/schema.ts
@@ -403,8 +403,8 @@ export interface UniverseEntry {
 
 /**
  * State configuration for the GitHub Gist backend. Holds the public gist
- * ID; the GitHub token is read from `GITHUB_TOKEN` only when the library
- * default-constructs the adapter.
+ * ID; the GitHub token is read from `BEDROCK_GITHUB_TOKEN` only when the
+ * library default-constructs the adapter.
  */
 export interface GistStateConfig {
 	/** Discriminator selecting the gist adapter. */

--- a/packages/bedrock/src/shell/build-state-port.example.spec.ts
+++ b/packages/bedrock/src/shell/build-state-port.example.spec.ts
@@ -6,7 +6,8 @@ it('Example 1', () => {
   const port = buildStatePort({
     fetch: async () =>
       new Response(JSON.stringify({ files: {} }), { status: 200 }),
-    getEnv: (name) => (name === 'GITHUB_TOKEN' ? 'ghp_example' : undefined),
+    getEnv: (name) =>
+      name === 'BEDROCK_GITHUB_TOKEN' ? 'ghp_example' : undefined,
     stateConfig: { backend: 'gist', gistId: 'abc123' },
   })
   expect(port.success).toBeTrue()

--- a/packages/bedrock/src/shell/build-state-port.spec.ts
+++ b/packages/bedrock/src/shell/build-state-port.spec.ts
@@ -45,7 +45,7 @@ describe(buildStatePort, () => {
 
 		const result = buildStatePort({
 			fetch: fetchFn,
-			getEnv: environmentFrom({ GITHUB_TOKEN: "ghp_test" }),
+			getEnv: environmentFrom({ BEDROCK_GITHUB_TOKEN: "ghp_test" }),
 			stateConfig: GIST_CONFIG,
 		});
 
@@ -56,24 +56,43 @@ describe(buildStatePort, () => {
 		expect(read.success).toBeTrue();
 	});
 
-	it("should pass the GITHUB_TOKEN value through to the gist adapter as a Bearer token", async () => {
-		expect.assertions(1);
+	it.for([
+		{
+			env: { BEDROCK_GITHUB_TOKEN: "ghp_preferred" },
+			expectedBearer: "Bearer ghp_preferred",
+			label: "BEDROCK_GITHUB_TOKEN",
+		},
+		{
+			env: { GITHUB_TOKEN: "ghp_legacy" },
+			expectedBearer: "Bearer ghp_legacy",
+			label: "GITHUB_TOKEN as fallback",
+		},
+		{
+			env: { BEDROCK_GITHUB_TOKEN: "ghp_preferred", GITHUB_TOKEN: "ghp_legacy" },
+			expectedBearer: "Bearer ghp_preferred",
+			label: "BEDROCK_GITHUB_TOKEN over GITHUB_TOKEN when both are set",
+		},
+	])(
+		"should send the credential resolved from $label as a Bearer token",
+		async ({ env, expectedBearer }) => {
+			expect.assertions(1);
 
-		const { calls, fetchFn } = fakeFetch(emptyFilesResponse);
+			const { calls, fetchFn } = fakeFetch(emptyFilesResponse);
 
-		const result = buildStatePort({
-			fetch: fetchFn,
-			getEnv: environmentFrom({ GITHUB_TOKEN: "ghp_secret" }),
-			stateConfig: GIST_CONFIG,
-		});
+			const result = buildStatePort({
+				fetch: fetchFn,
+				getEnv: environmentFrom(env),
+				stateConfig: GIST_CONFIG,
+			});
 
-		assert(result.success);
-		await result.data.read("production");
+			assert(result.success);
+			await result.data.read("production");
 
-		expect(calls[0]!.headers.get("authorization")).toBe("Bearer ghp_secret");
-	});
+			expect(calls[0]!.headers.get("authorization")).toBe(expectedBearer);
+		},
+	);
 
-	it("should return Err(missingCredential) when backend is gist and GITHUB_TOKEN is unset", () => {
+	it("should return Err(missingCredential) naming BEDROCK_GITHUB_TOKEN when no credential env var is set", () => {
 		expect.assertions(3);
 
 		const result = buildStatePort({
@@ -86,7 +105,7 @@ describe(buildStatePort, () => {
 		assert(result.err.kind === "missingCredential");
 
 		expect(result.err.kind).toBe("missingCredential");
-		expect(result.err.variable).toBe("GITHUB_TOKEN");
+		expect(result.err.variable).toBe("BEDROCK_GITHUB_TOKEN");
 		expect(result.err.purpose).toBe("stateBackend");
 	});
 
@@ -95,7 +114,7 @@ describe(buildStatePort, () => {
 
 		const result = buildStatePort({
 			fetch: neverFetch,
-			getEnv: environmentFrom({ GITHUB_TOKEN: "ghp_test" }),
+			getEnv: environmentFrom({ BEDROCK_GITHUB_TOKEN: "ghp_test" }),
 			stateConfig: { backend: "s3" },
 		});
 
@@ -110,7 +129,7 @@ describe(buildStatePort, () => {
 
 		const result = buildStatePort({
 			fetch: neverFetch,
-			getEnv: environmentFrom({ GITHUB_TOKEN: "ghp_test" }),
+			getEnv: environmentFrom({ BEDROCK_GITHUB_TOKEN: "ghp_test" }),
 			stateConfig: { backend: "s3" },
 		});
 
@@ -124,7 +143,7 @@ describe(buildStatePort, () => {
 		expect.assertions(1);
 
 		const result = buildStatePort({
-			getEnv: environmentFrom({ GITHUB_TOKEN: "ghp_test" }),
+			getEnv: environmentFrom({ BEDROCK_GITHUB_TOKEN: "ghp_test" }),
 			stateConfig: GIST_CONFIG,
 		});
 

--- a/packages/bedrock/src/shell/build-state-port.ts
+++ b/packages/bedrock/src/shell/build-state-port.ts
@@ -59,7 +59,7 @@ const STATE_PORT_HINT = "pass a custom statePort via opts.statePort";
  * const port = buildStatePort({
  *     fetch: async () =>
  *         new Response(JSON.stringify({ files: {} }), { status: 200 }),
- *     getEnv: (name) => (name === "GITHUB_TOKEN" ? "ghp_example" : undefined),
+ *     getEnv: (name) => (name === "BEDROCK_GITHUB_TOKEN" ? "ghp_example" : undefined),
  *     stateConfig: { backend: "gist", gistId: "abc123" },
  * });
  *
@@ -91,13 +91,13 @@ function buildGistStatePort(
 	stateConfig: GistStateConfig,
 	deps: BuildStatePortDeps,
 ): Result<StatePort, MissingCredentialError> {
-	const token = deps.getEnv("GITHUB_TOKEN");
+	const token = deps.getEnv("BEDROCK_GITHUB_TOKEN") ?? deps.getEnv("GITHUB_TOKEN");
 	if (token === undefined) {
 		return {
 			err: {
 				kind: "missingCredential",
 				purpose: "stateBackend",
-				variable: "GITHUB_TOKEN",
+				variable: "BEDROCK_GITHUB_TOKEN",
 			},
 			success: false,
 		};

--- a/packages/bedrock/src/shell/deploy.spec.ts
+++ b/packages/bedrock/src/shell/deploy.spec.ts
@@ -649,7 +649,7 @@ describe(deploy, () => {
 			config: configWithState(),
 			environment: "production",
 			fetch: fetchSpy,
-			getEnv: environmentFrom({ GITHUB_TOKEN: "ghp_test" }),
+			getEnv: environmentFrom({ BEDROCK_GITHUB_TOKEN: "ghp_test" }),
 			readFile: readIcon,
 			registry,
 		});
@@ -702,7 +702,7 @@ describe(deploy, () => {
 		const result = await deploy({
 			config: { environments: { production: {} }, state: { backend: "s3" } },
 			environment: "production",
-			getEnv: environmentFrom({ GITHUB_TOKEN: "ghp_test" }),
+			getEnv: environmentFrom({ BEDROCK_GITHUB_TOKEN: "ghp_test" }),
 			readFile: readIcon,
 			registry: stubRegistry(),
 		});
@@ -714,7 +714,7 @@ describe(deploy, () => {
 		expect(result.err.backend).toBe("s3");
 	});
 
-	it("should return Err(missingCredential) when GITHUB_TOKEN is unset on the default-construction state-port path", async () => {
+	it("should return Err(missingCredential) when BEDROCK_GITHUB_TOKEN is unset on the default-construction state-port path", async () => {
 		expect.assertions(2);
 
 		const result = await deploy({
@@ -728,7 +728,7 @@ describe(deploy, () => {
 		assert(!result.success);
 		assert(result.err.kind === "missingCredential");
 
-		expect(result.err.variable).toBe("GITHUB_TOKEN");
+		expect(result.err.variable).toBe("BEDROCK_GITHUB_TOKEN");
 		expect(result.err.purpose).toBe("stateBackend");
 	});
 
@@ -751,7 +751,10 @@ describe(deploy, () => {
 				universe: { universeId: "1" },
 			},
 			environment: "production",
-			getEnv: environmentFrom({ BEDROCK_API_KEY: "rbx-test", GITHUB_TOKEN: "ghp_test" }),
+			getEnv: environmentFrom({
+				BEDROCK_API_KEY: "rbx-test",
+				BEDROCK_GITHUB_TOKEN: "ghp_test",
+			}),
 			readFile: readIcon,
 			statePort: port,
 		});
@@ -771,7 +774,7 @@ describe(deploy, () => {
 				universe: { universeId: "1" },
 			},
 			environment: "production",
-			getEnv: environmentFrom({ GITHUB_TOKEN: "ghp_test" }),
+			getEnv: environmentFrom({ BEDROCK_GITHUB_TOKEN: "ghp_test" }),
 			readFile: readIcon,
 			statePort: inMemoryStatePort().port,
 		});
@@ -792,7 +795,10 @@ describe(deploy, () => {
 				state: { backend: "gist", gistId: "abc" },
 			},
 			environment: "production",
-			getEnv: environmentFrom({ BEDROCK_API_KEY: "rbx-test", GITHUB_TOKEN: "ghp_test" }),
+			getEnv: environmentFrom({
+				BEDROCK_API_KEY: "rbx-test",
+				BEDROCK_GITHUB_TOKEN: "ghp_test",
+			}),
 			readFile: readIcon,
 			statePort: inMemoryStatePort().port,
 		});

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -35,7 +35,7 @@ import { loadConfig as defaultLoadConfig, type LoadConfigOptions } from "./load-
 /**
  * Inputs for `deploy`. Every field except `environment` is optional;
  * omitted dependencies are default-constructed from the project config
- * and the environment variables `GITHUB_TOKEN` and `BEDROCK_API_KEY`.
+ * and the environment variables `BEDROCK_GITHUB_TOKEN` and `BEDROCK_API_KEY`.
  */
 export interface DeployOptions {
 	/** Pre-loaded, optionally-mutated project config. Omit to call `loadConfig()` automatically. */
@@ -59,7 +59,7 @@ export interface DeployOptions {
 	readonly readFile?: (path: string) => Promise<Uint8Array>;
 	/** Per-kind driver table consulted for create / update dispatch. Default-constructed from `BEDROCK_API_KEY` when omitted. */
 	readonly registry?: DriverRegistry;
-	/** Backend used to read the prior snapshot and persist the new one. Default-constructed from `config.state` and `GITHUB_TOKEN` when omitted. */
+	/** Backend used to read the prior snapshot and persist the new one. Default-constructed from `config.state` and `BEDROCK_GITHUB_TOKEN` when omitted. */
 	readonly statePort?: StatePort;
 }
 
@@ -118,7 +118,7 @@ interface PickRegistryInputs {
 
 /**
  * Run a full reconcile end-to-end. Default-constructs missing deps from
- * the project config and the environment variables `GITHUB_TOKEN` and
+ * the project config and the environment variables `BEDROCK_GITHUB_TOKEN` and
  * `BEDROCK_API_KEY`; never reads `process.env` when `statePort`,
  * `registry`, and `config` are all supplied explicitly.
  *

--- a/packages/bedrock/src/shell/preview-diff.spec.ts
+++ b/packages/bedrock/src/shell/preview-diff.spec.ts
@@ -226,7 +226,7 @@ describe(previewDiff, () => {
 		});
 	});
 
-	it("should surface missingCredential when buildStatePort cannot read GITHUB_TOKEN", async () => {
+	it("should surface missingCredential when buildStatePort cannot read BEDROCK_GITHUB_TOKEN", async () => {
 		expect.assertions(1);
 
 		const config: Config = {
@@ -246,7 +246,7 @@ describe(previewDiff, () => {
 		expect(result.err).toStrictEqual({
 			kind: "missingCredential",
 			purpose: "stateBackend",
-			variable: "GITHUB_TOKEN",
+			variable: "BEDROCK_GITHUB_TOKEN",
 		});
 	});
 
@@ -382,7 +382,7 @@ describe(previewDiff, () => {
 		const result = await previewDiff({
 			environment: "production",
 			fetch: async () => new Response(JSON.stringify({ files: {} }), { status: 200 }),
-			getEnv: (name) => (name === "GITHUB_TOKEN" ? "ghp_test" : undefined),
+			getEnv: (name) => (name === "BEDROCK_GITHUB_TOKEN" ? "ghp_test" : undefined),
 			loadConfig,
 			readFile: readIcon,
 		});

--- a/packages/bedrock/src/shell/preview-diff.ts
+++ b/packages/bedrock/src/shell/preview-diff.ts
@@ -35,7 +35,7 @@ import { loadConfig as defaultLoadConfig, type LoadConfigOptions } from "./load-
  * Inputs for `previewDiff`. Mirrors `DeployOptions` minus the apply-side
  * dependencies (`registry`); every field except `environment` is optional
  * and default-constructed from the project config and the environment
- * variables `GITHUB_TOKEN` (gist state backend) when omitted.
+ * variables `BEDROCK_GITHUB_TOKEN` (gist state backend) when omitted.
  */
 export interface PreviewDiffOptions {
 	/** Pre-loaded, optionally-mutated project config. Omit to call `loadConfig()` automatically. */
@@ -50,7 +50,7 @@ export interface PreviewDiffOptions {
 	readonly loadConfig?: (options?: LoadConfigOptions) => Promise<Result<Config, ConfigError>>;
 	/** Reads file bytes for resources that have file-backed inputs. Defaults to `node:fs/promises.readFile`. */
 	readonly readFile?: (path: string) => Promise<Uint8Array>;
-	/** Backend used to read the prior snapshot. Default-constructed from `config.state` and `GITHUB_TOKEN` when omitted. */
+	/** Backend used to read the prior snapshot. Default-constructed from `config.state` and `BEDROCK_GITHUB_TOKEN` when omitted. */
 	readonly statePort?: StatePort;
 }
 
@@ -96,7 +96,7 @@ interface ResolvedDeps {
 /**
  * Compute the operations `deploy` would apply for a target environment
  * without writing state. Default-constructs missing deps from the project
- * config and `GITHUB_TOKEN`; never reads `process.env` when `statePort`
+ * config and `BEDROCK_GITHUB_TOKEN`; never reads `process.env` when `statePort`
  * and `config` are both supplied explicitly.
  *
  * @param options - Target environment plus optional overrides.

--- a/packages/bedrock/tests/integration/cli/index.spec.ts
+++ b/packages/bedrock/tests/integration/cli/index.spec.ts
@@ -134,7 +134,7 @@ describe("cli program factory", () => {
 			expect(captured).toContain("Target environment");
 			expect(captured).toContain("Config file path");
 			expect(captured).toContain("BEDROCK_API_KEY");
-			expect(captured).toContain("GITHUB_TOKEN");
+			expect(captured).toContain("BEDROCK_GITHUB_TOKEN");
 		}
 	});
 
@@ -154,7 +154,7 @@ describe("cli program factory", () => {
 			expect(captured).toContain("Target environment");
 			expect(captured).toContain("Config file path");
 			expect(captured).toContain("BEDROCK_API_KEY");
-			expect(captured).toContain("GITHUB_TOKEN");
+			expect(captured).toContain("BEDROCK_GITHUB_TOKEN");
 		}
 	});
 


### PR DESCRIPTION
Closes #313.

## Summary

- Adds `BEDROCK_GITHUB_TOKEN` as the preferred credential for the gist state backend, with `GITHUB_TOKEN` retained as a silent legacy fallback so CI environments that set it automatically keep working.
- New resolution order, highest to lowest: `--github-token` CLI flag, `BEDROCK_GITHUB_TOKEN`, `GITHUB_TOKEN`. The flag override now writes under `BEDROCK_GITHUB_TOKEN` so it wins regardless of which env var is also set.
- Missing-credential error names `BEDROCK_GITHUB_TOKEN` only. The legacy fallback stays undocumented in the error surface.
- Updates README, root CLAUDE.md, the website home-landing copy, and JSDoc on `GistStateConfig`, `deploy`, `previewDiff`, and the CLI option descriptions to reference the canonical name.

## Why

Every other env var the tool reads is `BEDROCK_*`-prefixed (`BEDROCK_API_KEY`, `BEDROCK_ENVIRONMENT`); the unprefixed `GITHUB_TOKEN` was an outlier. Keeping it as a silent fallback avoids breaking CI environments where it is set automatically (GitHub Actions, etc.).

## Test plan

- [x] `pnpm test` green (3750 passing)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` succeeds
- [x] `pnpm mutate:changed` clean (9 killed / 0 survived on touched src/**)
- [x] `build-state-port.spec.ts` covers the three precedence cases via `it.for` (preferred only, legacy fallback, both set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)