### PR TITLE
feat(core): surface transport detail in network-failure deploy errors

### DIFF
--- a/packages/bedrock/src/adapters/clack-progress-adapter.spec.ts
+++ b/packages/bedrock/src/adapters/clack-progress-adapter.spec.ts
@@ -1,4 +1,4 @@
-import { OpenCloudError } from "@bedrock-rbx/ocale";
+import { NetworkError, OpenCloudError } from "@bedrock-rbx/ocale";
 
 import { fakeClackPort } from "#tests/helpers/clack";
 import { describe, expect, it } from "vitest";
@@ -153,6 +153,35 @@ describe(createClackProgressAdapter, () => {
 		});
 
 		expect(clack.logError).toHaveBeenCalledExactlyOnceWith("gamePass.vip-pass failed: boom");
+	});
+
+	it("should expand a network driverFailure with its transport code and failing call", () => {
+		expect.assertions(1);
+
+		const clack = fakeClackPort();
+		const port = createClackProgressAdapter({ clack });
+		const key = asResourceKey("start");
+
+		port.emit({
+			key,
+			environment: "development",
+			error: {
+				key,
+				cause: new NetworkError("Network request failed", {
+					cause: Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+					method: "POST",
+					url: "https://apis.roblox.com/universes/v1/9110019856/places/84607999013117/versions",
+				}),
+				kind: "driverFailure",
+			},
+			kind: "resourceOpFailed",
+			opType: "update",
+			resourceKind: "place",
+		});
+
+		expect(clack.logError).toHaveBeenCalledExactlyOnceWith(
+			"place.start failed: Network request failed (ECONNRESET) on POST https://apis.roblox.com/universes/v1/9110019856/places/84607999013117/versions",
+		);
 	});
 
 	it("should render resourceOpFailed for the unexpectedThrow ApplyError", () => {

--- a/packages/bedrock/src/adapters/clack-progress-adapter.ts
+++ b/packages/bedrock/src/adapters/clack-progress-adapter.ts
@@ -1,5 +1,5 @@
 import { createClackPort } from "../cli/clack-port.ts";
-import { type ClackPort, renderDeployError } from "../cli/render.ts";
+import { type ClackPort, describeDriverCause, renderDeployError } from "../cli/render.ts";
 import { resolveStateConfig } from "../core/resolve-state-config.ts";
 import {
 	type Config,
@@ -162,7 +162,7 @@ function renderResourceOpSucceeded(
 function describeApplyError(error: ApplyError): string {
 	switch (error.kind) {
 		case "driverFailure": {
-			return `failed: ${error.cause.message}`;
+			return `failed: ${describeDriverCause(error.cause)}`;
 		}
 		case "unexpectedThrow": {
 			return "unexpected error";

--- a/packages/bedrock/src/cli/render.spec.ts
+++ b/packages/bedrock/src/cli/render.spec.ts
@@ -1,4 +1,4 @@
-import { ApiError, PermissionError } from "@bedrock-rbx/ocale";
+import { ApiError, NetworkError, PermissionError } from "@bedrock-rbx/ocale";
 
 import { fakeClackPort } from "#tests/helpers/clack";
 import { describe, expect, it } from "vitest";
@@ -11,6 +11,7 @@ import type { SpawnOverrideError } from "./dispatch-override.ts";
 import type { ParseMigrateError } from "./parse-migrate-options.ts";
 import type { ParseOptionsError } from "./parse-options.ts";
 import {
+	describeDriverCause,
 	renderBuildStatePortError,
 	renderDeployError,
 	renderMigrateError,
@@ -247,6 +248,31 @@ describe(renderDeployError, () => {
 			},
 			expected:
 				"apply failed for 'main-place': HTTP 401 on places.publishVersion: missing required scopes 'universe-places:write', 'universe.place:write'. Grant them on the API key at https://create.roblox.com/credentials",
+		},
+		{
+			err: {
+				cause: {
+					applied: [],
+					failures: [
+						{
+							key: asResourceKey("start"),
+							cause: new NetworkError("Network request failed", {
+								cause: new TypeError("fetch failed", {
+									cause: Object.assign(new Error("read ECONNRESET"), {
+										code: "ECONNRESET",
+									}),
+								}),
+								method: "POST",
+								url: "https://apis.roblox.com/universes/v1/9110019856/places/84607999013117/versions?versionType=Published",
+							}),
+							kind: "driverFailure",
+						},
+					],
+				},
+				kind: "applyFailed",
+			},
+			expected:
+				"apply failed for 'start': Network request failed (ECONNRESET) on POST https://apis.roblox.com/universes/v1/9110019856/places/84607999013117/versions?versionType=Published",
 		},
 		{
 			err: {
@@ -687,5 +713,126 @@ describe(renderMigrationSummary, () => {
 			`action required: 1 fields need your input. See ${reportPath}`,
 		);
 		expect(port.logSuccess).not.toHaveBeenCalled();
+	});
+});
+
+describe(describeDriverCause, () => {
+	it("should expand a network error with its transport code and failing call", () => {
+		expect.assertions(1);
+
+		const err = new NetworkError("Network request failed", {
+			cause: new TypeError("fetch failed", {
+				cause: Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+			}),
+			method: "POST",
+			url: "https://apis.roblox.com/v2/places/1",
+		});
+
+		expect(describeDriverCause(err)).toBe(
+			"Network request failed (ECONNRESET) on POST https://apis.roblox.com/v2/places/1",
+		);
+	});
+
+	it("should ignore a non-string transport code and keep walking the cause chain", () => {
+		expect.assertions(1);
+
+		const err = new NetworkError("Network request failed", {
+			cause: Object.assign(new Error("outer"), {
+				cause: Object.assign(new Error("inner"), { code: "ETIMEDOUT" }),
+				code: 42,
+			}),
+			method: "GET",
+			url: "https://apis.roblox.com/v2/places/1",
+		});
+
+		expect(describeDriverCause(err)).toBe(
+			"Network request failed (ETIMEDOUT) on GET https://apis.roblox.com/v2/places/1",
+		);
+	});
+
+	it("should fall back to the cause message when no transport code is present", () => {
+		expect.assertions(1);
+
+		const err = new NetworkError("Network request failed", {
+			cause: new TypeError("fetch failed"),
+			method: "PATCH",
+			url: "https://apis.roblox.com/v2/places/1",
+		});
+
+		expect(describeDriverCause(err)).toBe(
+			"Network request failed (fetch failed) on PATCH https://apis.roblox.com/v2/places/1",
+		);
+	});
+
+	it.for<{ err: NetworkError; label: string }>([
+		{
+			err: new NetworkError("Network request failed", {
+				cause: Object.assign(new Error("reset"), { code: "ECONNRESET" }),
+				method: "POST",
+			}),
+			label: "url absent",
+		},
+		{
+			err: new NetworkError("Network request failed", {
+				cause: Object.assign(new Error("reset"), { code: "ECONNRESET" }),
+				url: "https://apis.roblox.com/v2/places/1",
+			}),
+			label: "method absent",
+		},
+	])("should omit the call target when $label", ({ err }) => {
+		expect.assertions(1);
+
+		expect(describeDriverCause(err)).toBe("Network request failed (ECONNRESET)");
+	});
+
+	it("should fall back to the bare message when neither a reason nor a target is available", () => {
+		expect.assertions(1);
+
+		const err = new NetworkError("Network request failed");
+
+		expect(describeDriverCause(err)).toBe("Network request failed");
+	});
+
+	it("should surface a non-network Open Cloud error's own message unchanged", () => {
+		expect.assertions(1);
+
+		const err = new ApiError("HTTP 504: gateway timeout", { statusCode: 504 });
+
+		expect(describeDriverCause(err)).toBe("HTTP 504: gateway timeout");
+	});
+
+	it("should not read a transport code that sits beyond the cause-depth cap", () => {
+		expect.assertions(1);
+
+		let chain: Error = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+		for (let index = 0; index < 4; index += 1) {
+			chain = new Error(`wrap ${String(index)}`, { cause: chain });
+		}
+
+		const err = new NetworkError("Network request failed", {
+			cause: chain,
+			method: "POST",
+			url: "https://apis.roblox.com/v2/places/1",
+		});
+
+		expect(describeDriverCause(err)).toBe(
+			"Network request failed (wrap 3) on POST https://apis.roblox.com/v2/places/1",
+		);
+	});
+
+	it("should stop walking a self-referential cause chain rather than loop forever", () => {
+		expect.assertions(1);
+
+		const cyclic = new Error("loop");
+		cyclic.cause = cyclic;
+		const err = new NetworkError("Network request failed", {
+			cause: cyclic,
+			method: "POST",
+			url: "https://apis.roblox.com/v2/places/1",
+		});
+
+		expect(describeDriverCause(err)).toBe(
+			"Network request failed (loop) on POST https://apis.roblox.com/v2/places/1",
+		);
 	});
 });

--- a/packages/bedrock/src/cli/render.ts
+++ b/packages/bedrock/src/cli/render.ts
@@ -1,4 +1,4 @@
-import { PermissionError } from "@bedrock-rbx/ocale";
+import { NetworkError, type OpenCloudError, PermissionError } from "@bedrock-rbx/ocale";
 
 import type { ConfigError } from "../core/config-error.ts";
 import type { MigrateError, MigrationSummary } from "../core/migrate/migration-report.ts";
@@ -217,14 +217,6 @@ export function renderStateWriteError(input: StateWriteErrorRender, port: ClackP
 	);
 }
 
-function permissionDetail(err: PermissionError): string {
-	const isPlural = err.requiredScopes.length > 1;
-	const label = isPlural ? "scopes" : "scope";
-	const pronoun = isPlural ? "them" : "it";
-	const scopeList = err.requiredScopes.map((scope) => `'${scope}'`).join(", ");
-	return `${err.message} on ${err.operationKey}: missing required ${label} ${scopeList}. Grant ${pronoun} on the API key at https://create.roblox.com/credentials`;
-}
-
 function safeStringify(value: unknown): string {
 	if (value instanceof Error) {
 		return value.message;
@@ -240,6 +232,65 @@ function safeStringify(value: unknown): string {
 	}
 }
 
+function permissionDetail(err: PermissionError): string {
+	const isPlural = err.requiredScopes.length > 1;
+	const label = isPlural ? "scopes" : "scope";
+	const pronoun = isPlural ? "them" : "it";
+	const scopeList = err.requiredScopes.map((scope) => `'${scope}'`).join(", ");
+	return `${err.message} on ${err.operationKey}: missing required ${label} ${scopeList}. Grant ${pronoun} on the API key at https://create.roblox.com/credentials`;
+}
+
+// Walks an error's `cause` chain for the first node-style string `code` (for
+// example `"ECONNRESET"`). A fetch transport reset surfaces as
+// `NetworkError → TypeError("fetch failed") → OS Error{code}`, so the code sits
+// several links down. Capped to avoid looping on a self-referential chain.
+// ocale computes this internally but does not export it; the bounded walk is
+// reproduced here so the renderer can name the transport failure.
+const MAX_CAUSE_DEPTH = 5;
+
+/**
+ * Describes the {@link OpenCloudError} behind a driver failure for one
+ * diagnostic line. A {@link NetworkError} otherwise collapses every transport
+ * failure into the same static `"Network request failed"`; this expands it with
+ * the node-style transport `code` (or the underlying cause's message) and the
+ * failing `METHOD url`, so an intermittent connection reset reads differently
+ * from a DNS failure without inspecting the cause by hand. Every other error
+ * surfaces its own `message` unchanged.
+ *
+ * @param err - The Open Cloud error carried on the failing apply op.
+ * @returns A single-line, human-readable failure detail.
+ */
+export function describeDriverCause(err: OpenCloudError): string {
+	if (err instanceof NetworkError) {
+		return describeNetworkError(err);
+	}
+
+	return err.message;
+}
+
+function findTransportCode(error: unknown): string | undefined {
+	let current: unknown = error;
+	for (let depth = 0; depth < MAX_CAUSE_DEPTH && current instanceof Error; depth += 1) {
+		const code = Reflect.get(current, "code");
+		if (typeof code === "string") {
+			return code;
+		}
+
+		current = current.cause;
+	}
+
+	return undefined;
+}
+
+function describeNetworkError(err: NetworkError): string {
+	const reason =
+		findTransportCode(err) ?? (err.cause instanceof Error ? err.cause.message : undefined);
+	const because = reason === undefined ? "" : ` (${reason})`;
+	const target =
+		err.method !== undefined && err.url !== undefined ? ` on ${err.method} ${err.url}` : "";
+	return `${err.message}${because}${target}`;
+}
+
 function applyCauseDetail(cause: ApplyError): string {
 	switch (cause.kind) {
 		case "driverFailure": {
@@ -247,7 +298,7 @@ function applyCauseDetail(cause: ApplyError): string {
 				return permissionDetail(cause.cause);
 			}
 
-			return cause.cause.message;
+			return describeDriverCause(cause.cause);
 		}
 		case "unexpectedThrow": {
 			return `unexpected error: ${safeStringify(cause.cause)}`;


### PR DESCRIPTION
## What changed

Deploy diagnostics for a transport-level failure now name the underlying
transport `code` and the failing call instead of the bare, static
`Network request failed`.

A `NetworkError` already carries the underlying `cause`, `method`, and `url`,
but both render sites surfaced only its `message`. A new pure helper
`describeDriverCause` expands a `NetworkError` with:

- the node-style transport `code` (e.g. `ECONNRESET`) found by walking the
  `cause` chain (bounded), or the immediate cause's message when no code is
  present;
- the failing `METHOD url`.

Every other `OpenCloudError` (e.g. `ApiError`, `PermissionError`) surfaces its
own `message` unchanged. The aggregate (`applyCauseDetail` in `cli/render.ts`)
and live-progress (`describeApplyError` in `adapters/clack-progress-adapter.ts`)
paths both delegate to it.

```text
Before: place.start failed: Network request failed
After:  place.start failed: Network request failed (ECONNRESET) on POST \
        https://apis.roblox.com/universes/v1/.../versions
```

## Why

An intermittent deploy failure surfaced only as `place.<key> failed: Network
request failed`, which hid both which call failed and why. Investigation traced
it to the second of two serialized place `publish` uploads getting its
connection dropped server-side (~30s) — but the opaque message made that
impossible to confirm from the log alone. Naming the transport `code` and the
`METHOD url` makes the failure mode legible and is the prerequisite for deciding
whether the publish path should opt into transport-error retry (tracked
separately).

## Scope

Render-only, in `@bedrock-rbx/core`. No change to `@bedrock-rbx/ocale`'s public
surface or error types; bedrock walks the already-exported `NetworkError`'s
cause chain itself.

## Tests

- Unit tests for `describeDriverCause` covering: transport code found (incl.
  deep in the chain), non-string code skipped, fallback to cause message,
  partial/absent `method`/`url`, bare-message fallback, non-network error
  passthrough, the cause-depth cap, and a self-referential chain.
- Integration assertions through both render paths (`renderDeployError`
  aggregate line and the `resourceOpFailed` progress line).
- Full suite green; 100% mutation score (0 survivors) on both touched
  `src/**` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Bedrock Architecture Review: Network Error Diagnostic Enhancement

### ✅ Architecture Compliance (FCIS Pattern)

**Correct Layer Placement:**
- `describeDriverCause()` is a pure function in the CLI rendering module (`cli/render.ts`), properly separated from core business logic
- Helper functions (`findTransportCode()`, `describeNetworkError()`, `permissionDetail()`) are internal and non-exported
- No I/O, no side effects—function transforms error objects into strings
- Correctly scoped to rendering; adapters call it but don't modify it

**Integration Points:**
- `cli/render.ts`: `applyCauseDetail()` dispatches to `describeDriverCause()` for driver failures (except `PermissionError`)
- `adapters/clack-progress-adapter.ts`: `describeApplyError()` uses it to format progress events
- Adapter imports function directly from render module (appropriate for internal infrastructure)

### ✅ Testing (TDD Compliance)

**Comprehensive Test Coverage:**
- **9 dedicated unit tests** for `describeDriverCause` covering:
  - Transport code extraction from nested cause chain (depth 2)
  - Non-string codes (value `42`) correctly skipped during chain walk
  - Fallback to cause message when no code present
  - Omission of call target when either `method` or `url` missing (parametrized test)
  - Bare message fallback when no diagnostic data available
  - Non-network `ApiError` passes through unchanged (type dispatch verification)
  - Cause-depth cap (`MAX_CAUSE_DEPTH = 5`) prevents reading codes beyond boundary
  - Self-referential cycles (`cyclic.cause = cyclic`) do not infinite-loop

- **Integration test** in `clack-progress-adapter.spec.ts`: validates `driverFailure` with `NetworkError` cause produces expanded message with transport code

- **Test naming compliance**: All follow `it("should <behavior>")` pattern
- **100% branch coverage**: Depth loop, code type check, reason fallback, target assembly all exercised

### ⚠️ Public API Export Without Example

**Concern:** `describeDriverCause()` is exported from `cli/render.ts` but carries no `@example` JSDoc block. Per CLAUDE.md, "Each public export carries a JSDoc `@example` block... Thoughtless exports accumulate semver debt."

**Mitigation:** The function is exported from a module (`cli/render.ts`), not from the package barrel (`src/index.ts`), so it is **not part of the published public API contract**. It is an internal CLI infrastructure export used by sibling adapters. The JSDoc does provide clear semantics (parameter, return type, and purpose), and the lack of `@example` is appropriate for an infrastructure function not meant for external consumers.

**Recommendation:** If this function is intended for programmatic use by consumers (library API), add `@example` block and re-export from `src/index.ts`. If it remains CLI infrastructure only, document its internal status in a JSDoc `@internal` tag for clarity.

### ✅ Code Quality & Constraints

- **TypeScript strict mode**: All code type-safe; no `any` types
- **Error handling**: Proper `instanceof` checks, `Reflect.get()` for property access to avoid exceptions
- **Open Cloud only**: Uses only `@bedrock-rbx/ocale` types (`NetworkError`, `OpenCloudError`, `PermissionError`, `ApiError`)
- **Defensive programming**: Bounded cause-chain traversal (depth limit prevents worst-case O(n²) scenarios), cycle detection via depth counter
- **Immutable constants**: `MAX_CAUSE_DEPTH = 5` is clear and documented implicitly via test of depth-4 threshold

### ✅ Integration & Backward Compatibility

- No changes to `@bedrock-rbx/ocale` public API—walks already-exported error cause chain
- `PermissionError` paths unchanged (special case preserved in `applyCauseDetail()`)
- Other `OpenCloudError` types (`ApiError`, etc.) surface their own messages unchanged
- No modifications to state, config, or port contracts

### Summary

This PR correctly implements TDD principles with exhaustive test coverage, respects FCIS boundaries by keeping rendering logic in the CLI layer, and safely accesses error chains without requiring changes to upstream packages. The only minor gap is clarifying the export scope of `describeDriverCause()` via JSDoc `@internal` or semver commitment via `@example` + barrel re-export. The implementation itself is sound.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->