### PR TITLE
feat(ocale): drop default request timeout for upload methods

### DIFF
--- a/packages/open-cloud/src/client/types.ts
+++ b/packages/open-cloud/src/client/types.ts
@@ -111,7 +111,15 @@ export interface OpenCloudClientOptions {
 	 * use the default `setTimeout`-backed sleep.
 	 */
 	readonly sleep?: SleepFunc;
-	/** Per-request timeout in milliseconds. Defaults to `30_000`. */
+	/**
+	 * Default per-request timeout in milliseconds for JSON-bound methods,
+	 * defaulting to `30_000`. Upload methods (those whose request body is
+	 * `FormData` or `Uint8Array`, such as place publishes and icon uploads)
+	 * have no default deadline and ignore this option: upload latency is
+	 * bandwidth-bound, and the SDK cannot size a wall-clock budget without
+	 * knowing payload size and link quality. Set a deadline on any single
+	 * call, upload or otherwise, with `options.timeout`.
+	 */
 	readonly timeout?: number;
 }
 

--- a/packages/open-cloud/src/internal/http/upload-request.spec.ts
+++ b/packages/open-cloud/src/internal/http/upload-request.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import type { HttpRequest } from "../../client/types.ts";
+import { isUploadRequest } from "./upload-request.ts";
+
+describe(isUploadRequest, () => {
+	it("should treat a FormData body as an upload request", () => {
+		expect.assertions(1);
+
+		const request = {
+			body: new FormData(),
+			method: "POST",
+			url: "/upload",
+		} satisfies HttpRequest;
+
+		expect(isUploadRequest(request)).toBeTrue();
+	});
+
+	it("should treat a Uint8Array body as an upload request", () => {
+		expect.assertions(1);
+
+		const request = {
+			body: new Uint8Array([1, 2, 3]),
+			method: "POST",
+			url: "/upload",
+		} satisfies HttpRequest;
+
+		expect(isUploadRequest(request)).toBeTrue();
+	});
+
+	it("should not treat a JSON body as an upload request", () => {
+		expect.assertions(1);
+
+		const request = { body: { name: "x" }, method: "POST", url: "/json" } satisfies HttpRequest;
+
+		expect(isUploadRequest(request)).toBeFalse();
+	});
+
+	it("should not treat a body-less request as an upload request", () => {
+		expect.assertions(1);
+
+		const request = { method: "GET", url: "/json" } satisfies HttpRequest;
+
+		expect(isUploadRequest(request)).toBeFalse();
+	});
+});

--- a/packages/open-cloud/src/internal/http/upload-request.ts
+++ b/packages/open-cloud/src/internal/http/upload-request.ts
@@ -1,0 +1,15 @@
+import type { HttpRequest } from "../../client/types.ts";
+
+/**
+ * Reports whether a request is an upload: its body is `FormData`
+ * (multipart) or `Uint8Array` (raw binary). Upload latency is
+ * bandwidth-bound rather than compute-bound, so the SDK applies no default
+ * request timeout to these requests; a sensible wall-clock budget depends on
+ * payload size and link quality the SDK cannot know.
+ *
+ * @param request - The built request to classify.
+ * @returns `true` when the body is `FormData` or `Uint8Array`.
+ */
+export function isUploadRequest(request: HttpRequest): boolean {
+	return request.body instanceof FormData || request.body instanceof Uint8Array;
+}

--- a/packages/open-cloud/src/internal/resource-client.spec.ts
+++ b/packages/open-cloud/src/internal/resource-client.spec.ts
@@ -37,6 +37,10 @@ function buildTestPostRequest(parameters: TestParameters): HttpRequest {
 	return { body: { id: parameters.id }, method: "POST", url: "/test" };
 }
 
+function buildTestUploadRequest(): HttpRequest {
+	return { body: new Uint8Array([1, 2, 3]), method: "POST", url: "/upload" };
+}
+
 const TEST_GET_SPEC: ResourceMethodSpec<TestParameters, TestResult> = {
 	buildRequest: (parameters) => okRequest({ method: "GET", url: `/test/${parameters.id}` }),
 	methodDefaults: IDEMPOTENT_METHOD_DEFAULTS,
@@ -50,6 +54,14 @@ const TEST_CREATE_SPEC: ResourceMethodSpec<TestParameters, TestResult> = {
 	methodDefaults: CREATE_METHOD_DEFAULTS,
 	methodKind: "create",
 	operationLimit: Object.freeze({ maxPerSecond: 5, operationKey: "test.create" }),
+	parse: parseTestResponse,
+};
+
+const TEST_UPLOAD_SPEC: ResourceMethodSpec<TestParameters, TestResult> = {
+	buildRequest: () => okRequest(buildTestUploadRequest()),
+	methodDefaults: CREATE_METHOD_DEFAULTS,
+	methodKind: "create",
+	operationLimit: Object.freeze({ maxPerSecond: 5, operationKey: "test.upload" }),
 	parse: parseTestResponse,
 };
 
@@ -211,6 +223,70 @@ describe(ResourceClient, () => {
 			assert(!result.success);
 
 			expect(httpClient.requests).toHaveLength(1);
+		});
+	});
+
+	describe("upload timeout policy", () => {
+		it("should drop the default timeout for an upload request with no per-request timeout", async () => {
+			expect.assertions(1);
+
+			const httpClient = createFakeHttpClient({ schemaValidation: "off" }).mockResponse({
+				status: 200,
+			});
+			const client = new ResourceClient({
+				apiKey: "client-key",
+				baseUrl: "https://apis.roblox.com",
+				httpClient,
+				sleep: createFakeSleep(),
+				timeout: 30_000,
+			});
+
+			await client.execute({ parameters: { id: "1" }, spec: TEST_UPLOAD_SPEC });
+
+			expect(httpClient.requests[0]?.config).toStrictEqual({
+				apiKey: "client-key",
+				baseUrl: "https://apis.roblox.com",
+			});
+		});
+
+		it("should apply an explicit per-request timeout to an upload request", async () => {
+			expect.assertions(1);
+
+			const httpClient = createFakeHttpClient({ schemaValidation: "off" }).mockResponse({
+				status: 200,
+			});
+			const client = new ResourceClient({
+				apiKey: "client-key",
+				httpClient,
+				sleep: createFakeSleep(),
+				timeout: 30_000,
+			});
+
+			await client.execute({
+				options: { timeout: 1000 },
+				parameters: { id: "1" },
+				spec: TEST_UPLOAD_SPEC,
+			});
+
+			expect(httpClient.requests[0]?.config.timeout).toBe(1000);
+		});
+
+		it("should keep the default timeout for a JSON request with no per-request timeout", async () => {
+			expect.assertions(1);
+
+			const httpClient = createFakeHttpClient({ schemaValidation: "off" }).mockResponse({
+				status: 200,
+			});
+			const client = new ResourceClient({
+				apiKey: "client-key",
+				httpClient,
+				sleep: createFakeSleep(),
+				timeout: 30_000,
+			});
+
+			await client.execute({ parameters: { id: "1" }, spec: TEST_CREATE_SPEC });
+
+			expect(httpClient.requests[0]?.config.timeout).toBe(30_000);
 		});
 	});
 

--- a/packages/open-cloud/src/internal/resource-client.ts
+++ b/packages/open-cloud/src/internal/resource-client.ts
@@ -6,6 +6,7 @@ import type {
 	HttpResponse,
 	OpenCloudClientOptions,
 	OpenCloudHooks,
+	RequestConfig,
 	RequestOptions,
 	SleepFunc,
 } from "../client/types.ts";
@@ -23,6 +24,7 @@ import {
 	type MethodKind,
 	type RetryResolvable,
 } from "./http/retry.ts";
+import { isUploadRequest } from "./http/upload-request.ts";
 
 /**
  * Describes a single resource method's shape for dispatch through
@@ -124,6 +126,18 @@ const CLIENT_DEFAULTS = Object.freeze({
 } satisfies Except<RetryResolvable, "apiKey">);
 
 /**
+ * Inputs to {@link buildRequestConfig}, bundled to keep the signature narrow.
+ */
+interface RequestConfigInputs {
+	/** The resolved config for this call. */
+	readonly merged: RetryResolvable;
+	/** The caller's per-request overrides, if any. */
+	readonly options: RequestOptions | undefined;
+	/** The built request, inspected for an upload body. */
+	readonly request: HttpRequest;
+}
+
+/**
  * Internal orchestrator shared by every Open Cloud resource client. Holds
  * the frozen client config, observability hooks, injected HTTP client and
  * sleep, and the per-effective-key rate-limit queue registry. Resource
@@ -184,11 +198,7 @@ export class ResourceClient {
 			return requestResult;
 		}
 
-		const requestConfig = {
-			apiKey: merged.apiKey,
-			baseUrl: merged.baseUrl,
-			timeout: merged.timeout,
-		};
+		const requestConfig = buildRequestConfig({ merged, options, request: requestResult.data });
 		const queue = this.#getQueue(merged.apiKey, spec.operationLimit);
 		const httpResult = await queue.acquire(async () => {
 			return executeWithRetry(requestResult.data, {
@@ -225,6 +235,27 @@ export class ResourceClient {
 		this.#queues.set(key, queue);
 		return queue;
 	}
+}
+
+/**
+ * Resolves the per-request {@link RequestConfig}. Upload requests
+ * ({@link isUploadRequest}) carry no default timeout: a multi-megabyte place
+ * file over a slow link is bandwidth-bound, so a client-side deadline only
+ * fires spuriously. An explicit `options.timeout` still applies to any
+ * request; every non-upload request keeps the merged default.
+ *
+ * @param inputs - The merged config, the built request, and per-request overrides.
+ * @returns The config to hand to the transport, with `timeout` omitted when
+ *   no client-side deadline should apply.
+ */
+function buildRequestConfig(inputs: RequestConfigInputs): RequestConfig {
+	const { merged, options, request } = inputs;
+	const shouldOmitDefaultTimeout = options?.timeout === undefined && isUploadRequest(request);
+	return {
+		apiKey: merged.apiKey,
+		baseUrl: merged.baseUrl,
+		...(shouldOmitDefaultTimeout ? {} : { timeout: merged.timeout }),
+	};
 }
 
 function enrichPermissionError<P, T>(

--- a/packages/open-cloud/src/resources/badges/client.ts
+++ b/packages/open-cloud/src/resources/badges/client.ts
@@ -110,6 +110,9 @@ interface BadgeLocalizationHandle {
 	 * upload cannot be created if the server fails mid-write. Source-language
 	 * icons remain on {@link BadgesClient.uploadIcon}.
 	 *
+	 * No default request timeout applies to this upload; pass `options.timeout`
+	 * to set a per-call deadline.
+	 *
 	 * @param parameters - Badge and language identifiers plus the image bytes
 	 *   to upload.
 	 * @param options - Optional per-request overrides.
@@ -170,6 +173,9 @@ export class BadgesClient {
 	/**
 	 * Creates a new badge under the supplied universe.
 	 *
+	 * No default request timeout applies to this upload; pass `options.timeout`
+	 * to set a per-call deadline.
+	 *
 	 * @param parameters - Creation fields including the universe, name, and
 	 *   icon image.
 	 * @param options - Optional per-request overrides.
@@ -206,6 +212,9 @@ export class BadgesClient {
 	 * badge. A subsequent upload for the same badge replaces the
 	 * existing source icon. Does not retry on 5xx so a duplicate icon
 	 * upload cannot be created if the server fails mid-write.
+	 *
+	 * No default request timeout applies to this upload; pass `options.timeout`
+	 * to set a per-call deadline.
 	 *
 	 * @param parameters - Identifier plus the image bytes to upload.
 	 * @param options - Optional per-request overrides.

--- a/packages/open-cloud/src/resources/developer-products/client.ts
+++ b/packages/open-cloud/src/resources/developer-products/client.ts
@@ -114,6 +114,9 @@ interface DeveloperProductLocalizationHandle {
 	 * the existing icon for that locale. Does not retry on 5xx so a duplicate
 	 * upload cannot be created if the server fails mid-write.
 	 *
+	 * No default request timeout applies to this upload; pass `options.timeout`
+	 * to set a per-call deadline.
+	 *
 	 * @param parameters - Product and language identifiers plus the image
 	 *   bytes to upload.
 	 * @param options - Optional per-request overrides.
@@ -178,6 +181,9 @@ export class DeveloperProductsClient {
 	/**
 	 * Creates a new developer product under the supplied universe.
 	 *
+	 * No default request timeout applies to this upload; pass `options.timeout`
+	 * to set a per-call deadline.
+	 *
 	 * @param parameters - Creation fields including the universe and product name.
 	 * @param options - Optional per-request overrides.
 	 * @returns A {@link Result} wrapping the parsed {@link DeveloperProduct} or
@@ -212,6 +218,9 @@ export class DeveloperProductsClient {
 	 * Callers that need the post-update state (for example to observe a
 	 * server-derived `updatedTimestamp`) chain {@link DeveloperProductsClient.get}
 	 * themselves so the GET only fires when actually needed.
+	 *
+	 * No default request timeout applies to this upload; pass `options.timeout`
+	 * to set a per-call deadline.
 	 *
 	 * @param parameters - The universe and product identifiers and the
 	 *   fields to update. Only fields explicitly provided are forwarded.

--- a/packages/open-cloud/src/resources/game-passes/client.ts
+++ b/packages/open-cloud/src/resources/game-passes/client.ts
@@ -126,6 +126,9 @@ interface GamePassLocalizationHandle {
 	 * existing icon for that locale. Does not retry on 5xx so a duplicate
 	 * upload cannot be created if the server fails mid-write.
 	 *
+	 * No default request timeout applies to this upload; pass `options.timeout`
+	 * to set a per-call deadline.
+	 *
 	 * @param parameters - Game pass and language identifiers plus the image
 	 *   bytes to upload.
 	 * @param options - Optional per-request overrides.
@@ -209,6 +212,9 @@ export class GamePassesClient {
 	/**
 	 * Creates a new game pass under the supplied universe.
 	 *
+	 * No default request timeout applies to this upload; pass `options.timeout`
+	 * to set a per-call deadline.
+	 *
 	 * @param parameters - Creation fields including the universe and pass name.
 	 * @param options - Optional per-request overrides.
 	 * @returns A {@link Result} wrapping the parsed {@link GamePass} or the
@@ -261,6 +267,9 @@ export class GamePassesClient {
 	 * observe a server-derived `updatedAt`) chain
 	 * {@link GamePassesClient.get} themselves so the GET only fires when
 	 * actually needed.
+	 *
+	 * No default request timeout applies to this upload; pass `options.timeout`
+	 * to set a per-call deadline.
 	 *
 	 * @param parameters - The universe and game pass identifiers and the
 	 *   fields to update. Only fields explicitly provided are forwarded.

--- a/packages/open-cloud/src/resources/places/client.ts
+++ b/packages/open-cloud/src/resources/places/client.ts
@@ -200,6 +200,9 @@ export class PlacesClient {
 	/**
 	 * Publishes a new live version of a place.
 	 *
+	 * No default request timeout applies to this upload; pass `options.timeout`
+	 * to set a per-call deadline.
+	 *
 	 * @param parameters - Universe and place identifiers, the place file
 	 *   bytes, and their declared `format`.
 	 * @param options - Optional per-request overrides (e.g. A different
@@ -220,6 +223,9 @@ export class PlacesClient {
 	 * promote it later. Shares a single per-API-key rate-limit queue with
 	 * `publish` because Roblox attributes both calls to the same per-minute
 	 * quota.
+	 *
+	 * No default request timeout applies to this upload; pass `options.timeout`
+	 * to set a per-call deadline.
 	 *
 	 * @param parameters - Universe and place identifiers, the place file
 	 *   bytes, and their declared `format`.

--- a/packages/open-cloud/src/resources/universes/client.ts
+++ b/packages/open-cloud/src/resources/universes/client.ts
@@ -201,6 +201,9 @@ interface UniverseIconHandle {
 	 * subsequent upload for the same `(universeId, languageCode)` pair
 	 * replaces the existing icon for that locale.
 	 *
+	 * No default request timeout applies to this upload; pass `options.timeout`
+	 * to set a per-call deadline.
+	 *
 	 * @param parameters - Universe and language identifiers plus the image
 	 *   bytes to upload.
 	 * @param options - Optional per-request overrides (e.g. A different
@@ -249,6 +252,9 @@ interface UniverseThumbnailsHandle {
 	 * Uploads a new thumbnail and appends it to the localized carousel. Use
 	 * {@link UniverseThumbnailsHandle.reorder} after multiple uploads to
 	 * set the display order.
+	 *
+	 * No default request timeout applies to this upload; pass `options.timeout`
+	 * to set a per-call deadline.
 	 *
 	 * @param parameters - Universe and language identifiers plus the image
 	 *   bytes to upload.


### PR DESCRIPTION
Closes #462

## What changed

Upload methods in `@bedrock-rbx/ocale` (resource methods whose request body is `FormData` or `Uint8Array`) no longer inherit the 30s default request timeout. Upload latency is bandwidth-bound rather than compute-bound, so a fixed wall-clock budget aborts large place files or slow links spuriously, and the SDK cannot size a sensible deadline without knowing the caller's payload size and link quality.

JSON-bound methods keep the existing 30s default. Any method, upload or otherwise, still honours an explicit per-call `options.timeout`.

The "upload method" definition is structural: a new pure predicate `isUploadRequest` classifies the built request by body type, so any future upload method picks up the same treatment automatically. The decision is made in `ResourceClient.execute`, where both the built request body and the raw caller `options` are still visible (by the time the request reaches the transport, the resolved timeout is indistinguishable from a default). When no client-side deadline should apply, the `timeout` key is omitted from the request config entirely, which `buildFetchOptions` already treats as "no `AbortSignal`".

## Acceptance criteria

- [x] An upload method with no `options.timeout` does not abort client-side, regardless of how long the request takes (the client-level `timeout` and the built-in default are both suppressed for uploads).
- [x] An upload method with an explicit `options.timeout` aborts at that deadline.
- [x] JSON-bound methods continue to apply the existing default when no `options.timeout` is passed.
- [x] The client-level `timeout` option's docstring describes which methods do and don't have a default.
- [x] Each of the 13 upload methods (`places.publish`/`save`, `badges.create`/`uploadIcon`/`localization.uploadIcon`, `developerProducts.create`/`update`/`localization.uploadIcon`, `gamePasses.create`/`update`/`localization.uploadIcon`, `universes.icon.upload`/`thumbnails.upload`) notes that no default deadline applies.

## Tests

New unit spec for `isUploadRequest` (FormData/Uint8Array → upload; JSON/body-less → not) and three integration specs in `resource-client.spec.ts` covering upload-no-timeout (no deadline), upload-with-explicit-timeout (honoured), and JSON-no-timeout (default kept). Full suite (1507 tests), typecheck, lint, build, and 100% mutation score on the touched `src/**` files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Bedrock Code Review: Drop Default Request Timeout for Upload Methods

## ✅ Architecture (FCIS Pattern) - COMPLIANT

**Core Layer (Pure Functions)**
- `isUploadRequest(request: HttpRequest): boolean` in `upload-request.ts` is a pure predicate with no I/O or side effects. Cleanly classifies upload requests by inspecting `request.body` for `FormData` or `Uint8Array`.
- `buildRequestConfig(inputs: RequestConfigInputs): RequestConfig` is a pure function with no side effects. Centralizes the conditional timeout logic: omits the timeout key when handling an upload request without explicit `options.timeout`.
- Both functions are isolated from the runtime HTTP layer and can be tested independently.

**Shell Layer (Orchestration)**
- `ResourceClient.execute()` correctly orchestrates the flow: builds the request, calls `buildRequestConfig()` to resolve the transport config, then delegates to the HTTP client.
- Decision to place timeout logic at this layer is sound—the request builder and caller options are both visible here, so future upload methods automatically inherit the behavior without modification.

**No violations**: No I/O or side effects in Core; business logic properly delegated to Shell.

---

## ✅ Testing (TDD Required) - COMPLIANT

**Test Naming & Structure**
All tests follow the `it("should <behavior>")` format:
- `isUploadRequest.spec.ts`: 4 tests covering FormData ✓, Uint8Array ✓, JSON object ✗, no body ✗
- `resource-client.spec.ts` "upload timeout policy": 3 integration tests
  - "should drop the default timeout for an upload request with no per-request timeout"
  - "should apply an explicit per-request timeout to an upload request"
  - "should keep the default timeout for a JSON request with no per-request timeout"

**Test Isolation & Mocking**
- Uses `FakeHttpClient` (from `#tests/helpers/fake-http-client-validated`) for HTTP mocking ✓
- Uses `createFakeSleep()` for deterministic retry/rate-limit timing ✓
- No real I/O; tests are fast and repeatable ✓

**Coverage**
- Core logic fully exercised: `isUploadRequest()` tests both positive (FormData, Uint8Array) and negative (JSON, absent) branches.
- Integration tests verify config passed to `HttpClient.request()`:
  - Upload without `options.timeout` → `config` lacks `timeout` field ✓
  - Upload with `options.timeout: 1000` → `config.timeout === 1000` ✓
  - JSON request → `config.timeout === 30_000` (default) ✓

**Assertion Discipline**
- Each test declares `expect.assertions(N)` to ensure expectations actually run ✓
- Assertions inspect the actual config object passed to the HTTP client, not mocked behavior ✓

---

## ✅ Test Isolation - COMPLIANT

| Layer | Implementation | Isolation |
|-------|---|---|
| Core (`isUploadRequest`) | Unit tests | Pure function, no seams needed |
| Shell (`ResourceClient.execute`) | Integration tests | Fake HTTP client + fake sleep |
| Adapter (HTTP layer) | Not modified in this PR | Receives config as-is |

---

## ✅ Code Quality - COMPLIANT

**TypeScript Strict Mode**
- No `any` types observed.
- Request and config types are properly typed with `HttpRequest`, `RequestConfig`, `RequestConfigInputs`.
- Spread operator usage for conditional `timeout` inclusion is type-safe: `...(shouldOmitDefaultTimeout ? {} : { timeout: merged.timeout })`.

**Error Handling**
- No new error cases introduced; timeout omission is transparent to callers.
- Explicit control via `options.timeout` remains always available.

**No Breaking Changes**
- Public API signatures unchanged.
- Behavior change (timeout omission for uploads) is backward-compatible: callers relying on no timeout for uploads benefit immediately; callers who need a deadline can supply `options.timeout`.

---

## ✅ Documentation - COMPLIANT

**Client-Level JSDoc** (`types.ts`)
- Updated `OpenCloudClientOptions.timeout` to clarify:
  - Default `30_000` ms applies to JSON-bound methods only.
  - Upload methods (FormData or Uint8Array bodies) have no default deadline.
  - Per-call `options.timeout` always honored.

**Method-Level JSDoc Updates**
All 13 upload methods documented consistently across six client files:
- `BadgeLocalizationHandle.uploadIcon`, `BadgesClient.create` (icon)
- `DeveloperProductLocalizationHandle.uploadIcon`, `DeveloperProductsClient.create`/`update`
- `GamePassLocalizationHandle.uploadIcon`, `GamePassesClient.create`/`update`
- `PlacesClient.publish`, `PlacesClient.save`
- `UniversesClient.icon.upload`, `UniversesClient.thumbnails.upload`

Each clarifies: "No default request timeout applies to this upload; pass `options.timeout` to set a per-call deadline."

---

## ✅ Per-Request Control - PRESERVED

The PR maintains Bedrock's per-request override pattern (ADR-012):
- Caller may pass `options.timeout` on any method (upload or JSON) to override or set a deadline.
- Example: `client.publish(params, { timeout: 60_000 })` for a 1-minute upload deadline.
- Aligns with the Stainless SDK pattern documented in `CLAUDE.md`.

---

## Summary

This PR cleanly implements upload timeout exemption within Bedrock's FCIS architecture. The pure `isUploadRequest()` predicate and `buildRequestConfig()` orchestrator are properly isolated and tested. All 7 new tests (4 unit, 3 integration) follow strict naming and isolation discipline. Documentation is comprehensive and consistent across all 13 affected upload methods. No breaking changes; per-call control is preserved. **Approved for merge.**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->