### PR TITLE
feat(core): record pending-rebuild place keys in state envelope

### DIFF
--- a/packages/bedrock/src/core/state-file.spec.ts
+++ b/packages/bedrock/src/core/state-file.spec.ts
@@ -82,6 +82,40 @@ describe(serializeStateFile, () => {
 
 		expect(serializeStateFile(state)).toContain("\n");
 	});
+
+	it("should serialize pending-rebuild place keys into the $bedrock envelope", () => {
+		expect.assertions(1);
+
+		const state: BedrockState = {
+			environment: "production",
+			pendingRebuild: new Set([asResourceKey("lobby"), asResourceKey("start-place")]),
+			resources: [],
+			version: 1,
+		};
+
+		expect(JSON.parse(serializeStateFile(state))).toStrictEqual({
+			$bedrock: { pendingRebuild: ["lobby", "start-place"], version: 1 },
+			environment: "production",
+			resources: [],
+		});
+	});
+
+	it("should omit pending-rebuild from the envelope when the marker set is empty", () => {
+		expect.assertions(1);
+
+		const state: BedrockState = {
+			environment: "production",
+			pendingRebuild: new Set(),
+			resources: [],
+			version: 1,
+		};
+
+		expect(JSON.parse(serializeStateFile(state))).toStrictEqual({
+			$bedrock: { version: 1 },
+			environment: "production",
+			resources: [],
+		});
+	});
 });
 
 const SAMPLE_FILE = "gist:abc123/state.production.json";
@@ -262,6 +296,111 @@ describe(parseStateFile, () => {
 
 		const result = parseStateFile(
 			JSON.stringify({ $bedrock: { version: 1 }, environment: "production", resources: {} }),
+			SAMPLE_FILE,
+		);
+
+		expect(result.success).toBeFalse();
+	});
+
+	it("should round-trip pending-rebuild markers through serialize and parse", () => {
+		expect.assertions(2);
+
+		const state: BedrockState = {
+			environment: "staging",
+			pendingRebuild: new Set([asResourceKey("start-place")]),
+			resources: [],
+			version: 1,
+		};
+
+		const result = parseStateFile(serializeStateFile(state), SAMPLE_FILE);
+
+		expect(result.success).toBeTrue();
+
+		assert(result.success);
+
+		expect(result.data).toStrictEqual(state);
+	});
+
+	it("should hydrate pending-rebuild markers from a $bedrock envelope list", () => {
+		expect.assertions(2);
+
+		const result = parseStateFile(
+			JSON.stringify({
+				$bedrock: { pendingRebuild: ["start-place", "lobby"], version: 1 },
+				environment: "production",
+				resources: [],
+			}),
+			SAMPLE_FILE,
+		);
+
+		expect(result.success).toBeTrue();
+
+		assert(result.success);
+
+		expect(result.data).toStrictEqual({
+			environment: "production",
+			pendingRebuild: new Set([asResourceKey("lobby"), asResourceKey("start-place")]),
+			resources: [],
+			version: 1,
+		});
+	});
+
+	it("should omit pending-rebuild when the envelope list is empty", () => {
+		expect.assertions(2);
+
+		const result = parseStateFile(
+			JSON.stringify({
+				$bedrock: { pendingRebuild: [], version: 1 },
+				environment: "production",
+				resources: [],
+			}),
+			SAMPLE_FILE,
+		);
+
+		expect(result.success).toBeTrue();
+
+		assert(result.success);
+
+		expect(result.data).toStrictEqual({
+			environment: "production",
+			resources: [],
+			version: 1,
+		});
+	});
+
+	it("should parse a v1 state file without pendingRebuild and leave version unchanged", () => {
+		expect.assertions(3);
+
+		const result = parseStateFile(
+			JSON.stringify({
+				$bedrock: { version: 1 },
+				environment: "production",
+				resources: [],
+			}),
+			SAMPLE_FILE,
+		);
+
+		expect(result.success).toBeTrue();
+
+		assert(result.success);
+
+		expect(result.data).toStrictEqual({
+			environment: "production",
+			resources: [],
+			version: 1,
+		});
+		expect(result.data?.pendingRebuild).toBeUndefined();
+	});
+
+	it("should err when pendingRebuild is not a list of strings", () => {
+		expect.assertions(1);
+
+		const result = parseStateFile(
+			JSON.stringify({
+				$bedrock: { pendingRebuild: "start-place", version: 1 },
+				environment: "production",
+				resources: [],
+			}),
 			SAMPLE_FILE,
 		);
 

--- a/packages/bedrock/src/core/state-file.spec.ts
+++ b/packages/bedrock/src/core/state-file.spec.ts
@@ -406,4 +406,34 @@ describe(parseStateFile, () => {
 
 		expect(result.success).toBeFalse();
 	});
+
+	it("should tolerate and drop an unknown $bedrock member for forward compatibility", () => {
+		expect.assertions(3);
+
+		const result = parseStateFile(
+			JSON.stringify({
+				$bedrock: { futureThing: "x", version: 1 },
+				environment: "production",
+				resources: [],
+			}),
+			SAMPLE_FILE,
+		);
+
+		expect(result.success).toBeTrue();
+
+		assert(result.success);
+		assert(result.data !== undefined);
+
+		expect(result.data).toStrictEqual({
+			environment: "production",
+			resources: [],
+			version: 1,
+		});
+
+		expect(JSON.parse(serializeStateFile(result.data))).toStrictEqual({
+			$bedrock: { version: 1 },
+			environment: "production",
+			resources: [],
+		});
+	});
 });

--- a/packages/bedrock/src/core/state-file.ts
+++ b/packages/bedrock/src/core/state-file.ts
@@ -2,6 +2,7 @@ import type { Result } from "@bedrock-rbx/ocale";
 
 import { ArkErrors, type } from "arktype";
 
+import type { ResourceKey } from "../types/ids.ts";
 import type { ResourceCurrentState } from "./resources.ts";
 import type { BedrockState, StateError } from "./state.ts";
 
@@ -18,7 +19,7 @@ const resourceShape = type({
 });
 
 const envelopeSchema = type({
-	$bedrock: { version: "1" },
+	$bedrock: { "pendingRebuild?": "string[]", "version": "1" },
 	environment: "string",
 	resources: resourceShape.array(),
 });
@@ -31,6 +32,10 @@ const envelopeSchema = type({
  * `$bedrock: { version: N }` envelope so that a future breaking change to the
  * schema can be detected and rejected at parse time rather than silently
  * accepted. The top-level `version` field is not duplicated on disk.
+ *
+ * A non-empty `pendingRebuild` set is written as a `pendingRebuild` list of
+ * keys alongside `version` inside the envelope; an empty or absent set is
+ * omitted so a happy-path file never shows the marker.
  *
  * @example
  *
@@ -56,7 +61,7 @@ const envelopeSchema = type({
  */
 export function serializeStateFile(state: BedrockState): string {
 	const envelope = {
-		$bedrock: { version: state.version },
+		$bedrock: bedrockMeta(state),
 		environment: state.environment,
 		resources: state.resources,
 	};
@@ -69,6 +74,10 @@ export function serializeStateFile(state: BedrockState): string {
  * A backend that reports "no state file for this environment yet" must pass
  * `undefined`: that distinguishes a legitimate first deploy from a file that
  * exists but cannot be trusted.
+ *
+ * A `pendingRebuild` list inside the envelope is hydrated back into the typed
+ * set; an absent or empty list leaves the field off the parsed state. A
+ * pre-existing v1 file without the field parses unchanged.
  *
  * @example
  *
@@ -107,10 +116,33 @@ export function parseStateFile(
 		return errState(file, `invalid state file: ${validated.summary}`);
 	}
 
+	return { data: toState(validated), success: true };
+}
+
+function bedrockMeta(state: BedrockState): {
+	pendingRebuild?: ReadonlyArray<ResourceKey>;
+	version: 1;
+} {
+	const { pendingRebuild, version } = state;
+	if (pendingRebuild === undefined || pendingRebuild.size === 0) {
+		return { version };
+	}
+
+	return { pendingRebuild: [...pendingRebuild], version };
+}
+
+function toState(validated: typeof envelopeSchema.infer): BedrockState {
 	const resources = validated.resources as unknown as ReadonlyArray<ResourceCurrentState>;
+	const pendingKeys = validated.$bedrock.pendingRebuild;
+	if (pendingKeys === undefined || pendingKeys.length === 0) {
+		return { environment: validated.environment, resources, version: 1 };
+	}
+
 	return {
-		data: { environment: validated.environment, resources, version: 1 },
-		success: true,
+		environment: validated.environment,
+		pendingRebuild: new Set(pendingKeys as unknown as ReadonlyArray<ResourceKey>),
+		resources,
+		version: 1,
 	};
 }
 

--- a/packages/bedrock/src/core/state.spec-d.ts
+++ b/packages/bedrock/src/core/state.spec-d.ts
@@ -5,7 +5,7 @@ import type { ResourceCurrentState } from "./resources.ts";
 import type { BedrockState, StateError } from "./state.ts";
 
 describe("BedrockState", () => {
-	it("should expose readonly environment, resources, and version fields", () => {
+	it("should expose readonly environment, pendingRebuild, resources, and version fields", () => {
 		expectTypeOf<BedrockState>().toEqualTypeOf<{
 			readonly environment: string;
 			readonly pendingRebuild?: ReadonlySet<ResourceKey>;

--- a/packages/bedrock/src/core/state.spec-d.ts
+++ b/packages/bedrock/src/core/state.spec-d.ts
@@ -1,5 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest";
 
+import type { ResourceKey } from "../types/ids.ts";
 import type { ResourceCurrentState } from "./resources.ts";
 import type { BedrockState, StateError } from "./state.ts";
 
@@ -7,6 +8,7 @@ describe("BedrockState", () => {
 	it("should expose readonly environment, resources, and version fields", () => {
 		expectTypeOf<BedrockState>().toEqualTypeOf<{
 			readonly environment: string;
+			readonly pendingRebuild?: ReadonlySet<ResourceKey>;
 			readonly resources: ReadonlyArray<ResourceCurrentState>;
 			readonly version: 1;
 		}>();
@@ -14,6 +16,12 @@ describe("BedrockState", () => {
 
 	it("should pin version to the literal 1, not number", () => {
 		expectTypeOf<BedrockState["version"]>().toEqualTypeOf<1>();
+	});
+
+	it("should type pendingRebuild as an optional readonly set of resource keys", () => {
+		expectTypeOf<BedrockState["pendingRebuild"]>().toEqualTypeOf<
+			ReadonlySet<ResourceKey> | undefined
+		>();
 	});
 });
 

--- a/packages/bedrock/src/core/state.ts
+++ b/packages/bedrock/src/core/state.ts
@@ -1,3 +1,4 @@
+import type { ResourceKey } from "../types/ids.ts";
 import type { ResourceCurrentState } from "./resources.ts";
 
 /**
@@ -51,6 +52,17 @@ import type { ResourceCurrentState } from "./resources.ts";
 export interface BedrockState {
 	/** Environment name this snapshot belongs to (e.g. `"production"`, `"staging"`). */
 	readonly environment: string;
+	/**
+	 * Place keys recorded as owing a rebuild, surfaced so a later deploy can
+	 * self-heal a place that published but never finished its follow-up build.
+	 *
+	 * Presence-only: a key is either listed or absent, never flagged `false`.
+	 * The field is omitted entirely when no place owes a rebuild, so a
+	 * happy-path snapshot never carries it. On disk the set is stored as a list
+	 * of keys inside the adapter-private `$bedrock` envelope, and an empty set
+	 * is dropped on write. The marker never participates in drift detection.
+	 */
+	readonly pendingRebuild?: ReadonlySet<ResourceKey>;
 	/** Current state of every resource Bedrock manages in this environment. */
 	readonly resources: ReadonlyArray<ResourceCurrentState>;
 	/** Schema-version literal; bumped only for breaking changes to the on-disk format. */


### PR DESCRIPTION
## What

Adds an optional, presence-only `pendingRebuild` set of place keys to the in-memory `BedrockState`, persisted as a list of keys inside the adapter-private `$bedrock` envelope (`{ $bedrock: { version, pendingRebuild } }`) — mapped to/from the typed field exactly as `version` is.

This is the **State** contract slice of the two-phase deploy work (ADR-026, parent #474): a place can be recorded as owing a rebuild so a later deploy can self-heal it.

## Why

Two-phase deploy needs durable state to know which places published but still owe a follow-up build. This PR lands only the contract + envelope mapping; the deploy logic that reads/writes the marker comes in follow-up slices.

## Behaviour

- `BedrockState` carries `readonly pendingRebuild?: ReadonlySet<ResourceKey>`.
- **Presence-only**: a key is listed or absent, never `false`. An empty set is omitted on write, so a happy-path state file never shows the marker.
- **v1-compatible**: a pre-existing file with no `pendingRebuild` parses unchanged; `version` is untouched. An older reader tolerates the field and drops it on its next write.
- The marker lives on the snapshot only — never on `ResourceCurrentState` and never an input to `diff`, so it cannot affect drift detection.
- `$bedrock` stays adapter-private: wrap/flatten lives entirely in `serializeStateFile`/`parseStateFile`; nothing outside an adapter sees the raw key.

## Reviewer notes

- Wrap/flatten mirrors the existing `version` mapping seam — no new layer, no special-casing.
- `string[]` → `ReadonlyArray<ResourceKey>` uses the same `as unknown as` brand cast already applied to `resources`.
- Tests cover serialize (populated / empty-omitted), parse (hydrate / empty-omitted / v1-compat / invalid type), round-trip, and the type-level shape. 100% coverage and 0 surviving mutants on touched `src/**` (verified locally via the normalized-diff mutate path).

Closes #477

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Bedrock Code Review: `pendingRebuild` State Field Implementation

## ✅ Architecture (FCIS Pattern) - COMPLIANT

**Core Layer Verification:**
- `state-file.ts` contains **pure functions only**: `serializeStateFile()`, `parseStateFile()`, and helpers `bedrockMeta()`, `toState()`
- **Zero I/O operations**: No file system, fetch, or network calls detected
- **Zero side effects**: Pure input→output transformations; state modifications are immutable
- **Adapter-private envelope**: The `$bedrock` key is wrapping/unwrapping only within these two functions; callers never see the raw key structure
- **No business logic in Shell/Adapters**: The envelope transformation is entirely Core-owned

**FCIS Structure Confirmed:**
- Core: `state.ts`, `state-file.ts` (pure contracts and transformations) ✓
- Ports: `state-port.ts` defines the interface ✓
- Adapters: `gist-state-adapter.ts` would call `parseStateFile`/`serializeStateFile` ✓
- Shell: Orchestration layer delegates to Core ✓

---

## ✅ Testing (TDD) - COMPLIANT

**Test Coverage Details:**

| Aspect | Tests | Status |
|--------|-------|--------|
| **Serialization** | "should serialize pending-rebuild place keys into the $bedrock envelope" + "should omit pending-rebuild from the envelope when the marker set is empty" | ✓ Both populated and empty cases tested |
| **Parsing** | "should round-trip pending-rebuild markers through serialize and parse" + "should hydrate pending-rebuild markers from a $bedrock envelope list" + "should omit pending-rebuild when the envelope list is empty" | ✓ Hydration, omission, and round-trip covered |
| **Backward Compatibility** | "should parse a v1 state file without pendingRebuild and leave version unchanged" | ✓ Pre-existing files without field parse successfully |
| **Validation** | "should err when pendingRebuild is not a list of strings" | ✓ Invalid types rejected |
| **Type Safety** | `state.spec-d.ts`: `expectTypeOf<BedrockState["pendingRebuild"]>().toEqualTypeOf<ReadonlySet<ResourceKey> \| undefined>()` | ✓ Compile-time type verification |

**Test Naming Convention:**
- ✓ All tests follow `it("should <behavior>")` format
- ✓ Example: `it("should serialize pending-rebuild place keys into the $bedrock envelope")`
- ✓ Clear, behavioral descriptions with no ambiguity

**Real Behavior Testing:**
- ✓ Tests call actual `serializeStateFile()` and `parseStateFile()` functions
- ✓ No mock objects detected; validation against real schema with arktype
- ✓ Round-trip testing ensures data fidelity through JSON stringify/parse cycles

**Coverage Claims:**
- PR objectives claim "100% code coverage with zero surviving mutants" on touched source files
- Test structure supports this claim with 139 new lines covering all branches:
  - Line 127: `if (pendingRebuild === undefined || pendingRebuild.size === 0)`
  - Line 137: `if (pendingKeys === undefined || pendingKeys.length === 0)`
  - Both true and false paths tested

---

## ✅ Test Isolation - COMPLIANT

**Core Layer Testing Model:**
- ✓ State-file tests are **unit tests** (not integration tests)
- ✓ No external dependencies: `@bedrock-rbx/ocale` (Result type) and `arktype` (schema) are library-only
- ✓ No fake adapters needed for Core testing
- ✓ Pure functions tested in isolation with controlled inputs
- ✓ Type tests (`state.spec-d.ts`) perform compile-time verification; no runtime dependencies

**Test Isolation Table:**
| Layer | Test Type | Isolation | Status |
|-------|-----------|-----------|--------|
| Core (state-file.ts) | Unit | Direct function calls | ✓ No mocks |
| Types (state.spec-d.ts) | Type | Compile-time `expectTypeOf` | ✓ No adapters |

---

## ✅ Security & Constraints - COMPLIANT

**Data Classification:**
- ✓ `pendingRebuild` field contains **resource keys only** (e.g., `"lobby"`, `"start-place"`)
- ✓ Resource keys are **public identifiers**, not secrets
- ✓ No credentials, tokens, API keys, or `ROBLOSECURITY` references
- ✓ No private/personal data stored

**Input Validation:**
- ✓ Zod schema (via arktype `type()`) validates envelope structure at parse boundary:
  ```
  $bedrock: { "pendingRebuild?": "string[]", "version": "1" }
  ```
- ✓ Invalid types rejected with `ArkErrors` → `StateError` (line 115-116)
- ✓ Schema enforces `pendingRebuild` must be an array of strings (ResourceKey type)

**Backward Compatibility:**
- ✓ Pre-v2 state files lacking `pendingRebuild` field parse unchanged (line 137: `if (pendingKeys === undefined)`)
- ✓ `version` field preserved at literal `1`
- ✓ `pendingRebuild` omitted from parsed state when absent or empty (line 138: returns state without field)
- ✓ No silent data loss; empty sets are explicitly omitted, not replaced with null/false

**Open Cloud Only:**
- ✓ Implementation uses Bedrock-native APIs and types
- ✓ No legacy Roblox API patterns detected
- ✓ Aligned with ADR-026 (two-phase deploy system)

---

## ✅ Code Quality - COMPLIANT

**TypeScript Strict Mode:**
- ✓ `readonly pendingRebuild?: ReadonlySet<ResourceKey>` — proper immutability on interface (state.ts line 65)
- ✓ Field is optional (undefined handling) but never null
- ✓ No `any` types on `pendingRebuild`-related code
- ✓ Type narrowing via arktype validation before `toState()` call (line 143: `as unknown as ReadonlyArray<ResourceKey>` is the known pattern for brand narrowing post-validation)

**Error Handling:**
- ✓ Typed `StateError` interface with discriminator `kind: "stateError"`
- ✓ Errors include file path + reason (line 155: `{ file, kind: "stateError", reason: ... }`)
- ✓ Caller can narrow on `result.success` boolean discriminator
- ✓ Examples in JSDoc show proper error handling pattern

**Readonly Enforcement:**
- ✓ `ReadonlySet<ResourceKey>` prevents mutations via state object
- ✓ `ReadonlyArray<ResourceCurrentState>` on resources field
- ✓ Interface properly declares all fields as `readonly`

**Code Organization:**
- ✓ Helper functions (`bedrockMeta`, `toState`, `parseJson`, `errState`) properly encapsulated as non-exported
- ✓ Clear separation of concerns: serialization, parsing, validation, error construction
- ✓ Documentation comments are precise and include examples

---

## 🔍 Implementation Details Verification

**Envelope Mapping Pattern:**
- **On Disk**: `{ $bedrock: { pendingRebuild?: string[], version: 1 }, environment, resources }`
- **In Memory**: `BedrockState { pendingRebuild?: ReadonlySet<ResourceKey>, ... }`
- **Transform**: `bedrockMeta()` converts `Set` → array (line 131: `[...pendingRebuild]`)
- **Reverse**: `toState()` converts array → `Set` (line 143: `new Set(pendingKeys)`)
- **Empty Omission**: Lines 127-128 omit field when `undefined` or size is 0 ✓

**Schema Definition:**
```javascript
const envelopeSchema = type({
  $bedrock: { "pendingRebuild?": "string[]", "version": "1" },
  environment: "string",
  resources: resourceShape.array(),
});
```
✓ Optional field marker (`?`) makes `pendingRebuild` schema-optional
✓ Version is literal string `"1"` (not number) for breaking-change detection
✓ Matches bedrockMeta return type signature (line 122-124)

**Exclusion from Drift Detection:**
- ✓ `pendingRebuild` resides on `BedrockState` only
- ✓ Not included in `ResourceCurrentState` (resources.ts — verified via grep; not visible in PR changes)
- ✓ Not fed into `diff` logic (diff.ts not modified in this PR)
- ✓ Documentation explicitly states "never participates in drift detection" (state.ts line 63)

---

## Summary

This PR successfully delivers the State contract component of ADR-026 with **zero architectural violations**. The implementation:

1. **Maintains FCIS Separation**: Core functions are pure, adapter-private envelope handling is confined to state-file.ts
2. **Achieves TDD Standards**: Comprehensive test coverage with 139 new lines, 100% test naming compliance, round-trip validation
3. **Ensures Proper Isolation**: Unit tests on Core layer with no external orchestration or mocking
4. **Upholds Security**: Public data only (resource keys), input validated at boundaries, backward-compatible
5. **Passes Code Quality**: Strict TypeScript, typed errors, immutable fields, clear documentation

**Ready for merge and integration with ADR-026 deploy logic.**

<!-- end of auto-generated comment: release notes by coderabbit.ai -->