### PR TITLE
feat(ocale): derive luau-execution request timeout from poll budget

### DIFF
--- a/docs/adr/010-sdk-managed-rate-limiting-and-retry.md
+++ b/docs/adr/010-sdk-managed-rate-limiting-and-retry.md
@@ -336,3 +336,54 @@ New public surface: `retryableTransportCodes` on `OpenCloudClientOptions` and
 `maxConsecutivePollFailures` on the poll options. The create idempotency
 guarantee is unchanged — duplicate-resource risk stays gated behind an
 explicit per-request opt-in.
+
+## Amendment: 2026-06-17, per-request timeout follows the poll budget for polled operations
+
+The original Decision treats the 30s per-request `timeout` as a universal
+default and the prior amendment reinforces it: "a genuine 30s timeout is a real
+signal, not a transient blip," and a self-abort — carrying no node-style
+`code` — is never retried. That holds for snappy CRUD, where 30s of silence is
+a genuine fault.
+
+It does not hold for `LuauExecutionClient.tasks.runUntilDone` /
+`pollUntilDone`. The submit endpoint only enqueues a task (it "does not wait for
+the task to complete"), and a poll `get` is a plain state read, so both should
+answer in well under a second. But Roblox's task-create and cold-`get` latencies
+routinely spike past 30s under load. When they do, the request self-aborts at
+the 30s default — an error the retry layer excludes by construction and the poll
+loop classifies as a hard failure — so the operation dies before its own
+wall-clock budget (`timeoutMs`) is ever consulted. This produced frequent,
+non-recoverable timeout failures in the jest-roblox-cli runner, whose poll
+budget is 5 minutes.
+
+The fix derives the per-request deadline from the budget the caller already
+declared rather than a fixed constant:
+
+- **`runUntilDone` and `pollUntilDone` default each submit and poll request's
+  `timeout` to `timeoutMs`** (falling back to the 300s default budget) when the
+  caller has not set one. The value is not a magic number — it is the patience
+  the caller already chose for the whole operation. A single request stays alive
+  long enough for the backend to answer or to surface a *retryable* status (a
+  5xx, or a TCP-level `ECONNRESET`) instead of a self-abort the retry layer
+  never retries.
+- **An explicit per-request `timeout` still wins**, via the same merge
+  precedence that scopes the retry fields. This is why the default is applied in
+  the options layer and not as a method default: for the idempotent poll `get`,
+  client config beats method defaults, but per-request options beat both.
+
+This is the same recognition behind dropping the default timeout for upload
+methods (christopher-buss/bedrock#463): the one-size 30s CRUD default does not
+fit every request class. The two carve-outs differ in shape — uploads omit the
+deadline entirely because their duration is bandwidth-bound and unknowable,
+whereas polled luau-execution requests keep a *finite* budget-derived deadline
+so a true black-hole still bails and a TCP reset stays retryable.
+
+No new public surface: the behavior lives in an internal helper applied at the
+two polling entry points and is not exported from the package barrel.
+
+A latent gap remains and is tracked separately
+(christopher-buss/bedrock#466): the poll budget is only checked between
+iterations and is not wired to an in-flight `AbortSignal`, so a single request
+is still not bounded by the *remaining* budget, and budget exhaustion mid-flight
+surfaces as a transport `NetworkError` rather than the documented
+`PollTimeoutError`.

--- a/packages/open-cloud/src/resources/luau-execution/client.ts
+++ b/packages/open-cloud/src/resources/luau-execution/client.ts
@@ -35,7 +35,11 @@ import {
 } from "../../internal/resource-client.ts";
 import type { Result } from "../../types.ts";
 import { buildPollDeps, submitAndPoll } from "./polling-helpers.ts";
-import { pollUntilDoneCore, type PollUntilDoneOptions } from "./polling.ts";
+import {
+	pollUntilDoneCore,
+	type PollUntilDoneOptions,
+	withBudgetRequestTimeout,
+} from "./polling.ts";
 
 function makeSpec<P, R>(spec: ResourceMethodSpec<P, R>): ResourceMethodSpec<P, R> {
 	return Object.freeze(spec);
@@ -216,10 +220,11 @@ function createTasksHandle(inner: ResourceClient): TasksHandle {
 			return inner.execute({ options, parameters, spec: LIST_LOGS_SPEC });
 		},
 		async pollUntilDone(ref, options = {}) {
-			return pollUntilDoneCore(buildPollDeps(inner, { options, ref }), options);
+			const resolved = withBudgetRequestTimeout(options);
+			return pollUntilDoneCore(buildPollDeps(inner, { options: resolved, ref }), resolved);
 		},
 		async runUntilDone(parameters, options = {}) {
-			return submitAndPoll(inner, { options, parameters });
+			return submitAndPoll(inner, { options: withBudgetRequestTimeout(options), parameters });
 		},
 		async submit(parameters, options) {
 			if ("versionId" in parameters) {

--- a/packages/open-cloud/src/resources/luau-execution/polling.spec.ts
+++ b/packages/open-cloud/src/resources/luau-execution/polling.spec.ts
@@ -18,6 +18,7 @@ import {
 	defaultPollDelay,
 	type PollDeps,
 	pollUntilDoneCore,
+	withBudgetRequestTimeout,
 } from "./polling.ts";
 
 const ref: LuauExecutionTaskRef = {
@@ -566,5 +567,27 @@ describe(defaultPollDelay, () => {
 		expect.assertions(1);
 
 		expect(defaultPollDelay(elapsedMs)).toBe(expected);
+	});
+});
+
+describe(withBudgetRequestTimeout, () => {
+	it("should derive the per-request timeout from the poll budget when none is set", () => {
+		expect.assertions(1);
+
+		expect(withBudgetRequestTimeout({ timeoutMs: 120_000 }).timeout).toBe(120_000);
+	});
+
+	it("should preserve an explicit per-request timeout over the poll budget", () => {
+		expect.assertions(1);
+
+		expect(withBudgetRequestTimeout({ timeout: 5_000, timeoutMs: 120_000 }).timeout).toBe(
+			5_000,
+		);
+	});
+
+	it("should fall back to the default poll budget when neither timeout nor timeoutMs is set", () => {
+		expect.assertions(1);
+
+		expect(withBudgetRequestTimeout({}).timeout).toBe(DEFAULT_POLL_TIMEOUT_MS);
 	});
 });

--- a/packages/open-cloud/src/resources/luau-execution/polling.ts
+++ b/packages/open-cloud/src/resources/luau-execution/polling.ts
@@ -100,15 +100,15 @@ interface PollOptions {
 /**
  * Defaults the per-request `timeout` to the effective poll budget when the
  * caller has not set one. A luau-execution submit and each poll `get` normally
- * answer in well under a second — the submit endpoint enqueues the task without
- * waiting for it to run — so the only job of a per-request deadline here is to
+ * answer in well under a second (the submit endpoint enqueues the task without
+ * waiting for it to run), so the only job of a per-request deadline here is to
  * bound a black-hole connection. Leaving these requests on the client-wide 30s
  * default (tuned for snappy CRUD) turns a slow-but-alive backend into a
- * self-abort — an error the retry layer never retries by construction — before
+ * self-abort, an error the retry layer never retries by construction, before
  * the loop's wall-clock budget is ever consulted. Deriving the deadline from
- * `timeoutMs` keeps a single request
- * alive exactly as long as the caller already agreed to wait for the whole
- * operation, so the backend can answer or surface a retryable status instead.
+ * `timeoutMs` keeps a single request alive exactly as long as the caller
+ * already agreed to wait for the whole operation, so the backend can answer or
+ * surface a retryable status instead.
  *
  * @param options - The caller's poll and per-request options.
  * @returns The options with `timeout` filled from the budget when it was unset.

--- a/packages/open-cloud/src/resources/luau-execution/polling.ts
+++ b/packages/open-cloud/src/resources/luau-execution/polling.ts
@@ -97,6 +97,30 @@ interface PollOptions {
 	readonly timeoutMs?: number;
 }
 
+/**
+ * Defaults the per-request `timeout` to the effective poll budget when the
+ * caller has not set one. A luau-execution submit and each poll `get` normally
+ * answer in well under a second — the submit endpoint enqueues the task without
+ * waiting for it to run — so the only job of a per-request deadline here is to
+ * bound a black-hole connection. Leaving these requests on the client-wide 30s
+ * default (tuned for snappy CRUD) turns a slow-but-alive backend into a
+ * self-abort — an error the retry layer never retries by construction — before
+ * the loop's wall-clock budget is ever consulted. Deriving the deadline from
+ * `timeoutMs` keeps a single request
+ * alive exactly as long as the caller already agreed to wait for the whole
+ * operation, so the backend can answer or surface a retryable status instead.
+ *
+ * @param options - The caller's poll and per-request options.
+ * @returns The options with `timeout` filled from the budget when it was unset.
+ */
+export function withBudgetRequestTimeout(options: PollUntilDoneOptions): PollUntilDoneOptions {
+	if (options.timeout !== undefined) {
+		return options;
+	}
+
+	return { ...options, timeout: options.timeoutMs ?? DEFAULT_POLL_TIMEOUT_MS };
+}
+
 const ABORTED = Symbol("poll-aborted");
 type Aborted = typeof ABORTED;
 

--- a/packages/open-cloud/tests/integration/resources/luau-execution/client.spec.ts
+++ b/packages/open-cloud/tests/integration/resources/luau-execution/client.spec.ts
@@ -349,6 +349,31 @@ describe(LuauExecutionClient, () => {
 			expect(result.success).toBeFalse();
 			expect(httpClient.requests).toHaveLength(1);
 		});
+
+		it("should derive the submit and poll request timeouts from the poll budget", async () => {
+			expect.assertions(2);
+
+			const submitBody = validInProgressTaskBody({
+				path: "universes/123/places/456/versions/789/luau-execution-sessions/session-1/tasks/task-1",
+				state: "QUEUED",
+			});
+			const httpClient = createFakeHttpClient()
+				.mockResponse({ body: submitBody, status: 200 })
+				.mockResponse({ body: completeBody, status: 200 });
+			const client = new LuauExecutionClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			await client.tasks.runUntilDone(
+				{ placeId: "456", script: "return 1", universeId: "123", versionId: "789" },
+				{ pollDelay: () => 0, timeoutMs: 120_000 },
+			);
+
+			expect(httpClient.requests[0]?.config.timeout).toBe(120_000);
+			expect(httpClient.requests[1]?.config.timeout).toBe(120_000);
+		});
 	});
 
 	describe("tasks.pollUntilDone", () => {
@@ -414,6 +439,46 @@ describe(LuauExecutionClient, () => {
 			assert(result.success);
 
 			expect(result.data.state).toBe("COMPLETE");
+		});
+
+		it("should derive the poll request timeout from the poll budget", async () => {
+			expect.assertions(1);
+
+			const httpClient = createFakeHttpClient().mockResponse({
+				body: completeBody,
+				status: 200,
+			});
+			const client = new LuauExecutionClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			await client.tasks.pollUntilDone(fullRef, { pollDelay: () => 0, timeoutMs: 120_000 });
+
+			expect(httpClient.requests[0]?.config.timeout).toBe(120_000);
+		});
+
+		it("should forward an explicit per-request timeout ahead of the poll budget", async () => {
+			expect.assertions(1);
+
+			const httpClient = createFakeHttpClient().mockResponse({
+				body: completeBody,
+				status: 200,
+			});
+			const client = new LuauExecutionClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: createFakeSleep(),
+			});
+
+			await client.tasks.pollUntilDone(fullRef, {
+				pollDelay: () => 0,
+				timeout: 5_000,
+				timeoutMs: 120_000,
+			});
+
+			expect(httpClient.requests[0]?.config.timeout).toBe(5_000);
 		});
 
 		// Slice 17: always requests view=BASIC


### PR DESCRIPTION
## What changed

`LuauExecutionClient.tasks.runUntilDone` / `pollUntilDone` now default each submit and poll request's per-request `timeout` to the caller's poll budget (`timeoutMs`, falling back to the 300s default) when the caller hasn't set one. An explicit per-request `timeout` still wins.

Implemented as a small internal helper `withBudgetRequestTimeout` applied at the two polling entry points. No new public surface: it is not exported from the package barrel.

## Why

The client-wide 30s default is tuned for snappy CRUD. Luau-execution's submit (which only enqueues, it "does not wait for the task to complete") and poll `get` (a plain state read) should answer in well under a second, but Roblox's task-create and cold-`get` latencies routinely spike past 30s under load. When that happens the request self-aborts at 30s, an error that carries no transport `code`, so the retry layer excludes it by construction and the poll loop classifies it as a hard failure. The operation dies before its own wall-clock budget (`timeoutMs`) is ever consulted.

This produced frequent, non-recoverable timeout failures in the jest-roblox-cli runner (5-minute poll budget). Deriving the per-request deadline from the budget the caller already declared keeps a request alive long enough for the backend to answer or surface a *retryable* status (a 5xx, or a TCP-level `ECONNRESET`) instead of a self-abort the retry layer never retries. The value is the patience the caller already chose, not a magic constant.

The default is applied in the options layer rather than as a method default on purpose: for the idempotent poll `get`, `mergeConfig` lets client config beat method defaults, but per-request options beat both, so only the options layer reliably reaches the poll request.

## Testing

- Unit: 3 tests pin `withBudgetRequestTimeout` (unset → budget, explicit wins, neither → default).
- Integration: submit + poll requests inherit the budget as `config.timeout`; an explicit `timeout` reaches `config.timeout` end-to-end ahead of the budget.
- Full ocale suite, typecheck, lint, build pass. Mutation testing on the touched `src/**` files: 100%, 0 survivors (run with a normalized `a/ b/` diff via `BEDROCK_DIFF_INPUT_FILE`, since this worktree's `diff.mnemonicPrefix=true` yields `c/ w/` prefixes that the changed-file detector skips).

## Notes

- Amends ADR-010 with a dated `2026-06-17` note. The original Decision asserts "a genuine 30s timeout is a real signal" with no exceptions; this carves one out, consistent with #463's upload-timeout exemption (uploads omit the deadline entirely as bandwidth-bound; luau keeps a *finite* budget-derived one so a black-hole still bails and a reset stays retryable).
- Latent gap tracked in #466: the poll budget is only checked between iterations, not wired to an in-flight `AbortSignal`, so a single request isn't bounded by *remaining* budget and mid-flight exhaustion surfaces as a `NetworkError` rather than `PollTimeoutError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Bedrock Code Review: LuauExecutionClient Polling Timeout Budget

## Architecture Compliance: ✅ PASS

**FCIS Pattern Adherence:**
- `withBudgetRequestTimeout()` is a pure function (no I/O, side effects, or external dependencies)
- Implements pure data transformation: accepts options, returns modified options with derived timeout
- Called from Shell layer (client methods) which delegates to Core layer (polling loop)
- No I/O, business logic, or dependency concerns in Core

**Example:** The function returns early (`if (options.timeout !== undefined) return options`) to preserve explicit values, then spreads and modifies only the timeout field. No state mutation, no side effects.

---

## Testing Compliance: ✅ PASS - TDD Standards Met

### Unit Tests (`polling.spec.ts`)
Three tests in dedicated `describe(withBudgetRequestTimeout, ...)` block covering all paths:
1. ✅ Derives `timeout` from `timeoutMs` when unset
2. ✅ Preserves explicit `timeout` (precedence)
3. ✅ Falls back to `DEFAULT_POLL_TIMEOUT_MS` as final fallback

**Test Quality:** All tests use `expect.assertions(1)` to enforce explicit counts. Tests verify actual return values, not mocks. Naming follows "should <behavior>" convention.

### Integration Tests (`client.spec.ts`)
Three tests verify end-to-end flow at Shell layer:
1. ✅ `tasks.runUntilDone` - Both submit AND poll requests inherit budget timeout (lines 405-415)
2. ✅ `tasks.pollUntilDone` - Poll request timeout derives from `timeoutMs` (lines 444-460)
3. ✅ `tasks.pollUntilDone` - Explicit `timeout` overrides budget (lines 462-482)

**Test Isolation:** All tests use injected fake HTTP client (`createFakeHttpClient()`) and fake sleep (`createFakeSleep()`). No actual network calls. Verifies `httpClient.requests[n].config.timeout` matches expectations, proving the timeout flows through the system.

---

## Test Isolation: ✅ PASS

| Layer | Testing | Isolation |
|-------|---------|-----------|
| **Core** | Unit tests on `withBudgetRequestTimeout` | None needed (pure function) |
| **Shell** | Integration tests on `runUntilDone` / `pollUntilDone` | Fake HTTP client (`createFakeHttpClient`) + fake sleep |
| **Result** | Real timeout values flow through merge config and reach requests | ✅ Verified |

**Evidence:** Integration tests construct a real `LuauExecutionClient` with injected fakes, call its public methods, and inspect the fake's recorded requests to verify `config.timeout` was set correctly. This tests real behavior, not mock behavior.

---

## Type Safety & Code Quality: ✅ PASS

**TypeScript Compliance:**
- Strict mode enabled (tsconfig extends `@bedrock-rbx/typescript-config`)
- Function signature explicit: `withBudgetRequestTimeout(options: PollUntilDoneOptions): PollUntilDoneOptions`
- No `any` types
- Types correctly merged via `PollUntilDoneOptions = PollOptions & RequestOptions`

**Precedence Chain (Correct):**
```
1. Explicit options.timeout (highest)  ← mergeConfig: per-request wins
2. Derived from options.timeoutMs      ← helper application
3. DEFAULT_POLL_TIMEOUT_MS (fallback)  ← 300 seconds
```

The three-tier fallback is implemented correctly and tested at each level.

---

## Public API Surface: ✅ PASS - No Breaking Changes

**Export Audit:**
- ❌ `withBudgetRequestTimeout` is NOT in `packages/open-cloud/src/resources/luau-execution/index.ts` (correct)
- ✅ Only exports: `LuauExecutionClient`, `defaultPollDelay`, `PollUntilDoneOptions`
- ✅ Public method signatures unchanged: `runUntilDone()` and `pollUntilDone()` accept same `PollUntilDoneOptions`
- ✅ Internal helper keeps implementation detail transparent to callers

---

## Security & Constraints: ✅ PASS

- No secrets in state or config
- No external API calls in helper
- No sensitive data manipulation
- Operation is safe: timeout scheduling only

---

## Implementation Quality: ✅ EXCELLENT

**Problem Solved:**
Under load, Roblox task-create and cold-`get` latencies spike past 30s. Requests self-abort at the client's universal 30s default *before* the caller's declared poll budget is consulted. Self-aborts carry no transport code, so the retry layer excludes them by construction. This caused frequent non-recoverable failures in jest-roblox-cli (5-minute poll budget).

**Solution Design:**
Derives per-request timeout from `timeoutMs` (caller's declared budget) rather than a fixed constant. Keeps requests alive long enough for backend to respond or surface retryable status (5xx, TCP reset) instead of self-aborting.

**Correctness:**
- Applied at both polling entry points: `pollUntilDone` (line 223) and `runUntilDone` (line 227)
- Ordered in options layer (not method default) so mergeConfig precedence works: per-request > client > fallback
- Explicit timeouts still win (line 2-3 of function body)

**Documentation:**
- ADR-010 amended with dated note (2026-06-17) explaining exemption to 30s default
- Known limitation tracked separately (issue `#466`): poll budget only checked between iterations, not via in-flight AbortSignal

---

## Overall Assessment

**✅ APPROVED FOR MERGE**

This PR demonstrates strong adherence to all Bedrock standards:

| Criterion | Status | Notes |
|-----------|--------|-------|
| FCIS Pattern | ✅ PASS | Pure core function, shell orchestration, no violations |
| TDD/Coverage | ✅ PASS | 6 tests (3 unit, 3 integration), all paths covered |
| Test Isolation | ✅ PASS | Proper fake injection, no network calls |
| Type Safety | ✅ PASS | Strict mode, no `any`, explicit signatures |
| Public API | ✅ PASS | Internal helper, no surface changes, transparent |
| Security | ✅ PASS | No secrets, no I/O, safe operation |
| Documentation | ✅ PASS | ADR amended, limitation acknowledged |

The feature solves a real production problem (frequent timeout failures under load on long-polling operations) through proper architectural layering, with comprehensive test coverage and clear documentation of design trade-offs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
