### PR TITLE
refactor(core): extract composable apply-and-persist reconcile pass

### DIFF
--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -24,7 +24,7 @@ import type { BedrockState, StateError } from "../core/state.ts";
 import type { ProgressPort } from "../ports/progress-port.ts";
 import type { DriverRegistry } from "../ports/resource-driver.ts";
 import type { StatePort } from "../ports/state-port.ts";
-import { type AggregateApplyError, applyOps } from "./apply-ops.ts";
+import type { AggregateApplyError } from "./apply-ops.ts";
 import { buildDefaultRegistry, type RegistryConfigError } from "./build-default-registry.ts";
 import { buildDesired, type BuildDesiredError } from "./build-desired.ts";
 import {
@@ -33,6 +33,7 @@ import {
 	type UnsupportedBackendError,
 } from "./build-state-port.ts";
 import { loadConfig as defaultLoadConfig, type LoadConfigOptions } from "./load-config.ts";
+import { applyAndPersist } from "./reconcile-pass.ts";
 
 /**
  * Inputs for `deploy`. Every field except `environment` is optional;
@@ -91,12 +92,6 @@ export type DeployError =
 			readonly kind: "stateWriteFailed";
 			readonly unsavedState: BedrockState;
 	  };
-
-interface SnapshotInputs {
-	readonly applied: Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>;
-	readonly environment: string;
-	readonly priorResources: ReadonlyArray<ResourceCurrentState>;
-}
 
 interface FinalizeInputs {
 	readonly applied: Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>;
@@ -303,33 +298,6 @@ async function resolveDeps(options: DeployOptions): Promise<Result<ResolvedDepsB
 	};
 }
 
-function mergeResources(
-	pre: ReadonlyArray<ResourceCurrentState>,
-	applied: ReadonlyArray<ResourceCurrentState>,
-): ReadonlyArray<ResourceCurrentState> {
-	const byKey = new Map<string, ResourceCurrentState>();
-	for (const resource of pre) {
-		byKey.set(`${resource.kind}:${resource.key}`, resource);
-	}
-
-	for (const resource of applied) {
-		byKey.set(`${resource.kind}:${resource.key}`, resource);
-	}
-
-	return [...byKey.values()];
-}
-
-function buildSnapshot(inputs: SnapshotInputs): BedrockState {
-	const appliedResources = inputs.applied.success
-		? inputs.applied.data
-		: inputs.applied.err.applied;
-	return {
-		environment: inputs.environment,
-		resources: mergeResources(inputs.priorResources, appliedResources),
-		version: 1,
-	};
-}
-
 function finalize(inputs: FinalizeInputs): Result<BedrockState, DeployError> {
 	// Check write before apply: only the write carries `unsavedState`.
 	if (!inputs.written.success) {
@@ -371,15 +339,16 @@ async function runReconcile(
 	}
 
 	const ops = diff(desired.data, priorResources);
-	const applied = await applyOps(ops, deps.registry, { environment, progress: deps.progress });
-	const merged = buildSnapshot({ applied, environment, priorResources });
+	const pass = await applyAndPersist({
+		environment,
+		ops,
+		priorResources,
+		progress: deps.progress,
+		registry: deps.registry,
+		statePort: deps.statePort,
+	});
 
-	const written = await deps.statePort.write(merged);
-	if (written.success) {
-		deps.progress.emit({ environment, kind: "stateWritten" });
-	}
-
-	return finalize({ applied, merged, written });
+	return finalize({ applied: pass.applied, merged: pass.merged, written: pass.written });
 }
 
 async function runDeploy(

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -11,7 +11,6 @@ import type { ConfigError } from "../core/config-error.ts";
 import { diff } from "../core/diff.ts";
 import { flattenConfig } from "../core/flatten.ts";
 import { resolveStateConfig, type StateNotConfiguredError } from "../core/resolve-state-config.ts";
-import type { ResourceCurrentState } from "../core/resources.ts";
 import type { Config, ResolvedConfig } from "../core/schema.ts";
 import {
 	type IncompletePassEntryError,
@@ -33,7 +32,7 @@ import {
 	type UnsupportedBackendError,
 } from "./build-state-port.ts";
 import { loadConfig as defaultLoadConfig, type LoadConfigOptions } from "./load-config.ts";
-import { applyAndPersist } from "./reconcile-pass.ts";
+import { applyAndPersist, type ReconcilePass } from "./reconcile-pass.ts";
 
 /**
  * Inputs for `deploy`. Every field except `environment` is optional;
@@ -92,12 +91,6 @@ export type DeployError =
 			readonly kind: "stateWriteFailed";
 			readonly unsavedState: BedrockState;
 	  };
-
-interface FinalizeInputs {
-	readonly applied: Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>;
-	readonly merged: BedrockState;
-	readonly written: Result<void, StateError>;
-}
 
 interface ResolvedDepsBase {
 	readonly config: ResolvedConfig;
@@ -298,24 +291,24 @@ async function resolveDeps(options: DeployOptions): Promise<Result<ResolvedDepsB
 	};
 }
 
-function finalize(inputs: FinalizeInputs): Result<BedrockState, DeployError> {
+function finalize(pass: ReconcilePass): Result<BedrockState, DeployError> {
 	// Check write before apply: only the write carries `unsavedState`.
-	if (!inputs.written.success) {
+	if (!pass.written.success) {
 		return {
 			err: {
-				cause: inputs.written.err,
+				cause: pass.written.err,
 				kind: "stateWriteFailed",
-				unsavedState: inputs.merged,
+				unsavedState: pass.merged,
 			},
 			success: false,
 		};
 	}
 
-	if (!inputs.applied.success) {
-		return { err: { cause: inputs.applied.err, kind: "applyFailed" }, success: false };
+	if (!pass.applied.success) {
+		return { err: { cause: pass.applied.err, kind: "applyFailed" }, success: false };
 	}
 
-	return { data: inputs.merged, success: true };
+	return { data: pass.merged, success: true };
 }
 
 async function runReconcile(
@@ -348,7 +341,7 @@ async function runReconcile(
 		statePort: deps.statePort,
 	});
 
-	return finalize({ applied: pass.applied, merged: pass.merged, written: pass.written });
+	return finalize(pass);
 }
 
 async function runDeploy(

--- a/packages/bedrock/src/shell/reconcile-pass.spec.ts
+++ b/packages/bedrock/src/shell/reconcile-pass.spec.ts
@@ -1,3 +1,5 @@
+import { OpenCloudError } from "@bedrock-rbx/ocale";
+
 import {
 	developerProductCurrent,
 	gamePassCurrent,
@@ -185,5 +187,40 @@ describe(applyAndPersist, () => {
 
 		expect(second.written).toStrictEqual({ err: stateError, success: false });
 		expect(second.merged.resources).toStrictEqual([alpha, vip]);
+	});
+
+	it("should snapshot only the survivors when an op in the pass fails to apply", async () => {
+		expect.assertions(2);
+
+		const failure = new OpenCloudError("create vip-pass: 503");
+		const registry: DriverRegistry = {
+			developerProduct: developerProductStub,
+			gamePass: {
+				async create(desired) {
+					return desired.key === "alpha-pass"
+						? { data: alpha, success: true }
+						: { err: failure, success: false };
+				},
+			},
+			place: placeStub,
+			universe: universeStub,
+		};
+		const { port, writes } = inMemoryStatePort();
+		const { port: progress } = recordingProgress();
+
+		const pass = await applyAndPersist({
+			environment: "production",
+			ops: [
+				createGamePassOp(asResourceKey("alpha-pass")),
+				createGamePassOp(asResourceKey("vip-pass")),
+			],
+			priorResources: [],
+			progress,
+			registry,
+			statePort: port,
+		});
+
+		expect(pass.applied.success).toBeFalse();
+		expect(writes[0]).toStrictEqual([alpha]);
 	});
 });

--- a/packages/bedrock/src/shell/reconcile-pass.spec.ts
+++ b/packages/bedrock/src/shell/reconcile-pass.spec.ts
@@ -1,0 +1,189 @@
+import {
+	developerProductCurrent,
+	gamePassCurrent,
+	gamePassDesired,
+	placeCurrent,
+	universeCurrent,
+} from "#tests/helpers/resources";
+import { describe, expect, it } from "vitest";
+
+import type { Operation } from "../core/operations.ts";
+import type { ResourceCurrentState } from "../core/resources.ts";
+import type { ProgressEvent, ProgressPort } from "../ports/progress-port.ts";
+import type { DriverRegistry, ResourceDriver } from "../ports/resource-driver.ts";
+import type { StatePort } from "../ports/state-port.ts";
+import { asResourceKey, type ResourceKey } from "../types/ids.ts";
+import { applyAndPersist } from "./reconcile-pass.ts";
+
+const alpha = gamePassCurrent({
+	key: asResourceKey("alpha-pass"),
+	name: "Alpha Pass",
+});
+const vip = gamePassCurrent({ key: asResourceKey("vip-pass") });
+
+function createGamePassOp(key: ResourceKey): Operation {
+	return { key, desired: gamePassDesired({ key }), type: "create" };
+}
+
+const developerProductStub: ResourceDriver<"developerProduct"> = {
+	async create() {
+		throw new Error("developerProduct driver must not run for this fixture");
+	},
+};
+
+const placeStub: ResourceDriver<"place"> = {
+	async create() {
+		throw new Error("place driver must not run for this fixture");
+	},
+};
+
+const universeStub: ResourceDriver<"universe"> = {
+	async create() {
+		throw new Error("universe driver must not run for this fixture");
+	},
+};
+
+function gamePassRegistry(byKey: Record<string, ResourceCurrentState<"gamePass">>): DriverRegistry {
+	return {
+		developerProduct: developerProductStub,
+		gamePass: {
+			async create(desired) {
+				const current = byKey[desired.key];
+				if (current === undefined) {
+					throw new Error(`no fixture for ${desired.key}`);
+				}
+
+				return { data: current, success: true };
+			},
+		},
+		place: placeStub,
+		universe: universeStub,
+	};
+}
+
+function recordingProgress(): { calls: Array<ProgressEvent>; port: ProgressPort } {
+	const calls: Array<ProgressEvent> = [];
+	return {
+		calls,
+		port: {
+			emit(event) {
+				calls.push(event);
+			},
+		},
+	};
+}
+
+function inMemoryStatePort(): {
+	port: StatePort;
+	writes: Array<ReadonlyArray<ResourceCurrentState>>;
+} {
+	const writes: Array<ReadonlyArray<ResourceCurrentState>> = [];
+	return {
+		port: {
+			async read() {
+				return { data: undefined, success: true };
+			},
+			async write(state) {
+				writes.push(state.resources);
+				return { data: undefined, success: true };
+			},
+		},
+		writes,
+	};
+}
+
+describe(applyAndPersist, () => {
+	it("should persist a partial snapshot then a cumulative snapshot across two passes", async () => {
+		expect.assertions(4);
+
+		const { port, writes } = inMemoryStatePort();
+		const registry = gamePassRegistry({ "alpha-pass": alpha, "vip-pass": vip });
+		const { calls, port: progress } = recordingProgress();
+
+		const first = await applyAndPersist({
+			environment: "production",
+			ops: [createGamePassOp(asResourceKey("alpha-pass"))],
+			priorResources: [],
+			progress,
+			registry,
+			statePort: port,
+		});
+
+		const second = await applyAndPersist({
+			environment: "production",
+			ops: [createGamePassOp(asResourceKey("vip-pass"))],
+			priorResources: first.merged.resources,
+			progress,
+			registry,
+			statePort: port,
+		});
+
+		expect(writes[0]).toStrictEqual([alpha]);
+		expect(writes[1]).toStrictEqual([alpha, vip]);
+		expect(second.merged.resources).toStrictEqual([alpha, vip]);
+		expect(calls.filter((event) => event.kind === "stateWritten")).toHaveLength(2);
+	});
+
+	it("should keep prior outputs of other kinds untouched while a pass updates one resource", async () => {
+		expect.assertions(1);
+
+		const priorProduct = developerProductCurrent();
+		const priorPlace = placeCurrent();
+		const priorUniverse = universeCurrent();
+		const { port, writes } = inMemoryStatePort();
+		const registry = gamePassRegistry({ "vip-pass": vip });
+		const { port: progress } = recordingProgress();
+
+		await applyAndPersist({
+			environment: "production",
+			ops: [createGamePassOp(asResourceKey("vip-pass"))],
+			priorResources: [priorProduct, priorPlace, priorUniverse],
+			progress,
+			registry,
+			statePort: port,
+		});
+
+		expect(writes[0]).toStrictEqual([priorProduct, priorPlace, priorUniverse, vip]);
+	});
+
+	it("should carry the cumulative snapshot in the failing write of a later pass", async () => {
+		expect.assertions(2);
+
+		const stateError = { file: "state.json", kind: "stateError" as const, reason: "EACCES" };
+		let writeCount = 0;
+		const port: StatePort = {
+			async read() {
+				return { data: undefined, success: true };
+			},
+			async write() {
+				writeCount += 1;
+				return writeCount === 1
+					? { data: undefined, success: true }
+					: { err: stateError, success: false };
+			},
+		};
+		const registry = gamePassRegistry({ "alpha-pass": alpha, "vip-pass": vip });
+		const { port: progress } = recordingProgress();
+
+		const first = await applyAndPersist({
+			environment: "production",
+			ops: [createGamePassOp(asResourceKey("alpha-pass"))],
+			priorResources: [],
+			progress,
+			registry,
+			statePort: port,
+		});
+
+		const second = await applyAndPersist({
+			environment: "production",
+			ops: [createGamePassOp(asResourceKey("vip-pass"))],
+			priorResources: first.merged.resources,
+			progress,
+			registry,
+			statePort: port,
+		});
+
+		expect(second.written).toStrictEqual({ err: stateError, success: false });
+		expect(second.merged.resources).toStrictEqual([alpha, vip]);
+	});
+});

--- a/packages/bedrock/src/shell/reconcile-pass.ts
+++ b/packages/bedrock/src/shell/reconcile-pass.ts
@@ -1,0 +1,105 @@
+import type { Result } from "@bedrock-rbx/ocale";
+
+import type { Operation } from "../core/operations.ts";
+import type { ResourceCurrentState } from "../core/resources.ts";
+import type { BedrockState, StateError } from "../core/state.ts";
+import type { ProgressPort } from "../ports/progress-port.ts";
+import type { DriverRegistry } from "../ports/resource-driver.ts";
+import type { StatePort } from "../ports/state-port.ts";
+import { type AggregateApplyError, applyOps } from "./apply-ops.ts";
+
+/**
+ * Inputs for a single {@link applyAndPersist} pass. `priorResources` is the
+ * cumulative baseline the pass folds its survivors into before writing, so a
+ * later pass receives the previous pass's `merged.resources` here.
+ */
+export interface ApplyAndPersistInputs {
+	/** Environment name threaded into `applyOps` reporting and the snapshot. */
+	readonly environment: string;
+	/** Subset of reconcile ops applied in this pass, in declaration order. */
+	readonly ops: ReadonlyArray<Operation>;
+	/** Resources already persisted; survivors merge on top, none are dropped. */
+	readonly priorResources: ReadonlyArray<ResourceCurrentState>;
+	/** Sink for per-resource, summary, and `stateWritten` progress events. */
+	readonly progress: ProgressPort;
+	/** Per-kind driver table consulted for create / update dispatch. */
+	readonly registry: DriverRegistry;
+	/** Backend the cumulative snapshot is written to. */
+	readonly statePort: StatePort;
+}
+
+/**
+ * Outcome of a single apply → snapshot → write pass. `merged` is the
+ * cumulative snapshot persisted by this pass; a caller threads
+ * `merged.resources` into a later pass as the next `priorResources`
+ * baseline, and passes the triple to the deploy-level `finalize`.
+ */
+export interface ReconcilePass {
+	/** The `applyOps` outcome: survivors on success, survivors + failures on error. */
+	readonly applied: Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>;
+	/** Cumulative snapshot built from `priorResources` plus this pass's survivors. */
+	readonly merged: BedrockState;
+	/** The state-write outcome; carries `merged` as the unsaved snapshot on failure. */
+	readonly written: Result<void, StateError>;
+}
+
+interface SnapshotInputs {
+	readonly applied: Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>;
+	readonly environment: string;
+	readonly priorResources: ReadonlyArray<ResourceCurrentState>;
+}
+
+/**
+ * Apply one subset of reconcile ops, fold the survivors into the prior
+ * resources, and persist the cumulative snapshot. Returns the apply
+ * outcome, the merged snapshot, and the write outcome so a caller can
+ * `finalize` the pass and thread `merged.resources` into a later pass as
+ * the new `priorResources` baseline. Emits `stateWritten` after a
+ * successful write.
+ *
+ * Invoking it more than once over disjoint op subsets accumulates one
+ * cumulative snapshot across the writes; a single-pass deploy calls it once.
+ *
+ * @param inputs - The op subset, the prior-resource baseline, and the
+ *   registry, state port, and progress port the pass drives.
+ * @returns The apply, snapshot, and write outcomes for the pass.
+ */
+export async function applyAndPersist(inputs: ApplyAndPersistInputs): Promise<ReconcilePass> {
+	const { environment, ops, priorResources, progress, registry, statePort } = inputs;
+	const applied = await applyOps(ops, registry, { environment, progress });
+	const merged = buildSnapshot({ applied, environment, priorResources });
+
+	const written = await statePort.write(merged);
+	if (written.success) {
+		progress.emit({ environment, kind: "stateWritten" });
+	}
+
+	return { applied, merged, written };
+}
+
+function mergeResources(
+	pre: ReadonlyArray<ResourceCurrentState>,
+	applied: ReadonlyArray<ResourceCurrentState>,
+): ReadonlyArray<ResourceCurrentState> {
+	const byKey = new Map<string, ResourceCurrentState>();
+	for (const resource of pre) {
+		byKey.set(`${resource.kind}:${resource.key}`, resource);
+	}
+
+	for (const resource of applied) {
+		byKey.set(`${resource.kind}:${resource.key}`, resource);
+	}
+
+	return [...byKey.values()];
+}
+
+function buildSnapshot(inputs: SnapshotInputs): BedrockState {
+	const appliedResources = inputs.applied.success
+		? inputs.applied.data
+		: inputs.applied.err.applied;
+	return {
+		environment: inputs.environment,
+		resources: mergeResources(inputs.priorResources, appliedResources),
+		version: 1,
+	};
+}

--- a/packages/bedrock/src/shell/reconcile-pass.ts
+++ b/packages/bedrock/src/shell/reconcile-pass.ts
@@ -9,26 +9,6 @@ import type { StatePort } from "../ports/state-port.ts";
 import { type AggregateApplyError, applyOps } from "./apply-ops.ts";
 
 /**
- * Inputs for a single {@link applyAndPersist} pass. `priorResources` is the
- * cumulative baseline the pass folds its survivors into before writing, so a
- * later pass receives the previous pass's `merged.resources` here.
- */
-export interface ApplyAndPersistInputs {
-	/** Environment name threaded into `applyOps` reporting and the snapshot. */
-	readonly environment: string;
-	/** Subset of reconcile ops applied in this pass, in declaration order. */
-	readonly ops: ReadonlyArray<Operation>;
-	/** Resources already persisted; survivors merge on top, none are dropped. */
-	readonly priorResources: ReadonlyArray<ResourceCurrentState>;
-	/** Sink for per-resource, summary, and `stateWritten` progress events. */
-	readonly progress: ProgressPort;
-	/** Per-kind driver table consulted for create / update dispatch. */
-	readonly registry: DriverRegistry;
-	/** Backend the cumulative snapshot is written to. */
-	readonly statePort: StatePort;
-}
-
-/**
  * Outcome of a single apply → snapshot → write pass. `merged` is the
  * cumulative snapshot persisted by this pass; a caller threads
  * `merged.resources` into a later pass as the next `priorResources`
@@ -41,6 +21,26 @@ export interface ReconcilePass {
 	readonly merged: BedrockState;
 	/** The state-write outcome; carries `merged` as the unsaved snapshot on failure. */
 	readonly written: Result<void, StateError>;
+}
+
+/**
+ * Inputs for a single {@link applyAndPersist} pass. `priorResources` is the
+ * cumulative baseline the pass folds its survivors into before writing, so a
+ * later pass receives the previous pass's `merged.resources` here.
+ */
+interface ApplyAndPersistInputs {
+	/** Environment name threaded into `applyOps` reporting and the snapshot. */
+	readonly environment: string;
+	/** Subset of reconcile ops applied in this pass, in declaration order. */
+	readonly ops: ReadonlyArray<Operation>;
+	/** Resources already persisted; survivors merge on top, none are dropped. */
+	readonly priorResources: ReadonlyArray<ResourceCurrentState>;
+	/** Sink for per-resource, summary, and `stateWritten` progress events. */
+	readonly progress: ProgressPort;
+	/** Per-kind driver table consulted for create / update dispatch. */
+	readonly registry: DriverRegistry;
+	/** Backend the cumulative snapshot is written to. */
+	readonly statePort: StatePort;
 }
 
 interface SnapshotInputs {
@@ -81,15 +81,12 @@ function mergeResources(
 	pre: ReadonlyArray<ResourceCurrentState>,
 	applied: ReadonlyArray<ResourceCurrentState>,
 ): ReadonlyArray<ResourceCurrentState> {
-	const byKey = new Map<string, ResourceCurrentState>();
-	for (const resource of pre) {
-		byKey.set(`${resource.kind}:${resource.key}`, resource);
-	}
-
-	for (const resource of applied) {
-		byKey.set(`${resource.kind}:${resource.key}`, resource);
-	}
-
+	// Later entries win on key collision; the Map keeps each key at its
+	// first-seen position, so prior resources hold their slot and applied
+	// survivors override in place, with applied-only keys appended.
+	const byKey = new Map(
+		[...pre, ...applied].map((resource) => [`${resource.kind}:${resource.key}`, resource]),
+	);
 	return [...byKey.values()];
 }
 


### PR DESCRIPTION
## What

Prefactor for two-phase deploy (ADR-026, parent #474). Extracts the deploy reconcile's `apply → snapshot → write` sequence out of `runReconcile` into a reusable `applyAndPersist` step in a new `shell/reconcile-pass.ts` module.

Each call applies one op subset over a `priorResources` baseline, folds the survivors into a cumulative snapshot, writes it, and returns `{ applied, merged, written }`. Threading one pass's `merged.resources` into the next accumulates a single cumulative snapshot across multiple writes, preserving prior outputs.

## Why

A later slice needs to apply a subset of ops, write state, then apply the remaining ops and write again — without rewriting the orchestrator. This makes the reconcile path composable while keeping single-pass deploy byte-identical.

## Behaviour

No external behaviour change. A single-pass deploy produces byte-identical **State** and the same `Result` as before. `runReconcile` simply calls `applyAndPersist` once and hands the outcome to `finalize`. No public API change — `applyAndPersist` is not re-exported from `src/index.ts`. No wire-format change.

## Acceptance criteria (#475)

- [x] Reconcile can apply an arbitrary op subset, persist a partial snapshot, then apply more and persist a cumulative one.
- [x] Snapshot merging across writes preserves prior **Outputs** (no resource dropped or clobbered).
- [x] The `stateWriteFailed` / `unsavedState` contract holds for each write.
- [x] All existing `deploy` and `applyOps` tests pass unchanged; no public API or wire-format change.
- [x] 100% coverage and no surviving mutants on touched `src/**`.

## Notes for reviewers

- Second commit is a small follow-up cleanup: `FinalizeInputs` was structurally identical to `ReconcilePass`, so `finalize` now takes the pass outcome directly.
- Verified: lint, typecheck, build, full test suite (2284), `reconcile-pass.ts` 100% coverage, and `mutate:changed` vs `origin/main` at 100% (0 survivors).

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)