### PR TITLE
feat(core): discover bedrock.config.* in .bedrock fallback directory

### DIFF
--- a/packages/bedrock/README.md
+++ b/packages/bedrock/README.md
@@ -110,7 +110,7 @@ export BEDROCK_GITHUB_TOKEN=...
 pnpm bedrock deploy --env production
 ```
 
-`bedrock deploy` discovers `bedrock.config.{ts,js,mjs,yaml,yml,json,luau}` in the current directory, loads it, and runs the same reconcile as the programmatic path. Output is rendered via `@clack/prompts` (interactive progress, summary, and error reporting).
+`bedrock deploy` discovers `bedrock.config.{ts,js,mjs,yaml,yml,json,luau}` in the current directory, loads it, and runs the same reconcile as the programmatic path. If no config sits at the project root, bedrock also looks inside `.bedrock/` so you can colocate the file with your other `.bedrock/` artifacts; a root-level config always wins on collision. Output is rendered via `@clack/prompts` (interactive progress, summary, and error reporting).
 
 `--env` may be repeated to deploy to multiple environments in one invocation; each environment is reconciled with its own merged config and its own state slot.
 

--- a/packages/bedrock/src/shell/load-config.spec.ts
+++ b/packages/bedrock/src/shell/load-config.spec.ts
@@ -745,6 +745,140 @@ describe(loadConfig, () => {
 		},
 	);
 
+	it("should discover bedrock.config.ts inside .bedrock/ when the project root has no config", async () => {
+		expect.assertions(1);
+
+		await withTemporaryDirectory(async (cwd) => {
+			const bedrockDirectory = join(cwd, ".bedrock");
+			mkdirSync(bedrockDirectory, { recursive: true });
+			writeFileSync(
+				join(bedrockDirectory, "bedrock.config.ts"),
+				[
+					"import { defineConfig } from '@bedrock-rbx/core';",
+					"export default defineConfig({",
+					"  environments: { production: {} },",
+					"  passes: {",
+					"    'vip-pass': {",
+					"      description: 'Loaded from .bedrock dir.',",
+					"      icon: { 'en-us': 'assets/vip-icon.png' },",
+					"      name: 'Nested Pass',",
+					"      price: 500,",
+					"    },",
+					"  },",
+					"});",
+				].join("\n"),
+			);
+
+			const result = await loadConfig({ cwd });
+
+			assert(result.success);
+
+			expect(result.data.passes!["vip-pass"]!.name).toBe("Nested Pass");
+		});
+	});
+
+	it.skipIf(!HAS_LUTE)(
+		"should discover bedrock.config.luau inside .bedrock/ when the project root has no config",
+		async () => {
+			expect.assertions(1);
+
+			await withTemporaryDirectory(async (cwd) => {
+				const bedrockDirectory = join(cwd, ".bedrock");
+				mkdirSync(bedrockDirectory, { recursive: true });
+				writeFileSync(
+					join(bedrockDirectory, "bedrock.config.luau"),
+					[
+						"return {",
+						"  environments = { production = {} },",
+						"  passes = {",
+						"    ['vip-pass'] = {",
+						"      description = 'Loaded from .bedrock dir.',",
+						"      icon = { ['en-us'] = 'assets/vip-icon.png' },",
+						"      name = 'Nested Luau Pass',",
+						"      price = 500,",
+						"    },",
+						"  },",
+						"}",
+						"",
+					].join("\n"),
+				);
+
+				const result = await loadConfig({ cwd });
+
+				assert(result.success);
+
+				expect(result.data.passes!["vip-pass"]!.name).toBe("Nested Luau Pass");
+			});
+		},
+	);
+
+	it("should prefer the root bedrock.config.* over .bedrock/ when both exist", async () => {
+		expect.assertions(1);
+
+		await withTemporaryDirectory(async (cwd) => {
+			const bedrockDirectory = join(cwd, ".bedrock");
+			mkdirSync(bedrockDirectory, { recursive: true });
+			writeFixtureConfig(cwd, [
+				"export default {",
+				"  environments: { production: {} },",
+				"  passes: {",
+				"    'vip-pass': {",
+				"      description: 'Root wins.',",
+				"      icon: { 'en-us': 'assets/vip-icon.png' },",
+				"      name: 'Root Pass',",
+				"      price: 500,",
+				"    },",
+				"  },",
+				"};",
+			]);
+			writeFileSync(
+				join(bedrockDirectory, "bedrock.config.ts"),
+				[
+					"export default {",
+					"  environments: { production: {} },",
+					"  passes: {",
+					"    'vip-pass': {",
+					"      description: 'Nested loses.',",
+					"      icon: { 'en-us': 'assets/vip-icon.png' },",
+					"      name: 'Nested Pass',",
+					"      price: 500,",
+					"    },",
+					"  },",
+					"};",
+				].join("\n"),
+			);
+
+			const result = await loadConfig({ cwd });
+
+			assert(result.success);
+
+			expect(result.data.passes!["vip-pass"]!.name).toBe("Root Pass");
+		});
+	});
+
+	it("should attribute a parseFailed error to the .bedrock/ config file when that is the only source", async () => {
+		expect.assertions(3);
+
+		await withTemporaryDirectory(async (cwd) => {
+			const bedrockDirectory = join(cwd, ".bedrock");
+			mkdirSync(bedrockDirectory, { recursive: true });
+			const malformedPath = join(bedrockDirectory, "bedrock.config.yaml");
+			writeFileSync(
+				malformedPath,
+				["passes:", "  vip-pass:", '    name: "VIP Pass', "    price: 500", ""].join("\n"),
+			);
+
+			const result = await loadConfig({ cwd });
+
+			assert(!result.success);
+			assert(result.err.kind === "parseFailed");
+
+			expect(result.err.kind).toBe("parseFailed");
+			expect(result.err.sourceFile).toBe(malformedPath);
+			expect(result.err.message.length).toBeGreaterThan(0);
+		});
+	});
+
 	it("should return a fresh copy on each call so mutation does not leak between invocations", async () => {
 		expect.assertions(1);
 

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -255,7 +255,7 @@ function resolveExplicitConfigFile(
 function findConfigInDirectory(directory: string): string | undefined {
 	for (const extension of DISCOVERY_EXTENSIONS) {
 		const candidate = join(directory, `bedrock.config.${extension}`);
-		if (existsSync(candidate)) {
+		if (isExistingFile(candidate)) {
 			return candidate;
 		}
 	}
@@ -263,6 +263,16 @@ function findConfigInDirectory(directory: string): string | undefined {
 	return undefined;
 }
 
+/**
+ * Pick the `.bedrock/bedrock.config.*` fallback only when no `bedrock.config.*`
+ * exists at the project root, letting c12 run its own discovery so a root file
+ * always wins. Other c12 sources (`.bedrockrc`, `package.json#bedrock`) are
+ * still merged in by c12 either way; the configFile we hand back wins
+ * overlapping keys per c12's standard layering precedence.
+ * @param cwd - The directory to search.
+ * @returns Absolute path of the `.bedrock/` candidate, or `undefined` to defer
+ * to c12's own discovery on the project root.
+ */
 function discoverConfigFallback(cwd: string): string | undefined {
 	if (findConfigInDirectory(cwd) !== undefined) {
 		return undefined;

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -20,7 +20,9 @@ export interface LoadConfigOptions {
 	 * Resolved relative to `cwd` when not absolute. Loaded as-is with no
 	 * extension search; if the file does not exist at the given path,
 	 * `loadConfig` returns `fileNotFound`. When omitted, `loadConfig`
-	 * discovers `bedrock.config.{ts,js,...}` from `cwd`.
+	 * discovers `bedrock.config.{ts,js,...}` from `cwd`, falling back to
+	 * `.bedrock/bedrock.config.{ts,js,...}` when the project root has
+	 * none.
 	 */
 	readonly configFile?: string;
 	/**
@@ -61,7 +63,7 @@ export async function loadConfigWith(
 		return explicit;
 	}
 
-	const configFile = explicit.data ?? findConfigInBedrockDirectory(cwd);
+	const configFile = explicit.data ?? discoverConfigFallback(cwd);
 
 	let resolved: Awaited<ReturnType<typeof c12LoadConfig<Record<string, unknown>>>>;
 	try {
@@ -261,7 +263,7 @@ function findConfigInDirectory(directory: string): string | undefined {
 	return undefined;
 }
 
-function findConfigInBedrockDirectory(cwd: string): string | undefined {
+function discoverConfigFallback(cwd: string): string | undefined {
 	if (findConfigInDirectory(cwd) !== undefined) {
 		return undefined;
 	}

--- a/packages/bedrock/src/shell/load-config.ts
+++ b/packages/bedrock/src/shell/load-config.ts
@@ -56,11 +56,12 @@ export async function loadConfigWith(
 	options?: LoadConfigOptions,
 ): Promise<Result<Config, ConfigError>> {
 	const cwd = options?.cwd ?? process.cwd();
-	const configFile =
-		options?.configFile === undefined ? undefined : resolveConfigPath(cwd, options.configFile);
-	if (configFile !== undefined && !isExistingFile(configFile)) {
-		return { err: { kind: "fileNotFound", searchedFrom: cwd }, success: false };
+	const explicit = resolveExplicitConfigFile(cwd, options?.configFile);
+	if (!explicit.success) {
+		return explicit;
 	}
+
+	const configFile = explicit.data ?? findConfigInBedrockDirectory(cwd);
 
 	let resolved: Awaited<ReturnType<typeof c12LoadConfig<Record<string, unknown>>>>;
 	try {
@@ -88,9 +89,12 @@ export async function loadConfigWith(
 /**
  * Discover, parse, and validate the project config.
  *
- * Looks for `bedrock.config.{ts,js,mjs,cjs,yaml,yml,json}`, `.bedrockrc*`,
- * and `package.json#bedrock` starting at `options.cwd` (or the current
- * working directory). Returns a fresh, mutable `Config` on every call so
+ * Looks for `bedrock.config.{ts,js,mjs,cjs,yaml,yml,json,luau}`,
+ * `.bedrockrc*`, and `package.json#bedrock` starting at `options.cwd` (or the
+ * current working directory). When no config sits at the project root, the
+ * loader also probes `.bedrock/bedrock.config.*` so users can colocate the
+ * file with their other `.bedrock/` artifacts. The project root always wins
+ * on collision. Returns a fresh, mutable `Config` on every call so
  * long-running scripts see up-to-date values.
  *
  * When the exported default is a function (sync or async), `loadConfig`
@@ -198,6 +202,12 @@ const NATIVE_CONFIG_EXTENSIONS = [
 	"yml",
 ] as const;
 
+// Discovery probes both the project root and `.bedrock/`. Native formats
+// outrank Luau wherever they coexist; root outranks `.bedrock/`.
+const DISCOVERY_EXTENSIONS = [...NATIVE_CONFIG_EXTENSIONS, "luau"] as const;
+
+const BEDROCK_CONFIG_DIRECTORY = ".bedrock";
+
 interface PickLuauTargetContext {
 	readonly callerConfigFile: string | undefined;
 	readonly cwd: string;
@@ -222,6 +232,41 @@ class EvaluatorThrow extends Error {
 		super();
 		this.configError = configError;
 	}
+}
+
+function resolveExplicitConfigFile(
+	cwd: string,
+	configFile: string | undefined,
+): Result<string | undefined, ConfigError> {
+	if (configFile === undefined) {
+		return { data: undefined, success: true };
+	}
+
+	const resolved = resolveConfigPath(cwd, configFile);
+	if (!isExistingFile(resolved)) {
+		return { err: { kind: "fileNotFound", searchedFrom: cwd }, success: false };
+	}
+
+	return { data: resolved, success: true };
+}
+
+function findConfigInDirectory(directory: string): string | undefined {
+	for (const extension of DISCOVERY_EXTENSIONS) {
+		const candidate = join(directory, `bedrock.config.${extension}`);
+		if (existsSync(candidate)) {
+			return candidate;
+		}
+	}
+
+	return undefined;
+}
+
+function findConfigInBedrockDirectory(cwd: string): string | undefined {
+	if (findConfigInDirectory(cwd) !== undefined) {
+		return undefined;
+	}
+
+	return findConfigInDirectory(join(cwd, BEDROCK_CONFIG_DIRECTORY));
 }
 
 /**
@@ -309,16 +354,20 @@ function extractConfigFileFromStack(err: unknown): string | undefined {
 	return undefined;
 }
 
-function discoverConfigFile(cwd: string): string | undefined {
+function findConfigEntry(directory: string): string | undefined {
 	let entries: ReadonlyArray<string>;
 	try {
-		entries = readdirSync(cwd);
+		entries = readdirSync(directory);
 	} catch {
 		return undefined;
 	}
 
 	const match = entries.toSorted().find((entry) => entry.startsWith("bedrock.config."));
-	return match === undefined ? undefined : join(cwd, match);
+	return match === undefined ? undefined : join(directory, match);
+}
+
+function discoverConfigFile(cwd: string): string | undefined {
+	return findConfigEntry(cwd) ?? findConfigEntry(join(cwd, BEDROCK_CONFIG_DIRECTORY));
 }
 
 function attributeLoadError(err: unknown, cwd: string): ConfigError {

--- a/packages/bedrock/tests/integration/cli/index.spec.ts
+++ b/packages/bedrock/tests/integration/cli/index.spec.ts
@@ -15,7 +15,19 @@ const manifest = require("../../../package.json") as { readonly version: string 
 // transitively-imported top-level statement to that test, classifying
 // genuinely-static schema mutants as "covered" (and surviving) instead
 // of "ignored" by `ignoreStatic`.
-const CLI_ENTRY = fileURLToPath(new URL("../../../src/cli/index.ts", import.meta.url));
+//
+// Strip the Stryker sandbox segment so the spawned bun child resolves
+// modules against the canonical source tree. Bun 1.3.13 returns the
+// package directory itself (EISDIR on `node_modules/sade`) when looking
+// up dependencies from inside `.stryker-tmp/sandbox-XXX/`, but resolves
+// the same dependencies correctly when pointed at the real package
+// path. This test only verifies that module evaluation produces no
+// side effects; the mutants live in the in-process suites below, so
+// using the canonical path here costs no coverage.
+const CLI_ENTRY = fileURLToPath(new URL("../../../src/cli/index.ts", import.meta.url)).replace(
+	/([\\/])\.stryker-tmp\1sandbox-[^\\/]+/,
+	"",
+);
 
 interface CapturedStreams {
 	readonly stderr: ReadonlyArray<string>;


### PR DESCRIPTION
## Summary
- `loadConfig` now also probes `.bedrock/bedrock.config.{ts,mts,cts,js,mjs,cjs,json,yaml,yml,luau}` when the project root has none, so users can colocate the config with their other `.bedrock/` artifacts (state, `deploy.ts`, `config.luau` types). Root config always wins on collision; no new public API.
- Parse-failure attribution walks the same fallback so error messages name the offending file inside `.bedrock/`.
- CLI module-evaluation integration test now spawns bun against the canonical source path, working around a bun 1.3.13 quirk that broke Stryker's dry run from inside `.stryker-tmp/sandbox-XXX/`.

## Test plan
- [x] `pnpm test --filter @bedrock-rbx/core` — 2257/2257 pass (4 new behaviour-slice tests for `.bedrock/` discovery + attribution)
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] `pnpm mutate:changed` — 100% mutation score on `load-config.ts` (13 killed, 0 survived)
- [ ] Smoke-test in a sandbox repo: with no root `bedrock.config.ts` and a valid `.bedrock/bedrock.config.ts`, `bedrock diff` loads the fallback

## Notes
- No breaking change for existing root-level configs.
- The bun-resolution workaround is brittle if Stryker changes its sandbox layout. An upstream bun fix would let us drop the regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Bedrock Code Review: .bedrock/ Config Discovery (PR `#461`)

## Architecture Compliance ✅

**FCIS Pattern Properly Maintained:**
- **Core Layer**: `validateConfig` in `core/schema.ts` remains pure (no I/O)
- **Shell Layer**: `loadConfigWith` and `loadConfig` properly orchestrate—they delegate to Core (`validateConfig`) and Adapters (`createLuteLuauEvaluator`), returning `Result<Config, ConfigError>` per ADR-009
- **Ports**: `LuauEvaluator` port in `ports/luau-evaluator.ts` properly defines the adapter contract
- **Adapters**: `lute-luau-evaluator.ts` is a proper driven adapter implementation

No I/O in Core layer. No business logic bleeding into Adapters. Shell functions are module-level orchestration only.

## Testing (TDD) ✅

**Test Coverage:**
- 4 new unit tests added for `.bedrock/` discovery and precedence:
  - `"should discover bedrock.config.ts inside .bedrock/ when the project root has no config"`
  - `"should discover bedrock.config.luau inside .bedrock/ when the project root has no config"`
  - `"should prefer the root bedrock.config.* over .bedrock/ when both exist"`
  - `"should attribute a parseFailed error to the .bedrock/ config file when that is the only source"`
- All test names follow the `"should <behavior>"` convention
- Mutation testing: 100% mutation score on `load-config.ts` (13 killed, 0 survived)
- 2257/2257 unit tests passing

**Test Isolation:** Tests use real file I/O via `withTemporaryDirectory` (proper integration testing approach), not mocks or stubs. The `loadConfigWith` function accepts an injected `LuauEvaluator` for shell-layer isolation.

**ADR-005 Compliance:** Auto-generated `.example.spec.ts` exists and reflects the public JSDoc `@example` block.

## Code Quality ✅

**Helper Functions Properly Factored:**
- `findConfigInDirectory(directory)` - encapsulates the discovery loop
- `discoverConfigFallback(cwd)` - implements the two-stage logic (root first, then `.bedrock/`)
- `resolveExplicitConfigFile(cwd, configFile)` - handles explicit path validation
- `attributeLoadError(err, cwd)` - walks the fallback path for error attribution via `discoverConfigFile`

**Constants Properly Scoped:**
- `DISCOVERY_EXTENSIONS` includes `.luau` alongside native formats
- `BEDROCK_CONFIG_DIRECTORY = ".bedrock"` is private module-level constant

**Error Handling:** `ConfigError` is a discriminated union with 5 well-defined cases (`fileNotFound`, `parseFailed`, `validationFailed`, `configFunctionFailed`, `luauRuntimeMissing`). Error attribution correctly reflects whether the fallback file was used.

**JSDoc Updated:**
- `LoadConfigOptions.configFile` now documents the fallback location
- `loadConfig` function comments expanded to describe `.bedrock/` probing and precedence rules

## Documentation ✅

README.md updated to state: "If no config sits at the project root, bedrock also looks inside `.bedrock/`; a root-level config always wins on collision."

## Public API ✅

No new public exports. `loadConfig` signature unchanged—fallback discovery is internal behavior. Fully backward compatible.

## Integration Test Workaround ⚠️ Acknowledged

The CLI integration test (`packages/bedrock/tests/integration/cli/index.spec.ts`) uses a Stryker sandbox workaround:
```ts
const CLI_ENTRY = fileURLToPath(new URL("../../../src/cli/index.ts", import.meta.url)).replace(
  /([\\/])\.stryker-tmp\1sandbox-[^\\/]+/,
  "",
);
```

**Assessment:**
- Necessary due to Bun 1.3.13 resolution bug inside Stryker sandboxes (documented in code comments)
- Correctly scoped: only affects the test, not production code
- Test behavior unchanged: still verifies module evaluation produces no stdout/stderr
- **Risk:** Brittle if Stryker changes sandbox path layout (already noted in PR)

## Summary

This PR implements `.bedrock/` fallback discovery following established Bedrock patterns with high-quality tests, proper error attribution, and full backward compatibility. All architectural and testing standards are met. The Stryker workaround is a pragmatic, documented, and appropriately scoped solution to a third-party tool issue.

**Status:** Approved for merge from architecture and standards perspective.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christopher-buss/bedrock/pull/461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->