### PR TITLE
fix(core): send only changed fields on place and universe updates

### DIFF
--- a/packages/bedrock/src/adapters/place-driver.spec.ts
+++ b/packages/bedrock/src/adapters/place-driver.spec.ts
@@ -6,7 +6,7 @@ import { placeCurrent, placeDesired } from "#tests/helpers/resources";
 import type { Except } from "type-fest";
 import { assert, describe, expect, it } from "vitest";
 
-import { asRobloxAssetId } from "../types/ids.ts";
+import { asRobloxAssetId, asSha256Hex } from "../types/ids.ts";
 import { createPlaceDriver, type PlaceDriverDeps } from "./place-driver.ts";
 
 const UNIVERSE_ID = asRobloxAssetId("1234567890");
@@ -214,6 +214,62 @@ describe(createPlaceDriver, () => {
 			`/cloud/v2/universes/${UNIVERSE_ID}/places/${PLACE_ID}?updateMask=description`,
 		);
 		expect(http.requests[1]!.request.body).toStrictEqual({ description: "Updated body." });
+	});
+
+	it("should skip the metadata PATCH on update when only the file hash changed", async () => {
+		expect.assertions(2);
+
+		const { driver, http } = makeDriver();
+		http.mockResponse({ body: { versionNumber: 4 }, status: 200 });
+
+		assert(driver.update !== undefined);
+
+		const current = placeCurrent({
+			description: "Body.",
+			displayName: "Lobby",
+			fileHash: asSha256Hex(
+				"0000000000000000000000000000000000000000000000000000000000000000",
+			),
+			serverSize: 25,
+		});
+		const result = await driver.update(
+			current,
+			placeDesired({ description: "Body.", displayName: "Lobby", serverSize: 25 }),
+		);
+
+		assert(result.success);
+
+		expect(http.requests).toHaveLength(1);
+		expect(http.requests[0]!.request.method).toBe("POST");
+	});
+
+	it("should omit unchanged metadata fields from the updateMask on update", async () => {
+		expect.assertions(3);
+
+		const { driver, http } = makeDriver();
+		http.mockResponse({ body: { versionNumber: 5 }, status: 200 });
+		http.mockResponse({
+			body: validPlaceBody({ description: "New body." }),
+			status: 200,
+		});
+
+		assert(driver.update !== undefined);
+
+		const current = placeCurrent({
+			description: "Old body.",
+			displayName: "Lobby",
+			serverSize: 25,
+		});
+		await driver.update(
+			current,
+			placeDesired({ description: "New body.", displayName: "Lobby", serverSize: 25 }),
+		);
+
+		expect(http.requests).toHaveLength(2);
+		expect(http.requests[1]!.request.url).toBe(
+			`/cloud/v2/universes/${UNIVERSE_ID}/places/${PLACE_ID}?updateMask=description`,
+		);
+		expect(http.requests[1]!.request.body).toStrictEqual({ description: "New body." });
 	});
 
 	it("should surface a Result.err when the metadata PATCH fails after a successful publish", async () => {

--- a/packages/bedrock/src/adapters/place-driver.ts
+++ b/packages/bedrock/src/adapters/place-driver.ts
@@ -1,8 +1,8 @@
 import { ApiError, type OpenCloudError, type Result } from "@bedrock-rbx/ocale";
-import type { PlacesClient, UpdatePlaceParameters } from "@bedrock-rbx/ocale/places";
+import type { PlacesClient } from "@bedrock-rbx/ocale/places";
 
+import { changedPlaceMetadata } from "../core/kinds/place.ts";
 import type { PlaceDesiredState, PlaceOutputs, ResourceCurrentState } from "../core/resources.ts";
-import { PLACE_MANAGED_METADATA_FIELDS } from "../core/resources.ts";
 import type { ResourceDriver } from "../ports/resource-driver.ts";
 import type { RobloxAssetId } from "../types/ids.ts";
 
@@ -46,6 +46,11 @@ export interface PlaceDriverDeps {
 	readonly readFile: (path: string) => Promise<Uint8Array>;
 	/** Universe that owns every place this driver publishes. */
 	readonly universeId: RobloxAssetId;
+}
+
+interface PublishInputs {
+	readonly current: ResourceCurrentState<"place"> | undefined;
+	readonly desired: PlaceDesiredState;
 }
 
 /**
@@ -121,31 +126,12 @@ export interface PlaceDriverDeps {
 export function createPlaceDriver(deps: PlaceDriverDeps): ResourceDriver<"place"> {
 	return {
 		async create(desired) {
-			return publishPlace(deps, desired);
+			return publishPlace(deps, { current: undefined, desired });
 		},
-		async update(_current, desired) {
-			return publishPlace(deps, desired);
+		async update(current, desired) {
+			return publishPlace(deps, { current, desired });
 		},
 	};
-}
-
-function buildMetadataParameters(
-	universeId: RobloxAssetId,
-	desired: PlaceDesiredState,
-): undefined | UpdatePlaceParameters {
-	const metadata = PLACE_MANAGED_METADATA_FIELDS.reduce<Partial<UpdatePlaceParameters>>(
-		(accumulator, field) => {
-			const value = desired[field];
-			return value === undefined ? accumulator : { ...accumulator, [field]: value };
-		},
-		{},
-	);
-
-	if (Object.keys(metadata).length === 0) {
-		return undefined;
-	}
-
-	return { ...metadata, placeId: desired.placeId, universeId };
 }
 
 function detectFormat(filePath: string): "rbxl" | "rbxlx" | undefined {
@@ -188,16 +174,21 @@ async function publishVersion(
 
 async function publishPlace(
 	deps: PlaceDriverDeps,
-	desired: PlaceDesiredState,
+	inputs: PublishInputs,
 ): Promise<Result<ResourceCurrentState<"place">, OpenCloudError>> {
+	const { current, desired } = inputs;
 	const publishResult = await publishVersion(deps, desired);
 	if (!publishResult.success) {
 		return publishResult;
 	}
 
-	const metadataParameters = buildMetadataParameters(deps.universeId, desired);
-	if (metadataParameters !== undefined) {
-		const metadataResult = await deps.client.update(metadataParameters);
+	const metadata = changedPlaceMetadata(desired, current);
+	if (Object.keys(metadata).length > 0) {
+		const metadataResult = await deps.client.update({
+			...metadata,
+			placeId: desired.placeId,
+			universeId: deps.universeId,
+		});
 		if (!metadataResult.success) {
 			return metadataResult;
 		}

--- a/packages/bedrock/src/adapters/universe-driver.spec.ts
+++ b/packages/bedrock/src/adapters/universe-driver.spec.ts
@@ -7,7 +7,7 @@ import {
 } from "@bedrock-rbx/ocale/testing";
 import { UniversesClient } from "@bedrock-rbx/ocale/universes";
 
-import { PLATFORM_FLAG_ROWS, universeDesired } from "#tests/helpers/resources";
+import { PLATFORM_FLAG_ROWS, universeCurrent, universeDesired } from "#tests/helpers/resources";
 import { assert, describe, expect, it } from "vitest";
 
 import { SOCIAL_LINK_FIELDS, UNIVERSE_SINGLETON_KEY } from "../core/resources.ts";
@@ -204,6 +204,50 @@ describe(createUniverseDriver, () => {
 		assert(result.success);
 
 		expect(result.data.outputs.rootPlaceId).toBe("4711");
+	});
+
+	it("should omit unchanged managed flags from the universe updateMask on update", async () => {
+		expect.assertions(2);
+
+		const { driver, http } = makeDriver();
+		http.mockResponse({
+			body: validUniverseBody({ rootPlace: ROOT_PLACE_PATH }),
+			status: 200,
+		});
+
+		assert(driver.update !== undefined);
+
+		await driver.update(
+			universeCurrent({ desktopEnabled: true, voiceChatEnabled: false }),
+			universeDesired({ desktopEnabled: true, voiceChatEnabled: true }),
+		);
+
+		expect(http.requests[0]!.request.url).toBe(
+			`/cloud/v2/universes/${UNIVERSE_ID}?updateMask=voiceChatEnabled`,
+		);
+		expect(http.requests[0]!.request.body).toStrictEqual({ voiceChatEnabled: true });
+	});
+
+	it("should skip the root-place displayName patch when displayName is unchanged on update", async () => {
+		expect.assertions(2);
+
+		const { driver, http } = makeDriver();
+		http.mockResponse({
+			body: validUniverseBody({ rootPlace: ROOT_PLACE_PATH }),
+			status: 200,
+		});
+
+		assert(driver.update !== undefined);
+
+		await driver.update(
+			universeCurrent({ displayName: "Same", voiceChatEnabled: false }),
+			universeDesired({ displayName: "Same", voiceChatEnabled: true }),
+		);
+
+		expect(http.requests).toHaveLength(1);
+		expect(http.requests[0]!.request.url).toBe(
+			`/cloud/v2/universes/${UNIVERSE_ID}?updateMask=voiceChatEnabled`,
+		);
 	});
 
 	it("should surface a 404 as an adoption error naming the config key and universeId", async () => {

--- a/packages/bedrock/src/adapters/universe-driver.ts
+++ b/packages/bedrock/src/adapters/universe-driver.ts
@@ -2,8 +2,8 @@ import { ApiError, type OpenCloudError, type Result } from "@bedrock-rbx/ocale";
 import type { PlacesClient } from "@bedrock-rbx/ocale/places";
 import type { UniversesClient, UpdateUniverseParameters } from "@bedrock-rbx/ocale/universes";
 
+import { changedUniverseFields } from "../core/kinds/universe.ts";
 import {
-	copyDeclaredSocialLinks,
 	type ResourceCurrentState,
 	SOCIAL_LINK_FIELDS,
 	UNIVERSE_MANAGED_FLAGS,
@@ -32,6 +32,7 @@ interface ResolvedUniverse {
 }
 
 interface ReconcileInputs {
+	readonly current: ResourceCurrentState<"universe"> | undefined;
 	readonly deps: UniverseDriverDeps;
 	readonly desired: UniverseDesiredState;
 }
@@ -128,10 +129,10 @@ interface ReconcileInputs {
 export function createUniverseDriver(deps: UniverseDriverDeps): ResourceDriver<"universe"> {
 	return {
 		async create(desired) {
-			return reconcileUniverse({ deps, desired });
+			return reconcileUniverse({ current: undefined, deps, desired });
 		},
-		async update(_current, desired) {
-			return reconcileUniverse({ deps, desired });
+		async update(current, desired) {
+			return reconcileUniverse({ current, deps, desired });
 		},
 	};
 }
@@ -146,21 +147,23 @@ function toCurrentState(
 	};
 }
 
-function buildParameters(desired: UniverseDesiredState): UpdateUniverseParameters {
+function buildParameters(
+	desired: UniverseDesiredState,
+	fields: ReadonlySet<string>,
+): UpdateUniverseParameters {
 	const base = UNIVERSE_MANAGED_FLAGS.reduce<UpdateUniverseParameters>(
-		(accumulator, flag) => {
-			const isEnabled = desired[flag];
-			return isEnabled === undefined ? accumulator : { ...accumulator, [flag]: isEnabled };
-		},
+		(accumulator, flag) =>
+			fields.has(flag) ? { ...accumulator, [flag]: desired[flag] } : accumulator,
 		{ universeId: desired.universeId },
 	);
 
-	const withPrice =
-		"privateServerPriceRobux" in desired
-			? { ...base, privateServerPriceRobux: desired.privateServerPriceRobux }
-			: base;
+	const withPrice = fields.has("privateServerPriceRobux")
+		? { ...base, privateServerPriceRobux: desired.privateServerPriceRobux }
+		: base;
 
-	return { ...withPrice, ...copyDeclaredSocialLinks(desired) };
+	return SOCIAL_LINK_FIELDS.reduce<UpdateUniverseParameters>((accumulator, field) => {
+		return fields.has(field) ? { ...accumulator, [field]: desired[field] } : accumulator;
+	}, withPrice);
 }
 
 function wrapUpdateError(err: OpenCloudError, desired: UniverseDesiredState): OpenCloudError {
@@ -174,24 +177,21 @@ function wrapUpdateError(err: OpenCloudError, desired: UniverseDesiredState): Op
 	return err;
 }
 
-function hasUniverseLevelUpdate(desired: UniverseDesiredState): boolean {
-	if (UNIVERSE_MANAGED_FLAGS.some((flag) => desired[flag] !== undefined)) {
-		return true;
-	}
-
-	if ("privateServerPriceRobux" in desired) {
-		return true;
-	}
-
-	return SOCIAL_LINK_FIELDS.some((field) => field in desired);
+function hasUniverseLevelUpdate(fields: ReadonlySet<string>): boolean {
+	return (
+		UNIVERSE_MANAGED_FLAGS.some((flag) => fields.has(flag)) ||
+		fields.has("privateServerPriceRobux") ||
+		SOCIAL_LINK_FIELDS.some((field) => fields.has(field))
+	);
 }
 
 async function resolveUniverse(
 	deps: UniverseDriverDeps,
-	desired: UniverseDesiredState,
+	target: { desired: UniverseDesiredState; fields: ReadonlySet<string> },
 ): Promise<Result<ResolvedUniverse, OpenCloudError>> {
-	const result = hasUniverseLevelUpdate(desired)
-		? await deps.universes.update(buildParameters(desired))
+	const { desired, fields } = target;
+	const result = hasUniverseLevelUpdate(fields)
+		? await deps.universes.update(buildParameters(desired, fields))
 		: await deps.universes.get({ universeId: desired.universeId });
 
 	if (!result.success) {
@@ -215,16 +215,18 @@ async function resolveUniverse(
 async function reconcileUniverse(
 	inputs: ReconcileInputs,
 ): Promise<Result<ResourceCurrentState<"universe">, OpenCloudError>> {
-	const { deps, desired } = inputs;
-	const universeResult = await resolveUniverse(deps, desired);
+	const { current, deps, desired } = inputs;
+	const fields = changedUniverseFields(desired, current);
+	const universeResult = await resolveUniverse(deps, { desired, fields });
 	if (!universeResult.success) {
 		return universeResult;
 	}
 
 	const { rootPlaceId } = universeResult.data;
-	if (desired.displayName !== undefined) {
+	const displayName = fields.has("displayName") ? desired.displayName : undefined;
+	if (displayName !== undefined) {
 		const placesResult = await deps.places.update({
-			displayName: desired.displayName,
+			displayName,
 			placeId: rootPlaceId,
 			universeId: desired.universeId,
 		});

--- a/packages/bedrock/src/core/kinds/place.spec.ts
+++ b/packages/bedrock/src/core/kinds/place.spec.ts
@@ -2,7 +2,7 @@ import { placeCurrent, placeDesired } from "#tests/helpers/resources";
 import { assert, describe, expect, it } from "vitest";
 
 import { asResourceKey, asRobloxAssetId, asSha256Hex } from "../../types/ids.ts";
-import { placeKind } from "./place.ts";
+import { changedPlaceMetadata, placeKind } from "./place.ts";
 
 const ALT_HASH = asSha256Hex("a3f2c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852e1b0");
 
@@ -301,6 +301,43 @@ describe("placeKind", () => {
 					placeCurrent({ description: "Old body.", displayName: "Old" }),
 				),
 			).toStrictEqual(["fileHash", "displayName", "description"]);
+		});
+	});
+
+	describe(changedPlaceMetadata, () => {
+		it("should include every declared metadata field when no current state is given", () => {
+			expect.assertions(1);
+
+			expect(
+				changedPlaceMetadata(
+					placeDesired({ description: "Body.", displayName: "Lobby", serverSize: 25 }),
+				),
+			).toStrictEqual({ description: "Body.", displayName: "Lobby", serverSize: 25 });
+		});
+
+		it("should return an empty object when no metadata is declared on create", () => {
+			expect.assertions(1);
+
+			expect(changedPlaceMetadata(placeDesired())).toStrictEqual({});
+		});
+
+		it("should keep only metadata whose declared value differs from current", () => {
+			expect.assertions(1);
+
+			expect(
+				changedPlaceMetadata(
+					placeDesired({
+						description: "New body.",
+						displayName: "Lobby",
+						serverSize: 25,
+					}),
+					placeCurrent({
+						description: "Old body.",
+						displayName: "Lobby",
+						serverSize: 25,
+					}),
+				),
+			).toStrictEqual({ description: "New body." });
 		});
 	});
 });

--- a/packages/bedrock/src/core/kinds/place.ts
+++ b/packages/bedrock/src/core/kinds/place.ts
@@ -20,6 +20,41 @@ const entrySchema = type({
 	"serverSize?": OPTIONAL_POSITIVE_INTEGER,
 }).onUndeclaredKey("reject");
 
+type PlaceMetadataField = (typeof PLACE_MANAGED_METADATA_FIELDS)[number];
+
+/** Managed metadata fields with their non-`undefined` declared values. */
+type PlaceMetadataPatch = {
+	readonly [Field in PlaceMetadataField]?: NonNullable<PlaceDesiredState[Field]>;
+};
+
+/**
+ * Select the managed metadata fields (`displayName`, `description`,
+ * `serverSize`) the driver must `PATCH` to converge `current` onto `desired`.
+ * A field is emitted only when it is declared (`!== undefined`) and either no
+ * `current` is known (a create, where every declared field must be pushed) or
+ * its value differs from the recorded state. Both drift detection
+ * ({@link changedFieldsBetween}) and the place driver's `updateMask` builder
+ * route through this single predicate so the two cannot diverge.
+ *
+ * @param desired - Desired place state from the resolved config.
+ * @param current - Last-known state, or `undefined` on create.
+ * @returns Partial state holding only the metadata fields to patch, in the
+ *   fixed `PLACE_MANAGED_METADATA_FIELDS` order.
+ */
+export function changedPlaceMetadata(
+	desired: PlaceDesiredState,
+	current?: ResourceCurrentState<"place">,
+): PlaceMetadataPatch {
+	return PLACE_MANAGED_METADATA_FIELDS.reduce<PlaceMetadataPatch>((accumulator, field) => {
+		const value = desired[field];
+		if (value === undefined || value === current?.[field]) {
+			return accumulator;
+		}
+
+		return { ...accumulator, [field]: value };
+	}, {});
+}
+
 function flatten(config: ResolvedConfig): ReadonlyArray<PlaceDesiredInput> {
 	return Object.entries(config.places ?? {}).map<PlaceDesiredInput>(([key, entry]) => {
 		return {
@@ -66,10 +101,7 @@ function changedFieldsBetween(
 		...(desired.fileHash === current.fileHash ? [] : ["fileHash"]),
 		...(desired.filePath === current.filePath ? [] : ["filePath"]),
 		...(desired.placeId === current.placeId ? [] : ["placeId"]),
-		...PLACE_MANAGED_METADATA_FIELDS.filter((field) => {
-			const desiredValue = desired[field];
-			return desiredValue !== undefined && desiredValue !== current[field];
-		}),
+		...Object.keys(changedPlaceMetadata(desired, current)),
 	];
 }
 

--- a/packages/bedrock/src/core/kinds/universe.spec.ts
+++ b/packages/bedrock/src/core/kinds/universe.spec.ts
@@ -4,7 +4,7 @@ import { assert, describe, expect, it } from "vitest";
 
 import { asRobloxAssetId } from "../../types/ids.ts";
 import { SOCIAL_LINK_FIELDS, UNIVERSE_SINGLETON_KEY } from "../resources.ts";
-import { universeKind } from "./universe.ts";
+import { changedUniverseFields, universeKind } from "./universe.ts";
 
 const NORMALIZE_IO_NEVER = {
 	readFile: async (): Promise<Uint8Array> => {
@@ -309,6 +309,59 @@ describe("universeKind", () => {
 				"discordSocialLink",
 			]);
 		});
+	});
+});
+
+describe(changedUniverseFields, () => {
+	const sampleLink = { title: "Old", uri: "https://example.com/old" };
+
+	it("should return every declared field when no current state is given", () => {
+		expect.assertions(1);
+
+		expect(
+			changedUniverseFields(
+				universeDesired({
+					discordSocialLink: { title: "New", uri: "https://discord.gg/new" },
+					displayName: "Fun Universe",
+					privateServerPriceRobux: 250,
+					voiceChatEnabled: true,
+				}),
+			),
+		).toStrictEqual(
+			new Set([
+				"discordSocialLink",
+				"displayName",
+				"privateServerPriceRobux",
+				"voiceChatEnabled",
+			]),
+		);
+	});
+
+	it("should return an empty set when nothing is declared on create", () => {
+		expect.assertions(1);
+
+		expect(changedUniverseFields(universeDesired())).toStrictEqual(new Set());
+	});
+
+	it("should narrow to only the drifted fields when a current state is given", () => {
+		expect.assertions(1);
+
+		expect(
+			changedUniverseFields(
+				universeDesired({
+					discordSocialLink: sampleLink,
+					displayName: "Same",
+					privateServerPriceRobux: 250,
+					voiceChatEnabled: true,
+				}),
+				universeCurrent({
+					discordSocialLink: sampleLink,
+					displayName: "Same",
+					privateServerPriceRobux: 250,
+					voiceChatEnabled: false,
+				}),
+			),
+		).toStrictEqual(new Set(["voiceChatEnabled"]));
 	});
 });
 

--- a/packages/bedrock/src/core/kinds/universe.ts
+++ b/packages/bedrock/src/core/kinds/universe.ts
@@ -44,6 +44,74 @@ const entrySchema = type({
 	"youtubeSocialLink?": socialLinkOrUndefined,
 }).onUndeclaredKey("reject");
 
+/**
+ * Resolve the managed field names the universe driver must apply to converge
+ * `current` onto `desired`. On update (a known `current`) this is exactly
+ * {@link changedFieldsBetween}, so the constructed `updateMask` and the
+ * root-place `displayName` patch touch only drifted fields. On create
+ * (`current` omitted) every declared field is returned so a freshly adopted
+ * universe is fully reconciled. Sharing this predicate with drift detection
+ * keeps the patch set and the diff from diverging.
+ *
+ * @param desired - Desired universe state from the resolved config.
+ * @param current - Last-known state, or `undefined` on create.
+ * @returns Set of managed field names to apply (`universeId` aside).
+ */
+export function changedUniverseFields(
+	desired: UniverseDesiredState,
+	current?: ResourceCurrentState<"universe">,
+): ReadonlySet<string> {
+	return new Set(
+		current === undefined
+			? declaredUniverseFields(desired)
+			: changedFieldsBetween(desired, current),
+	);
+}
+
+function socialLinkEqual(a: SocialLink | undefined, b: SocialLink | undefined): boolean {
+	if (a === undefined) {
+		return b === undefined;
+	}
+
+	if (b === undefined) {
+		return false;
+	}
+
+	return a.title === b.title && a.uri === b.uri;
+}
+
+function changedFieldsBetween(
+	desired: UniverseDesiredState,
+	current: ResourceCurrentState<"universe">,
+): ReadonlyArray<string> {
+	return [
+		...(desired.universeId === current.universeId ? [] : ["universeId"]),
+		...UNIVERSE_MANAGED_FLAGS.filter((flag) => {
+			const isDesiredEnabled = desired[flag];
+			return isDesiredEnabled !== undefined && isDesiredEnabled !== current[flag];
+		}),
+		...(desired.displayName === undefined || desired.displayName === current.displayName
+			? []
+			: ["displayName"]),
+		...("privateServerPriceRobux" in desired &&
+		desired.privateServerPriceRobux !== current.privateServerPriceRobux
+			? ["privateServerPriceRobux"]
+			: []),
+		...SOCIAL_LINK_FIELDS.filter(
+			(field) => field in desired && !socialLinkEqual(desired[field], current[field]),
+		),
+	];
+}
+
+function declaredUniverseFields(desired: UniverseDesiredState): ReadonlyArray<string> {
+	return [
+		...UNIVERSE_MANAGED_FLAGS.filter((flag) => desired[flag] !== undefined),
+		...(desired.displayName === undefined ? [] : ["displayName"]),
+		...("privateServerPriceRobux" in desired ? ["privateServerPriceRobux"] : []),
+		...SOCIAL_LINK_FIELDS.filter((field) => field in desired),
+	];
+}
+
 function flatten(config: ResolvedConfig): ReadonlyArray<UniverseDesiredInput> {
 	const entry = config.universe;
 	if (entry === undefined) {
@@ -96,41 +164,6 @@ async function normalize(
 	_io: KindIo,
 ): Promise<Result<UniverseDesiredState, BuildDesiredError>> {
 	return { data: buildBaseDesired(input), success: true };
-}
-
-function socialLinkEqual(a: SocialLink | undefined, b: SocialLink | undefined): boolean {
-	if (a === undefined) {
-		return b === undefined;
-	}
-
-	if (b === undefined) {
-		return false;
-	}
-
-	return a.title === b.title && a.uri === b.uri;
-}
-
-function changedFieldsBetween(
-	desired: UniverseDesiredState,
-	current: ResourceCurrentState<"universe">,
-): ReadonlyArray<string> {
-	return [
-		...(desired.universeId === current.universeId ? [] : ["universeId"]),
-		...UNIVERSE_MANAGED_FLAGS.filter((flag) => {
-			const isDesiredEnabled = desired[flag];
-			return isDesiredEnabled !== undefined && isDesiredEnabled !== current[flag];
-		}),
-		...(desired.displayName === undefined || desired.displayName === current.displayName
-			? []
-			: ["displayName"]),
-		...("privateServerPriceRobux" in desired &&
-		desired.privateServerPriceRobux !== current.privateServerPriceRobux
-			? ["privateServerPriceRobux"]
-			: []),
-		...SOCIAL_LINK_FIELDS.filter(
-			(field) => field in desired && !socialLinkEqual(desired[field], current[field]),
-		),
-	];
 }
 
 function fieldsEqual(

--- a/packages/bedrock/src/core/kinds/universe.ts
+++ b/packages/bedrock/src/core/kinds/universe.ts
@@ -55,7 +55,10 @@ const entrySchema = type({
  *
  * @param desired - Desired universe state from the resolved config.
  * @param current - Last-known state, or `undefined` on create.
- * @returns Set of managed field names to apply (`universeId` aside).
+ * @returns Set of managed field names the driver should apply. On the update
+ *   path it mirrors {@link changedFieldsBetween} and so can include
+ *   `universeId` when the adopted identifier itself differs; the driver uses
+ *   `universeId` only as the request identifier, never as a patch field.
  */
 export function changedUniverseFields(
 	desired: UniverseDesiredState,


### PR DESCRIPTION
## What

Place and universe resource updates now compute a **minimal patch** from the `current` state the driver already receives, instead of re-sending every declared managed field on any change.

- **Place** — a file-only republish no longer drags along a `displayName,description,serverSize` PATCH. When no managed field drifted, the metadata PATCH is skipped entirely; otherwise the `updateMask` lists only the changed fields.
- **Universe** — the `updateMask` covers only drifted flags/price/social-links, and the root-place `displayName` PATCH is skipped when `displayName` hasn't moved.

On **create** (resource untracked) every declared field is still pushed, so a freshly adopted resource fully converges.

## Why

The `ResourceDriver.update` port hands each driver the last-known `current` state precisely so it can build a minimal patch — but the place and universe drivers ignored it and re-sent all declared fields. The visible symptom: a deploy that only rebuilt a place's `.rbxl` still issued a metadata PATCH for untouched `displayName/description/serverSize`. That spurious PATCH is what self-abort-timed-out in a downstream deploy (`Network request failed (The operation timed out.) on PATCH …?updateMask=displayName,description,serverSize`). Together with #470 (idempotent-retry on self-abort), this closes the loop: once the metadata genuinely lands in state, future file-only rebuilds go quiet.

## How

Two new pure predicates act as the single source of truth shared by drift detection and the `updateMask` builder, so the diff and the wire patch cannot diverge:

- `changedPlaceMetadata(desired, current?)` — `core/kinds/place.ts`
- `changedUniverseFields(desired, current?)` — `core/kinds/universe.ts`

No port/operation signature change — drivers compute from `current` exactly as the port intends. Two commits, one per behaviour slice (place, universe).

## Reviewer notes

- **No ADR** (bug fix).
- The create path keeps key-presence semantics for universe tri-state clearable fields (price, social links), so an explicitly-declared clear is still pushed on first adopt — this is why place (object patch) and universe (changed-name set) deliberately differ rather than sharing one predicate.
- `gamePass` / `developerProduct` drivers also ignore `current` but don't exhibit the spurious-PATCH symptom today; generalising minimal-patch across all kinds would be a port-contract change and is intentionally left out of scope.

## Verification

`pnpm lint` · `pnpm build` · `pnpm typecheck` · `pnpm test` (3953 passed) · `pnpm mutate:changed` (100% on all four touched files) — all green via the pre-commit hook on both commits.