### PR TITLE
fix: use relative path for worktree hook commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,7 +30,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "bun ${CLAUDE_PROJECT_DIR}/scripts/worktree-create.ts",
+						"command": "bun scripts/worktree-create.ts",
 						"timeout": 600
 					}
 				]
@@ -41,7 +41,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "bun ${CLAUDE_PROJECT_DIR}/scripts/worktree-remove.ts",
+						"command": "bun scripts/worktree-remove.ts",
 						"timeout": 120
 					}
 				]


### PR DESCRIPTION
## Problem

The merged WorktreeCreate/WorktreeRemove hooks used `bun ${CLAUDE_PROJECT_DIR}/scripts/worktree-*.ts`. The desktop "create in worktree" flow runs hook commands **without** substituting `${CLAUDE_PROJECT_DIR}`, so bun received a literal path and failed:

```
WorktreeCreate hook failed: bun ${CLAUDE_PROJECT_DIR}/scripts/worktree-create.ts:
error: Module not found "${CLAUDE_PROJECT_DIR}/scripts/worktree-create.ts"
```

## Fix

Drop the prefix; run the hooks via the relative `bun scripts/worktree-*.ts`. The scripts already resolve the project dir from `CLAUDE_PROJECT_DIR` when set and fall back to the hook's cwd (project root) when it isn't — which is exactly this case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)