### PR TITLE
docs: add adr-026 for codegen and two-phase deploy

### DIFF
--- a/docs/adr/026-codegen-and-two-phase-deploy.md
+++ b/docs/adr/026-codegen-and-two-phase-deploy.md
@@ -1,0 +1,238 @@
+# ADR-026: Codegen and Two-Phase Deploy
+
+**Date:** 2026-06-22  **Status:** Accepted
+
+Decision Makers: Maintainer
+Tags: deploy, codegen, state, data-model, ports, two-phase, core
+
+## Context
+
+Game code needs to reference Roblox-assigned asset IDs (game-pass IDs,
+developer-product IDs, icon asset IDs) by a stable **Key** rather than a
+hardcoded number. Today those IDs only exist in **State** after a deploy
+provisions them, and consuming them is left entirely to the user
+(Mantle parity). Issue #119 asks bedrock to optionally generate source files
+from deployed **Outputs**. ADR-017 already named "post-deploy Luau constant
+generation" as a motivating use case for the programmatic surface.
+
+A harder, related problem sits on top of codegen. A place's `rbxm` is built
+*before* deploy, but a deploy may `create` a provisioned asset and mint a *new*
+ID the build needed to embed. The pre-built artifact therefore cannot contain
+an ID that did not exist when it was built. The common workaround generates
+asset source *after* deploy and commits it back (often via a CI bot), so the new
+ID only reaches the game on a *second* deploy. The two-deploy lag and the
+load-bearing commit step are the pain this ADR removes.
+
+Key constraints shaping the design:
+
+- bedrock is FCIS + Ports (ADR-018). The engine performs no I/O it was not
+  handed; running a user's build is arbitrary I/O.
+- A place is an opaque artifact to bedrock. The engine cannot inspect an `rbxm`
+  to learn which assets it references; its only signals are **Operation**-level
+  (`create` mints a new ID, `update`/`noop` do not), and there are no
+  inter-resource edges in the diff algebra (ADR-019).
+- Config is validated data loaded multi-format via c12 (TS/JS/YAML/JSON/Luau).
+  Functions cannot live in it.
+- Provisioned `create` (game-pass / developer-product POST) is **not**
+  idempotent — a retry mints a duplicate.
+- `applyOps` is parallel and continue-on-failure with a fixed internal apply
+  ordering — universe first, then the rest concurrently (ADR-023). A batch can
+  therefore succeed partially, returning an `AggregateApplyError` of survivors
+  plus failures. `applyOps` dispatches only non-`noop` ops.
+- A `statePort.write` can itself fail after remote creates succeed; ADR-023
+  defines the resulting orphan-recovery contract (`unsavedState`).
+- The common Roblox shape is one artifact serving several environments, with
+  IDs resolved at runtime; codegen for it must see *all* environments' state.
+
+To avoid colliding with ADR-023's apply-level "Phase 1 / Phase 2" (universe vs.
+the rest), this ADR names its two halves the **asset stage** and the
+**republish stage**.
+
+## Decision
+
+### Codegen (opt-in, issue #119 proper)
+
+A three-tier opt-in ladder: (1) no codegen — IDs live only in **State**;
+(2) **Codegen** — emit **Outputs** to source files; (3) **Two-phase deploy** —
+rebuild and republish a place on top.
+
+When enabled, codegen runs after the asset stage on every deploy. The
+customizable unit is the **Emitter**: a layered API where declarative
+`{ path, language }` yields a working file with no code, and an optional `emit`
+override takes full control of layout. `emit` receives the current state of
+**all declared environments** and returns a keyed array of files; bedrock writes
+them. bedrock never commits — the generated file is regenerable from **State**
+and is not on the deploy's critical path.
+
+**Cross-environment read.** The environment list comes from `config.environments`.
+`deploy` reads each environment's snapshot via `statePort.read(env)` — fresh for
+the environment being deployed (the in-flight result), last-known for the rest.
+An environment that has never deployed reads `undefined` and is presented to the
+emitter as having no resources; the emitter decides whether to omit it or emit a
+placeholder. This assumes one backend credential can read every environment's
+state (true for the gist backend); a backend that partitions credentials per
+environment would surface only the environments it can read.
+
+**Partial asset failure.** Because the asset stage is continue-on-failure,
+codegen emits source only for keys that resolved to real IDs and omits keys
+whose `create` failed (derived from `AggregateApplyError.failures`). No
+half-resolved ID reaches a build.
+
+The default emitter targets **Luau** (universal across Roblox projects), with an
+opt-in `.d.ts` companion so roblox-ts consumers get type-safety over the same
+Luau module without a parallel TypeScript emitter. Generated-file location and
+its relationship to ADR-025's managed `.bedrock/` directory and `@bedrock` alias
+are settled at implementation time; the default path is user-configurable.
+
+### Two-phase deploy
+
+Activates iff a **Rebuild hook** is supplied **and** the diff contains a
+provisioned `create` **or** any place carries a `pendingRebuild` marker. Trigger
+is "any provisioned create," not declared per-resource dependencies: bedrock has
+no inter-resource edges and a stray rebuild is cheap, whereas a dependency graph
+is new state surface that goes stale. Because there are no edges, the marker is
+set for **all** places in the deploy, not a computed subset.
+
+A two-phase deploy splits the single apply into two:
+
+1. **Asset stage** — `applyOps` runs with place ops withheld (universe and
+   provisioned assets only, keeping ADR-023's internal universe-first ordering).
+   New IDs are minted here.
+2. **Checkpoint write** — persist asset outputs and set the `pendingRebuild`
+   marker, before the rebuild can fail.
+3. **Codegen** — write the generated file(s) from current state.
+4. **Rebuild hook** — invoked (wrapped; a throw does not abort the checkpointed
+   state). Returns a keyed array of rebuilt place artifacts.
+5. **Republish stage** — a second `applyOps` over the place ops, using the
+   returned artifact bytes as desired input. A place under `pendingRebuild` whose
+   diff was `noop` is republished via a **synthesized `update` op** injected by
+   `deploy` (its `changedFields` records the forced rebuild), since `applyOps`
+   never dispatches `noop`s.
+6. **Final write** — clear the marker for every place the hook actually
+   republished and persist place versions.
+
+The **Rebuild hook** is one callback per deploy, receiving post-asset-stage
+state and returning a keyed array of rebuilt place artifacts. bedrock owns the
+orchestration; the hook owns the build. bedrock does not know how to build.
+
+### Failure and convergence
+
+bedrock keeps its existing non-transactional model — there is no all-or-revert.
+Two rules make two-phase safe:
+
+1. **Checkpoint before the risky step.** Asset outputs are persisted *before*
+   the rebuild can fail, narrowing the window for duplicate provisioning. It does
+   not close it: if the checkpoint write itself fails, freshly-minted
+   non-idempotent IDs are unpersisted and a retry re-creates them — the same
+   orphan window ADR-023 documents, recovered the same way (`unsavedState`).
+2. **`pendingRebuild` marker for self-healing.** A checkpointed `create` `noop`s
+   on the next run, so the create trigger alone cannot re-fire — a recovered
+   build would otherwise leave a green-but-stale place. The marker, set at
+   checkpoint and cleared per-place on successful republish, re-activates
+   two-phase on retry.
+
+Marker lifecycle: `absent → set at checkpoint → present across codegen +
+rebuild → cleared at final write for each republished place`. On a failed
+rebuild or republish the marker stays set and the deploy returns an error.
+
+**Marker present but no rebuild hook** (e.g. a CLI run against a YAML config
+after a hooked run failed) is a **hard error**: the deploy refuses to report
+success while a rebuild is owed and cannot be performed. An escape hatch clears
+the marker for a user deliberately abandoning two-phase.
+
+**Partial asset failure** aborts the rebuild: survivors and the marker are
+persisted, codegen emits only resolved keys, and the deploy returns an error;
+the next run retries via the marker rather than building against missing IDs.
+
+### State contract
+
+`pendingRebuild` is bedrock bookkeeping — neither user-declared desired state
+nor Roblox-returned **Outputs**. It is stored as a **list of resource keys in
+the file-level `$bedrock` envelope** (`{ $bedrock: { version, pendingRebuild } }`),
+preserving ADR-019's invariant that the `$bedrock` key is **adapter-private**:
+adapters map it to and from a typed, core-visible `BedrockState.pendingRebuild`
+field, exactly as they already flatten/re-wrap `version`. `ResourceCurrentState`
+is unchanged — no per-resource key, no public per-resource type change. The
+marker is **presence-only** (a key is listed or absent, never a `false`); a
+clean republish removes the key from the list, and the on-disk list is omitted
+when empty so a happy-path state never shows it.
+
+This is a v1-compatible, optional envelope addition: the existing envelope schema
+ignores unknown `$bedrock` members, so a pre-ADR-026 reader tolerates the field
+(and, not knowing two-phase, simply drops it on its next write — harmless, since
+that binary performs no rebuilds). `serializeStateFile`/`parseStateFile` own the
+`BedrockState.pendingRebuild` ↔ envelope mapping; `mergeResources` is unaffected
+because the marker no longer rides on resource entries. The marker never
+participates in **Drift** — it is not a resource field.
+
+### Surface
+
+Function hooks (`emit`, `rebuild`) are supplied through `DeployOptions`
+(programmatic), with optional pickup from a TS/JS config module so the CLI can
+use them. Declarative codegen knobs live in `Config`. Two-phase and custom
+emitters are therefore **TS/JS only**; YAML/JSON/Luau configs get the default
+emitter and no rebuild. This is inherent — a build is arbitrary code.
+
+Surfacing icon asset IDs in codegen is free (they are already in game-pass
+**Outputs** and the emitter sees full state). Codegen emits the real minted ID
+for a redacted resource (ADR-024); redaction hides content, not identity. A
+generic image-upload resource kind is out of scope and deferred.
+
+## Considered Options
+
+- **Bedrock exposes primitives; a wrapper orchestrates.** Rejected for the
+  default path: the single smart `deploy` call is the DX goal. Primitives may
+  still be exposed underneath as an escape hatch.
+- **Bedrock embeds the build.** Rejected: makes `deploy` non-deterministic and
+  couples the engine to a build toolchain. The injected hook keeps I/O at the
+  edge.
+- **Declared per-resource dependencies for the trigger.** Rejected for v1: new
+  config surface and the first inter-resource edge in an edge-free diff engine,
+  to avoid a cheap, harmless extra rebuild.
+- **Resource-level `$bedrock` for the marker.** Rejected: contradicts ADR-019's
+  adapter-private invariant, forces a public `ResourceCurrentState` type change,
+  and (because `serializeStateFile` rebuilds the envelope from typed resources)
+  would silently drop the marker on every write. The envelope-list form avoids
+  all three.
+- **Force-flag recovery instead of a marker.** Rejected: a recovered build
+  silently reports success over a stale place.
+- **Last-codegen-hash fingerprint instead of a key list.** Deferred: more
+  precise (catches icon-only changes) but more state surface than needed to
+  prove the flow; noted as the eventual direction.
+- **Splitting codegen and two-phase into separate ADRs.** Rejected: the
+  dependency is one-directional (two-phase needs codegen; codegen stands alone),
+  but the state-contract and port additions only make sense alongside the
+  orchestration that motivates them, so they are recorded together.
+
+## Consequences
+
+- `BedrockState` gains an optional, typed `pendingRebuild` field; the on-disk
+  `$bedrock` envelope gains a `pendingRebuild` list. `serializeStateFile` and
+  `parseStateFile` own the mapping; `ResourceCurrentState` and `mergeResources`
+  are untouched. v1-compatible.
+- Deploys now perform an intermediate checkpoint `statePort.write` mid-reconcile,
+  so the `stateWriteFailed.unsavedState` contract (ADR-023) applies to two writes.
+- A two-phase deploy invokes `applyOps` twice (asset stage, then republish
+  stage) and `deploy` may synthesize an `update` op for a forced republish.
+- Codegen reads every declared environment's state once per enabled deploy.
+- A new driven concept (the **Emitter**) and a new injected callback (the
+  **Rebuild hook**) join the port surface.
+- Two-phase is unavailable to non-TS/JS configs by construction.
+- Hand-rolled post-deploy generators and commit bots become removable: codegen +
+  the rebuild hook make a single deploy self-contained.
+
+## Related Decisions
+
+- ADR-017 (programmatic IaC + CLI) — names post-deploy constant generation; the
+  hooks live on the programmatic surface.
+- ADR-018 (FCIS + primary/driven ports) — the rebuild hook and emitter are
+  injected, keeping I/O at the edge.
+- ADR-019 (state data model & diff algebra) — the `$bedrock` envelope, the
+  adapter-private invariant, and the diff algebra this marker stays out of.
+- ADR-021 (file-backed resource kinds) — places publish by file hash; the
+  republish stage feeds rebuilt bytes through the same path.
+- ADR-023 (apply semantics) — phase ordering, continue-on-failure aggregate
+  outcome, and the orphan-recovery contract the checkpoint inherits.
+- ADR-024 (redaction) — codegen emits real IDs for redacted resources.
+- ADR-025 (Luau type definitions) — the default Luau emitter and `.d.ts`
+  companion relate to the Luau distribution story.

--- a/docs/adr/026-codegen-and-two-phase-deploy.md
+++ b/docs/adr/026-codegen-and-two-phase-deploy.md
@@ -40,7 +40,7 @@ Key constraints shaping the design:
   therefore succeed partially, returning an `AggregateApplyError` of survivors
   plus failures. `applyOps` dispatches only non-`noop` ops.
 - A `statePort.write` can itself fail after remote creates succeed; ADR-023
-  defines the resulting orphan-recovery contract (`unsavedState`).
+  defines the resulting orphan-recovery contract (`stateWriteFailed.unsavedState`).
 - The common Roblox shape is one artifact serving several environments, with
   IDs resolved at runtime; codegen for it must see *all* environments' state.
 
@@ -60,8 +60,8 @@ When enabled, codegen runs after the asset stage on every deploy. The
 customizable unit is the **Emitter**: a layered API where declarative
 `{ path, language }` yields a working file with no code, and an optional `emit`
 override takes full control of layout. `emit` receives the current state of
-**all declared environments** and returns a keyed array of files; bedrock writes
-them. bedrock never commits — the generated file is regenerable from **State**
+**all declared environments** and returns a list of file descriptors to write,
+each carrying an output `path` and its contents; bedrock writes them. bedrock never commits — the generated file is regenerable from **State**
 and is not on the deploy's critical path.
 
 **Cross-environment read.** The environment list comes from `config.environments`.
@@ -86,7 +86,7 @@ are settled at implementation time; the default path is user-configurable.
 
 ### Two-phase deploy
 
-Activates iff a **Rebuild hook** is supplied **and** the diff contains a
+Activates iff a **Rebuild hook** is supplied **and** either the diff contains a
 provisioned `create` **or** any place carries a `pendingRebuild` marker. Trigger
 is "any provisioned create," not declared per-resource dependencies: bedrock has
 no inter-resource edges and a stray rebuild is cheap, whereas a dependency graph
@@ -102,7 +102,8 @@ A two-phase deploy splits the single apply into two:
    marker, before the rebuild can fail.
 3. **Codegen** — write the generated file(s) from current state.
 4. **Rebuild hook** — invoked (wrapped; a throw does not abort the checkpointed
-   state). Returns a keyed array of rebuilt place artifacts.
+   state). Returns an array of per-place entries, each carrying the place
+   **Key** and its rebuilt artifact.
 5. **Republish stage** — a second `applyOps` over the place ops, using the
    returned artifact bytes as desired input. A place under `pendingRebuild` whose
    diff was `noop` is republished via a **synthesized `update` op** injected by
@@ -112,7 +113,8 @@ A two-phase deploy splits the single apply into two:
    republished and persist place versions.
 
 The **Rebuild hook** is one callback per deploy, receiving post-asset-stage
-state and returning a keyed array of rebuilt place artifacts. bedrock owns the
+state and returning an array of per-place entries, each carrying the place
+**Key** and its rebuilt artifact. bedrock owns the
 orchestration; the hook owns the build. bedrock does not know how to build.
 
 ### Failure and convergence
@@ -124,7 +126,8 @@ Two rules make two-phase safe:
    the rebuild can fail, narrowing the window for duplicate provisioning. It does
    not close it: if the checkpoint write itself fails, freshly-minted
    non-idempotent IDs are unpersisted and a retry re-creates them — the same
-   orphan window ADR-023 documents, recovered the same way (`unsavedState`).
+   orphan window ADR-023 documents, recovered the same way
+   (`stateWriteFailed.unsavedState`).
 2. **`pendingRebuild` marker for self-healing.** A checkpointed `create` `noop`s
    on the next run, so the create trigger alone cannot re-fire — a recovered
    build would otherwise leave a green-but-stale place. The marker, set at
@@ -214,7 +217,8 @@ generic image-upload resource kind is out of scope and deferred.
   so the `stateWriteFailed.unsavedState` contract (ADR-023) applies to two writes.
 - A two-phase deploy invokes `applyOps` twice (asset stage, then republish
   stage) and `deploy` may synthesize an `update` op for a forced republish.
-- Codegen reads every declared environment's state once per enabled deploy.
+- Codegen reads every declared environment's state once per deploy where codegen
+  is enabled.
 - A new driven concept (the **Emitter**) and a new injected callback (the
   **Rebuild hook**) join the port surface.
 - Two-phase is unavailable to non-TS/JS configs by construction.

--- a/docs/adr/026-codegen-and-two-phase-deploy.md
+++ b/docs/adr/026-codegen-and-two-phase-deploy.md
@@ -1,6 +1,6 @@
 # ADR-026: Codegen and Two-Phase Deploy
 
-**Date:** 2026-06-22  **Status:** Accepted
+**Date:** 2026-06-22 **Status:** Accepted
 
 Decision Makers: Maintainer
 Tags: deploy, codegen, state, data-model, ports, two-phase, core

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,6 +35,7 @@ things are the way they are.
 | [023](./023-apply-semantics-parallel-continue-on-failure.md) | Apply Semantics — Parallel, Continue-on-Failure, Per-Op Progress Events | Accepted | 2026-05-14 |
 | [024](./024-resource-redaction.md) | Resource Redaction for Pre-Release Environments | Accepted | 2026-05-14 |
 | [025](./025-luau-type-definitions.md) | Luau type definitions for `bedrock.config.luau` | Accepted | 2026-05-19 |
+| [026](./026-codegen-and-two-phase-deploy.md) | Codegen and Two-Phase Deploy | Accepted | 2026-06-22 |
 
 ## Creating a New ADR
 

--- a/packages/bedrock/CONTEXT.md
+++ b/packages/bedrock/CONTEXT.md
@@ -103,7 +103,7 @@ The deploy mode where a provisioned `create` mints a new asset ID that the place
 _Avoid_: two-pass, multi-stage, rebuild deploy
 
 **Rebuild hook**:
-The injected callback bedrock invokes during a **Two-phase deploy** to regenerate the place artifact once new asset IDs exist. Bedrock owns the orchestration; the hook owns the build, taking the post-asset deploy state and returning a keyed array of rebuilt place artifacts. Bedrock does not know how to build.
+The injected callback bedrock invokes during a **Two-phase deploy** to regenerate the place artifact once new asset IDs exist. Bedrock owns the orchestration; the hook owns the build, taking the post-asset deploy state and returning an array of per-place entries, each carrying the place **Key** and its rebuilt artifact. Bedrock does not know how to build.
 _Avoid_: builder, build step, compile hook
 
 **Pending rebuild**:

--- a/packages/bedrock/CONTEXT.md
+++ b/packages/bedrock/CONTEXT.md
@@ -88,6 +88,32 @@ _Avoid_: logger, reporter, telemetry
 The user-facing discriminator in config that selects which **State port** adapter to construct at runtime (e.g. `state: { backend: "gist" }` picks the Gist adapter). Each backend value names exactly one adapter; today only the State port is backend-configurable.
 _Avoid_: provider, driver, storage
 
+### Code generation
+
+**Codegen**:
+Opt-in feature that writes deployed **Outputs** to persisted source files the game references by **Key** instead of by hardcoded ID. Off by default — the floor is Mantle parity, where IDs live only in **State** and consuming them is the user's problem.
+_Avoid_: scaffolding, templating, asset map
+
+**Emitter**:
+The user-overridable function that turns deploy state into generated file content for **Codegen**. Receives state for every declared **Environment** (fresh for the one just deployed, last-known for the rest) and returns the files to write; bedrock ships a default so the simple case needs no code, while a custom emitter owns its layout entirely.
+_Avoid_: generator, formatter, template, renderer
+
+**Two-phase deploy**:
+The deploy mode where a provisioned `create` mints a new asset ID that the place artifact must embed before it is published. Splits the apply into an **asset stage** (apply assets, checkpoint state, run **Codegen**, invoke the **Rebuild hook**) and a **republish stage** (publish the rebuilt places). Activates only when a **Rebuild hook** is supplied and either a provisioned `create` occurs or a **Pending rebuild** marker is set; otherwise the deploy publishes places normally.
+_Avoid_: two-pass, multi-stage, rebuild deploy
+
+**Rebuild hook**:
+The injected callback bedrock invokes during a **Two-phase deploy** to regenerate the place artifact once new asset IDs exist. Bedrock owns the orchestration; the hook owns the build, taking the post-asset deploy state and returning a keyed array of rebuilt place artifacts. Bedrock does not know how to build.
+_Avoid_: builder, build step, compile hook
+
+**Pending rebuild**:
+A presence-only bookkeeping marker — a place **Key** listed in the `$bedrock` envelope's `pendingRebuild` list — recording a place whose required asset IDs have been minted but not yet embedded and republished. Set for every place at the checkpoint write when a **Two-phase deploy** activates; cleared per place on a successful republish (the key is removed, never set `false`; an empty list is omitted), so a happy-path state never shows it. Lets a two-phase deploy self-heal after a failed **Rebuild hook**, since the assets themselves now `noop`; a marker present with no hook available is a hard error.
+_Avoid_: dirty flag, needs-redeploy, stale marker
+
+**`$bedrock` namespace**:
+The reserved, **adapter-private** key on the on-disk state envelope carrying bedrock's own bookkeeping — the schema `version` and the **Pending rebuild** list — distinct from user-declared desired state and Roblox-returned **Outputs**. Adapters flatten it on read into typed `BedrockState` fields and re-wrap it on write; nothing outside an adapter sees the raw key, and its contents never participate in **Drift**.
+_Avoid_: metadata, internal, reserved
+
 ### Patterns
 
 **Adoption**:


### PR DESCRIPTION
## What

Adds **ADR-026: Codegen and Two-Phase Deploy** (Accepted) plus the glossary terms it introduces. Records the design reached in a grilling session for issue #119 and the deploy-ordering problem layered on top of it.

## Why

Game code needs to reference Roblox-assigned asset IDs by **Key**, and a place's `rbxm` is built *before* deploy — so a newly-`create`d asset ID can't be embedded without a second deploy. ADR-026 captures the decision to solve both with one opt-in flow.

## The decision

- **Codegen** (opt-in, #119 proper): emit deployed **Outputs** to source files via a layered **Emitter** API (declarative default + `emit` override), receiving all environments' state. Default targets Luau + opt-in `.d.ts`.
- **Two-phase deploy**: when a provisioned `create` happens and a **Rebuild hook** is supplied, split the apply into an *asset stage* (apply assets → checkpoint state → codegen → rebuild hook) and a *republish stage* (publish rebuilt places). bedrock orchestrates; the injected hook owns the build.
- **Self-healing convergence**: a presence-only `pendingRebuild` marker in the adapter-private `$bedrock` envelope (mapped to a typed `BedrockState.pendingRebuild`) re-triggers two-phase after a failed rebuild instead of going green-but-stale.

## Scope

Docs only — ADR + `CONTEXT.md` glossary (**Codegen**, **Emitter**, **Two-phase deploy**, **Rebuild hook**, **Pending rebuild**, **`$bedrock` namespace**). No implementation in this PR.

Relates to #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary: ADR-026 Documentation PR

### Overview
This PR documents ADR-026 (Codegen and Two-Phase Deploy) and extends the glossary in `CONTEXT.md` with six new terms. The ADR addresses issue `#119` and captures design decisions for an opt-in code-generation system that coordinates with a two-phase deployment workflow.

### Architectural Assessment

**FCIS Compliance:** ✓ The design properly respects Bedrock's FCIS architecture:
- **Core**: Diff algebra remains pure; codegen and two-phase orchestration are shell-level concerns
- **Shell**: `deploy` orchestrates the two-phase flow and invokes hooks but does not implement the build
- **Ports/Adapters**: The **Emitter** and **Rebuild hook** are injected dependencies (driven ports); the **State port** is already established; drivers handle I/O
- **No I/O in Core**: Codegen reads state cross-environment but is invoked post-asset-stage; the rebuild hook is external injection

**Key Design Decisions:**
1. **Three-tier opt-in ladder** (no codegen → codegen → two-phase deploy) provides a clear graduation path
2. **Checkpoint-before-risky-step** safety pattern (persist asset outputs before rebuild can fail) aligns with ADR-023's orphan-recovery contract
3. **`pendingRebuild` marker for self-healing** activates two-phase on retry without requiring inter-resource dependencies, avoiding new state surface in the diff algebra
4. **Envelope-level marker storage** preserves ADR-019's adapter-private invariant (no per-resource type change; `BedrockState.pendingRebuild` ↔ `$bedrock` envelope mapping owned by serialization layer)
5. **Hook-driven build ownership** (bedrock orchestrates, hook implements) prevents coupling to build toolchains
6. **TS/JS-only two-phase** (not available to YAML/JSON/Luau configs) is inherent—arbitrary code cannot live in declarative configs

**Consistency with Existing ADRs:**
Properly cross-references and builds on ADR-017 (programmatic surface), ADR-018 (FCIS+Ports), ADR-019 (state model), ADR-023 (apply semantics), and others. No contradictions detected.

**Glossary Extensions:**
Six terms added to `CONTEXT.md` align perfectly with ADR-026 language and follow existing glossary format (term, definition, avoidance list). Terms properly distinguish Bedrock concepts (Codegen, Emitter, Two-phase deploy, Rebuild hook, Pending rebuild) and the reserved `$bedrock` namespace from other patterns.

### Code Quality

**Documentation Quality:** ✓ Clear, well-structured ADR following the established format
- Context articulates the problem and constraints (partial failure, non-idempotent creates, parallel apply semantics)
- Decision section is precise about activation conditions, checkpoint timing, marker lifecycle, and surface limitations
- Considered options document non-chosen paths with rationale
- Consequences itemize the state additions and orchestration implications
- Related decisions provide visibility into ADR dependencies

**v1 Compatibility:** ✓ Envelope schema remains backward-compatible; unknown `$bedrock` members are ignored by pre-ADR-026 readers

### No Implementation Blocking Issues

The PR is documentation-only and introduces no code. All architectural decisions are sound and implementable within the existing framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->