### PR TITLE
fix(ocale): classify non-json error responses by http status

### DIFF
--- a/packages/bedrock/tests/integration/cli/deploy-override.spec.ts
+++ b/packages/bedrock/tests/integration/cli/deploy-override.spec.ts
@@ -93,11 +93,13 @@ describe("cli deploy override discovery end-to-end", () => {
 
 		expect(code).toBe(0);
 		expect(harness.deploy).not.toHaveBeenCalled();
-		// bun canonicalizes the script path in argv[1] (on macOS the temp dir's
-		// `/var` symlink resolves to `/private/var`), so compare against the
-		// real path of the file discoverOverride resolved.
+		// bun canonicalizes the script path in argv[1]: on macOS the temp dir's
+		// `/var` symlink resolves to `/private/var`, and on Windows 8.3 short
+		// names (CHRIST~1) expand to their long form. realpathSync.native matches
+		// that OS-level canonicalization on every platform; the JS realpathSync
+		// leaves Windows short names intact and would mismatch.
 		expect(readProbe()).toStrictEqual({
-			args: [realpathSync(project.overridePath), "--env", "production"],
+			args: [realpathSync.native(project.overridePath), "--env", "production"],
 			cli: "1",
 		});
 		expect(harness.clack.outro).toHaveBeenCalledExactlyOnceWith("deploy succeeded");

--- a/packages/open-cloud/src/internal/http/fetch-client.spec.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.spec.ts
@@ -676,6 +676,29 @@ describe(createFetchHttpClient, () => {
 		expect(result.err.message).toBe("Failed to parse response body (content-type: unknown)");
 	});
 
+	it("should truncate the raw body retained on a 2xx parse failure", async () => {
+		expect.assertions(1);
+
+		const rawBody = "x".repeat(1000);
+		async function fakeFetch(): Promise<Response> {
+			return new Response(rawBody, {
+				headers: { "content-type": "application/json" },
+				status: 200,
+			});
+		}
+
+		const client = createFetchHttpClient(fakeFetch);
+		const result = await client.request(
+			{ method: "GET", url: "/test" },
+			{ apiKey: "key", baseUrl: "https://example.com" },
+		);
+
+		assert(!result.success);
+		assert(result.err instanceof ApiError);
+
+		expect(result.err.details).toBe("x".repeat(500));
+	});
+
 	it("should classify a non-2xx response with a non-JSON body by its status", async () => {
 		expect.assertions(4);
 

--- a/packages/open-cloud/src/internal/http/fetch-client.spec.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.spec.ts
@@ -630,11 +630,14 @@ describe(createFetchHttpClient, () => {
 		expect(result.err.message).toBe("HTTP 418 (code ALONE)");
 	});
 
-	it("should return ApiError when response body is not valid JSON", async () => {
-		expect.assertions(2);
+	it("should enrich the error when a 2xx body is not valid JSON", async () => {
+		expect.assertions(4);
 
 		async function fakeFetch(): Promise<Response> {
-			return new Response("not json", { status: 200 });
+			return new Response("not json", {
+				headers: { "content-type": "application/json" },
+				status: 200,
+			});
 		}
 
 		const client = createFetchHttpClient(fakeFetch);
@@ -646,8 +649,77 @@ describe(createFetchHttpClient, () => {
 		assert(!result.success);
 		assert(result.err instanceof ApiError);
 
-		expect(result.err.message).toBe("Failed to parse response body");
 		expect(result.err.statusCode).toBe(200);
+		expect(result.err.message).toBe(
+			"Failed to parse response body (content-type: application/json)",
+		);
+		expect(result.err.details).toBe("not json");
+		expect(result.err.cause).toBeInstanceOf(SyntaxError);
+	});
+
+	it("should label content-type unknown when a 2xx parse failure has no content-type", async () => {
+		expect.assertions(1);
+
+		async function fakeFetch(): Promise<Response> {
+			return new Response(new TextEncoder().encode("not json"), { status: 200 });
+		}
+
+		const client = createFetchHttpClient(fakeFetch);
+		const result = await client.request(
+			{ method: "GET", url: "/test" },
+			{ apiKey: "key", baseUrl: "https://example.com" },
+		);
+
+		assert(!result.success);
+		assert(result.err instanceof ApiError);
+
+		expect(result.err.message).toBe("Failed to parse response body (content-type: unknown)");
+	});
+
+	it("should classify a non-2xx response with a non-JSON body by its status", async () => {
+		expect.assertions(4);
+
+		async function fakeFetch(): Promise<Response> {
+			return new Response("<html>502 Bad Gateway</html>", {
+				headers: { "content-type": "text/html" },
+				status: 502,
+			});
+		}
+
+		const client = createFetchHttpClient(fakeFetch);
+		const result = await client.request(
+			{ method: "GET", url: "/test" },
+			{ apiKey: "key", baseUrl: "https://example.com" },
+		);
+
+		assert(!result.success);
+		assert(result.err instanceof ApiError);
+
+		expect(result.err.statusCode).toBe(502);
+		expect(result.err.message).toBe("HTTP 502");
+		expect(result.err.code).toBeUndefined();
+		expect(result.err.details).toBe("<html>502 Bad Gateway</html>");
+	});
+
+	it("should truncate the raw body retained on a non-JSON error response", async () => {
+		expect.assertions(2);
+
+		const rawBody = "x".repeat(1000);
+		async function fakeFetch(): Promise<Response> {
+			return new Response(rawBody, { status: 503 });
+		}
+
+		const client = createFetchHttpClient(fakeFetch);
+		const result = await client.request(
+			{ method: "GET", url: "/test" },
+			{ apiKey: "key", baseUrl: "https://example.com" },
+		);
+
+		assert(!result.success);
+		assert(result.err instanceof ApiError);
+
+		expect(result.err.details).toBe("x".repeat(500));
+		expect(result.err.statusCode).toBe(503);
 	});
 
 	it.for([{ status: 204 }, { status: 200 }])(

--- a/packages/open-cloud/src/internal/http/fetch-client.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.ts
@@ -6,6 +6,18 @@ import type { Result } from "../../types.ts";
 import { tryCatch } from "../utils/try-catch.ts";
 import type { HttpClient, HttpRequest, HttpResponse, RequestConfig } from "./types.ts";
 
+// Caps the raw body retained when a response cannot be parsed, so a multi-KB
+// HTML error page is not surfaced or logged whole.
+const MAX_DETAIL_LENGTH = 500;
+
+const CONTENT_TYPE_HEADER = "content-type";
+
+interface ParseFailureArgs {
+	readonly cause: Error;
+	readonly response: Response;
+	readonly text: string;
+}
+
 interface ApiErrorMessageParts {
 	readonly code: string | undefined;
 	readonly message: string | undefined;
@@ -116,10 +128,10 @@ export function buildFetchOptions(request: HttpRequest, config: RequestConfig): 
 	if (request.body instanceof FormData) {
 		options.body = request.body;
 	} else if (request.body instanceof Uint8Array) {
-		headers.set("content-type", "application/octet-stream");
+		headers.set(CONTENT_TYPE_HEADER, "application/octet-stream");
 		options.body = request.body;
 	} else if (request.body !== undefined) {
-		headers.set("content-type", "application/json");
+		headers.set(CONTENT_TYPE_HEADER, "application/json");
 		options.body = JSON.stringify(request.body);
 	}
 
@@ -244,22 +256,46 @@ function createRateLimitError(response: Response): RateLimitError {
 	});
 }
 
-async function readResponseBody(
-	response: Response,
-): Promise<Result<JSONValue | undefined, OpenCloudError>> {
+/**
+ * Parses response text as JSON, returning the underlying `SyntaxError` on
+ * failure rather than throwing. The synchronous sibling of {@link tryCatch}.
+ *
+ * @param text - The raw response body text.
+ * @returns A Result wrapping the parsed value, or the parse error.
+ */
+function parseJson(text: string): Result<JSONValue> {
 	try {
-		const text = await response.text();
-		return { data: text === "" ? undefined : JSON.parse(text), success: true };
-	} catch {
-		return {
-			err: new ApiError("Failed to parse response body", { statusCode: response.status }),
-			success: false,
-		};
+		return { data: JSON.parse(text), success: true };
+	} catch (err) {
+		return { err: err instanceof Error ? err : new Error(String(err)), success: false };
 	}
 }
 
 /**
+ * Builds the error for a 2xx response whose body could not be parsed as JSON,
+ * preserving the parse `cause`, the (truncated) raw body, and the declared
+ * content-type so the failure can be diagnosed after the fact.
+ *
+ * @param args - The Response, raw body text, and underlying parse error.
+ * @returns An ApiError carrying the diagnostic context.
+ */
+function parseFailureError({ cause, response, text }: ParseFailureArgs): ApiError {
+	const contentType = response.headers.get(CONTENT_TYPE_HEADER) ?? "unknown";
+	return new ApiError(`Failed to parse response body (content-type: ${contentType})`, {
+		cause,
+		details: text.slice(0, MAX_DETAIL_LENGTH),
+		statusCode: response.status,
+	});
+}
+
+/**
  * Classifies a fetch `Response` into a typed `Result`.
+ *
+ * The body is read once and parsed best-effort. Error responses (status >= 300)
+ * never require valid JSON: an error body that is not valid JSON (for example
+ * an HTML gateway page) degrades to a status-based {@link ApiError} carrying
+ * the raw text. A parse failure is only fatal on a 2xx, where a parseable body is part
+ * of the contract.
  *
  * @param response - The raw fetch Response to classify.
  * @returns A Result containing an HttpResponse on success or an OpenCloudError on failure.
@@ -269,18 +305,22 @@ async function classifyResponse(response: Response): Promise<Result<HttpResponse
 		return { err: createRateLimitError(response), success: false };
 	}
 
-	const bodyResult = await readResponseBody(response);
-	if (!bodyResult.success) {
-		return bodyResult;
-	}
+	const text = await response.text();
+	const parsed: Result<JSONValue | undefined> =
+		text === "" ? { data: undefined, success: true } : parseJson(text);
 
 	if (response.status >= 300) {
-		return { err: createApiError(response.status, bodyResult.data), success: false };
+		const body = parsed.success ? parsed.data : text.slice(0, MAX_DETAIL_LENGTH);
+		return { err: createApiError(response.status, body), success: false };
+	}
+
+	if (!parsed.success) {
+		return { err: parseFailureError({ cause: parsed.err, response, text }), success: false };
 	}
 
 	return {
 		data: {
-			body: bodyResult.data,
+			body: parsed.data,
 			headers: headersToRecord(response.headers),
 			status: response.status,
 		},


### PR DESCRIPTION
## What

`classifyResponse` JSON-parsed the response body *before* considering the HTTP status, inside a bare `catch {}` that discarded the bytes, the content-type, and the underlying `SyntaxError`. Two consequences:

- A non-JSON **error** response (e.g. an HTML `502` from the edge/gateway) surfaced as the opaque `Failed to parse response body` instead of its real status.
- A genuine parse failure carried nothing actionable — only `.statusCode`.

Now the body is read once and parsed best-effort, branching by status:

- **non-2xx + non-JSON** → a status-based `ApiError` (`HTTP 502`), with the raw (truncated) text in `details`.
- **2xx + non-JSON** → still fatal (a parseable body is part of the contract), but now carries the `SyntaxError` as `cause`, the truncated body in `details`, and the content-type in the message.

No public-API change — reuses the already-exported `ApiError` options (`details`, and `cause` via `ErrorOptions`). Retry behaviour is unchanged: the parse-failure `ApiError` already carried the real status, so `shouldRetry` already keyed off it.

## Why

A consumer (jest-roblox-cli) hit a flaky `Backend Error: Failed to parse response body` whose `Caused by` chain dead-ended, with no way to tell what came back or whether it was transient. The bytes were destroyed before the error left ocale, so the message could not be improved consumer-side. This classifies the response correctly and preserves the diagnostics needed to investigate a non-reproducible failure.

## Also included

- `test(core)`: the `deploy-override` e2e compared bun's `argv[1]` against `realpathSync`, which on Windows leaves 8.3 short names (`CHRIST~1`) intact while bun reports the long form. Switched to `realpathSync.native`, which canonicalizes on every platform and still resolves the macOS `/var` symlink. This was a pre-existing, Windows-only failure blocking the commit gate, unrelated to the ocale change.

## Verification

- ocale: 60 tests pass, typecheck clean, lint clean
- mutation on `fetch-client.ts`: **100%**, 0 survivors
- core `deploy-override` test: now passes

## Follow-up

- #457 tracks a separate failure-origin / "report to bedrock" attribution idea, scoped to the `Malformed <X> response` parser path (the real likely-ocale-bug signal). Not addressed here.
- No jest-roblox-cli change needed: its renderer already walks `.cause` to depth 5, so `HTTP <status>` and the `SyntaxError` line surface automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Bedrock Code Review: HTTP Response Classification (PR `#458`)

## Architecture Compliance

### FCIS Pattern Assessment
✓ **Adapter Layer Properly Isolated**: `fetch-client.ts` is correctly positioned as an HTTP adapter in `packages/open-cloud/src/internal/http/`. The refactoring maintains clear boundaries:
- Helper functions (`parseJson`, `parseFailureError`) handle pure data transformation
- Main logic (`classifyResponse`) orchestrates response classification
- No business logic bleeds into the adapter

✓ **No I/O in Core**: Response parsing logic is appropriately scoped to the adapter layer.

### Code Quality

✓ **TypeScript Strict Mode**: File uses proper typing with `SyntaxError` and `ApiError` error objects.

✓ **Error Handling**: 
- New `parseFailureError` helper function properly constructs typed `ApiError` instances with:
  - `details` field for truncated raw body (max 500 chars)
  - `cause` property for preserving `SyntaxError` chain
  - `message` field containing content-type information
- Maintains backward compatibility; reuses existing `ApiError` options (ErrorOptions pattern)
- Status-based classification distinguishes between non-2xx errors (not fatal) and 2xx parse failures (fatal)

⚠️ **Constants Definition**: PR introduces `BODY_DETAIL_LIMIT = 500` and `CONTENT_TYPE_HEADER` constants. These should be verified as module-scoped private constants (not public API).

## Testing (TDD Compliance)

### Test Coverage Quality
✓ **Comprehensive Test Suite**: 4 new test cases added to `fetch-client.spec.ts`:
1. **2xx parse failure with known content-type**: Validates `ApiError.message` includes content-type, `statusCode` preserved, raw body truncated in `details`, `SyntaxError` attached as `cause`
2. **2xx parse failure with missing content-type**: Tests fallback to "unknown" content-type label
3. **2xx body truncation**: Verifies 500-character limit enforcement
4. **Non-2xx non-JSON error classification**: Validates HTTP status-based error message (e.g., "HTTP 502"), undefined `code`, full body in `details`
5. **Non-2xx body truncation**: Verifies truncation applies to error responses too

✓ **Proper Test Naming**: Uses `it("should <behavior>")` format (e.g., "should fail to parse a 2xx response with invalid JSON")

✓ **Test Isolation**: Unit tests use mocked fetch responses via `nock` or similar HTTP mocking (not actual I/O)

### Test Adequacy Assessment
⚠️ **Assertion Detail**: Tests verify critical properties but should confirm:
- Branch coverage: Both `status < 300` and `status >= 300` paths exercised
- Error chain integrity: `cause` property correctly chains `SyntaxError`
- Truncation boundaries: Verify exactly 500 chars retained (not 499, not 501)

**Estimated coverage**: Tests cover the refactored logic paths. Mutation test claim ("100% with 0 survivors") should be independently verified.

## Behavioral Changes

### Problem Resolution
✓ **Issue Addressed**: PR fixes the original problem where non-JSON HTTP 502 responses were misclassified as "Failed to parse response body" instead of being reported with actual status.

**Before**: Single `readResponseBody` helper threw on parse failure for all status codes, losing HTTP status context.

**After**: Dual-path logic:
- Non-2xx non-JSON → `ApiError` with status-based message and truncated body
- 2xx non-JSON → `ApiError` with parse error cause and content-type context

✓ **Backward Compatibility**: No public API changes; existing error handling clients remain compatible.

✓ **Retry Behavior Unchanged**: Classification logic modifications don't affect retry policies.

## Secondary Changes

✓ **Path Canonicalization (deploy-override)**: Test change from `realpathSync()` to `realpathSync.native()` correctly addresses Windows path handling. Comment documenting platform-specific behavior (macOS `/private/var`, Windows short-name expansion) is appropriate.

## Security & Constraints

✓ **No Secrets Exposure**: Body truncation prevents accidental credential leakage in error logs (500-char limit reasonable for diagnostic purposes).

✓ **Open Cloud Boundary**: Changes are isolated to open-cloud HTTP adapter; no legacy Roblox API contamination.

## Recommendations

1. **Verify Truncation Precision**: Confirm 500-character limit aligns with log retention policies and UX expectations for error diagnostics.

2. **Test Content-Type Handling**: Ensure tests validate behavior when `content-type` header is malformed or uses unexpected charset declarations.

3. **Mutation Testing Documentation**: Document how the "100% survivors, 0 kills" result was achieved—verify boundary conditions (empty body, exactly 500 chars, status=300, etc.) are tested.

4. **Follow-up PR `#457`**: The related "failure-origin / report to bedrock" attribution tracking is appropriately deferred per PR description.

---

**Overall Assessment**: Architecture, testing, and code quality standards are met. Implementation correctly isolates HTTP adapter concerns and improves diagnostic value for non-reproducible failures. Changes are minimal, focused, and backward-compatible.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->