### PR TITLE
feat(core): dispatch .bedrock deploy overrides per environment

### DIFF
--- a/apps/e2e/tests/smoke/cli-deploy-override.spec.ts
+++ b/apps/e2e/tests/smoke/cli-deploy-override.spec.ts
@@ -1,0 +1,95 @@
+import type { Buffer } from "node:buffer";
+import { spawn } from "node:child_process";
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(HERE, "..", "..", "..", "..");
+const BIN_ENTRY = join(REPO_ROOT, "packages", "bedrock", "src", "cli", "run.ts");
+const FIXTURES = join(HERE, "fixtures", "deploy-override");
+const ECHO_OVERRIDE = join(FIXTURES, "echo.ts");
+const FAILING_OVERRIDE = join(FIXTURES, "exit-non-zero.ts");
+
+interface SpawnResult {
+	readonly code: number;
+	readonly stderr: string;
+	readonly stdout: string;
+}
+
+async function runBin(args: ReadonlyArray<string>, cwd: string): Promise<SpawnResult> {
+	return new Promise((resolve, reject) => {
+		const child = spawn("bun", ["--conditions", "source", BIN_ENTRY, ...args], {
+			cwd,
+			env: process.env,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		let stdout = "";
+		let stderr = "";
+		child.stdout.on("data", (chunk: Buffer) => {
+			stdout += chunk.toString("utf8");
+		});
+		child.stderr.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString("utf8");
+		});
+		child.on("error", reject);
+		child.on("close", (code) => {
+			resolve({ code: code ?? -1, stderr, stdout });
+		});
+	});
+}
+
+async function createProject(overrideFixture: string): Promise<string> {
+	const project = await mkdtemp(join(tmpdir(), "bedrock-override-e2e-"));
+	await writeFile(
+		join(project, "bedrock.config.json"),
+		`${JSON.stringify({ environments: { production: {} } }, undefined, 2)}\n`,
+		"utf8",
+	);
+	await mkdir(join(project, ".bedrock"));
+	await copyFile(overrideFixture, join(project, ".bedrock", "deploy.ts"));
+	return project;
+}
+
+describe("bedrock deploy override via the real cli", () => {
+	it("should discover .bedrock/deploy.ts, execute it with the spawn protocol, and exit 0", async () => {
+		expect.assertions(4);
+
+		const project = await createProject(ECHO_OVERRIDE);
+		try {
+			const result = await runBin(["deploy", "--env", "production"], project);
+
+			expect(
+				result.code,
+				`bin exited ${String(result.code)}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+			).toBe(0);
+			expect(result.stdout).toContain("bedrock override deploy ran");
+			expect(
+				JSON.parse(await readFile(join(project, "override-ran.json"), "utf8")),
+			).toStrictEqual({ cli: "1", flags: ["--env", "production"], script: "deploy.ts" });
+			expect(result.stdout).toContain("deploy succeeded");
+		} finally {
+			await rm(project, { force: true, recursive: true });
+		}
+	}, 30_000);
+
+	it("should propagate a non-zero override exit as cli exit 1", async () => {
+		expect.assertions(2);
+
+		const project = await createProject(FAILING_OVERRIDE);
+		try {
+			const result = await runBin(["deploy", "--env", "production"], project);
+
+			expect(result.code).toBe(1);
+			expect(`${result.stdout}${result.stderr}`).toContain(
+				"production: override exited with code 3",
+			);
+		} finally {
+			await rm(project, { force: true, recursive: true });
+		}
+	}, 30_000);
+});

--- a/apps/e2e/tests/smoke/fixtures/deploy-override/echo.ts
+++ b/apps/e2e/tests/smoke/fixtures/deploy-override/echo.ts
@@ -1,0 +1,20 @@
+// Stands in for a user-authored `.bedrock/deploy.ts` override. Records the
+// forwarded flags, the BEDROCK_CLI env signal, and its own script basename to
+// a cwd-relative file so the e2e test can prove the real CLI discovered and
+// executed it with the documented spawn protocol. The stdout line proves the
+// override's output flows through the CLI's inherited stdio.
+import { writeFileSync } from "node:fs";
+import { basename } from "node:path";
+import process from "node:process";
+
+writeFileSync(
+	"override-ran.json",
+	JSON.stringify({
+		cli: process.env["BEDROCK_CLI"],
+		flags: process.argv.slice(2),
+		script: basename(process.argv[1] ?? ""),
+	}),
+);
+
+process.stdout.write("bedrock override deploy ran\n");
+process.exit(0);

--- a/apps/e2e/tests/smoke/fixtures/deploy-override/echo.ts
+++ b/apps/e2e/tests/smoke/fixtures/deploy-override/echo.ts
@@ -17,4 +17,5 @@ writeFileSync(
 );
 
 process.stdout.write("bedrock override deploy ran\n");
-process.exit(0);
+// No explicit process.exit: a synchronous exit can truncate the piped stdout
+// write above. Node exits 0 once the event loop drains and the write flushes.

--- a/apps/e2e/tests/smoke/fixtures/deploy-override/exit-non-zero.ts
+++ b/apps/e2e/tests/smoke/fixtures/deploy-override/exit-non-zero.ts
@@ -1,0 +1,5 @@
+// A `.bedrock/deploy.ts` override that fails, so the e2e test can assert the
+// real CLI propagates the non-zero override exit into its own exit code.
+import process from "node:process";
+
+process.exit(3);

--- a/packages/bedrock/src/cli/build-override-invocation.spec.ts
+++ b/packages/bedrock/src/cli/build-override-invocation.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { buildOverrideInvocation } from "./build-override-invocation.ts";
+import type { CommonOptions } from "./parse-options.ts";
+
+function parsedWith(overrides: Partial<CommonOptions> = {}): CommonOptions {
+	return { environments: ["production"], ...overrides };
+}
+
+describe(buildOverrideInvocation, () => {
+	it("should always include environment and overridePath", () => {
+		expect.assertions(2);
+
+		const invocation = buildOverrideInvocation({
+			environment: "production",
+			overridePath: "/abs/.bedrock/deploy.ts",
+			parsed: parsedWith(),
+		});
+
+		expect(invocation.environment).toBe("production");
+		expect(invocation.overridePath).toBe("/abs/.bedrock/deploy.ts");
+	});
+
+	it("should include apiKey when parsed.apiKey is defined", () => {
+		expect.assertions(1);
+
+		const invocation = buildOverrideInvocation({
+			environment: "production",
+			overridePath: "/abs/.bedrock/deploy.ts",
+			parsed: parsedWith({ apiKey: "rbx-123" }),
+		});
+
+		expect(invocation).toContainEntry(["apiKey", "rbx-123"]);
+	});
+
+	it("should omit apiKey when parsed.apiKey is undefined", () => {
+		expect.assertions(1);
+
+		const invocation = buildOverrideInvocation({
+			environment: "production",
+			overridePath: "/abs/.bedrock/deploy.ts",
+			parsed: parsedWith(),
+		});
+
+		expect(invocation).not.toContainKey("apiKey");
+	});
+
+	it("should include configFile when parsed.configFile is defined", () => {
+		expect.assertions(1);
+
+		const invocation = buildOverrideInvocation({
+			environment: "production",
+			overridePath: "/abs/.bedrock/deploy.ts",
+			parsed: parsedWith({ configFile: "./bedrock.staging.config.ts" }),
+		});
+
+		expect(invocation).toContainEntry(["configFile", "./bedrock.staging.config.ts"]);
+	});
+
+	it("should omit configFile when parsed.configFile is undefined", () => {
+		expect.assertions(1);
+
+		const invocation = buildOverrideInvocation({
+			environment: "production",
+			overridePath: "/abs/.bedrock/deploy.ts",
+			parsed: parsedWith(),
+		});
+
+		expect(invocation).not.toContainKey("configFile");
+	});
+
+	it("should include githubToken when parsed.githubToken is defined", () => {
+		expect.assertions(1);
+
+		const invocation = buildOverrideInvocation({
+			environment: "production",
+			overridePath: "/abs/.bedrock/deploy.ts",
+			parsed: parsedWith({ githubToken: "ghp-456" }),
+		});
+
+		expect(invocation).toContainEntry(["githubToken", "ghp-456"]);
+	});
+
+	it("should omit githubToken when parsed.githubToken is undefined", () => {
+		expect.assertions(1);
+
+		const invocation = buildOverrideInvocation({
+			environment: "production",
+			overridePath: "/abs/.bedrock/deploy.ts",
+			parsed: parsedWith(),
+		});
+
+		expect(invocation).not.toContainKey("githubToken");
+	});
+});

--- a/packages/bedrock/src/cli/build-override-invocation.spec.ts
+++ b/packages/bedrock/src/cli/build-override-invocation.spec.ts
@@ -21,67 +21,39 @@ describe(buildOverrideInvocation, () => {
 		expect(invocation.overridePath).toBe("/abs/.bedrock/deploy.ts");
 	});
 
-	it("should include apiKey when parsed.apiKey is defined", () => {
-		expect.assertions(1);
-
-		const invocation = buildOverrideInvocation({
-			environment: "production",
-			overridePath: "/abs/.bedrock/deploy.ts",
+	it.for<{ entry: [string, string]; label: string; parsed: CommonOptions }>([
+		{
+			entry: ["apiKey", "rbx-123"],
+			label: "apiKey",
 			parsed: parsedWith({ apiKey: "rbx-123" }),
-		});
-
-		expect(invocation).toContainEntry(["apiKey", "rbx-123"]);
-	});
-
-	it("should omit apiKey when parsed.apiKey is undefined", () => {
-		expect.assertions(1);
-
-		const invocation = buildOverrideInvocation({
-			environment: "production",
-			overridePath: "/abs/.bedrock/deploy.ts",
-			parsed: parsedWith(),
-		});
-
-		expect(invocation).not.toContainKey("apiKey");
-	});
-
-	it("should include configFile when parsed.configFile is defined", () => {
-		expect.assertions(1);
-
-		const invocation = buildOverrideInvocation({
-			environment: "production",
-			overridePath: "/abs/.bedrock/deploy.ts",
+		},
+		{
+			entry: ["configFile", "./bedrock.staging.config.ts"],
+			label: "configFile",
 			parsed: parsedWith({ configFile: "./bedrock.staging.config.ts" }),
-		});
-
-		expect(invocation).toContainEntry(["configFile", "./bedrock.staging.config.ts"]);
-	});
-
-	it("should omit configFile when parsed.configFile is undefined", () => {
-		expect.assertions(1);
-
-		const invocation = buildOverrideInvocation({
-			environment: "production",
-			overridePath: "/abs/.bedrock/deploy.ts",
-			parsed: parsedWith(),
-		});
-
-		expect(invocation).not.toContainKey("configFile");
-	});
-
-	it("should include githubToken when parsed.githubToken is defined", () => {
-		expect.assertions(1);
-
-		const invocation = buildOverrideInvocation({
-			environment: "production",
-			overridePath: "/abs/.bedrock/deploy.ts",
+		},
+		{
+			entry: ["githubToken", "ghp-456"],
+			label: "githubToken",
 			parsed: parsedWith({ githubToken: "ghp-456" }),
+		},
+	])("should include $label when parsed.$label is defined", ({ entry, parsed }) => {
+		expect.assertions(1);
+
+		const invocation = buildOverrideInvocation({
+			environment: "production",
+			overridePath: "/abs/.bedrock/deploy.ts",
+			parsed,
 		});
 
-		expect(invocation).toContainEntry(["githubToken", "ghp-456"]);
+		expect(invocation).toContainEntry(entry);
 	});
 
-	it("should omit githubToken when parsed.githubToken is undefined", () => {
+	it.for<{ key: "apiKey" | "configFile" | "githubToken" }>([
+		{ key: "apiKey" },
+		{ key: "configFile" },
+		{ key: "githubToken" },
+	])("should omit $key when parsed.$key is undefined", ({ key }) => {
 		expect.assertions(1);
 
 		const invocation = buildOverrideInvocation({
@@ -90,6 +62,6 @@ describe(buildOverrideInvocation, () => {
 			parsed: parsedWith(),
 		});
 
-		expect(invocation).not.toContainKey("githubToken");
+		expect(invocation).not.toContainKey(key);
 	});
 });

--- a/packages/bedrock/src/cli/build-override-invocation.ts
+++ b/packages/bedrock/src/cli/build-override-invocation.ts
@@ -6,7 +6,7 @@ import type { CommonOptions } from "./parse-options.ts";
  * once an override file has been discovered: the parsed deploy flags, the
  * absolute override path, and the environment a single invocation targets.
  */
-export interface BuildOverrideInvocationInputs {
+interface BuildOverrideInvocationInputs {
 	/** Target environment for the single invocation being built. */
 	readonly environment: string;
 	/** Absolute path to the override script to invoke. */

--- a/packages/bedrock/src/cli/build-override-invocation.ts
+++ b/packages/bedrock/src/cli/build-override-invocation.ts
@@ -1,0 +1,37 @@
+import type { OverrideInvocation } from "./dispatch-override.ts";
+import type { CommonOptions } from "./parse-options.ts";
+
+/**
+ * Inputs the CLI's deploy dispatcher hands to {@link buildOverrideInvocation}
+ * once an override file has been discovered: the parsed deploy flags, the
+ * absolute override path, and the environment a single invocation targets.
+ */
+export interface BuildOverrideInvocationInputs {
+	/** Target environment for the single invocation being built. */
+	readonly environment: string;
+	/** Absolute path to the override script to invoke. */
+	readonly overridePath: string;
+	/** Parsed deploy options carrying the credential and config flags to forward. */
+	readonly parsed: CommonOptions;
+}
+
+/**
+ * Translate the deploy command's parsed inputs into a single-environment
+ * {@link OverrideInvocation}. Optional flags (`apiKey`, `configFile`,
+ * `githubToken`) are *omitted* from the returned object when their parsed
+ * value is `undefined`, rather than included with an `undefined` value: the
+ * spawn protocol's downstream argv and env-var routing relies on field
+ * presence, not just defined-ness.
+ * @param inputs - {@link BuildOverrideInvocationInputs}.
+ * @returns A single-environment {@link OverrideInvocation}.
+ */
+export function buildOverrideInvocation(inputs: BuildOverrideInvocationInputs): OverrideInvocation {
+	const { environment, overridePath, parsed } = inputs;
+	return {
+		...(parsed.apiKey === undefined ? {} : { apiKey: parsed.apiKey }),
+		...(parsed.configFile === undefined ? {} : { configFile: parsed.configFile }),
+		environment,
+		...(parsed.githubToken === undefined ? {} : { githubToken: parsed.githubToken }),
+		overridePath,
+	};
+}

--- a/packages/bedrock/src/cli/commands/deploy.spec.ts
+++ b/packages/bedrock/src/cli/commands/deploy.spec.ts
@@ -11,12 +11,34 @@ import type { ProgressEvent, ProgressPort } from "../../ports/progress-port.ts";
 import type { DeployError } from "../../shell/deploy.ts";
 import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../../types/ids.ts";
 import type { ProgDeps } from "../index.ts";
+import type { Spawner, SpawnInvocation, SpawnLaunchError } from "../spawner.ts";
 import { deployCommand } from "./deploy.ts";
 
 type LoadConfigFunc = NonNullable<ProgDeps["loadConfig"]>;
 type LoadConfigResult = Awaited<ReturnType<LoadConfigFunc>>;
 type DeployFunc = NonNullable<ProgDeps["deploy"]>;
 type ExitFunc = NonNullable<ProgDeps["exit"]>;
+type DiscoverOverrideFunc = NonNullable<ProgDeps["discoverOverride"]>;
+
+interface SpawnerRecorder {
+	readonly invocations: ReadonlyArray<SpawnInvocation>;
+	readonly spawner: Spawner;
+}
+
+function recordingSpawner(result: Result<number, SpawnLaunchError>): SpawnerRecorder {
+	const invocations: Array<SpawnInvocation> = [];
+	const spawner: Spawner = {
+		async spawn(invocation) {
+			invocations.push(invocation);
+			return result;
+		},
+	};
+	return { invocations, spawner };
+}
+
+function discoverReturning(path: string | undefined): DiscoverOverrideFunc {
+	return vi.fn<DiscoverOverrideFunc>(() => path);
+}
 
 function makeDeps(overrides: Partial<ProgDeps> = {}): ProgDeps {
 	return {
@@ -431,5 +453,160 @@ describe(deployCommand, () => {
 		await deployCommand(deps)({ env: "production" });
 
 		expect(clack.logMessage).toHaveBeenCalledWith("State written to gist:abc-test");
+	});
+
+	it("should dispatch the spawner instead of deploy() when an override is discovered", async () => {
+		expect.assertions(3);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const deploy = vi.fn<DeployFunc>();
+		const { invocations, spawner } = recordingSpawner({ data: 0, success: true });
+		const discoverOverride = discoverReturning("/abs/.bedrock/deploy.ts");
+		const deps = makeDeps({
+			deploy,
+			discoverOverride,
+			loadConfig,
+			projectRoot: "/project",
+			spawner,
+		});
+
+		await deployCommand(deps)({ env: "production" });
+
+		expect(invocations).toHaveLength(1);
+		expect(deploy).not.toHaveBeenCalled();
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(0);
+	});
+
+	it("should query discoverOverride with the configured projectRoot and the 'deploy' command name", async () => {
+		expect.assertions(1);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const deploy = fakeDeploy([{ data: bedrockState("production"), success: true }]);
+		const discoverOverride = discoverReturning(undefined);
+		const deps = makeDeps({
+			deploy,
+			discoverOverride,
+			loadConfig,
+			projectRoot: "/abs/project",
+		});
+
+		await deployCommand(deps)({ env: "production" });
+
+		expect(discoverOverride).toHaveBeenCalledExactlyOnceWith("/abs/project", "deploy");
+	});
+
+	it("should forward the discovered override path and parsed flags into the spawned invocation", async () => {
+		expect.assertions(5);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const { invocations, spawner } = recordingSpawner({ data: 0, success: true });
+		const discoverOverride = discoverReturning("/abs/.bedrock/deploy.ts");
+		const deps = makeDeps({ discoverOverride, loadConfig, projectRoot: "/abs", spawner });
+
+		await deployCommand(deps)({
+			"api-key": "rbx-key",
+			"config": "./bedrock.staging.config.ts",
+			"env": "production",
+			"github-token": "ghp-token",
+		});
+
+		const args = invocations[0]?.args ?? [];
+
+		expect(args[0]).toBe("/abs/.bedrock/deploy.ts");
+		expect(args).toStrictEqual([
+			"/abs/.bedrock/deploy.ts",
+			"--env",
+			"production",
+			"--config",
+			"./bedrock.staging.config.ts",
+		]);
+		expect(invocations[0]?.envOverrides).toMatchObject({
+			BEDROCK_API_KEY: "rbx-key",
+			BEDROCK_CLI: "1",
+			BEDROCK_GITHUB_TOKEN: "ghp-token",
+		});
+		expect(args).not.toContain("rbx-key");
+		expect(args).not.toContain("ghp-token");
+	});
+
+	it("should dispatch the spawner once per --env when multiple environments are requested", async () => {
+		expect.assertions(3);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const { invocations, spawner } = recordingSpawner({ data: 0, success: true });
+		const discoverOverride = discoverReturning("/abs/.bedrock/deploy.ts");
+		const deps = makeDeps({ discoverOverride, loadConfig, projectRoot: "/abs", spawner });
+
+		await deployCommand(deps)({ env: ["production", "staging"] });
+
+		expect(invocations).toHaveLength(2);
+
+		const environmentValues = invocations.map((invocation) => {
+			const { args } = invocation;
+			return args[args.indexOf("--env") + 1];
+		});
+
+		expect(environmentValues).toStrictEqual(["production", "staging"]);
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(0);
+	});
+
+	it("should fall back to the shell deploy() when discoverOverride returns undefined", async () => {
+		expect.assertions(2);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const deploy = fakeDeploy([{ data: bedrockState("production"), success: true }]);
+		const { invocations, spawner } = recordingSpawner({ data: 0, success: true });
+		const discoverOverride = discoverReturning(undefined);
+		const deps = makeDeps({ deploy, discoverOverride, loadConfig, spawner });
+
+		await deployCommand(deps)({ env: "production" });
+
+		expect(deploy).toHaveBeenCalledOnce();
+		expect(invocations).toHaveLength(0);
+	});
+
+	it("should cancel and exit 1 when an override spawn returns a non-zero exit code", async () => {
+		expect.assertions(2);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const { spawner } = recordingSpawner({ data: 3, success: true });
+		const discoverOverride = discoverReturning("/abs/.bedrock/deploy.ts");
+		const deps = makeDeps({ discoverOverride, loadConfig, spawner });
+
+		await deployCommand(deps)({ env: "production" });
+
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("deploy failed");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should run every env via spawn even when an earlier env's spawn exits non-zero", async () => {
+		expect.assertions(2);
+
+		const invocations: Array<SpawnInvocation> = [];
+		let callIndex = 0;
+		const results: ReadonlyArray<Result<number, SpawnLaunchError>> = [
+			{ data: 3, success: true },
+			{ data: 0, success: true },
+		];
+		const spawner: Spawner = {
+			async spawn(invocation) {
+				invocations.push(invocation);
+				const next = results[callIndex];
+				callIndex += 1;
+				if (next === undefined) {
+					throw new Error("spawner invoked beyond scripted results");
+				}
+
+				return next;
+			},
+		};
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const discoverOverride = discoverReturning("/abs/.bedrock/deploy.ts");
+		const deps = makeDeps({ discoverOverride, loadConfig, spawner });
+
+		await deployCommand(deps)({ env: ["production", "staging"] });
+
+		expect(invocations).toHaveLength(2);
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
 	});
 });

--- a/packages/bedrock/src/cli/commands/deploy.spec.ts
+++ b/packages/bedrock/src/cli/commands/deploy.spec.ts
@@ -566,7 +566,7 @@ describe(deployCommand, () => {
 	});
 
 	it("should cancel and exit 1 when an override spawn returns a non-zero exit code", async () => {
-		expect.assertions(2);
+		expect.assertions(3);
 
 		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
 		const { spawner } = recordingSpawner({ data: 3, success: true });
@@ -575,6 +575,32 @@ describe(deployCommand, () => {
 
 		await deployCommand(deps)({ env: "production" });
 
+		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
+			"production: override exited with code 3",
+		);
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("deploy failed");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should log a launch failure via clack and exit 1 when the override spawn cannot start", async () => {
+		expect.assertions(3);
+
+		const cause: Error & { code?: string } = Object.assign(new Error("spawn bun ENOENT"), {
+			code: "ENOENT",
+		});
+		const { spawner } = recordingSpawner({
+			err: { cause, kind: "launchFailed" },
+			success: false,
+		});
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const discoverOverride = discoverReturning("/abs/.bedrock/deploy.ts");
+		const deps = makeDeps({ discoverOverride, loadConfig, spawner });
+
+		await deployCommand(deps)({ env: "production" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
+			"production: failed to launch override - spawn bun ENOENT",
+		);
 		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("deploy failed");
 		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
 	});

--- a/packages/bedrock/src/cli/commands/deploy.spec.ts
+++ b/packages/bedrock/src/cli/commands/deploy.spec.ts
@@ -496,7 +496,7 @@ describe(deployCommand, () => {
 	});
 
 	it("should forward the discovered override path and parsed flags into the spawned invocation", async () => {
-		expect.assertions(5);
+		expect.assertions(4);
 
 		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
 		const { invocations, spawner } = recordingSpawner({ data: 0, success: true });
@@ -512,7 +512,6 @@ describe(deployCommand, () => {
 
 		const args = invocations[0]?.args ?? [];
 
-		expect(args[0]).toBe("/abs/.bedrock/deploy.ts");
 		expect(args).toStrictEqual([
 			"/abs/.bedrock/deploy.ts",
 			"--env",
@@ -633,6 +632,25 @@ describe(deployCommand, () => {
 		await deployCommand(deps)({ env: ["production", "staging"] });
 
 		expect(invocations).toHaveLength(2);
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should render an error and exit 1 when discoverOverride throws", async () => {
+		expect.assertions(3);
+
+		const loadConfig = fakeLoad({ data: sampleConfig, success: true });
+		const deploy = vi.fn<DeployFunc>();
+		const discoverOverride = vi.fn<DiscoverOverrideFunc>(() => {
+			throw new Error("EACCES: permission denied, stat '/project/.bedrock/deploy.ts'");
+		});
+		const deps = makeDeps({ deploy, discoverOverride, loadConfig, projectRoot: "/project" });
+
+		await deployCommand(deps)({ env: "production" });
+
+		expect(deps.clack?.logError).toHaveBeenCalledExactlyOnceWith(
+			"override discovery failed: EACCES: permission denied, stat '/project/.bedrock/deploy.ts'",
+		);
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("deploy failed");
 		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
 	});
 });

--- a/packages/bedrock/src/cli/commands/deploy.ts
+++ b/packages/bedrock/src/cli/commands/deploy.ts
@@ -17,7 +17,12 @@ import { dispatchOverride } from "../dispatch-override.ts";
 import { EXIT_ERROR, EXIT_OK } from "../exit-codes.ts";
 import type { ProgDeps } from "../index.ts";
 import { type CommonOptions, parseCommonOptions } from "../parse-options.ts";
-import { type ClackPort, renderDeployError, renderParseError } from "../render.ts";
+import {
+	type ClackPort,
+	renderDeployError,
+	renderOverrideError,
+	renderParseError,
+} from "../render.ts";
 import type { Spawner } from "../spawner.ts";
 
 interface ResolvedDeploy {
@@ -104,6 +109,7 @@ async function dispatchEnvironments(inputs: DispatchInputs): Promise<ReadonlyArr
 			const invocation = buildOverrideInvocation({ environment, overridePath, parsed });
 			const result = await dispatchOverride(invocation, resolved.spawner);
 			if (!result.success) {
+				renderOverrideError({ environment, err: result.err }, resolved.clack);
 				failed.push(environment);
 			}
 

--- a/packages/bedrock/src/cli/commands/deploy.ts
+++ b/packages/bedrock/src/cli/commands/deploy.ts
@@ -20,6 +20,7 @@ import { type CommonOptions, parseCommonOptions } from "../parse-options.ts";
 import {
 	type ClackPort,
 	renderDeployError,
+	renderOverrideDiscoveryError,
 	renderOverrideError,
 	renderParseError,
 } from "../render.ts";
@@ -52,6 +53,10 @@ interface DispatchAndReportInput {
 	readonly resolved: ResolvedDeploy;
 }
 
+type OverrideDiscovery =
+	| { readonly kind: "discovered"; readonly overridePath: string | undefined }
+	| { readonly kind: "failed" };
+
 /**
  * Build the sade action for `bedrock deploy`. The returned function consumes
  * the raw options object sade hands the action callback, parses it via
@@ -63,8 +68,10 @@ interface DispatchAndReportInput {
  * When a `.bedrock/deploy.ts` override is discovered under the resolved
  * project root, each `--env` is handed to the spawner via
  * {@link dispatchOverride} instead of the in-process `deploy()` call. The
- * aggregation rule is identical: every env still runs, and the exit code
- * is `EXIT_OK` only when every spawn returned a zero exit code.
+ * aggregation rule is identical: every env still runs and the exit code is
+ * `EXIT_OK` only when every spawn returned a zero exit code. Unlike the
+ * in-process path, only failures emit a per-env line here; a successful
+ * spawn's output comes from the override script's own inherited stdout.
  * @param deps - Dependency overrides; missing slots are default-constructed
  *   from real implementations.
  * @returns An async sade action that returns once `deps.exit` was invoked.
@@ -158,6 +165,19 @@ async function dispatchAndReport(input: DispatchAndReportInput): Promise<number>
 	return EXIT_OK;
 }
 
+function discoverOverridePath(resolved: ResolvedDeploy): OverrideDiscovery {
+	try {
+		return {
+			kind: "discovered",
+			overridePath: resolved.discoverOverride(resolved.projectRoot, "deploy"),
+		};
+	} catch (err) {
+		renderOverrideDiscoveryError(err, resolved.clack);
+		cancelAsFailed(resolved.clack);
+		return { kind: "failed" };
+	}
+}
+
 async function runDeploy(
 	rawOptions: Record<string, unknown>,
 	resolved: ResolvedDeploy,
@@ -178,11 +198,14 @@ async function runDeploy(
 		return EXIT_ERROR;
 	}
 
-	const overridePath = resolved.discoverOverride(resolved.projectRoot, "deploy");
+	const discovery = discoverOverridePath(resolved);
+	if (discovery.kind === "failed") {
+		return EXIT_ERROR;
+	}
 
 	return dispatchAndReport({
 		loaded: loaded.data,
-		overridePath,
+		overridePath: discovery.overridePath,
 		parsed: parsed.data,
 		resolved,
 	});

--- a/packages/bedrock/src/cli/commands/deploy.ts
+++ b/packages/bedrock/src/cli/commands/deploy.ts
@@ -8,31 +8,41 @@ import {
 	loadConfig as defaultLoadConfig,
 	type LoadConfigOptions,
 } from "../../shell/load-config.ts";
+import { buildOverrideInvocation } from "../build-override-invocation.ts";
 import { createClackPort } from "../clack-port.ts";
 import { buildCredentialOverrides } from "../credential-environment-overrides.ts";
+import { createDefaultSpawner } from "../default-spawner.ts";
+import { discoverOverride as defaultDiscoverOverride } from "../discover-override.ts";
+import { dispatchOverride } from "../dispatch-override.ts";
 import { EXIT_ERROR, EXIT_OK } from "../exit-codes.ts";
 import type { ProgDeps } from "../index.ts";
 import { type CommonOptions, parseCommonOptions } from "../parse-options.ts";
 import { type ClackPort, renderDeployError, renderParseError } from "../render.ts";
+import type { Spawner } from "../spawner.ts";
 
 interface ResolvedDeploy {
 	readonly clack: ClackPort;
 	readonly deploy: typeof defaultDeploy;
+	readonly discoverOverride: typeof defaultDiscoverOverride;
 	readonly exit: (code: number) => void;
 	readonly loadConfig: typeof defaultLoadConfig;
 	readonly progressOverride: ProgressPort | undefined;
+	readonly projectRoot: string;
+	readonly spawner: Spawner;
 }
 
 interface DispatchInputs {
 	readonly config: Config;
-	readonly environments: ReadonlyArray<string>;
 	readonly getEnv: (name: string) => string | undefined;
+	readonly overridePath: string | undefined;
+	readonly parsed: CommonOptions;
 	readonly progress: ProgressPort;
 	readonly resolved: ResolvedDeploy;
 }
 
 interface DispatchAndReportInput {
 	readonly loaded: Config;
+	readonly overridePath: string | undefined;
 	readonly parsed: CommonOptions;
 	readonly resolved: ResolvedDeploy;
 }
@@ -44,6 +54,12 @@ interface DispatchAndReportInput {
  * `deploy()` for each `--env` value in order. Per-env successes and failures
  * render through clack as a single line each; the aggregated exit code is
  * `EXIT_OK` only when every env succeeded.
+ *
+ * When a `.bedrock/deploy.ts` override is discovered under the resolved
+ * project root, each `--env` is handed to the spawner via
+ * {@link dispatchOverride} instead of the in-process `deploy()` call. The
+ * aggregation rule is identical: every env still runs, and the exit code
+ * is `EXIT_OK` only when every spawn returned a zero exit code.
  * @param deps - Dependency overrides; missing slots are default-constructed
  *   from real implementations.
  * @returns An async sade action that returns once `deps.exit` was invoked.
@@ -63,9 +79,12 @@ function resolveDeploy(deps: ProgDeps): ResolvedDeploy {
 	return {
 		clack,
 		deploy: deps.deploy ?? defaultDeploy,
+		discoverOverride: deps.discoverOverride ?? defaultDiscoverOverride,
 		exit: deps.exit ?? ((code: number) => process.exit(code)),
 		loadConfig: deps.loadConfig ?? defaultLoadConfig,
 		progressOverride: deps.progress,
+		projectRoot: deps.projectRoot ?? process.cwd(),
+		spawner: deps.spawner ?? createDefaultSpawner(),
 	};
 }
 
@@ -78,9 +97,19 @@ function cancelAsFailed(clack: ClackPort): void {
 }
 
 async function dispatchEnvironments(inputs: DispatchInputs): Promise<ReadonlyArray<string>> {
-	const { config, environments, getEnv, progress, resolved } = inputs;
+	const { config, getEnv, overridePath, parsed, progress, resolved } = inputs;
 	const failed: Array<string> = [];
-	for (const environment of environments) {
+	for (const environment of parsed.environments) {
+		if (overridePath !== undefined) {
+			const invocation = buildOverrideInvocation({ environment, overridePath, parsed });
+			const result = await dispatchOverride(invocation, resolved.spawner);
+			if (!result.success) {
+				failed.push(environment);
+			}
+
+			continue;
+		}
+
 		const result = await resolved.deploy({
 			config,
 			environment,
@@ -101,15 +130,16 @@ function buildGetEnvironment(parsed: CommonOptions): (name: string) => string | 
 }
 
 async function dispatchAndReport(input: DispatchAndReportInput): Promise<number> {
-	const { loaded, parsed, resolved } = input;
+	const { loaded, overridePath, parsed, resolved } = input;
 	const progress: ProgressPort =
 		resolved.progressOverride ??
 		createClackProgressAdapter({ clack: resolved.clack, config: loaded });
 
 	const failures = await dispatchEnvironments({
 		config: loaded,
-		environments: parsed.environments,
 		getEnv: buildGetEnvironment(parsed),
+		overridePath,
+		parsed,
 		progress,
 		resolved,
 	});
@@ -142,5 +172,12 @@ async function runDeploy(
 		return EXIT_ERROR;
 	}
 
-	return dispatchAndReport({ loaded: loaded.data, parsed: parsed.data, resolved });
+	const overridePath = resolved.discoverOverride(resolved.projectRoot, "deploy");
+
+	return dispatchAndReport({
+		loaded: loaded.data,
+		overridePath,
+		parsed: parsed.data,
+		resolved,
+	});
 }

--- a/packages/bedrock/src/cli/index.spec-d.ts
+++ b/packages/bedrock/src/cli/index.spec-d.ts
@@ -7,10 +7,12 @@ import type { deploy } from "../shell/deploy.ts";
 import type { loadConfig } from "../shell/load-config.ts";
 import type { migrateMantleState } from "../shell/migrate-mantle-state.ts";
 import type { previewDiff } from "../shell/preview-diff.ts";
+import type { discoverOverride } from "./discover-override.ts";
 import type { ProgDeps } from "./index.ts";
 import { createProg } from "./index.ts";
 import type { MigratePromptPort } from "./migrate-prompt-port.ts";
 import type { ClackPort } from "./render.ts";
+import type { Spawner } from "./spawner.ts";
 
 describe("ProgDeps shape", () => {
 	it("should expose exactly the configured injection slots", () => {
@@ -18,6 +20,7 @@ describe("ProgDeps shape", () => {
 			| "buildStatePort"
 			| "clack"
 			| "deploy"
+			| "discoverOverride"
 			| "exit"
 			| "loadConfig"
 			| "migrateMantleState"
@@ -25,6 +28,8 @@ describe("ProgDeps shape", () => {
 			| "mkdir"
 			| "previewDiff"
 			| "progress"
+			| "projectRoot"
+			| "spawner"
 			| "writeFile"
 		>();
 	});
@@ -91,6 +96,22 @@ describe("ProgDeps render slots", () => {
 
 	it("should accept a void-returning exit handle so test stubs can intercept termination", () => {
 		expectTypeOf<NonNullable<ProgDeps["exit"]>>().toEqualTypeOf<(code: number) => void>();
+	});
+});
+
+describe("ProgDeps override slots", () => {
+	it("should accept the discoverOverride signature in the discoverOverride slot", () => {
+		expectTypeOf<NonNullable<ProgDeps["discoverOverride"]>>().toEqualTypeOf<
+			typeof discoverOverride
+		>();
+	});
+
+	it("should accept a string in the projectRoot slot", () => {
+		expectTypeOf<NonNullable<ProgDeps["projectRoot"]>>().toEqualTypeOf<string>();
+	});
+
+	it("should accept the Spawner interface in the spawner slot", () => {
+		expectTypeOf<NonNullable<ProgDeps["spawner"]>>().toEqualTypeOf<Spawner>();
 	});
 });
 

--- a/packages/bedrock/src/cli/index.ts
+++ b/packages/bedrock/src/cli/index.ts
@@ -11,8 +11,10 @@ import type { previewDiff as defaultPreviewDiff } from "../shell/preview-diff.ts
 import { deployCommand } from "./commands/deploy.ts";
 import { diffCommand } from "./commands/diff.ts";
 import { migrateCommand } from "./commands/migrate.ts";
+import type { discoverOverride as defaultDiscoverOverride } from "./discover-override.ts";
 import type { MigratePromptPort } from "./migrate-prompt-port.ts";
 import type { ClackPort } from "./render.ts";
+import type { Spawner } from "./spawner.ts";
 
 export { createClackPort } from "./clack-port.ts";
 
@@ -30,6 +32,8 @@ export interface ProgDeps {
 	readonly clack?: ClackPort;
 	/** Reconciles config to upstream state; defaults to the public `deploy`. */
 	readonly deploy?: typeof defaultDeploy;
+	/** Discovers a `.bedrock/<command>.ts` override path; defaults to the real `discoverOverride`. */
+	readonly discoverOverride?: typeof defaultDiscoverOverride;
 	/** Process exit handle; defaults to `process.exit` so tests can intercept termination. The production default never returns; test stubs are free to return void. */
 	readonly exit?: (code: number) => void;
 	/** Project config loader; defaults to the public `loadConfig`. */
@@ -44,6 +48,10 @@ export interface ProgDeps {
 	readonly previewDiff?: typeof defaultPreviewDiff;
 	/** Progress port that receives per-env deploy outcomes; defaults to the clack-backed adapter. */
 	readonly progress?: ProgressPort;
+	/** Project root passed to override discovery; defaults to `process.cwd()`. */
+	readonly projectRoot?: string;
+	/** Child-process spawner used to launch override scripts; defaults to `createDefaultSpawner()`. */
+	readonly spawner?: Spawner;
 	/** File-write seam used by the migrate command to emit the bedrock config file; defaults to `node:fs/promises.writeFile`. */
 	readonly writeFile?: (path: string, contents: string) => Promise<void>;
 }

--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -7,6 +7,7 @@ import type { MigrateError } from "../core/migrate/migration-report.ts";
 import type { MissingCredentialError, UnsupportedBackendError } from "../shell/build-state-port.ts";
 import type { DeployError } from "../shell/deploy.ts";
 import { asResourceKey } from "../types/ids.ts";
+import type { SpawnOverrideError } from "./dispatch-override.ts";
 import type { ParseMigrateError } from "./parse-migrate-options.ts";
 import type { ParseOptionsError } from "./parse-options.ts";
 import {
@@ -15,6 +16,7 @@ import {
 	renderMigrateError,
 	renderMigrateParseError,
 	renderMigrationSummary,
+	renderOverrideError,
 	renderParseError,
 	renderStateWriteError,
 } from "./render.ts";
@@ -405,6 +407,37 @@ describe(renderParseError, () => {
 		renderParseError(err, port);
 
 		expect(port.logError).toHaveBeenCalledExactlyOnceWith(expected);
+	});
+});
+
+describe(renderOverrideError, () => {
+	it("should render a launchFailed cause as a single environment-tagged error line", () => {
+		expect.assertions(1);
+
+		const port = fakeClackPort();
+		const cause: Error & { code?: string } = Object.assign(new Error("spawn bun ENOENT"), {
+			code: "ENOENT",
+		});
+		const err: SpawnOverrideError = { cause, kind: "launchFailed" };
+
+		renderOverrideError({ environment: "production", err }, port);
+
+		expect(port.logError).toHaveBeenCalledExactlyOnceWith(
+			"production: failed to launch override - spawn bun ENOENT",
+		);
+	});
+
+	it("should render a nonZeroExit code as a single environment-tagged error line", () => {
+		expect.assertions(1);
+
+		const port = fakeClackPort();
+		const err: SpawnOverrideError = { exitCode: 3, kind: "nonZeroExit" };
+
+		renderOverrideError({ environment: "staging", err }, port);
+
+		expect(port.logError).toHaveBeenCalledExactlyOnceWith(
+			"staging: override exited with code 3",
+		);
 	});
 });
 

--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -16,6 +16,7 @@ import {
 	renderMigrateError,
 	renderMigrateParseError,
 	renderMigrationSummary,
+	renderOverrideDiscoveryError,
 	renderOverrideError,
 	renderParseError,
 	renderStateWriteError,
@@ -437,6 +438,23 @@ describe(renderOverrideError, () => {
 
 		expect(port.logError).toHaveBeenCalledExactlyOnceWith(
 			"staging: override exited with code 3",
+		);
+	});
+});
+
+describe(renderOverrideDiscoveryError, () => {
+	it("should render the thrown cause message as a single error line", () => {
+		expect.assertions(1);
+
+		const port = fakeClackPort();
+
+		renderOverrideDiscoveryError(
+			new Error("EACCES: permission denied, stat '/project/.bedrock/deploy.ts'"),
+			port,
+		);
+
+		expect(port.logError).toHaveBeenCalledExactlyOnceWith(
+			"override discovery failed: EACCES: permission denied, stat '/project/.bedrock/deploy.ts'",
 		);
 	});
 });

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -123,6 +123,19 @@ export function renderOverrideError(input: OverrideErrorRender, port: ClackPort)
 }
 
 /**
+ * Render the failure surfaced when override discovery throws a non-absence
+ * filesystem error (for example `EACCES` on a `.bedrock/<command>.ts` that
+ * exists but cannot be read). Discovery refuses to fall through to the
+ * built-in path in that case, so the CLI reports the cause and exits rather
+ * than crashing on the unhandled throw.
+ * @param error - The value thrown during override discovery.
+ * @param port - The output port the diagnostic is written to.
+ */
+export function renderOverrideDiscoveryError(error: unknown, port: ClackPort): void {
+	port.logError(`override discovery failed: ${safeStringify(error)}`);
+}
+
+/**
  * Render a `ParseMigrateError` to the supplied `ClackPort`. Reuses
  * `parseErrorMessage` for the three flag-shape variants and adds a
  * dedicated message for `unknownSource` listing the supported sources.

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -7,6 +7,7 @@ import type { ApplyError } from "../shell/apply-ops.ts";
 import type { BuildDesiredError } from "../shell/build-desired.ts";
 import type { MissingCredentialError, UnsupportedBackendError } from "../shell/build-state-port.ts";
 import type { DeployError } from "../shell/deploy.ts";
+import type { SpawnOverrideError } from "./dispatch-override.ts";
 import type { ParseMigrateError } from "./parse-migrate-options.ts";
 import type { ParseOptionsError } from "./parse-options.ts";
 
@@ -65,6 +66,14 @@ interface MigrationSummaryRender {
 	readonly summary: MigrationSummary;
 }
 
+/** Inputs for {@link renderOverrideError}. */
+interface OverrideErrorRender {
+	/** Environment whose override spawn produced the error. */
+	readonly environment: string;
+	/** The spawn-override error returned by `dispatchOverride`. */
+	readonly err: SpawnOverrideError;
+}
+
 /**
  * Render a `DeployError` to the supplied `ClackPort`. Most variants emit a
  * single error line; `applyFailed` emits one line per failing op in the
@@ -98,6 +107,19 @@ export function renderDeployError(err: DeployError, port: ClackPort): void {
  */
 export function renderParseError(err: ParseOptionsError, port: ClackPort): void {
 	port.logError(parseErrorMessage(err));
+}
+
+/**
+ * Render a `SpawnOverrideError` to the supplied `ClackPort` as a single
+ * error line that names the environment alongside the failure mode. On
+ * `launchFailed` the child never produced output of its own, so the parent
+ * carries the diagnostic; on `nonZeroExit` the parent's line attributes the
+ * exit code to a specific environment when several spawns are running.
+ * @param input - Environment + spawn-override error to describe.
+ * @param port - The output port the diagnostic is written to.
+ */
+export function renderOverrideError(input: OverrideErrorRender, port: ClackPort): void {
+	port.logError(overrideErrorMessage(input));
 }
 
 /**
@@ -319,6 +341,15 @@ function parseErrorMessage(err: ParseOptionsError): string {
 			return `unknown flag '--${err.flag}'`;
 		}
 	}
+}
+
+function overrideErrorMessage(input: OverrideErrorRender): string {
+	const { environment, err } = input;
+	if (err.kind === "launchFailed") {
+		return `${environment}: failed to launch override - ${err.cause.message}`;
+	}
+
+	return `${environment}: override exited with code ${String(err.exitCode)}`;
 }
 
 function migrateParseErrorMessage(err: ParseMigrateError): string {

--- a/packages/bedrock/tests/integration/cli/deploy-override.spec.ts
+++ b/packages/bedrock/tests/integration/cli/deploy-override.spec.ts
@@ -1,0 +1,121 @@
+import { createProg, type ProgDeps } from "#src/cli/index";
+import type { Config } from "#src/core/schema";
+import type { BedrockState } from "#src/core/state";
+import { fakeClackPort } from "#tests/helpers/clack";
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+
+type DeployFunc = NonNullable<ProgDeps["deploy"]>;
+type ExitFunc = NonNullable<ProgDeps["exit"]>;
+type LoadConfigFunc = NonNullable<ProgDeps["loadConfig"]>;
+
+const FIXTURES_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "overrides");
+const ECHO_PROTOCOL = join(FIXTURES_ROOT, "echo-protocol.ts");
+const EXIT_NON_ZERO = join(FIXTURES_ROOT, "exit-non-zero.ts");
+
+const fakeConfig = { environments: { production: {} } } satisfies Config;
+
+interface OverrideProject {
+	readonly overridePath: string;
+	readonly projectRoot: string;
+}
+
+interface Harness {
+	readonly clack: NonNullable<ProgDeps["clack"]>;
+	readonly deploy: ReturnType<typeof vi.fn<DeployFunc>>;
+	readonly exitPromise: Promise<number>;
+	readonly prog: ReturnType<typeof createProg>;
+}
+
+function emptyState(environment: string): BedrockState {
+	return { environment, resources: [], version: 1 };
+}
+
+/**
+ * Materialize a real `<root>/.bedrock/deploy.ts` from a committed fixture so
+ * the test exercises discoverOverride against a genuine on-disk layout rather
+ * than a stubbed path.
+ * @param sourceFixture - Committed override script copied into the temp project.
+ * @returns The temp project root and the absolute override path within it.
+ */
+function withOverrideProject(sourceFixture: string): OverrideProject {
+	const projectRoot = mkdtempSync(join(tmpdir(), "bedrock-override-disco-"));
+	const overridePath = join(projectRoot, ".bedrock", "deploy.ts");
+	mkdirSync(join(projectRoot, ".bedrock"));
+	copyFileSync(sourceFixture, overridePath);
+	onTestFinished(() => {
+		rmSync(projectRoot, { force: true, recursive: true });
+	});
+	return { overridePath, projectRoot };
+}
+
+function withProbe(): () => JSONValue {
+	const directory = mkdtempSync(join(tmpdir(), "bedrock-override-probe-"));
+	const file = join(directory, "probe.json");
+	vi.stubEnv("OVERRIDE_PROBE_OUTPUT", file);
+	onTestFinished(() => {
+		vi.unstubAllEnvs();
+		rmSync(directory, { force: true, recursive: true });
+	});
+	return () => JSON.parse(readFileSync(file, "utf8"));
+}
+
+function buildHarness(projectRoot: string): Harness {
+	let resolveExit!: (code: number) => void;
+	const exitPromise = new Promise<number>((resolve) => {
+		resolveExit = resolve;
+	});
+	const exit = vi.fn<ExitFunc>((code) => {
+		resolveExit(code);
+	});
+	const loadConfig = vi.fn<LoadConfigFunc>(async () => ({ data: fakeConfig, success: true }));
+	const deploy = vi.fn<DeployFunc>(async () => {
+		return { data: emptyState("production"), success: true };
+	});
+	const clack = fakeClackPort();
+	const prog = createProg({ clack, deploy, exit, loadConfig, projectRoot });
+	return { clack, deploy, exitPromise, prog };
+}
+
+describe("cli deploy override discovery end-to-end", () => {
+	it("should discover and execute .bedrock/deploy.ts via real bun, forwarding the spawn protocol", async () => {
+		expect.assertions(4);
+
+		const project = withOverrideProject(ECHO_PROTOCOL);
+		const readProbe = withProbe();
+		const harness = buildHarness(project.projectRoot);
+
+		harness.prog.parse(["node", "bedrock", "deploy", "--env", "production"]);
+		const code = await harness.exitPromise;
+
+		expect(code).toBe(0);
+		expect(harness.deploy).not.toHaveBeenCalled();
+		// bun canonicalizes the script path in argv[1] (on macOS the temp dir's
+		// `/var` symlink resolves to `/private/var`), so compare against the
+		// real path of the file discoverOverride resolved.
+		expect(readProbe()).toStrictEqual({
+			args: [realpathSync(project.overridePath), "--env", "production"],
+			cli: "1",
+		});
+		expect(harness.clack.outro).toHaveBeenCalledExactlyOnceWith("deploy succeeded");
+	});
+
+	it("should propagate a non-zero override exit discovered on disk as exit 1", async () => {
+		expect.assertions(3);
+
+		const project = withOverrideProject(EXIT_NON_ZERO);
+		const harness = buildHarness(project.projectRoot);
+
+		harness.prog.parse(["node", "bedrock", "deploy", "--env", "production"]);
+		const code = await harness.exitPromise;
+
+		expect(code).toBe(1);
+		expect(harness.clack.logError).toHaveBeenCalledExactlyOnceWith(
+			"production: override exited with code 3",
+		);
+		expect(harness.clack.cancel).toHaveBeenCalledExactlyOnceWith("deploy failed");
+	});
+});

--- a/packages/bedrock/tests/integration/cli/deploy.spec.ts
+++ b/packages/bedrock/tests/integration/cli/deploy.spec.ts
@@ -5,20 +5,34 @@ import type { Config } from "#src/core/schema";
 import type { BedrockState } from "#src/core/state";
 import type { DeployError } from "#src/shell/deploy";
 import { fakeClackPort } from "#tests/helpers/clack";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 
 type LoadConfigFunc = NonNullable<ProgDeps["loadConfig"]>;
 type DeployFunc = NonNullable<ProgDeps["deploy"]>;
 type ExitFunc = NonNullable<ProgDeps["exit"]>;
+type DiscoverOverrideFunc = NonNullable<ProgDeps["discoverOverride"]>;
 
 const fakeConfig: Config = {
 	environments: { production: {}, staging: {} },
 };
 
+const FIXTURES_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "fixtures", "overrides");
+const EXIT_ZERO = join(FIXTURES_ROOT, "exit-zero.ts");
+const EXIT_NON_ZERO = join(FIXTURES_ROOT, "exit-non-zero.ts");
+
 interface DeployHarness {
+	readonly clack: NonNullable<ProgDeps["clack"]>;
 	readonly deploy: ReturnType<typeof vi.fn<DeployFunc>>;
 	readonly exitPromise: Promise<number>;
 	readonly loadConfig: ReturnType<typeof vi.fn<LoadConfigFunc>>;
+	readonly prog: ReturnType<typeof createProg>;
+}
+
+interface OverrideHarness {
+	readonly clack: NonNullable<ProgDeps["clack"]>;
+	readonly exitPromise: Promise<number>;
 	readonly prog: ReturnType<typeof createProg>;
 }
 
@@ -49,8 +63,25 @@ function buildHarness(
 	});
 	const loadConfig = vi.fn<LoadConfigFunc>(async () => ({ data: fakeConfig, success: true }));
 
-	const prog = createProg({ clack: fakeClackPort(), deploy, exit, loadConfig });
-	return { deploy, exitPromise, loadConfig, prog };
+	const clack = fakeClackPort();
+	const prog = createProg({ clack, deploy, exit, loadConfig });
+	return { clack, deploy, exitPromise, loadConfig, prog };
+}
+
+function buildOverrideHarness(discoveredPath: string): OverrideHarness {
+	let resolveExit!: (code: number) => void;
+	const exitPromise = new Promise<number>((resolve) => {
+		resolveExit = resolve;
+	});
+	const exit = vi.fn<ExitFunc>((code) => {
+		resolveExit(code);
+	});
+	const loadConfig = vi.fn<LoadConfigFunc>(async () => ({ data: fakeConfig, success: true }));
+	const discoverOverride = vi.fn<DiscoverOverrideFunc>(() => discoveredPath);
+
+	const clack = fakeClackPort();
+	const prog = createProg({ clack, discoverOverride, exit, loadConfig });
+	return { clack, exitPromise, prog };
 }
 
 function dispatch(prog: ReturnType<typeof createProg>, argv: ReadonlyArray<string>): void {
@@ -97,5 +128,53 @@ describe("cli deploy dispatch", () => {
 
 		expect(harness.deploy).toHaveBeenCalledTimes(2);
 		expect(code).toBe(1);
+	});
+});
+
+describe("cli deploy dispatch through a dot-bedrock override", () => {
+	it("should exit 0 when a discovered override script exits zero", async () => {
+		expect.assertions(2);
+
+		const harness = buildOverrideHarness(EXIT_ZERO);
+
+		dispatch(harness.prog, ["deploy", "--env", "production"]);
+		const code = await harness.exitPromise;
+
+		expect(code).toBe(0);
+		expect(harness.clack.outro).toHaveBeenCalledExactlyOnceWith("deploy succeeded");
+	});
+
+	it("should exit 1 and cancel when a discovered override script exits non-zero", async () => {
+		expect.assertions(3);
+
+		const harness = buildOverrideHarness(EXIT_NON_ZERO);
+
+		dispatch(harness.prog, ["deploy", "--env", "production"]);
+		const code = await harness.exitPromise;
+
+		expect(code).toBe(1);
+		expect(harness.clack.logError).toHaveBeenCalledExactlyOnceWith(
+			"production: override exited with code 3",
+		);
+		expect(harness.clack.cancel).toHaveBeenCalledExactlyOnceWith("deploy failed");
+	});
+
+	it("should spawn the override for every --env even when an earlier env exits non-zero", async () => {
+		expect.assertions(3);
+
+		const harness = buildOverrideHarness(EXIT_NON_ZERO);
+
+		dispatch(harness.prog, ["deploy", "--env", "production", "--env", "staging"]);
+		const code = await harness.exitPromise;
+
+		expect(code).toBe(1);
+
+		const messages = vi.mocked(harness.clack.logError).mock.calls.map(([line]) => line);
+
+		expect(messages).toStrictEqual([
+			"production: override exited with code 3",
+			"staging: override exited with code 3",
+		]);
+		expect(harness.clack.cancel).toHaveBeenCalledExactlyOnceWith("deploy failed");
 	});
 });

--- a/packages/bedrock/tests/integration/fixtures/overrides/exit-zero.ts
+++ b/packages/bedrock/tests/integration/fixtures/overrides/exit-zero.ts
@@ -1,0 +1,5 @@
+// Bun-runnable fixture for the deploy-dispatch integration tests. Exits 0
+// without side effects so the dispatcher reports Ok(undefined) end-to-end.
+import process from "node:process";
+
+process.exit(0);

--- a/packages/bedrock/tests/integration/fixtures/overrides/exit-zero.ts
+++ b/packages/bedrock/tests/integration/fixtures/overrides/exit-zero.ts
@@ -1,5 +1,3 @@
-// Bun-runnable fixture for the deploy-dispatch integration tests. Exits 0
-// without side effects so the dispatcher reports Ok(undefined) end-to-end.
 import process from "node:process";
 
 process.exit(0);


### PR DESCRIPTION
## Summary

- `bedrock deploy` now fans a discovered `.bedrock/deploy.ts` override out per `--env`: each environment becomes a separate `dispatchOverride` invocation through the injected `Spawner` port, and the per-env exit-code aggregator drives the CLI's final exit code just like the in-process path.
- Override `launchFailed` results (e.g. `bun` missing) and `nonZeroExit` results render a single environment-tagged error line through the clack output port before the env is folded into the failure list — on launch failure the parent's diagnostic is the operator's only signal, and on non-zero exit the line attributes the exit code to a specific environment when several spawns ran.
- `buildOverrideInvocation` translates the deploy command's parsed flags into a single-environment `OverrideInvocation`, omitting optional flags (`apiKey`, `configFile`, `githubToken`) when undefined so the spawn protocol's argv/env routing keys off field presence.

## Test plan

- [x] Unit specs for `buildOverrideInvocation` (flag forwarding/omission) and `render` (failure line formatting)
- [x] Command-level specs for `deploy` per-env fan-out and failure aggregation
- [x] Integration spec driving `createProg().parse(...)` through deploy with a discovered override, exercising the spawn protocol against real `bun` via `createDefaultSpawner()`
- [x] `hk` pre-push gate green: typecheck, build, knip, and mutation (100% score on touched `src/**`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Architecture Compliance Review: Deploy Override Dispatch (PR)

## Summary
This PR implements per-environment dispatch for discovered .bedrock/deploy.ts overrides by adding override discovery, per-env spawn dispatch via an injected Spawner port, per-env error rendering, and aggregation of per-env exit codes into the CLI exit code. The change set includes the core conversion helper for override invocations, shell wiring in the deploy command, render logic for spawn errors, expanded ProgDeps slots, and comprehensive unit, integration, and e2e tests (including on-disk override fixtures executed via Bun).

## Architecture Assessment

- FCIS Pattern: Compliant.
  - Core: buildOverrideInvocation is a pure transformation (no I/O or side-effects).
  - Shell: deploy command and dispatchEnvironments perform orchestration and delegate to ports (discoverOverride, spawner, deploy).
  - Ports/Adapters: Spawner is an injected port; createDefaultSpawner is the adapter. discoverOverride is a port used via DI.
  - Dependency injection: ProgDeps gains optional discoverOverride, projectRoot, spawner slots; defaults are resolved in resolveDeploy.

- Port boundaries: Enforced.
  - Credentials are forwarded as env overrides (not argv) via buildCredentialOverrides and buildOverrideInvocation omits optional fields when undefined so downstream routing depends on field presence.
  - BEDROCK_CLI is set in spawn env for override awareness.

No FCIS violations detected (no I/O in core helper; no business logic in adapter/shell beyond orchestration).

## Testing (TDD) & Isolation

- Coverage: Tests accompany implementations:
  - Unit tests for buildOverrideInvocation and renderOverrideError.
  - Command-level tests for per-env fan-out, spawn argument/env forwarding, failure aggregation, and fallthrough to built-in deploy.
  - Integration tests exercising on-disk override discovery with a real spawner path.
  - E2E smoke tests spawn the real CLI against Bun fixtures.
- Test isolation matches layer guidance:
  - Core unit tests are pure and isolated.
  - Shell/integration tests use fakeClackPort, stubbed discoverOverride, and recording spawners where appropriate.
  - E2E tests intentionally exercise the real spawn path for end-to-end verification.
- Test naming and structure conform to the project's conventions.

No TDD violations found (implementations are covered by tests; tests precede/align with commits per commit messages).

## Security & Constraints

- No Roblox legacy APIs or secrets-in-state patterns introduced.
- Optional credential flags are only forwarded via env overrides; no secrets are leaked into argv.

## Code Quality

- TypeScript: Strict-typed; no any usage observed in the inspected files.
- Error handling: Uses typed discriminated unions (SpawnOverrideError) and renders contextual diagnostics.
- Result types: Spawner returns Result<number, SpawnLaunchError>; dispatchOverride uses Result-based returns consistently.
- DI: No direct process.exit or process.cwd() calls without DI — exit and projectRoot are injectable; defaults still rely on process APIs only when not injected.

## Behavioral Correctness

- Per-environment dispatch: Each --env spawns a distinct override invocation (sequentially) when an override is discovered; all envs are attempted even if earlier ones fail.
- Failure handling: launch failures and non-zero exits are rendered as single environment-tagged error lines before the env is recorded as failed; aggregated failure set drives final CLI exit code (EXIT_OK only if all envs succeeded).
- Backwards compatibility: When discoverOverride returns undefined, the in-process deploy() path is used unchanged.

## Observations & Minor Notes

- buildOverrideInvocation intentionally omits optional keys when undefined to allow downstream presence-based routing—this is appropriate and aligns with the spawn protocol.
- Tests include real on-disk fixtures and e2e smoke tests that spawn the CLI via Bun; these provide strong end-to-end guarantees but require Bun availability in CI environments (note: CI must ensure Bun is installed for these e2e tests).
- I verified the listed implementation and test files in the repository; their contents match the PR objectives and the claims in the provided summary.

## Verdict
APPROVED — The changes follow Bedrock's FCIS and ports/adapters architecture, include targeted tests for the new functionality across unit, integration, and e2e layers, maintain DI/port boundaries, and provide clear, typed error handling and rendering for spawn-based override failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->