### PR TITLE
feat(core): emit deploy events through progress port

### DIFF
--- a/packages/bedrock/src/adapters/clack-progress-adapter.ts
+++ b/packages/bedrock/src/adapters/clack-progress-adapter.ts
@@ -1,3 +1,4 @@
+import { createClackPort } from "../cli/clack-port.ts";
 import { type ClackPort, renderDeployError } from "../cli/render.ts";
 import { resolveStateConfig } from "../core/resolve-state-config.ts";
 import { type Config, isGistStateConfig, type StateConfig } from "../core/schema.ts";
@@ -59,6 +60,26 @@ export function createClackProgressAdapter(deps: ClackProgressAdapterDeps): Prog
 			renderEvent(event, deps);
 		},
 	};
+}
+
+/**
+ * Build a {@link ProgressPort} for the default CLI rendering path: wires a
+ * fresh {@link createClackPort} into {@link createClackProgressAdapter}. The
+ * `config` argument is forwarded so `stateWritten` events can name the
+ * persistence backend; pass `undefined` when the config has not yet loaded.
+ *
+ * Internal: used by `deploy()`'s default-port resolver when callers omit
+ * `progress` and `BEDROCK_CLI` is set.
+ *
+ * @param config - Pre-loaded config used to format the state-backend label,
+ *   or `undefined` to render the generic placeholder.
+ * @returns A clack-backed `ProgressPort` that writes to `process.stdout`.
+ */
+export function createDefaultProgressAdapter(config: Config | undefined): ProgressPort {
+	const clack = createClackPort();
+	return config === undefined
+		? createClackProgressAdapter({ clack })
+		: createClackProgressAdapter({ clack, config });
 }
 
 function applySummaryLine(event: Extract<ProgressEvent, { kind: "applySummary" }>): string {

--- a/packages/bedrock/src/adapters/clack-progress-adapter.ts
+++ b/packages/bedrock/src/adapters/clack-progress-adapter.ts
@@ -1,7 +1,12 @@
 import { createClackPort } from "../cli/clack-port.ts";
 import { type ClackPort, renderDeployError } from "../cli/render.ts";
 import { resolveStateConfig } from "../core/resolve-state-config.ts";
-import { type Config, isGistStateConfig, type StateConfig } from "../core/schema.ts";
+import {
+	type Config,
+	isGistStateConfig,
+	type ResolvedConfig,
+	type StateConfig,
+} from "../core/schema.ts";
 import type {
 	ProgressEvent,
 	ProgressPort,
@@ -16,11 +21,12 @@ export interface ClackProgressAdapterDeps {
 	/** Output port the events are rendered through. */
 	readonly clack: ClackPort;
 	/**
-	 * Loaded project config; the `stateWritten` case resolves the per-environment
-	 * `StateConfig` against this to format the backend label. When omitted,
-	 * `stateWritten` renders the generic `"state"` placeholder.
+	 * Loaded project config (raw `Config` or env-resolved `ResolvedConfig`);
+	 * the `stateWritten` case resolves the per-environment `StateConfig`
+	 * against this to format the backend label. When omitted, `stateWritten`
+	 * renders the generic `"state"` placeholder.
 	 */
-	readonly config?: Config;
+	readonly config?: Config | ResolvedConfig;
 }
 
 /**
@@ -65,17 +71,20 @@ export function createClackProgressAdapter(deps: ClackProgressAdapterDeps): Prog
 /**
  * Build a {@link ProgressPort} for the default CLI rendering path: wires a
  * fresh {@link createClackPort} into {@link createClackProgressAdapter}. The
- * `config` argument is forwarded so `stateWritten` events can name the
- * persistence backend; pass `undefined` when the config has not yet loaded.
+ * `config` argument (raw `Config` or env-resolved `ResolvedConfig`) is
+ * forwarded so `stateWritten` events can name the persistence backend; pass
+ * `undefined` when the config has not yet loaded.
  *
  * Internal: used by `deploy()`'s default-port resolver when callers omit
  * `progress` and `BEDROCK_CLI` is set.
  *
- * @param config - Pre-loaded config used to format the state-backend label,
- *   or `undefined` to render the generic placeholder.
+ * @param config - Pre-loaded or env-resolved config used to format the
+ *   state-backend label, or `undefined` to render the generic placeholder.
  * @returns A clack-backed `ProgressPort` that writes to `process.stdout`.
  */
-export function createDefaultProgressAdapter(config: Config | undefined): ProgressPort {
+export function createDefaultProgressAdapter(
+	config: Config | ResolvedConfig | undefined,
+): ProgressPort {
 	const clack = createClackPort();
 	return config === undefined
 		? createClackProgressAdapter({ clack })
@@ -101,7 +110,10 @@ function stateConfigLabel(state: StateConfig): string {
 	return state.backend;
 }
 
-function formatStateLabel(config: Config | undefined, environment: string): string {
+function formatStateLabel(
+	config: Config | ResolvedConfig | undefined,
+	environment: string,
+): string {
 	if (config === undefined) {
 		return "state";
 	}

--- a/packages/bedrock/src/cli/commands/deploy.spec.ts
+++ b/packages/bedrock/src/cli/commands/deploy.spec.ts
@@ -60,11 +60,25 @@ function fakeLoad(result: LoadConfigResult): LoadConfigFunc {
 
 function fakeDeploy(mapping: ReadonlyArray<Result<BedrockState, DeployError>>): DeployFunc {
 	let callIndex = 0;
-	return vi.fn<DeployFunc>(async () => {
+	return vi.fn<DeployFunc>(async (options) => {
 		const next = mapping[callIndex];
 		callIndex += 1;
 		if (next === undefined) {
 			throw new Error("fakeDeploy invoked with no scripted result");
+		}
+
+		if (next.success) {
+			options.progress?.emit({
+				environment: options.environment,
+				kind: "deploySuccess",
+				resourceCount: next.data.resources.length,
+			});
+		} else {
+			options.progress?.emit({
+				environment: options.environment,
+				error: next.err,
+				kind: "deployFailure",
+			});
 		}
 
 		return next;

--- a/packages/bedrock/src/cli/commands/deploy.ts
+++ b/packages/bedrock/src/cli/commands/deploy.ts
@@ -87,14 +87,7 @@ async function dispatchEnvironments(inputs: DispatchInputs): Promise<ReadonlyArr
 			getEnv,
 			progress,
 		});
-		if (result.success) {
-			progress.emit({
-				environment,
-				kind: "deploySuccess",
-				resourceCount: result.data.resources.length,
-			});
-		} else {
-			progress.emit({ environment, error: result.err, kind: "deployFailure" });
+		if (!result.success) {
 			failed.push(environment);
 		}
 	}

--- a/packages/bedrock/src/shell/deploy.spec.ts
+++ b/packages/bedrock/src/shell/deploy.spec.ts
@@ -1,6 +1,8 @@
 import { OpenCloudError } from "@bedrock-rbx/ocale";
 
 import { placeCurrent, universeCurrent } from "#tests/helpers/resources";
+import { Buffer } from "node:buffer";
+import process from "node:process";
 import { assert, describe, expect, it, vi } from "vitest";
 
 import type { GistFetch } from "../adapters/gist-state-adapter.ts";
@@ -11,7 +13,7 @@ import type { ProgressEvent, ProgressPort } from "../ports/progress-port.ts";
 import type { DriverRegistry, ResourceDriver } from "../ports/resource-driver.ts";
 import type { StatePort } from "../ports/state-port.ts";
 import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../types/ids.ts";
-import { deploy } from "./deploy.ts";
+import { deploy, type DeployError } from "./deploy.ts";
 
 // Empty bytes hash to SHA-256 `e3b0c44...`; keeping readIcon in lockstep with
 // the hash constant lets the noop test assert "desired matches current" without
@@ -158,6 +160,16 @@ function stubRegistryWithVipCreate(): DriverRegistry {
 		},
 		place: placeStub,
 		universe: universeStub,
+	};
+}
+
+async function failingLoadConfig(): Promise<{
+	err: { kind: "fileNotFound"; searchedFrom: string };
+	success: false;
+}> {
+	return {
+		err: { kind: "fileNotFound", searchedFrom: "/tmp" },
+		success: false,
 	};
 }
 
@@ -885,7 +897,7 @@ describe(deploy, () => {
 		}
 	});
 
-	it("should not invoke getEnv when statePort, registry, and config are all supplied", async () => {
+	it("should not invoke getEnv when statePort, registry, config, and progress are all supplied", async () => {
 		expect.assertions(1);
 
 		const getEnvironment = vi.fn<(name: string) => string | undefined>();
@@ -894,6 +906,7 @@ describe(deploy, () => {
 			config: vipPassConfig(),
 			environment: "production",
 			getEnv: getEnvironment,
+			progress: { emit() {} },
 			readFile: readIcon,
 			registry: stubRegistryWithVipCreate(),
 			statePort: inMemoryStatePort().port,
@@ -1079,6 +1092,266 @@ describe(deploy, () => {
 
 			expect(calls.some((event) => event.kind === "resourceOpStarted")).toBeTrue();
 			expect(calls.some((event) => event.kind === "applySummary")).toBeTrue();
+		});
+
+		it("should emit exactly one deploySuccess event with environment and resourceCount on a successful reconcile", async () => {
+			expect.assertions(1);
+
+			const { port: statePort } = inMemoryStatePort();
+			const { calls, port: progress } = recordingProgress();
+
+			await deploy({
+				config: vipPassConfig(),
+				environment: "production",
+				progress,
+				readFile: readIcon,
+				registry: stubRegistryWithVipCreate(),
+				statePort,
+			});
+
+			const terminal = calls.filter((event) => event.kind === "deploySuccess");
+
+			expect(terminal).toStrictEqual([
+				{ environment: "production", kind: "deploySuccess", resourceCount: 1 },
+			]);
+		});
+
+		it.for<{
+			arrange: () => Parameters<typeof deploy>[0];
+			label: string;
+			matchError: (error: DeployError) => boolean;
+		}>([
+			{
+				arrange: () => {
+					return {
+						environment: "production",
+						loadConfig: failingLoadConfig,
+						readFile: readIcon,
+						registry: stubRegistry(),
+						statePort: inMemoryStatePort().port,
+					};
+				},
+				label: "configLoadFailed",
+				matchError: (error) => error.kind === "configLoadFailed",
+			},
+			{
+				arrange: () => {
+					const stateError = {
+						file: ".bedrock/state/production.json",
+						kind: "stateError" as const,
+						reason: "Corrupt JSON",
+					};
+					return {
+						config: vipPassConfig(),
+						environment: "production",
+						readFile: readIcon,
+						registry: stubRegistry(),
+						statePort: {
+							async read() {
+								return { err: stateError, success: false };
+							},
+							async write() {
+								return { data: undefined, success: true };
+							},
+						},
+					};
+				},
+				label: "stateReadFailed",
+				matchError: (error) => error.kind === "stateReadFailed",
+			},
+			{
+				arrange: () => {
+					const cause = new OpenCloudError("create vip-pass: 503");
+					return {
+						config: vipPassConfig(),
+						environment: "production",
+						readFile: readIcon,
+						registry: {
+							...stubRegistry(),
+							gamePass: {
+								async create() {
+									return { err: cause, success: false };
+								},
+							},
+						},
+						statePort: inMemoryStatePort().port,
+					};
+				},
+				label: "applyFailed",
+				matchError: (error) => error.kind === "applyFailed",
+			},
+			{
+				arrange: () => {
+					const stateError = {
+						file: ".bedrock/state/production.json",
+						kind: "stateError" as const,
+						reason: "EACCES",
+					};
+					return {
+						config: vipPassConfig(),
+						environment: "production",
+						readFile: readIcon,
+						registry: stubRegistryWithVipCreate(),
+						statePort: {
+							async read() {
+								return { data: undefined, success: true };
+							},
+							async write() {
+								return { err: stateError, success: false };
+							},
+						},
+					};
+				},
+				label: "stateWriteFailed",
+				matchError: (error) => error.kind === "stateWriteFailed",
+			},
+		])(
+			"should emit exactly one deployFailure event carrying the original $label error",
+			async ({ arrange, matchError }) => {
+				expect.assertions(2);
+
+				const { calls, port: progress } = recordingProgress();
+				const options = arrange();
+
+				const result = await deploy({ ...options, progress });
+
+				assert(!result.success);
+				const failures = calls.filter((event) => event.kind === "deployFailure");
+
+				expect(failures).toHaveLength(1);
+
+				assert(failures[0]?.kind === "deployFailure");
+
+				expect(
+					matchError(failures[0].error) && failures[0].error === result.err,
+				).toBeTrue();
+			},
+		);
+
+		it("should pass the environment name verbatim through the deployFailure event", async () => {
+			expect.assertions(1);
+
+			const { calls, port: progress } = recordingProgress();
+
+			await deploy({
+				config: vipPassConfig(),
+				environment: "ghost",
+				progress,
+				readFile: readIcon,
+				registry: stubRegistry(),
+				statePort: inMemoryStatePort().port,
+			});
+
+			const failures = calls.filter((event) => event.kind === "deployFailure");
+
+			expect(failures.map((event) => event.environment)).toStrictEqual(["ghost"]);
+		});
+	});
+
+	describe("default port resolution", () => {
+		it("should not consult BEDROCK_CLI when an explicit progress port is supplied", async () => {
+			expect.assertions(2);
+
+			const { port: statePort } = inMemoryStatePort();
+			const calls: Array<ProgressEvent> = [];
+			const progress: ProgressPort = {
+				emit(event) {
+					calls.push(event);
+				},
+			};
+			const getEnvironment = vi.fn<(name: string) => string | undefined>((name) => {
+				return name === "BEDROCK_API_KEY" ? "rbx-test" : undefined;
+			});
+
+			await deploy({
+				config: vipPassConfig(),
+				environment: "production",
+				getEnv: getEnvironment,
+				progress,
+				readFile: readIcon,
+				registry: stubRegistryWithVipCreate(),
+				statePort,
+			});
+
+			expect(calls.some((event) => event.kind === "deploySuccess")).toBeTrue();
+			expect(getEnvironment.mock.calls.some(([name]) => name === "BEDROCK_CLI")).toBeFalse();
+		});
+
+		it("should default to the clack adapter when progress is omitted and BEDROCK_CLI is set", async () => {
+			expect.assertions(1);
+
+			const chunks: Array<string> = [];
+			const writeSpy = vi
+				.spyOn(process.stdout, "write")
+				.mockImplementation((chunk: string | Uint8Array): boolean => {
+					chunks.push(
+						typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+					);
+					return true;
+				});
+
+			try {
+				const { port: statePort } = inMemoryStatePort();
+
+				await deploy({
+					config: vipPassConfig(),
+					environment: "production",
+					getEnv: environmentFrom({ BEDROCK_API_KEY: "rbx-test", BEDROCK_CLI: "1" }),
+					readFile: readIcon,
+					registry: stubRegistryWithVipCreate(),
+					statePort,
+				});
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			expect(chunks.join("")).toContain("production: 1 resources reconciled");
+		});
+
+		it("should default to a no-op port when progress is omitted and BEDROCK_CLI is unset", async () => {
+			expect.assertions(1);
+
+			const writeSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+			try {
+				const { port: statePort } = inMemoryStatePort();
+
+				await deploy({
+					config: vipPassConfig(),
+					environment: "production",
+					getEnv: environmentFrom({ BEDROCK_API_KEY: "rbx-test" }),
+					readFile: readIcon,
+					registry: stubRegistryWithVipCreate(),
+					statePort,
+				});
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			expect(writeSpy).not.toHaveBeenCalled();
+		});
+
+		it("should default to a no-op port when progress is omitted and BEDROCK_CLI is empty string", async () => {
+			expect.assertions(1);
+
+			const writeSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+			try {
+				const { port: statePort } = inMemoryStatePort();
+
+				await deploy({
+					config: vipPassConfig(),
+					environment: "production",
+					getEnv: environmentFrom({ BEDROCK_API_KEY: "rbx-test", BEDROCK_CLI: "" }),
+					readFile: readIcon,
+					registry: stubRegistryWithVipCreate(),
+					statePort,
+				});
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			expect(writeSpy).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/bedrock/src/shell/deploy.spec.ts
+++ b/packages/bedrock/src/shell/deploy.spec.ts
@@ -1277,6 +1277,26 @@ describe(deploy, () => {
 			expect(getEnvironment.mock.calls.some(([name]) => name === "BEDROCK_CLI")).toBeFalse();
 		});
 
+		it("should consult getEnv with 'BEDROCK_CLI' when progress is omitted", async () => {
+			expect.assertions(1);
+
+			const { port: statePort } = inMemoryStatePort();
+			const getEnvironment = vi.fn<(name: string) => string | undefined>((name) => {
+				return name === "BEDROCK_API_KEY" ? "rbx-test" : undefined;
+			});
+
+			await deploy({
+				config: vipPassConfig(),
+				environment: "production",
+				getEnv: getEnvironment,
+				readFile: readIcon,
+				registry: stubRegistryWithVipCreate(),
+				statePort,
+			});
+
+			expect(getEnvironment.mock.calls.some(([name]) => name === "BEDROCK_CLI")).toBeTrue();
+		});
+
 		it("should default to the clack adapter when progress is omitted and BEDROCK_CLI is set", async () => {
 			expect.assertions(1);
 

--- a/packages/bedrock/src/shell/deploy.spec.ts
+++ b/packages/bedrock/src/shell/deploy.spec.ts
@@ -13,7 +13,7 @@ import type { ProgressEvent, ProgressPort } from "../ports/progress-port.ts";
 import type { DriverRegistry, ResourceDriver } from "../ports/resource-driver.ts";
 import type { StatePort } from "../ports/state-port.ts";
 import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../types/ids.ts";
-import { deploy, type DeployError } from "./deploy.ts";
+import { deploy, type DeployError, isCliEnvironmentFlagSet } from "./deploy.ts";
 
 // Empty bytes hash to SHA-256 `e3b0c44...`; keeping readIcon in lockstep with
 // the hash constant lets the noop test assert "desired matches current" without
@@ -1396,5 +1396,37 @@ describe(deploy, () => {
 
 			expect(writeSpy).not.toHaveBeenCalled();
 		});
+	});
+});
+
+describe(isCliEnvironmentFlagSet, () => {
+	it("should return false when value is undefined", () => {
+		expect.assertions(1);
+		expect(isCliEnvironmentFlagSet(undefined)).toBeFalse();
+	});
+
+	it("should return false when value is the empty string", () => {
+		expect.assertions(1);
+		expect(isCliEnvironmentFlagSet("")).toBeFalse();
+	});
+
+	it("should return true when value is a single non-empty character", () => {
+		expect.assertions(1);
+		expect(isCliEnvironmentFlagSet("1")).toBeTrue();
+	});
+
+	it("should return true when value is the literal '0' since only the empty string is rejected", () => {
+		expect.assertions(1);
+		expect(isCliEnvironmentFlagSet("0")).toBeTrue();
+	});
+
+	it("should return true when value is a single-space string since only the empty string is rejected", () => {
+		expect.assertions(1);
+		expect(isCliEnvironmentFlagSet(" ")).toBeTrue();
+	});
+
+	it("should return true when value is a multi-character non-empty string", () => {
+		expect.assertions(1);
+		expect(isCliEnvironmentFlagSet("true")).toBeTrue();
 	});
 });

--- a/packages/bedrock/src/shell/deploy.spec.ts
+++ b/packages/bedrock/src/shell/deploy.spec.ts
@@ -1308,6 +1308,49 @@ describe(deploy, () => {
 			expect(chunks.join("")).toContain("production: 1 resources reconciled");
 		});
 
+		it("should render stateWritten with the loaded backend label when options.config is omitted but loadConfig succeeds and BEDROCK_CLI is set", async () => {
+			expect.assertions(1);
+
+			const chunks: Array<string> = [];
+			const writeSpy = vi
+				.spyOn(process.stdout, "write")
+				.mockImplementation((chunk: string | Uint8Array): boolean => {
+					chunks.push(
+						typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"),
+					);
+					return true;
+				});
+
+			try {
+				const loadedConfig: Config = {
+					environments: { production: {} },
+					passes: {
+						"vip-pass": {
+							name: "VIP Pass",
+							description: "Grants VIP perks.",
+							icon: { "en-us": "assets/vip-icon.png" },
+							price: 500,
+						},
+					},
+					state: { backend: "gist", gistId: "abc-test" },
+				};
+				const { port: statePort } = inMemoryStatePort();
+
+				await deploy({
+					environment: "production",
+					getEnv: environmentFrom({ BEDROCK_API_KEY: "rbx-test", BEDROCK_CLI: "1" }),
+					loadConfig: async () => ({ data: loadedConfig, success: true }),
+					readFile: readIcon,
+					registry: stubRegistryWithVipCreate(),
+					statePort,
+				});
+			} finally {
+				writeSpy.mockRestore();
+			}
+
+			expect(chunks.join("")).toContain("State written to gist:abc-test");
+		});
+
 		it("should default to a no-op port when progress is omitted and BEDROCK_CLI is unset", async () => {
 			expect.assertions(1);
 

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -196,10 +196,24 @@ interface EmitTerminalEventInputs {
  * ```
  */
 export async function deploy(options: DeployOptions): Promise<Result<BedrockState, DeployError>> {
-	const progress = resolveProgressPort(options);
-	const result = await runDeploy(options, progress);
-	emitTerminalEvent({ environment: options.environment, progress, result });
-	return result;
+	if (options.progress !== undefined) {
+		return runAndEmit(options, options.progress);
+	}
+
+	const cliFlag = getEnvironmentOf(options)("BEDROCK_CLI");
+	if (cliFlag === undefined || cliFlag === "") {
+		return runAndEmit(options, createNoOpProgressAdapter());
+	}
+
+	return runWithDeferredClackProgress(options);
+}
+
+function readProcessEnvironment(name: string): string | undefined {
+	return process.env[name];
+}
+
+function getEnvironmentOf(options: DeployOptions): (name: string) => string | undefined {
+	return options.getEnv ?? readProcessEnvironment;
 }
 
 async function pickConfig(options: DeployOptions): Promise<Result<Config, DeployError>> {
@@ -214,14 +228,6 @@ async function pickConfig(options: DeployOptions): Promise<Result<Config, Deploy
 	}
 
 	return { data: loaded.data, success: true };
-}
-
-function readProcessEnvironment(name: string): string | undefined {
-	return process.env[name];
-}
-
-function getEnvironmentOf(options: DeployOptions): (name: string) => string | undefined {
-	return options.getEnv ?? readProcessEnvironment;
 }
 
 function pickStatePort(
@@ -376,19 +382,6 @@ async function runDeploy(
 	return runReconcile(options.environment, { ...resolved.data, progress });
 }
 
-function resolveProgressPort(options: DeployOptions): ProgressPort {
-	if (options.progress !== undefined) {
-		return options.progress;
-	}
-
-	const cliFlag = getEnvironmentOf(options)("BEDROCK_CLI");
-	if (cliFlag !== undefined && cliFlag !== "") {
-		return createDefaultProgressAdapter(options.config);
-	}
-
-	return createNoOpProgressAdapter();
-}
-
 function emitTerminalEvent(inputs: EmitTerminalEventInputs): void {
 	const { environment, progress, result } = inputs;
 	if (result.success) {
@@ -401,4 +394,35 @@ function emitTerminalEvent(inputs: EmitTerminalEventInputs): void {
 	}
 
 	progress.emit({ environment, error: result.err, kind: "deployFailure" });
+}
+
+async function runAndEmit(
+	options: DeployOptions,
+	progress: ProgressPort,
+): Promise<Result<BedrockState, DeployError>> {
+	const result = await runDeploy(options, progress);
+	emitTerminalEvent({ environment: options.environment, progress, result });
+	return result;
+}
+
+async function runWithDeferredClackProgress(
+	options: DeployOptions,
+): Promise<Result<BedrockState, DeployError>> {
+	// Defer building the clack adapter until config has resolved so the
+	// `stateWritten` label reflects the loaded backend (e.g. `gist:abc`)
+	// even when callers omit `options.config` and rely on `loadConfig()`.
+	// On early failure, fall back to the caller-supplied `options.config`
+	// (which may be undefined), keeping the generic `"state"` placeholder.
+	const resolved = await resolveDeps(options);
+	const labelConfig = resolved.success ? resolved.data.config : options.config;
+	const progress = createDefaultProgressAdapter(labelConfig);
+
+	if (!resolved.success) {
+		emitTerminalEvent({ environment: options.environment, progress, result: resolved });
+		return resolved;
+	}
+
+	const result = await runReconcile(options.environment, { ...resolved.data, progress });
+	emitTerminalEvent({ environment: options.environment, progress, result });
+	return result;
 }

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -128,6 +128,19 @@ interface EmitTerminalEventInputs {
 }
 
 /**
+ * Decide whether `BEDROCK_CLI` should select the clack-backed default
+ * progress adapter. Exported for direct unit coverage of the boundary
+ * (`undefined` and empty string both flip to no-op; any non-empty value
+ * picks clack).
+ *
+ * @param value - Raw `BEDROCK_CLI` value as returned by `getEnv`.
+ * @returns `true` if the clack adapter should be the default.
+ */
+export function isCliEnvironmentFlagSet(value: string | undefined): boolean {
+	return value !== undefined && value !== "";
+}
+
+/**
  * Run a full reconcile end-to-end. Default-constructs missing deps from
  * the project config and the environment variables `BEDROCK_GITHUB_TOKEN`
  * and `BEDROCK_API_KEY`; emits a terminal `deploySuccess` or `deployFailure`
@@ -200,8 +213,7 @@ export async function deploy(options: DeployOptions): Promise<Result<BedrockStat
 		return runAndEmit(options, options.progress);
 	}
 
-	const cliFlag = getEnvironmentOf(options)("BEDROCK_CLI");
-	if (cliFlag === undefined || cliFlag === "") {
+	if (!isCliEnvironmentFlagSet(getEnvironmentOf(options)("BEDROCK_CLI"))) {
 		return runAndEmit(options, createNoOpProgressAdapter());
 	}
 

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -3,7 +3,9 @@ import type { Result } from "@bedrock-rbx/ocale";
 import { readFile as nodeReadFile } from "node:fs/promises";
 import process from "node:process";
 
+import { createDefaultProgressAdapter } from "../adapters/clack-progress-adapter.ts";
 import type { GistFetch } from "../adapters/gist-state-adapter.ts";
+import { createNoOpProgressAdapter } from "../adapters/no-op-progress-adapter.ts";
 import { assertAllReconcilable } from "../core/assert-all-reconcilable.ts";
 import type { ConfigError } from "../core/config-error.ts";
 import { diff } from "../core/diff.ts";
@@ -102,12 +104,15 @@ interface FinalizeInputs {
 	readonly written: Result<void, StateError>;
 }
 
-interface ResolvedDeps {
+interface ResolvedDepsBase {
 	readonly config: ResolvedConfig;
-	readonly progress: ProgressPort | undefined;
 	readonly readFile: (path: string) => Promise<Uint8Array>;
 	readonly registry: DriverRegistry;
 	readonly statePort: StatePort;
+}
+
+interface ResolvedDeps extends ResolvedDepsBase {
+	readonly progress: ProgressPort;
 }
 
 interface PickRegistryInputs {
@@ -116,11 +121,21 @@ interface PickRegistryInputs {
 	readonly readFile: (path: string) => Promise<Uint8Array>;
 }
 
+interface EmitTerminalEventInputs {
+	readonly environment: string;
+	readonly progress: ProgressPort;
+	readonly result: Result<BedrockState, DeployError>;
+}
+
 /**
  * Run a full reconcile end-to-end. Default-constructs missing deps from
- * the project config and the environment variables `BEDROCK_GITHUB_TOKEN` and
- * `BEDROCK_API_KEY`; never reads `process.env` when `statePort`,
- * `registry`, and `config` are all supplied explicitly.
+ * the project config and the environment variables `BEDROCK_GITHUB_TOKEN`
+ * and `BEDROCK_API_KEY`; emits a terminal `deploySuccess` or `deployFailure`
+ * event through the resolved `progress` port. When `progress` is omitted,
+ * the default port comes from `BEDROCK_CLI`: a non-empty value selects the
+ * clack-backed adapter, any other reading selects the no-op adapter. No
+ * environment lookups happen when `statePort`, `registry`, `config`, and
+ * `progress` are all supplied explicitly.
  *
  * @param options - Target environment plus optional overrides.
  * @returns The persisted `BedrockState` on success, or a stage-tagged
@@ -181,12 +196,10 @@ interface PickRegistryInputs {
  * ```
  */
 export async function deploy(options: DeployOptions): Promise<Result<BedrockState, DeployError>> {
-	const resolved = await resolveDeps(options);
-	if (!resolved.success) {
-		return resolved;
-	}
-
-	return runReconcile(options.environment, resolved.data);
+	const progress = resolveProgressPort(options);
+	const result = await runDeploy(options, progress);
+	emitTerminalEvent({ environment: options.environment, progress, result });
+	return result;
 }
 
 async function pickConfig(options: DeployOptions): Promise<Result<Config, DeployError>> {
@@ -243,7 +256,7 @@ function pickRegistry(inputs: PickRegistryInputs): Result<DriverRegistry, Deploy
 	});
 }
 
-async function resolveDeps(options: DeployOptions): Promise<Result<ResolvedDeps, DeployError>> {
+async function resolveDeps(options: DeployOptions): Promise<Result<ResolvedDepsBase, DeployError>> {
 	const config = await pickConfig(options);
 	if (!config.success) {
 		return config;
@@ -256,7 +269,6 @@ async function resolveDeps(options: DeployOptions): Promise<Result<ResolvedDeps,
 
 	const effective = selected.data;
 	const readFile = options.readFile ?? nodeReadFile;
-
 	const statePort = pickStatePort(options, effective);
 	if (!statePort.success) {
 		return statePort;
@@ -268,13 +280,7 @@ async function resolveDeps(options: DeployOptions): Promise<Result<ResolvedDeps,
 	}
 
 	return {
-		data: {
-			config: effective,
-			progress: options.progress,
-			readFile,
-			registry: registry.data,
-			statePort: statePort.data,
-		},
+		data: { config: effective, readFile, registry: registry.data, statePort: statePort.data },
 		success: true,
 	};
 }
@@ -347,17 +353,52 @@ async function runReconcile(
 	}
 
 	const ops = diff(desired.data, priorResources);
-	const applied = await applyOps(
-		ops,
-		deps.registry,
-		deps.progress === undefined ? undefined : { environment, progress: deps.progress },
-	);
+	const applied = await applyOps(ops, deps.registry, { environment, progress: deps.progress });
 	const merged = buildSnapshot({ applied, environment, priorResources });
 
 	const written = await deps.statePort.write(merged);
 	if (written.success) {
-		deps.progress?.emit({ environment, kind: "stateWritten" });
+		deps.progress.emit({ environment, kind: "stateWritten" });
 	}
 
 	return finalize({ applied, merged, written });
+}
+
+async function runDeploy(
+	options: DeployOptions,
+	progress: ProgressPort,
+): Promise<Result<BedrockState, DeployError>> {
+	const resolved = await resolveDeps(options);
+	if (!resolved.success) {
+		return resolved;
+	}
+
+	return runReconcile(options.environment, { ...resolved.data, progress });
+}
+
+function resolveProgressPort(options: DeployOptions): ProgressPort {
+	if (options.progress !== undefined) {
+		return options.progress;
+	}
+
+	const cliFlag = getEnvironmentOf(options)("BEDROCK_CLI");
+	if (cliFlag !== undefined && cliFlag !== "") {
+		return createDefaultProgressAdapter(options.config);
+	}
+
+	return createNoOpProgressAdapter();
+}
+
+function emitTerminalEvent(inputs: EmitTerminalEventInputs): void {
+	const { environment, progress, result } = inputs;
+	if (result.success) {
+		progress.emit({
+			environment,
+			kind: "deploySuccess",
+			resourceCount: result.data.resources.length,
+		});
+		return;
+	}
+
+	progress.emit({ environment, error: result.err, kind: "deployFailure" });
 }

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -420,11 +420,6 @@ async function runAndEmit(
 async function runWithDeferredClackProgress(
 	options: DeployOptions,
 ): Promise<Result<BedrockState, DeployError>> {
-	// Defer building the clack adapter until config has resolved so the
-	// `stateWritten` label reflects the loaded backend (e.g. `gist:abc`)
-	// even when callers omit `options.config` and rely on `loadConfig()`.
-	// On early failure, fall back to the caller-supplied `options.config`
-	// (which may be undefined), keeping the generic `"state"` placeholder.
 	const resolved = await resolveDeps(options);
 	const labelConfig = resolved.success ? resolved.data.config : options.config;
 	const progress = createDefaultProgressAdapter(labelConfig);


### PR DESCRIPTION
## Summary
- `deploy()` now emits exactly one `deploySuccess` (with environment + resource count) on success, or one `deployFailure` (carrying the original `DeployError`) on any failure stage, through the resolved `ProgressPort`.
- When `progress` is omitted, the default port comes from `BEDROCK_CLI`: a non-empty value picks the clack-backed adapter (via new internal `createDefaultProgressAdapter`), anything else picks the no-op adapter. Explicitly-supplied `progress` short-circuits the env lookup.
- CLI's `dispatchEnvironments` stops emitting per-env events itself; rendering is unchanged because the clack adapter still handles `deploySuccess` / `deployFailure`.

Closes #247.

## Test plan
- [x] `pnpm --filter @bedrock-rbx/core test src/shell/deploy.spec.ts` — 37 passing (10 new: terminal-event emission per stage, default-port resolution via `BEDROCK_CLI`, injected-port short-circuit).
- [x] `pnpm --filter @bedrock-rbx/core test src/cli/commands/deploy.spec.ts` — 19 passing; fake deploy now mirrors real emission so existing assertions still cover the clack render output.
- [x] `pnpm --filter @bedrock-rbx/core test tests/integration/cli/deploy.spec.ts` — integration tests unchanged and green.
- [x] `pnpm gen:example-tests && pnpm test` — 3770 passing, 7 skipped.
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm build` — clean.
- [ ] `pnpm mutate:changed` — short-circuits to "no modified files" against `HEAD` after commit, which is by design. Running with `MUTATE_BASE_REF=HEAD~1` exposes a **pre-existing** Stryker dry-run failure in `tests/integration/cli/index.spec.ts > should not produce stdout or stderr writes during module evaluation` (also fails on `origin/main` without this PR's changes). Mutation analysis on the touched files is unblocked once that integration test is sandbox-safe; flagging here rather than fixing in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Pull Request Review: feat(core): emit deploy events through progress port

## Architecture Compliance (FCIS Pattern) ✓

**Adherence to separation of concerns:**
- **Core**: No changes; remains pure functions (diff, buildDesired, resolveStateConfig)
- **Shell**: Proper orchestration layer; `deploy()` correctly delegates to core and adapters without I/O
  - New helpers (`emitTerminalEvent`, `runAndEmit`, `runWithDeferredClackProgress`) are orchestration functions
  - `runReconcile` properly passes `progress: ProgressPort` to `applyOps` and emits `stateWritten` after successful state write
- **Ports**: `ProgressPort` is correctly implemented as a driven (secondary) port interface
- **Adapters**: Three concrete implementations provided:
  - `createClackProgressAdapter()`: renders events through ClackPort
  - `createDefaultProgressAdapter()`: factory combining ClackPort creation with adapter
  - `createNoOpProgressAdapter()`: silent fallback

**No violations detected**: All I/O remains at adapter boundaries; business logic stays in core and shell orchestration.

## Testing Compliance (TDD + 100% Coverage) ✓

**Test structure is sound:**
- Core: Unit tests validate pure transformations (`diff`, flatten, resolve)
- Shell: Integration tests with fake StatePort and DriverRegistry provide realistic scenarios
- Adapters: Clack and no-op adapters tested with mock ports
- CLI: Proper integration tests with injectable dependencies

**Coverage of new functionality:**
- **Progress event emission**: 
  - `deploySuccess` verified to emit exactly once on reconcile success with correct `environment` and `resourceCount`
  - `deployFailure` verified to emit exactly once on any failure stage with original `DeployError` preserved
  - `stateWritten` tested after successful state write
- **Default progress resolution**:
  - When `progress` provided: uses it directly without consulting environment
  - When `progress` omitted and `BEDROCK_CLI` set: clack adapter selected
  - When `progress` omitted and `BEDROCK_CLI` unset/empty: no-op adapter selected
- **Boundary cases**: Dedicated unit tests for `isCliEnvironmentFlagSet` cover `undefined`, empty string, `"0"`, whitespace, multi-character strings
- **Deferred clack construction**: Test validates that `stateWritten` label reflects loaded backend (e.g., `gist:abc-test`) even when config loaded during deploy

**Test file sizes indicate comprehensive coverage**: 1452 lines in `deploy.spec.ts`, 370+ lines added to CLI tests, plus dedicated `clack-progress-adapter.spec.ts`.

## Test Isolation ✓

- **Core functions**: Tested as pure; no I/O mocks needed
- **Shell functions**: Integration tests use `inMemoryStatePort()` (fake) and stubbed drivers
- **Adapters**: Tested with fake/mock ClackPort implementations
- **CLI**: Properly isolated via dependency injection (`ProgDeps`); CLI tests inject fake `deploy`, `loadConfig`, and progress ports

CLI test helper `fakeDeploy()` correctly emits progress events before returning scripted results, simulating real shell behavior.

## Code Quality ✓

- **TypeScript**: Strict mode compliance; proper `Result<T, Error>` return types throughout
- **Type refinements**: `ClackProgressAdapterDeps.config` correctly broadened to `Config | ResolvedConfig | undefined` to handle both raw and resolved configs
- **Error handling**: Full `DeployError` union carried through `deployFailure` events; original error shape preserved
- **Helper functions**: Well-factored (`emitTerminalEvent` for terminal event logic, `runAndEmit` for common flow, `runWithDeferredClackProgress` for deferred adapter construction)
- **JSDoc**: Existing documentation updated with config parameter details; examples align with new behavior
- **Exported helpers**: `isCliEnvironmentFlagSet` appropriately exported for test clarity and potential reuse

## Implementation Details

**Progress port wiring:**
- `DeployOptions` gains optional `progress?: ProgressPort` parameter
- `deploy()` logic: if `progress` provided → use it; else if `BEDROCK_CLI` set → clack; else → no-op
- Deferred clack construction until after `resolveDeps` ensures `stateWritten` label uses actual loaded backend
- Fallback to caller-supplied `options.config` on early resolution failure maintains graceful degradation

**CLI behavior preservation:**
- `dispatchEnvironments()` no longer emits per-environment clack events directly
- Events now flow through injected `progress` port passed to `deploy()`
- `dispatchAndReport()` constructs `ProgressPort` from loaded config when `progressOverride` absent
- Rendering unchanged; clack adapter still handles identical output via same event types

**Mutation testing alignment:**
- Boundary mutations around `isCliEnvironmentFlagSet` explicitly covered by dedicated unit tests
- Assertion that `getEnv("BEDROCK_CLI")` is invoked when progress omitted prevents surviving mutant on env lookup
- Test assertions for exactly-one-event emission kill mutants on event emission loops

## Potential Concerns

None identified. The implementation:
- Maintains backward compatibility (progress parameter optional)
- Follows established patterns in codebase
- Has comprehensive test coverage with boundary case validation
- Respects FCIS architecture throughout
- Properly isolates test concerns by layer
- Includes clear comments explaining deferred construction rationale

All commit objectives from issue `#247` appear satisfied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/454?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->