### PR TITLE
feat(core): add override-file discovery

### DIFF
--- a/packages/bedrock/src/cli/discover-override.spec.ts
+++ b/packages/bedrock/src/cli/discover-override.spec.ts
@@ -1,0 +1,79 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { discoverOverride } from "./discover-override.ts";
+
+// Walking up from a temp file inside the workspace tree finds @bedrock-rbx/core
+// via the workspace root's node_modules, regardless of pnpm's hoist decisions.
+// node_modules/.cache is the conventional location for tool ephemera and is
+// already gitignored.
+const WORKSPACE_TEMP_ROOT = join(
+	dirname(dirname(dirname(fileURLToPath(import.meta.url)))),
+	"node_modules",
+	".cache",
+);
+
+async function withTemporaryDirectory<T>(run: (directory: string) => Promise<T>): Promise<T> {
+	mkdirSync(WORKSPACE_TEMP_ROOT, { recursive: true });
+	const directory = mkdtempSync(join(WORKSPACE_TEMP_ROOT, "bedrock-discover-override-"));
+	try {
+		return await run(directory);
+	} finally {
+		rmSync(directory, { force: true, recursive: true });
+	}
+}
+
+describe(discoverOverride, () => {
+	it("should return the resolved absolute path when the override file exists", async () => {
+		expect.assertions(1);
+
+		await withTemporaryDirectory(async (cwd) => {
+			mkdirSync(join(cwd, ".bedrock"));
+			const expected = join(cwd, ".bedrock", "deploy.ts");
+			writeFileSync(expected, "export default () => {};");
+
+			expect(discoverOverride(cwd, "deploy")).toBe(expected);
+		});
+	});
+
+	it("should return undefined when the .bedrock directory does not exist", async () => {
+		expect.assertions(1);
+
+		await withTemporaryDirectory(async (cwd) => {
+			expect(discoverOverride(cwd, "deploy")).toBeUndefined();
+		});
+	});
+
+	it("should return undefined when .bedrock exists but the command file is absent", async () => {
+		expect.assertions(1);
+
+		await withTemporaryDirectory(async (cwd) => {
+			mkdirSync(join(cwd, ".bedrock"));
+
+			expect(discoverOverride(cwd, "deploy")).toBeUndefined();
+		});
+	});
+
+	it("should return undefined when a different command override exists in .bedrock", async () => {
+		expect.assertions(1);
+
+		await withTemporaryDirectory(async (cwd) => {
+			mkdirSync(join(cwd, ".bedrock"));
+			writeFileSync(join(cwd, ".bedrock", "diff.ts"), "export default () => {};");
+
+			expect(discoverOverride(cwd, "deploy")).toBeUndefined();
+		});
+	});
+
+	it("should return undefined when the candidate path exists as a directory rather than a file", async () => {
+		expect.assertions(1);
+
+		await withTemporaryDirectory(async (cwd) => {
+			mkdirSync(join(cwd, ".bedrock", "deploy.ts"), { recursive: true });
+
+			expect(discoverOverride(cwd, "deploy")).toBeUndefined();
+		});
+	});
+});

--- a/packages/bedrock/src/cli/discover-override.spec.ts
+++ b/packages/bedrock/src/cli/discover-override.spec.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, onTestFinished } from "vitest";
 
 import type { StatProbe } from "./discover-override.ts";
 import { discoverOverride, discoverOverrideWith } from "./discover-override.ts";
@@ -28,76 +28,70 @@ const WORKSPACE_TEMP_ROOT = join(
 	".cache",
 );
 
-async function withTemporaryDirectory<T>(run: (directory: string) => Promise<T>): Promise<T> {
+function createTemporaryDirectory(): string {
 	mkdirSync(WORKSPACE_TEMP_ROOT, { recursive: true });
 	const directory = mkdtempSync(join(WORKSPACE_TEMP_ROOT, "bedrock-discover-override-"));
-	try {
-		return await run(directory);
-	} finally {
+	onTestFinished(() => {
 		rmSync(directory, { force: true, recursive: true });
-	}
+	});
+	return directory;
 }
 
 describe(discoverOverride, () => {
-	it("should return the resolved absolute path when the override file exists", async () => {
+	it("should return the resolved absolute path when the override file exists", () => {
 		expect.assertions(1);
 
-		await withTemporaryDirectory(async (cwd) => {
-			mkdirSync(join(cwd, ".bedrock"));
-			const expected = join(cwd, ".bedrock", "deploy.ts");
-			writeFileSync(expected, "export default () => {};");
+		const cwd = createTemporaryDirectory();
+		mkdirSync(join(cwd, ".bedrock"));
+		const expected = join(cwd, ".bedrock", "deploy.ts");
+		writeFileSync(expected, "export default () => {};");
 
-			expect(discoverOverride(cwd, "deploy")).toBe(expected);
-		});
+		expect(discoverOverride(cwd, "deploy")).toBe(expected);
 	});
 
-	it("should return undefined when the .bedrock directory does not exist", async () => {
+	it("should return undefined when the .bedrock directory does not exist", () => {
 		expect.assertions(1);
 
-		await withTemporaryDirectory(async (cwd) => {
-			expect(discoverOverride(cwd, "deploy")).toBeUndefined();
-		});
+		const cwd = createTemporaryDirectory();
+
+		expect(discoverOverride(cwd, "deploy")).toBeUndefined();
 	});
 
-	it("should return undefined when .bedrock exists but the command file is absent", async () => {
+	it("should return undefined when .bedrock exists but the command file is absent", () => {
 		expect.assertions(1);
 
-		await withTemporaryDirectory(async (cwd) => {
-			mkdirSync(join(cwd, ".bedrock"));
+		const cwd = createTemporaryDirectory();
+		mkdirSync(join(cwd, ".bedrock"));
 
-			expect(discoverOverride(cwd, "deploy")).toBeUndefined();
-		});
+		expect(discoverOverride(cwd, "deploy")).toBeUndefined();
 	});
 
-	it("should return undefined when a different command override exists in .bedrock", async () => {
+	it("should return undefined when a different command override exists in .bedrock", () => {
 		expect.assertions(1);
 
-		await withTemporaryDirectory(async (cwd) => {
-			mkdirSync(join(cwd, ".bedrock"));
-			writeFileSync(join(cwd, ".bedrock", "diff.ts"), "export default () => {};");
+		const cwd = createTemporaryDirectory();
+		mkdirSync(join(cwd, ".bedrock"));
+		writeFileSync(join(cwd, ".bedrock", "diff.ts"), "export default () => {};");
 
-			expect(discoverOverride(cwd, "deploy")).toBeUndefined();
-		});
+		expect(discoverOverride(cwd, "deploy")).toBeUndefined();
 	});
 
-	it("should return undefined when the candidate path exists as a directory rather than a file", async () => {
+	it("should return undefined when the candidate path exists as a directory rather than a file", () => {
 		expect.assertions(1);
 
-		await withTemporaryDirectory(async (cwd) => {
-			mkdirSync(join(cwd, ".bedrock", "deploy.ts"), { recursive: true });
+		const cwd = createTemporaryDirectory();
+		mkdirSync(join(cwd, ".bedrock", "deploy.ts"), { recursive: true });
 
-			expect(discoverOverride(cwd, "deploy")).toBeUndefined();
-		});
+		expect(discoverOverride(cwd, "deploy")).toBeUndefined();
 	});
 
-	it("should return undefined when .bedrock itself is a regular file rather than a directory", async () => {
+	it("should return undefined when .bedrock itself is a regular file rather than a directory", () => {
 		expect.assertions(1);
 
-		await withTemporaryDirectory(async (cwd) => {
-			writeFileSync(join(cwd, ".bedrock"), "not a directory");
+		const cwd = createTemporaryDirectory();
+		writeFileSync(join(cwd, ".bedrock"), "not a directory");
 
-			expect(discoverOverride(cwd, "deploy")).toBeUndefined();
-		});
+		expect(discoverOverride(cwd, "deploy")).toBeUndefined();
 	});
 
 	it.for<[label: string, command: string]>([
@@ -109,19 +103,18 @@ describe(discoverOverride, () => {
 		["uppercase", "Deploy"],
 		["leading hyphen", "-rf"],
 	])(
-		"should return undefined for a malformed command name (%s) without touching the filesystem",
-		async ([, command]) => {
+		"should return undefined for a malformed command name (%s) without invoking the stat probe",
+		([, command]) => {
 			expect.assertions(1);
 
-			await withTemporaryDirectory(async (cwd) => {
-				// A `.bedrock/` directory with a permissive file present
-				// proves the early-return path skipped the stat — otherwise
-				// path traversal could resolve into something real.
-				mkdirSync(join(cwd, ".bedrock"));
-				writeFileSync(join(cwd, ".bedrock", "diff.ts"), "export default () => {};");
+			// A throwing stat proves the early-return path skipped the
+			// filesystem entirely. If validation regressed and the path was
+			// resolved, the stat call would surface the synthetic error.
+			const stat = throwingStat(new Error("stat must not run for a malformed command"));
 
-				expect(discoverOverride(cwd, command)).toBeUndefined();
-			});
+			expect(
+				discoverOverrideWith({ command, projectRoot: "/project", stat }),
+			).toBeUndefined();
 		},
 	);
 

--- a/packages/bedrock/src/cli/discover-override.spec.ts
+++ b/packages/bedrock/src/cli/discover-override.spec.ts
@@ -3,7 +3,20 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-import { discoverOverride } from "./discover-override.ts";
+import type { StatProbe } from "./discover-override.ts";
+import { discoverOverride, discoverOverrideWith } from "./discover-override.ts";
+
+function throwingStat(error: unknown): StatProbe {
+	return () => {
+		throw error;
+	};
+}
+
+function errnoError(code: string): NodeJS.ErrnoException {
+	const error: NodeJS.ErrnoException = new Error(`synthetic ${code}`);
+	error.code = code;
+	return error;
+}
 
 // Walking up from a temp file inside the workspace tree finds @bedrock-rbx/core
 // via the workspace root's node_modules, regardless of pnpm's hoist decisions.
@@ -75,5 +88,94 @@ describe(discoverOverride, () => {
 
 			expect(discoverOverride(cwd, "deploy")).toBeUndefined();
 		});
+	});
+
+	it("should return undefined when .bedrock itself is a regular file rather than a directory", async () => {
+		expect.assertions(1);
+
+		await withTemporaryDirectory(async (cwd) => {
+			writeFileSync(join(cwd, ".bedrock"), "not a directory");
+
+			expect(discoverOverride(cwd, "deploy")).toBeUndefined();
+		});
+	});
+
+	it.for<[label: string, command: string]>([
+		["empty string", ""],
+		["parent traversal", "../etc/passwd"],
+		["embedded traversal", "deploy/../diff"],
+		["path separator", "foo/bar"],
+		["leading dot", "..bedrock"],
+		["uppercase", "Deploy"],
+		["leading hyphen", "-rf"],
+	])(
+		"should return undefined for a malformed command name (%s) without touching the filesystem",
+		async ([, command]) => {
+			expect.assertions(1);
+
+			await withTemporaryDirectory(async (cwd) => {
+				// A `.bedrock/` directory with a permissive file present
+				// proves the early-return path skipped the stat — otherwise
+				// path traversal could resolve into something real.
+				mkdirSync(join(cwd, ".bedrock"));
+				writeFileSync(join(cwd, ".bedrock", "diff.ts"), "export default () => {};");
+
+				expect(discoverOverride(cwd, command)).toBeUndefined();
+			});
+		},
+	);
+
+	it.for<[label: string, code: string]>([
+		["ENOENT", "ENOENT"],
+		["ENOTDIR", "ENOTDIR"],
+	])(
+		"should return undefined when the stat probe rejects with an absence-style error code (%s)",
+		([, code]) => {
+			expect.assertions(1);
+
+			const stat = throwingStat(errnoError(code));
+
+			expect(
+				discoverOverrideWith({ command: "deploy", projectRoot: "/project", stat }),
+			).toBeUndefined();
+		},
+	);
+
+	it.for<[label: string, code: string]>([
+		["EACCES", "EACCES"],
+		["EPERM", "EPERM"],
+		["EBUSY", "EBUSY"],
+	])(
+		"should rethrow when the stat probe rejects with a non-absence error code (%s) so dispatch cannot silently fall back to the built-in command",
+		([, code]) => {
+			expect.assertions(1);
+
+			const error = errnoError(code);
+			const stat = throwingStat(error);
+
+			expect(() =>
+				discoverOverrideWith({ command: "deploy", projectRoot: "/project", stat }),
+			).toThrow(error);
+		},
+	);
+
+	it("should rethrow when the stat probe throws a non-Error value", () => {
+		expect.assertions(1);
+
+		const stat = throwingStat("not an Error instance");
+
+		expect(() =>
+			discoverOverrideWith({ command: "deploy", projectRoot: "/project", stat }),
+		).toThrow("not an Error instance");
+	});
+
+	it("should rethrow when the stat probe throws an Error without a code property", () => {
+		expect.assertions(1);
+
+		const stat = throwingStat(new Error("no code attached"));
+
+		expect(() =>
+			discoverOverrideWith({ command: "deploy", projectRoot: "/project", stat }),
+		).toThrow("no code attached");
 	});
 });

--- a/packages/bedrock/src/cli/discover-override.ts
+++ b/packages/bedrock/src/cli/discover-override.ts
@@ -1,0 +1,28 @@
+import { statSync } from "node:fs";
+import { resolve } from "node:path";
+
+const OVERRIDE_DIR_NAME = ".bedrock";
+const OVERRIDE_EXTENSION = ".ts";
+
+/**
+ * Resolve the path of a user-authored `.bedrock/<command>.ts` override for the
+ * given command, or return `undefined` when no such file exists.
+ *
+ * The CLI uses this primitive to decide whether a subcommand invocation should
+ * be handed to an override script or run through the built-in path. The
+ * folder name and file extension are fixed; only an exact filename match for
+ * the requested command is considered.
+ * @param projectRoot - The directory `bedrock` was invoked from, against which
+ * `.bedrock/<command>.ts` is resolved.
+ * @param command - The CLI subcommand name to look up (`deploy`, `diff`, ...).
+ * @returns The absolute path to the override file when it exists, otherwise
+ * `undefined`.
+ */
+export function discoverOverride(projectRoot: string, command: string): string | undefined {
+	const candidate = resolve(projectRoot, OVERRIDE_DIR_NAME, `${command}${OVERRIDE_EXTENSION}`);
+	try {
+		return statSync(candidate).isFile() ? candidate : undefined;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/bedrock/src/cli/discover-override.ts
+++ b/packages/bedrock/src/cli/discover-override.ts
@@ -1,28 +1,95 @@
+import type { Stats } from "node:fs";
 import { statSync } from "node:fs";
 import { resolve } from "node:path";
 
 const OVERRIDE_DIR_NAME = ".bedrock";
 const OVERRIDE_EXTENSION = ".ts";
 
+// Mirrors the shape of every built-in `sade` subcommand (`deploy`, `diff`,
+// `migrate`). Rejecting anything else stops a malformed argv (`..`, `foo/bar`,
+// `""`) from path-traversing out of `.bedrock/` via `resolve`.
+const VALID_COMMAND = /^[a-z][a-z0-9-]*$/;
+
 /**
- * Resolve the path of a user-authored `.bedrock/<command>.ts` override for the
- * given command, or return `undefined` when no such file exists.
- *
- * The CLI uses this primitive to decide whether a subcommand invocation should
- * be handed to an override script or run through the built-in path. The
- * folder name and file extension are fixed; only an exact filename match for
- * the requested command is considered.
- * @param projectRoot - The directory `bedrock` was invoked from, against which
- * `.bedrock/<command>.ts` is resolved.
- * @param command - The CLI subcommand name to look up (`deploy`, `diff`, ...).
+ * Probes a path's filesystem metadata. Tests inject a fake to exercise
+ * non-absence error paths (`EACCES`, malformed thrown values) that
+ * real-fs fixtures cannot trigger reliably on Windows.
+ */
+export type StatProbe = (path: string) => Pick<Stats, "isFile">;
+
+/**
+ * Inputs to {@link discoverOverrideWith}. The stat seam is internal — the
+ * public {@link discoverOverride} entry point binds it to `node:fs.statSync`.
+ */
+export interface DiscoverOverrideInputs {
+	/** CLI subcommand name. Must match `/^[a-z][a-z0-9-]*$/`. */
+	readonly command: string;
+	/** Project root path. Relative inputs resolve against `process.cwd()`. */
+	readonly projectRoot: string;
+	/** Filesystem stat seam. */
+	readonly stat: StatProbe;
+}
+
+/**
+ * Stat-injectable variant of {@link discoverOverride}. Exported so tests can
+ * drive `EACCES`-class errors and malformed-throw cases that real fs fixtures
+ * cannot reliably produce on every supported OS.
+ * @param inputs - {@link DiscoverOverrideInputs}.
  * @returns The absolute path to the override file when it exists, otherwise
  * `undefined`.
  */
-export function discoverOverride(projectRoot: string, command: string): string | undefined {
-	const candidate = resolve(projectRoot, OVERRIDE_DIR_NAME, `${command}${OVERRIDE_EXTENSION}`);
-	try {
-		return statSync(candidate).isFile() ? candidate : undefined;
-	} catch {
+export function discoverOverrideWith(inputs: DiscoverOverrideInputs): string | undefined {
+	const { command, projectRoot, stat } = inputs;
+
+	if (!VALID_COMMAND.test(command)) {
 		return undefined;
 	}
+
+	const candidate = resolve(projectRoot, OVERRIDE_DIR_NAME, `${command}${OVERRIDE_EXTENSION}`);
+	try {
+		return stat(candidate).isFile() ? candidate : undefined;
+	} catch (err) {
+		if (isAbsenceError(err)) {
+			return undefined;
+		}
+
+		throw err;
+	}
+}
+
+/**
+ * Resolve the path of a user-authored `.bedrock/<command>.ts` override for
+ * the given command, or return `undefined` when no such file exists.
+ *
+ * The CLI uses this primitive to decide whether a subcommand invocation
+ * should be handed to an override script or run through the built-in path.
+ * `undefined` therefore means "fall through to the built-in implementation",
+ * so only absence-style stat failures (`ENOENT`, `ENOTDIR`) are swallowed.
+ * Permission and other errors propagate; the dispatcher must refuse to
+ * silently route a `deploy` (or any other destructive command) through the
+ * built-in path when the override file demonstrably exists but is
+ * unreadable.
+ *
+ * `command` is validated against the subcommand grammar before any path
+ * construction. An out-of-shape input cannot be a real subcommand and
+ * returns `undefined` without touching the filesystem.
+ * @param projectRoot - Absolute path of the directory `bedrock` was invoked
+ * from. Relative inputs are resolved against `process.cwd()`.
+ * @param command - The CLI subcommand name to look up (`deploy`, `diff`,
+ * ...). Must match `/^[a-z][a-z0-9-]*$/`; anything else returns `undefined`.
+ * @returns The absolute path to the override file when it exists, otherwise
+ * `undefined`.
+ * @throws When the stat call fails with anything other than `ENOENT` or
+ * `ENOTDIR` (e.g. `EACCES`, `EPERM`).
+ */
+export function discoverOverride(projectRoot: string, command: string): string | undefined {
+	return discoverOverrideWith({ command, projectRoot, stat: statSync });
+}
+
+function isAbsenceError(error: unknown): boolean {
+	if (!(error instanceof Error) || !("code" in error)) {
+		return false;
+	}
+
+	return error.code === "ENOENT" || error.code === "ENOTDIR";
 }

--- a/packages/bedrock/src/cli/discover-override.ts
+++ b/packages/bedrock/src/cli/discover-override.ts
@@ -21,7 +21,7 @@ export type StatProbe = (path: string) => Pick<Stats, "isFile">;
  * Inputs to {@link discoverOverrideWith}. The stat seam is internal — the
  * public {@link discoverOverride} entry point binds it to `node:fs.statSync`.
  */
-export interface DiscoverOverrideInputs {
+interface DiscoverOverrideInputs {
 	/** CLI subcommand name. Must match `/^[a-z][a-z0-9-]*$/`. */
 	readonly command: string;
 	/** Project root path. Relative inputs resolve against `process.cwd()`. */


### PR DESCRIPTION
## Summary

Adds the lookup primitive used by the CLI to decide whether a `bedrock <command>` invocation should be handed to a user-authored `.bedrock/<command>.ts` override or run through the built-in path.

- `discoverOverride(projectRoot, command)` returns the absolute path when `.bedrock/<command>.ts` exists, `undefined` otherwise
- Folder name (`.bedrock/`) and extension (`.ts`) are fixed
- `command` is validated against `/^[a-z][a-z0-9-]*$/` before any path construction (blocks `..`, `foo/bar`, empty inputs from traversing out of `.bedrock/`)
- Only absence-style stat failures (`ENOENT`/`ENOTDIR`) are swallowed; `EACCES`/`EPERM`/etc. propagate so dispatch cannot silently fall back to the built-in command when an override demonstrably exists but is unreadable
- Lives in `src/cli/` as a CLI-internal primitive — not exported from the public barrel
- Internal `discoverOverrideWith` seam exposes an injectable `stat` probe for testing non-absence error paths that real-fs fixtures cannot reliably produce on Windows

Closes #246.

## Test plan

- [x] `pnpm --filter @bedrock-rbx/core test discover-override` — 20/20 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm lint:unused` (knip) — clean
- [x] `pnpm mutate:changed` — 100% mutation score, 0 survivors
- [x] Pre-commit hook (`hk`) — full lint/typecheck/test/build pass

## Review notes

Reviewed across 2 iterations by codex adversarial-review + opus general-purpose agent.

**Iteration 1 — applied**:
- Narrowed catch to absence-style errors only (both reviewers)
- Added regex validation on `command` to block path traversal (opus)
- Added `discoverOverrideWith` seam so the new error semantics are testable on Windows (mutation testing required it)

**Iteration 2 — accepted as known follow-up, not in scope for #246**:
- [ ] Wire `discoverOverride` into CLI dispatch in `src/cli/index.ts` / `src/cli/run.ts` — flagged by codex as "dead code until dispatch routes through it". The issue explicitly defers dispatch wiring to a sibling slice ("This is the discovery primitive used by the CLI..."), and the parent PRD #160 tracks the routing work separately.

Iteration-2 opus review found no critical or major issues with the current state.

## Behaviours covered

| Case | Expected |
| --- | --- |
| `.bedrock/<command>.ts` exists | resolved absolute path |
| `.bedrock/` directory absent | `undefined` |
| `.bedrock/` exists, command file absent | `undefined` |
| `.bedrock/<other>.ts` exists, different command requested | `undefined` |
| Candidate path exists as a directory | `undefined` |
| `.bedrock` itself is a regular file (parent not a directory) | `undefined` |
| Malformed `command` (empty, traversal, separator, uppercase, hyphen-prefix) | `undefined`, no fs call |
| Stat fails with `ENOENT`/`ENOTDIR` | `undefined` |
| Stat fails with `EACCES`/`EPERM`/`EBUSY` | rethrows |
| Stat throws non-Error or Error without `code` | rethrows |