### PR TITLE
feat(ocale): adapt rate-limit pacing to the live remaining budget

### DIFF
--- a/.changeset/adaptive-rate-limit-pacing.md
+++ b/.changeset/adaptive-rate-limit-pacing.md
@@ -1,0 +1,5 @@
+---
+"@bedrock-rbx/ocale": minor
+---
+
+Adapt rate-limit pacing to the live remaining budget. The client now reads `x-ratelimit-remaining` / `x-ratelimit-reset` off every response and, per API key, spaces requests across the live window (holding until reset once the budget is spent) instead of relying only on the static, schema-derived per-operation limits and reactive 429 handling. A sibling operation on the same key can pre-empt a 429 the static bucket cannot foresee; the static token bucket remains the cold-start and header-absent fallback. `RateLimitError` gains a `remaining` field carrying the exhausted-budget signal from a 429, and multi-window `x-ratelimit-reset` values are parsed correctly.

--- a/docs/adr/010-sdk-managed-rate-limiting-and-retry.md
+++ b/docs/adr/010-sdk-managed-rate-limiting-and-retry.md
@@ -387,3 +387,77 @@ iterations and is not wired to an in-flight `AbortSignal`, so a single request
 is still not bounded by the *remaining* budget, and budget exhaustion mid-flight
 surfaces as a transport `NetworkError` rather than the documented
 `PollTimeoutError`.
+
+## Amendment: 2026-06-22, adaptive throttling from the live remaining budget
+
+The original Decision paces requests with a **static** per-operation token
+bucket (`requestsPerSecond` from the vendored OpenAPI) and recovers from a 429
+reactively via `x-ratelimit-reset`. Two facts, established by a live probe
+against the real API (one API key + IP), show that static pacing is
+structurally unreliable and that better information was being discarded:
+
+- **The static constants drift from reality.** The schema encodes 200/min for
+  `Cloud_GetLuauExecutionSessionTask`; the probe measured a real ceiling of
+  exactly 100/min on `Cloud_GetUniverse`, and the human docs disagree with both.
+  A hardcoded ceiling cannot track an undocumented limit.
+- **Roblox returns the live budget on every response.** `x-ratelimit-remaining`
+  (and `-limit`, `-reset`) appear on 200/403/429 across four API families —
+  absent only on a 404 (the gateway short-circuits before the rate-limit layer).
+  So the headers are best-effort, not guaranteed.
+
+Two parsing facts also surfaced: on a 429, `x-ratelimit-reset` is a
+comma-separated **list** of per-window resets (e.g. `"22, 0"`), and `retry-after`
+(5s) **understates** the true reset (22s). The list parse is reduced with
+`max` for reset (longest wait) and `min` for remaining (most constrained); the
+`retry-after`-understates-`reset` finding is why the SDK keeps preferring
+`x-ratelimit-reset` over the header the docs nominally recommend.
+
+The amendment adds a **header-primed budget gate** alongside the existing
+machinery (which is unchanged and remains the fallback):
+
+- **Observe every response.** Each attempt parses a `{ remaining, resetSeconds }`
+  sample and folds it back into the gate. A 2xx carries the budget in its
+  headers; a 429 carries it on `RateLimitError.remaining` — previously the 429
+  path built no header record, so the one response that proves exhaustion
+  dropped its budget signal. That error now carries `remaining`.
+- **Gate per attempt, not per acquire.** The token bucket grants one token for a
+  whole logical call, so gating only at acquisition cannot stop the retry-loop
+  attempts that share the token. The gate lives in the `send` closure and runs
+  before every attempt.
+- **Two pacing regimes.** While budget remains, requests are spaced evenly over
+  the time left in the window (`timeLeft / remaining`), so a burst does not spend
+  the window up front and then stall; the first send in a window goes
+  immediately. Once the budget is spent, requests hold until reset. Pacing runs
+  at the **server-observed** rate, so it self-corrects when the static ceiling is
+  wrong.
+- **Per-key scope, not per-operation.** The gate keys one budget per API key.
+  A per-operation tracker was prototyped and dropped: every operation reports the
+  same most-constrained `remaining`, and a per-key tracker drawn down by all
+  operations is always the binding constraint, so a per-operation tracker could
+  never independently fire. Per-key is also where the value is — a deploy's 429s
+  come from many operations sharing the per-key window, which a per-operation
+  bucket cannot see.
+- **Last-writer-wins observation.** Observe time is monotonic (stamped when the
+  response resolves), so the most recent sample is the best estimate; no
+  timestamp-staleness bookkeeping is kept.
+
+Static-bucket pacing is retained for cold start (no sample yet) and for
+endpoints that omit the headers (404s and any future gap), since a missing or
+non-numeric header parses to `undefined` and leaves that scope on static pacing.
+
+Known limitations (residual, accepted): the per-key `remaining` is the *minimum*
+across all of Roblox's overlapping windows, so when only a route-specific window
+is exhausted the gate over-throttles other operations on that key until the next
+observation refreshes it; a concurrent burst before the first observation can
+still overshoot (bounded — the next observation corrects it, and the reactive
+429 retry path remains as defense in depth); and the multi-client/multi-process
+per-key hazard from the original Decision is unchanged. Auto-correcting the
+static `requestsPerSecond` from `x-ratelimit-limit` is intentionally **not**
+attempted — `remaining`/`reset` already demote the static value to a pure
+fallback.
+
+No new public surface: the gate is internal, parsing reductions are internal,
+and `RateLimitError` only gains a `remaining` field (additive). A consumer hook
+to observe proactive holds (`onRateLimitHeaders`) was considered and deferred to
+avoid overloading the existing `onRateLimit` callback, which already signals both
+static-bucket and retry waits.

--- a/packages/open-cloud/CLAUDE.md
+++ b/packages/open-cloud/CLAUDE.md
@@ -70,8 +70,12 @@ clients; consumers pay only for the services they import.
 ### 4. Rate Limiting and Retries Built-In
 
 The SDK manages concurrency, rate limiting, and retries internally. Consumers
-fire requests and the SDK queues them. Rate limits are per-operation, sourced
-from the vendored OpenAPI schema. Retries are idempotency-aware:
+fire requests and the SDK queues them. Pacing is **header-primed**: a per-API-key
+budget gate reads `x-ratelimit-remaining`/`-reset` off every response and spaces
+requests across the live window (holding until reset once the budget is spent),
+self-correcting when the server's real limit differs from the schema. A static
+per-operation token bucket sourced from the vendored OpenAPI schema remains the
+cold-start and header-absent fallback. Retries are idempotency-aware:
 
 | Operation | 429 (Rate Limit) | 5xx (Server Error) |
 | --------- | ---------------- | ------------------ |

--- a/packages/open-cloud/src/errors/rate-limit.spec.ts
+++ b/packages/open-cloud/src/errors/rate-limit.spec.ts
@@ -52,4 +52,20 @@ describe(RateLimitError, () => {
 
 		expect(error.cause).toBe(cause);
 	});
+
+	it("should store remaining when provided", () => {
+		expect.assertions(1);
+
+		const error = new RateLimitError("rate limited", { remaining: 0, retryAfterSeconds: 22 });
+
+		expect(error.remaining).toBe(0);
+	});
+
+	it("should default remaining to undefined when omitted", () => {
+		expect.assertions(1);
+
+		const error = new RateLimitError("rate limited", { retryAfterSeconds: 5 });
+
+		expect(error.remaining).toBeUndefined();
+	});
 });

--- a/packages/open-cloud/src/errors/rate-limit.ts
+++ b/packages/open-cloud/src/errors/rate-limit.ts
@@ -4,6 +4,12 @@ import { OpenCloudError } from "./base.ts";
  * Options for constructing a {@link RateLimitError}.
  */
 export interface RateLimitErrorOptions extends ErrorOptions {
+	/**
+	 * Requests still allowed in the throttled window, read from
+	 * `x-ratelimit-remaining` (the most-constrained window). `undefined` when
+	 * the header was absent. Typically `0` on a genuine 429.
+	 */
+	remaining?: number | undefined;
 	/** Seconds to wait before retrying the request. */
 	retryAfterSeconds: number;
 }
@@ -27,6 +33,8 @@ export interface RateLimitErrorOptions extends ErrorOptions {
  */
 export class RateLimitError extends OpenCloudError {
 	public override readonly name = "RateLimitError";
+	/** Requests left in the throttled window, or `undefined` if not reported. */
+	public readonly remaining: number | undefined;
 	public readonly retryAfterSeconds: number;
 
 	/**
@@ -38,5 +46,6 @@ export class RateLimitError extends OpenCloudError {
 	constructor(message: string, options: RateLimitErrorOptions) {
 		super(message, options);
 		this.retryAfterSeconds = options.retryAfterSeconds;
+		this.remaining = options.remaining;
 	}
 }

--- a/packages/open-cloud/src/errors/rate-limit.ts
+++ b/packages/open-cloud/src/errors/rate-limit.ts
@@ -7,7 +7,9 @@ export interface RateLimitErrorOptions extends ErrorOptions {
 	/**
 	 * Requests still allowed in the throttled window, read from
 	 * `x-ratelimit-remaining` (the most-constrained window). `undefined` when
-	 * the header was absent. Typically `0` on a genuine 429.
+	 * the header is absent or carries no finite numeric token; parsed
+	 * independently of `x-ratelimit-reset`, so a valid value survives a
+	 * non-numeric reset. Typically `0` on a genuine 429.
 	 */
 	remaining?: number | undefined;
 	/** Seconds to wait before retrying the request. */

--- a/packages/open-cloud/src/internal/http/budget-gate.spec.ts
+++ b/packages/open-cloud/src/internal/http/budget-gate.spec.ts
@@ -73,10 +73,33 @@ describe(BudgetGate, () => {
 
 		gate.observe("k", { remaining: 2, resetSeconds: 60 });
 		await gate.gate("k");
-		// Two concurrent gates: serialization means the second waits for the
-		// first's reserve, so only one sleeps. Without it, both read the same
-		// budget and both sleep, recording two waits.
 		await Promise.all([gate.gate("k"), gate.gate("k")]);
+
+		expect(clock.waits).toStrictEqual([60_000]);
+	});
+
+	it("should keep gating after a failed attempt", async () => {
+		expect.assertions(2);
+
+		const clock = createFakeClock();
+		let shouldReject = true;
+		async function sleep(ms: number): Promise<void> {
+			if (shouldReject) {
+				shouldReject = false;
+				throw new Error("sleep failed");
+			}
+
+			return clock.sleep(ms);
+		}
+
+		const gate = new BudgetGate(sleep);
+
+		gate.observe("k", { remaining: 1, resetSeconds: 60 });
+		await gate.gate("k");
+
+		await expect(gate.gate("k")).rejects.toThrow("sleep failed");
+
+		await gate.gate("k");
 
 		expect(clock.waits).toStrictEqual([60_000]);
 	});

--- a/packages/open-cloud/src/internal/http/budget-gate.spec.ts
+++ b/packages/open-cloud/src/internal/http/budget-gate.spec.ts
@@ -1,0 +1,68 @@
+import { createFakeClock } from "#tests/helpers/fake-clock";
+import { describe, expect, it } from "vitest";
+
+import { BudgetGate } from "./budget-gate.ts";
+
+describe(BudgetGate, () => {
+	it("should not wait before any sample is observed", async () => {
+		expect.assertions(1);
+
+		const clock = createFakeClock();
+		const gate = new BudgetGate(clock.sleep);
+
+		await gate.gate(["op"]);
+
+		expect(clock.waits).toStrictEqual([]);
+	});
+
+	it("should sleep until reset once a key's budget is exhausted", async () => {
+		expect.assertions(1);
+
+		const clock = createFakeClock();
+		const gate = new BudgetGate(clock.sleep);
+
+		gate.observe(["op"], { remaining: 1, resetSeconds: 60 });
+		await gate.gate(["op"]);
+		await gate.gate(["op"]);
+
+		expect(clock.waits).toStrictEqual([60_000]);
+	});
+
+	it("should sleep for the most-constrained key when gating on several", async () => {
+		expect.assertions(1);
+
+		const clock = createFakeClock();
+		const gate = new BudgetGate(clock.sleep);
+
+		gate.observe(["key"], { remaining: 0, resetSeconds: 30 });
+		gate.observe(["op"], { remaining: 5, resetSeconds: 60 });
+		await gate.gate(["key", "op"]);
+
+		expect(clock.waits).toStrictEqual([30_000]);
+	});
+
+	it("should reserve a slot on every gated key", async () => {
+		expect.assertions(1);
+
+		const clock = createFakeClock();
+		const gate = new BudgetGate(clock.sleep);
+
+		gate.observe(["a", "b"], { remaining: 1, resetSeconds: 60 });
+		await gate.gate(["a", "b"]);
+		await gate.gate(["b"]);
+
+		expect(clock.waits).toStrictEqual([60_000]);
+	});
+
+	it("should ignore an undefined sample and stay on static pacing", async () => {
+		expect.assertions(1);
+
+		const clock = createFakeClock();
+		const gate = new BudgetGate(clock.sleep);
+
+		gate.observe(["op"], undefined);
+		await gate.gate(["op"]);
+
+		expect(clock.waits).toStrictEqual([]);
+	});
+});

--- a/packages/open-cloud/src/internal/http/budget-gate.spec.ts
+++ b/packages/open-cloud/src/internal/http/budget-gate.spec.ts
@@ -10,48 +10,34 @@ describe(BudgetGate, () => {
 		const clock = createFakeClock();
 		const gate = new BudgetGate(clock.sleep);
 
-		await gate.gate(["op"]);
+		await gate.gate("k");
 
 		expect(clock.waits).toStrictEqual([]);
 	});
 
-	it("should sleep until reset once a key's budget is exhausted", async () => {
+	it("should sleep until reset once the scope's budget is exhausted", async () => {
 		expect.assertions(1);
 
 		const clock = createFakeClock();
 		const gate = new BudgetGate(clock.sleep);
 
-		gate.observe(["op"], { remaining: 1, resetSeconds: 60 });
-		await gate.gate(["op"]);
-		await gate.gate(["op"]);
+		gate.observe("k", { remaining: 1, resetSeconds: 60 });
+		await gate.gate("k");
+		await gate.gate("k");
 
 		expect(clock.waits).toStrictEqual([60_000]);
 	});
 
-	it("should sleep for the most-constrained key when gating on several", async () => {
+	it("should track scopes independently", async () => {
 		expect.assertions(1);
 
 		const clock = createFakeClock();
 		const gate = new BudgetGate(clock.sleep);
 
-		gate.observe(["key"], { remaining: 0, resetSeconds: 30 });
-		gate.observe(["op"], { remaining: 5, resetSeconds: 60 });
-		await gate.gate(["key", "op"]);
+		gate.observe("a", { remaining: 0, resetSeconds: 60 });
+		await gate.gate("b");
 
-		expect(clock.waits).toStrictEqual([30_000]);
-	});
-
-	it("should reserve a slot on every gated key", async () => {
-		expect.assertions(1);
-
-		const clock = createFakeClock();
-		const gate = new BudgetGate(clock.sleep);
-
-		gate.observe(["a", "b"], { remaining: 1, resetSeconds: 60 });
-		await gate.gate(["a", "b"]);
-		await gate.gate(["b"]);
-
-		expect(clock.waits).toStrictEqual([60_000]);
+		expect(clock.waits).toStrictEqual([]);
 	});
 
 	it("should ignore an undefined sample and stay on static pacing", async () => {
@@ -60,8 +46,8 @@ describe(BudgetGate, () => {
 		const clock = createFakeClock();
 		const gate = new BudgetGate(clock.sleep);
 
-		gate.observe(["op"], undefined);
-		await gate.gate(["op"]);
+		gate.observe("k", undefined);
+		await gate.gate("k");
 
 		expect(clock.waits).toStrictEqual([]);
 	});

--- a/packages/open-cloud/src/internal/http/budget-gate.spec.ts
+++ b/packages/open-cloud/src/internal/http/budget-gate.spec.ts
@@ -51,4 +51,33 @@ describe(BudgetGate, () => {
 
 		expect(clock.waits).toStrictEqual([]);
 	});
+
+	it("should space the next send evenly while budget remains", async () => {
+		expect.assertions(1);
+
+		const clock = createFakeClock();
+		const gate = new BudgetGate(clock.sleep);
+
+		gate.observe("k", { remaining: 2, resetSeconds: 60 });
+		await gate.gate("k");
+		await gate.gate("k");
+
+		expect(clock.waits).toStrictEqual([60_000]);
+	});
+
+	it("should serialize concurrent gates on the same scope", async () => {
+		expect.assertions(1);
+
+		const clock = createFakeClock();
+		const gate = new BudgetGate(clock.sleep);
+
+		gate.observe("k", { remaining: 2, resetSeconds: 60 });
+		await gate.gate("k");
+		// Two concurrent gates: serialization means the second waits for the
+		// first's reserve, so only one sleeps. Without it, both read the same
+		// budget and both sleep, recording two waits.
+		await Promise.all([gate.gate("k"), gate.gate("k")]);
+
+		expect(clock.waits).toStrictEqual([60_000]);
+	});
 });

--- a/packages/open-cloud/src/internal/http/budget-gate.ts
+++ b/packages/open-cloud/src/internal/http/budget-gate.ts
@@ -33,12 +33,15 @@ export class BudgetGate {
 
 	/**
 	 * Holds until the scope's budget permits a send, then reserves one slot.
+	 * Runs after the prior gate on the same scope settles, whether it resolved
+	 * or rejected, so one failed attempt cannot poison later gates on the key.
 	 *
 	 * @param scope - The scope key to gate on (the effective API key).
 	 */
 	public async gate(scope: string): Promise<void> {
 		const previous = this.#chains.get(scope) ?? Promise.resolve();
-		const mine = previous.then(async () => this.#gateOnce(scope));
+		const runGate = async (): Promise<void> => this.#gateOnce(scope);
+		const mine = previous.then(runGate, runGate);
 		this.#chains.set(scope, mine);
 		await mine;
 	}

--- a/packages/open-cloud/src/internal/http/budget-gate.ts
+++ b/packages/open-cloud/src/internal/http/budget-gate.ts
@@ -4,11 +4,14 @@ import type { RateLimitSample } from "./rate-limit-sample.ts";
 
 /**
  * Header-primed rate-limit gate shared across a client. Holds one
- * {@link BudgetTracker} per scope key (per-operation and per-API-key). Before
- * each request the caller gates on the relevant scope keys — sleeping if any is
- * exhausted — and after each response folds the parsed sample back onto those
- * keys. Prevents 429s the static token bucket cannot foresee, notably the
- * per-key window shared across operations.
+ * {@link BudgetTracker} per API key, since the tightest Roblox window is the
+ * per-key one shared across every operation. Before each request the caller
+ * gates on the request's key — sleeping if its budget is spent — and after
+ * each response folds the parsed sample back in, so a sibling operation on the
+ * same key can head off a 429 the static per-operation token bucket cannot
+ * foresee. A per-operation tracker is deliberately not kept: every operation
+ * reports the same most-constrained `remaining`, so a per-key tracker (drawn
+ * down by all operations) is always the binding constraint.
  */
 export class BudgetGate {
 	readonly #sleep: SleepFunc;
@@ -24,55 +27,44 @@ export class BudgetGate {
 	}
 
 	/**
-	 * Holds until every scope key permits a send, then reserves one slot on
-	 * each. The wait is the longest across keys, so the most-constrained window
-	 * governs.
+	 * Holds until the scope's budget permits a send, then reserves one slot.
 	 *
-	 * @param keys - Scope keys to gate on (e.g. The API key and operation key).
+	 * @param scope - The scope key to gate on (the effective API key).
 	 */
-	public async gate(keys: ReadonlyArray<string>): Promise<void> {
-		const now = Date.now();
-		let waitMs = 0;
-		for (const key of keys) {
-			waitMs = Math.max(waitMs, this.#tracker(key).waitMs(now));
-		}
-
+	public async gate(scope: string): Promise<void> {
+		const tracker = this.#tracker(scope);
+		const waitMs = tracker.waitMs(Date.now());
 		if (waitMs > 0) {
 			await this.#sleep(waitMs);
 		}
 
-		for (const key of keys) {
-			this.#tracker(key).reserve();
-		}
+		tracker.reserve();
 	}
 
 	/**
-	 * Folds a response's parsed budget back onto each scope key. A `undefined`
-	 * sample (headers absent or non-numeric) is ignored, leaving the gate on
-	 * static pacing for that scope.
+	 * Folds a response's parsed budget back onto the scope. A `undefined`
+	 * sample (headers absent or non-numeric) is ignored, leaving the scope on
+	 * static pacing.
 	 *
-	 * @param keys - The same scope keys passed to {@link gate}.
+	 * @param scope - The same scope key passed to {@link gate}.
 	 * @param sample - Parsed sample, or `undefined` when none was reported.
 	 */
-	public observe(keys: ReadonlyArray<string>, sample: RateLimitSample | undefined): void {
+	public observe(scope: string, sample: RateLimitSample | undefined): void {
 		if (sample === undefined) {
 			return;
 		}
 
-		const now = Date.now();
-		for (const key of keys) {
-			this.#tracker(key).observe(sample, now);
-		}
+		this.#tracker(scope).observe(sample, Date.now());
 	}
 
-	#tracker(key: string): BudgetTracker {
-		const existing = this.#trackers.get(key);
+	#tracker(scope: string): BudgetTracker {
+		const existing = this.#trackers.get(scope);
 		if (existing !== undefined) {
 			return existing;
 		}
 
 		const tracker = new BudgetTracker();
-		this.#trackers.set(key, tracker);
+		this.#trackers.set(scope, tracker);
 		return tracker;
 	}
 }

--- a/packages/open-cloud/src/internal/http/budget-gate.ts
+++ b/packages/open-cloud/src/internal/http/budget-gate.ts
@@ -6,14 +6,19 @@ import type { RateLimitSample } from "./rate-limit-sample.ts";
  * Header-primed rate-limit gate shared across a client. Holds one
  * {@link BudgetTracker} per API key, since the tightest Roblox window is the
  * per-key one shared across every operation. Before each request the caller
- * gates on the request's key — sleeping if its budget is spent — and after
- * each response folds the parsed sample back in, so a sibling operation on the
- * same key can head off a 429 the static per-operation token bucket cannot
- * foresee. A per-operation tracker is deliberately not kept: every operation
- * reports the same most-constrained `remaining`, so a per-key tracker (drawn
- * down by all operations) is always the binding constraint.
+ * gates on the request's key (sleeping if its budget is spent), and after each
+ * response folds the parsed sample back in, so a sibling operation on the same
+ * key can head off a 429 the static per-operation token bucket cannot foresee.
+ * A per-operation tracker is deliberately not kept: every operation reports the
+ * same most-constrained `remaining`, so a per-key tracker (drawn down by all
+ * operations) is always the binding constraint.
+ *
+ * Gating is serialized per scope through a promise chain so concurrent
+ * requests on one key cannot read the same budget and reserve the same slot;
+ * each waits for the prior gate's reserve before computing its own.
  */
 export class BudgetGate {
+	readonly #chains = new Map<string, Promise<void>>();
 	readonly #sleep: SleepFunc;
 	readonly #trackers = new Map<string, BudgetTracker>();
 
@@ -32,13 +37,10 @@ export class BudgetGate {
 	 * @param scope - The scope key to gate on (the effective API key).
 	 */
 	public async gate(scope: string): Promise<void> {
-		const tracker = this.#tracker(scope);
-		const waitMs = tracker.waitMs(Date.now());
-		if (waitMs > 0) {
-			await this.#sleep(waitMs);
-		}
-
-		tracker.reserve(Date.now());
+		const previous = this.#chains.get(scope) ?? Promise.resolve();
+		const mine = previous.then(async () => this.#gateOnce(scope));
+		this.#chains.set(scope, mine);
+		await mine;
 	}
 
 	/**
@@ -55,6 +57,16 @@ export class BudgetGate {
 		}
 
 		this.#tracker(scope).observe(sample, Date.now());
+	}
+
+	async #gateOnce(scope: string): Promise<void> {
+		const tracker = this.#tracker(scope);
+		const waitMs = tracker.waitMs(Date.now());
+		if (waitMs > 0) {
+			await this.#sleep(waitMs);
+		}
+
+		tracker.reserve(Date.now());
 	}
 
 	#tracker(scope: string): BudgetTracker {

--- a/packages/open-cloud/src/internal/http/budget-gate.ts
+++ b/packages/open-cloud/src/internal/http/budget-gate.ts
@@ -1,0 +1,78 @@
+import type { SleepFunc } from "../utils/sleep.ts";
+import { BudgetTracker } from "./budget-tracker.ts";
+import type { RateLimitSample } from "./rate-limit-sample.ts";
+
+/**
+ * Header-primed rate-limit gate shared across a client. Holds one
+ * {@link BudgetTracker} per scope key (per-operation and per-API-key). Before
+ * each request the caller gates on the relevant scope keys — sleeping if any is
+ * exhausted — and after each response folds the parsed sample back onto those
+ * keys. Prevents 429s the static token bucket cannot foresee, notably the
+ * per-key window shared across operations.
+ */
+export class BudgetGate {
+	readonly #sleep: SleepFunc;
+	readonly #trackers = new Map<string, BudgetTracker>();
+
+	/**
+	 * Creates a gate bound to an injectable sleep.
+	 *
+	 * @param sleep - Injectable sleep (tests pass a fake clock).
+	 */
+	constructor(sleep: SleepFunc) {
+		this.#sleep = sleep;
+	}
+
+	/**
+	 * Holds until every scope key permits a send, then reserves one slot on
+	 * each. The wait is the longest across keys, so the most-constrained window
+	 * governs.
+	 *
+	 * @param keys - Scope keys to gate on (e.g. The API key and operation key).
+	 */
+	public async gate(keys: ReadonlyArray<string>): Promise<void> {
+		const now = Date.now();
+		let waitMs = 0;
+		for (const key of keys) {
+			waitMs = Math.max(waitMs, this.#tracker(key).waitMs(now));
+		}
+
+		if (waitMs > 0) {
+			await this.#sleep(waitMs);
+		}
+
+		for (const key of keys) {
+			this.#tracker(key).reserve();
+		}
+	}
+
+	/**
+	 * Folds a response's parsed budget back onto each scope key. A `undefined`
+	 * sample (headers absent or non-numeric) is ignored, leaving the gate on
+	 * static pacing for that scope.
+	 *
+	 * @param keys - The same scope keys passed to {@link gate}.
+	 * @param sample - Parsed sample, or `undefined` when none was reported.
+	 */
+	public observe(keys: ReadonlyArray<string>, sample: RateLimitSample | undefined): void {
+		if (sample === undefined) {
+			return;
+		}
+
+		const now = Date.now();
+		for (const key of keys) {
+			this.#tracker(key).observe(sample, now);
+		}
+	}
+
+	#tracker(key: string): BudgetTracker {
+		const existing = this.#trackers.get(key);
+		if (existing !== undefined) {
+			return existing;
+		}
+
+		const tracker = new BudgetTracker();
+		this.#trackers.set(key, tracker);
+		return tracker;
+	}
+}

--- a/packages/open-cloud/src/internal/http/budget-gate.ts
+++ b/packages/open-cloud/src/internal/http/budget-gate.ts
@@ -38,7 +38,7 @@ export class BudgetGate {
 			await this.#sleep(waitMs);
 		}
 
-		tracker.reserve();
+		tracker.reserve(Date.now());
 	}
 
 	/**

--- a/packages/open-cloud/src/internal/http/budget-tracker.spec.ts
+++ b/packages/open-cloud/src/internal/http/budget-tracker.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { BudgetTracker } from "./budget-tracker.ts";
+
+describe(BudgetTracker, () => {
+	it("should not wait before any sample is observed", () => {
+		expect.assertions(1);
+
+		const tracker = new BudgetTracker();
+
+		expect(tracker.waitMs(0)).toBe(0);
+	});
+
+	it("should not wait while budget remains", () => {
+		expect.assertions(1);
+
+		const tracker = new BudgetTracker();
+		tracker.observe({ remaining: 2, resetSeconds: 60 }, 0);
+
+		expect(tracker.waitMs(0)).toBe(0);
+	});
+
+	it("should wait until reset once a reserve exhausts the budget", () => {
+		expect.assertions(1);
+
+		const tracker = new BudgetTracker();
+		tracker.observe({ remaining: 1, resetSeconds: 60 }, 0);
+		tracker.reserve();
+
+		expect(tracker.waitMs(0)).toBe(60_000);
+	});
+
+	it("should not wait at the instant the window resets", () => {
+		expect.assertions(1);
+
+		const tracker = new BudgetTracker();
+		tracker.observe({ remaining: 0, resetSeconds: 1 }, 0);
+
+		expect(tracker.waitMs(1000)).toBe(0);
+	});
+
+	it("should not wait once the window has passed", () => {
+		expect.assertions(1);
+
+		const tracker = new BudgetTracker();
+		tracker.observe({ remaining: 0, resetSeconds: 1 }, 0);
+
+		expect(tracker.waitMs(1500)).toBe(0);
+	});
+
+	it("should wait the time left just before the window resets", () => {
+		expect.assertions(1);
+
+		const tracker = new BudgetTracker();
+		tracker.observe({ remaining: 0, resetSeconds: 1 }, 0);
+
+		expect(tracker.waitMs(999)).toBe(1);
+	});
+
+	it("should not decrement budget while unprimed", () => {
+		expect.assertions(1);
+
+		const tracker = new BudgetTracker();
+		tracker.reserve();
+
+		expect(tracker.waitMs(0)).toBe(0);
+	});
+
+	it("should let a fresh reading replace an exhausted window", () => {
+		expect.assertions(1);
+
+		const tracker = new BudgetTracker();
+		tracker.observe({ remaining: 0, resetSeconds: 60 }, 0);
+		tracker.observe({ remaining: 5, resetSeconds: 60 }, 0);
+
+		expect(tracker.waitMs(0)).toBe(0);
+	});
+});

--- a/packages/open-cloud/src/internal/http/budget-tracker.spec.ts
+++ b/packages/open-cloud/src/internal/http/budget-tracker.spec.ts
@@ -11,21 +11,42 @@ describe(BudgetTracker, () => {
 		expect(tracker.waitMs(0)).toBe(0);
 	});
 
-	it("should not wait while budget remains", () => {
+	it("should let the first paced send go immediately while budget remains", () => {
 		expect.assertions(1);
 
 		const tracker = new BudgetTracker();
-		tracker.observe({ remaining: 2, resetSeconds: 60 }, 0);
+		tracker.observe({ remaining: 4, resetSeconds: 60 }, 0);
 
 		expect(tracker.waitMs(0)).toBe(0);
 	});
 
-	it("should wait until reset once a reserve exhausts the budget", () => {
+	it("should space later sends evenly across the time left in the window", () => {
+		expect.assertions(1);
+
+		const tracker = new BudgetTracker();
+		tracker.observe({ remaining: 4, resetSeconds: 60 }, 0);
+		tracker.reserve(0);
+
+		// 3 left over the 60s window → one every 20s.
+		expect(tracker.waitMs(0)).toBe(20_000);
+	});
+
+	it("should not wait once the spaced slot has already passed", () => {
+		expect.assertions(1);
+
+		const tracker = new BudgetTracker();
+		tracker.observe({ remaining: 2, resetSeconds: 60 }, 0);
+		tracker.reserve(0);
+
+		expect(tracker.waitMs(50_000)).toBe(0);
+	});
+
+	it("should hold until reset once a reserve exhausts the budget", () => {
 		expect.assertions(1);
 
 		const tracker = new BudgetTracker();
 		tracker.observe({ remaining: 1, resetSeconds: 60 }, 0);
-		tracker.reserve();
+		tracker.reserve(0);
 
 		expect(tracker.waitMs(0)).toBe(60_000);
 	});
@@ -48,7 +69,7 @@ describe(BudgetTracker, () => {
 		expect(tracker.waitMs(1500)).toBe(0);
 	});
 
-	it("should wait the time left just before the window resets", () => {
+	it("should hold the time left just before the window resets", () => {
 		expect.assertions(1);
 
 		const tracker = new BudgetTracker();
@@ -57,11 +78,11 @@ describe(BudgetTracker, () => {
 		expect(tracker.waitMs(999)).toBe(1);
 	});
 
-	it("should not decrement budget while unprimed", () => {
+	it("should not throw or wait when reserving while unprimed", () => {
 		expect.assertions(1);
 
 		const tracker = new BudgetTracker();
-		tracker.reserve();
+		tracker.reserve(0);
 
 		expect(tracker.waitMs(0)).toBe(0);
 	});

--- a/packages/open-cloud/src/internal/http/budget-tracker.ts
+++ b/packages/open-cloud/src/internal/http/budget-tracker.ts
@@ -5,9 +5,9 @@ const MS_PER_SECOND = 1000;
 /** Live window state for one scope: budget left and when it resets. */
 interface WindowState {
 	/** Best estimate of requests still allowed before the window resets. */
-	predictedRemaining: number;
+	readonly predictedRemaining: number;
 	/** Absolute time (ms) the window resets to full. */
-	resetAt: number;
+	readonly resetAt: number;
 }
 
 /**
@@ -19,7 +19,7 @@ interface WindowState {
  * the time left in the window (`timeLeft / remaining`), so a burst does not
  * spend the whole window's budget up front and then stall. Once the budget is
  * spent, requests hold until the window resets. Budget and reset time move
- * together as one window, so the tracker is either unprimed or fully primed —
+ * together as one window, so the tracker is either unprimed or fully primed,
  * never half-known.
  */
 export class BudgetTracker {
@@ -52,7 +52,10 @@ export class BudgetTracker {
 	public reserve(now: number): void {
 		this.#lastAllowedAt = now;
 		if (this.#window !== undefined) {
-			this.#window.predictedRemaining -= 1;
+			this.#window = {
+				...this.#window,
+				predictedRemaining: this.#window.predictedRemaining - 1,
+			};
 		}
 	}
 

--- a/packages/open-cloud/src/internal/http/budget-tracker.ts
+++ b/packages/open-cloud/src/internal/http/budget-tracker.ts
@@ -1,0 +1,64 @@
+import type { RateLimitSample } from "./rate-limit-sample.ts";
+
+const MS_PER_SECOND = 1000;
+
+/** Live window state for one scope: budget left and when it resets. */
+interface WindowState {
+	/** Best estimate of requests still allowed before the window resets. */
+	predictedRemaining: number;
+	/** Absolute time (ms) the window resets to full. */
+	resetAt: number;
+}
+
+/**
+ * Tracks the live rate-limit budget for a single scope (one operation, or one
+ * API key). Primed by `observe` from response headers and drawn down by
+ * `reserve` as requests leave, so `waitMs` can hold a request that would
+ * otherwise be throttled until the window resets. Budget and reset time move
+ * together as one window, so the tracker is either unprimed or fully primed —
+ * never half-known.
+ */
+export class BudgetTracker {
+	#window: undefined | WindowState = undefined;
+
+	/**
+	 * Folds a fresh server reading in, replacing any prior window. The latest
+	 * reading wins: observe time is monotonic, so the most recently resolved
+	 * response is the best current estimate.
+	 *
+	 * @param sample - Parsed `remaining`/`resetSeconds` from a response.
+	 * @param now - The current time in ms.
+	 */
+	public observe(sample: RateLimitSample, now: number): void {
+		this.#window = {
+			predictedRemaining: sample.remaining,
+			resetAt: now + sample.resetSeconds * MS_PER_SECOND,
+		};
+	}
+
+	/**
+	 * Accounts for one request leaving by decrementing the prediction. A
+	 * no-op while unprimed; an expired window is handled by `waitMs` clamping
+	 * to zero, so no roll bookkeeping is needed here.
+	 */
+	public reserve(): void {
+		if (this.#window !== undefined) {
+			this.#window.predictedRemaining -= 1;
+		}
+	}
+
+	/**
+	 * Milliseconds to wait before the next request is allowed.
+	 *
+	 * @param now - The current time in ms.
+	 * @returns `0` when a request may go now (unprimed, budget remains, or the
+	 *   window has already passed); otherwise the time until reset.
+	 */
+	public waitMs(now: number): number {
+		if (this.#window === undefined || this.#window.predictedRemaining > 0) {
+			return 0;
+		}
+
+		return Math.max(0, this.#window.resetAt - now);
+	}
+}

--- a/packages/open-cloud/src/internal/http/budget-tracker.ts
+++ b/packages/open-cloud/src/internal/http/budget-tracker.ts
@@ -11,20 +11,27 @@ interface WindowState {
 }
 
 /**
- * Tracks the live rate-limit budget for a single scope (one operation, or one
- * API key). Primed by `observe` from response headers and drawn down by
- * `reserve` as requests leave, so `waitMs` can hold a request that would
- * otherwise be throttled until the window resets. Budget and reset time move
+ * Tracks the live rate-limit budget for a single scope. Primed by `observe`
+ * from response headers and drawn down by `reserve` as requests leave, so
+ * `waitMs` can pace requests across the window.
+ *
+ * Pacing has two regimes. While budget remains, requests are spread evenly over
+ * the time left in the window (`timeLeft / remaining`), so a burst does not
+ * spend the whole window's budget up front and then stall. Once the budget is
+ * spent, requests hold until the window resets. Budget and reset time move
  * together as one window, so the tracker is either unprimed or fully primed —
  * never half-known.
  */
 export class BudgetTracker {
+	/** Time (ms) the most recent request was allowed out, for spacing. */
+	#lastAllowedAt: number | undefined = undefined;
 	#window: undefined | WindowState = undefined;
 
 	/**
 	 * Folds a fresh server reading in, replacing any prior window. The latest
 	 * reading wins: observe time is monotonic, so the most recently resolved
-	 * response is the best current estimate.
+	 * response is the best current estimate. The spacing reference is left
+	 * untouched so a window refresh does not reset pacing mid-stream.
 	 *
 	 * @param sample - Parsed `remaining`/`resetSeconds` from a response.
 	 * @param now - The current time in ms.
@@ -37,11 +44,13 @@ export class BudgetTracker {
 	}
 
 	/**
-	 * Accounts for one request leaving by decrementing the prediction. A
-	 * no-op while unprimed; an expired window is handled by `waitMs` clamping
-	 * to zero, so no roll bookkeeping is needed here.
+	 * Accounts for one request leaving at `now`: records the spacing reference
+	 * and decrements the prediction. A no-op on the prediction while unprimed.
+	 *
+	 * @param now - The time the request was allowed out, in ms.
 	 */
-	public reserve(): void {
+	public reserve(now: number): void {
+		this.#lastAllowedAt = now;
 		if (this.#window !== undefined) {
 			this.#window.predictedRemaining -= 1;
 		}
@@ -51,14 +60,25 @@ export class BudgetTracker {
 	 * Milliseconds to wait before the next request is allowed.
 	 *
 	 * @param now - The current time in ms.
-	 * @returns `0` when a request may go now (unprimed, budget remains, or the
-	 *   window has already passed); otherwise the time until reset.
+	 * @returns `0` when a request may go now (unprimed, or the first paced send);
+	 *   the time until reset when the budget is spent; otherwise the time until
+	 *   this request's evenly-spaced slot.
 	 */
 	public waitMs(now: number): number {
-		if (this.#window === undefined || this.#window.predictedRemaining > 0) {
+		if (this.#window === undefined) {
 			return 0;
 		}
 
-		return Math.max(0, this.#window.resetAt - now);
+		const { predictedRemaining, resetAt } = this.#window;
+		if (predictedRemaining <= 0) {
+			return Math.max(0, resetAt - now);
+		}
+
+		if (this.#lastAllowedAt === undefined) {
+			return 0;
+		}
+
+		const interval = (resetAt - now) / predictedRemaining;
+		return Math.max(0, this.#lastAllowedAt + interval - now);
 	}
 }

--- a/packages/open-cloud/src/internal/http/fetch-client.spec.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.spec.ts
@@ -223,6 +223,12 @@ describe(parseRetryAfterSeconds, () => {
 
 		expect(parseRetryAfterSeconds("0, 22")).toBe(22);
 	});
+
+	it("should reject non-finite tokens such as Infinity", () => {
+		expect.assertions(1);
+
+		expect(parseRetryAfterSeconds("Infinity")).toBe(0);
+	});
 });
 
 describe(buildUrl, () => {
@@ -534,6 +540,29 @@ describe(createFetchHttpClient, () => {
 
 		expect(result.err.remaining).toBe(0);
 		expect(result.err.retryAfterSeconds).toBe(22);
+	});
+
+	it("should capture remaining even when the reset header is non-numeric", async () => {
+		expect.assertions(2);
+
+		async function fakeFetch(): Promise<Response> {
+			return new Response("rate limited", {
+				headers: { "x-ratelimit-remaining": "3", "x-ratelimit-reset": "abc" },
+				status: 429,
+			});
+		}
+
+		const client = createFetchHttpClient(fakeFetch);
+		const result = await client.request(
+			{ method: "GET", url: "/test" },
+			{ apiKey: "key", baseUrl: "https://example.com" },
+		);
+
+		assert(!result.success);
+		assert(result.err instanceof RateLimitError);
+
+		expect(result.err.remaining).toBe(3);
+		expect(result.err.retryAfterSeconds).toBe(0);
 	});
 
 	it("should return RateLimitError with retryAfterSeconds 0 when header missing", async () => {

--- a/packages/open-cloud/src/internal/http/fetch-client.spec.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.spec.ts
@@ -211,6 +211,18 @@ describe(parseRetryAfterSeconds, () => {
 
 		expect(parseRetryAfterSeconds("-3")).toBe(0);
 	});
+
+	it("should take the largest window from a comma-separated 429 reset header", () => {
+		expect.assertions(1);
+
+		expect(parseRetryAfterSeconds("22, 0")).toBe(22);
+	});
+
+	it("should take the largest window regardless of token order", () => {
+		expect.assertions(1);
+
+		expect(parseRetryAfterSeconds("0, 22")).toBe(22);
+	});
 });
 
 describe(buildUrl, () => {

--- a/packages/open-cloud/src/internal/http/fetch-client.spec.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.spec.ts
@@ -489,7 +489,7 @@ describe(createFetchHttpClient, () => {
 	});
 
 	it("should return RateLimitError for 429 with x-ratelimit-reset header", async () => {
-		expect.assertions(2);
+		expect.assertions(3);
 
 		async function fakeFetch(): Promise<Response> {
 			return new Response("rate limited", {
@@ -509,6 +509,31 @@ describe(createFetchHttpClient, () => {
 
 		expect(result.err.retryAfterSeconds).toBe(5);
 		expect(result.err.message).toBe("Rate limited");
+		// No x-ratelimit-remaining header → remaining is not reported.
+		expect(result.err.remaining).toBeUndefined();
+	});
+
+	it("should capture remaining from x-ratelimit-remaining on a 429", async () => {
+		expect.assertions(2);
+
+		async function fakeFetch(): Promise<Response> {
+			return new Response("rate limited", {
+				headers: { "x-ratelimit-remaining": "0, 70000", "x-ratelimit-reset": "22, 0" },
+				status: 429,
+			});
+		}
+
+		const client = createFetchHttpClient(fakeFetch);
+		const result = await client.request(
+			{ method: "GET", url: "/test" },
+			{ apiKey: "key", baseUrl: "https://example.com" },
+		);
+
+		assert(!result.success);
+		assert(result.err instanceof RateLimitError);
+
+		expect(result.err.remaining).toBe(0);
+		expect(result.err.retryAfterSeconds).toBe(22);
 	});
 
 	it("should return RateLimitError with retryAfterSeconds 0 when header missing", async () => {

--- a/packages/open-cloud/src/internal/http/fetch-client.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.ts
@@ -82,18 +82,28 @@ export function extractErrorMessage(body: unknown): string | undefined {
 }
 
 /**
- * Parses the `x-ratelimit-reset` header value into seconds.
+ * Parses the `x-ratelimit-reset` header value into seconds. On a 429 the header
+ * is a comma-separated list of per-window reset times (e.g. `"22, 0"`, one entry
+ * per rate-limit window); the largest value is the longest-resetting window and
+ * the only safe wait that won't retry into a still-exhausted window. A single
+ * value is treated as a one-element list.
  *
  * @param headerValue - The raw header value, or `undefined` if missing.
  * @returns The number of seconds to wait, or 0 if missing/invalid.
  */
 export function parseRetryAfterSeconds(headerValue: string | undefined): number {
-	const parsed = Number(headerValue);
-	if (Number.isNaN(parsed)) {
+	if (headerValue === undefined) {
 		return 0;
 	}
 
-	return Math.max(0, Math.floor(parsed));
+	const seconds = headerValue
+		.split(",")
+		.map((part) => Number(part))
+		.filter((value) => !Number.isNaN(value));
+
+	// An all-NaN header leaves `seconds` empty, so `Math.max(...[])` is
+	// -Infinity and the outer `Math.max(0, ...)` clamps it back to 0.
+	return Math.max(0, Math.floor(Math.max(...seconds)));
 }
 
 /**

--- a/packages/open-cloud/src/internal/http/fetch-client.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.ts
@@ -4,6 +4,7 @@ import { NetworkError } from "../../errors/network-error.ts";
 import { RateLimitError } from "../../errors/rate-limit.ts";
 import type { Result } from "../../types.ts";
 import { tryCatch } from "../utils/try-catch.ts";
+import { parseRateLimitHeaders } from "./rate-limit-sample.ts";
 import type { HttpClient, HttpRequest, HttpResponse, RequestConfig } from "./types.ts";
 
 // Caps the raw body retained when a response cannot be parsed, so a multi-KB
@@ -263,10 +264,10 @@ function createApiError(status: number, body: JSONValue | undefined): ApiError {
 }
 
 function createRateLimitError(response: Response): RateLimitError {
+	const headers = headersToRecord(response.headers);
 	return new RateLimitError("Rate limited", {
-		retryAfterSeconds: parseRetryAfterSeconds(
-			response.headers.get("x-ratelimit-reset") ?? undefined,
-		),
+		remaining: parseRateLimitHeaders(headers)?.remaining,
+		retryAfterSeconds: parseRetryAfterSeconds(headers["x-ratelimit-reset"]),
 	});
 }
 

--- a/packages/open-cloud/src/internal/http/fetch-client.ts
+++ b/packages/open-cloud/src/internal/http/fetch-client.ts
@@ -4,7 +4,7 @@ import { NetworkError } from "../../errors/network-error.ts";
 import { RateLimitError } from "../../errors/rate-limit.ts";
 import type { Result } from "../../types.ts";
 import { tryCatch } from "../utils/try-catch.ts";
-import { parseRateLimitHeaders } from "./rate-limit-sample.ts";
+import { reduceRateLimitTokens } from "./rate-limit-sample.ts";
 import type { HttpClient, HttpRequest, HttpResponse, RequestConfig } from "./types.ts";
 
 // Caps the raw body retained when a response cannot be parsed, so a multi-KB
@@ -93,18 +93,7 @@ export function extractErrorMessage(body: unknown): string | undefined {
  * @returns The number of seconds to wait, or 0 if missing/invalid.
  */
 export function parseRetryAfterSeconds(headerValue: string | undefined): number {
-	if (headerValue === undefined) {
-		return 0;
-	}
-
-	const seconds = headerValue
-		.split(",")
-		.map((part) => Number(part))
-		.filter((value) => !Number.isNaN(value));
-
-	// An all-NaN header leaves `seconds` empty, so `Math.max(...[])` is
-	// -Infinity and the outer `Math.max(0, ...)` clamps it back to 0.
-	return Math.max(0, Math.floor(Math.max(...seconds)));
+	return reduceRateLimitTokens(headerValue, (a, b) => Math.max(a, b)) ?? 0;
 }
 
 /**
@@ -266,7 +255,9 @@ function createApiError(status: number, body: JSONValue | undefined): ApiError {
 function createRateLimitError(response: Response): RateLimitError {
 	const headers = headersToRecord(response.headers);
 	return new RateLimitError("Rate limited", {
-		remaining: parseRateLimitHeaders(headers)?.remaining,
+		remaining: reduceRateLimitTokens(headers["x-ratelimit-remaining"], (a, b) =>
+			Math.min(a, b),
+		),
 		retryAfterSeconds: parseRetryAfterSeconds(headers["x-ratelimit-reset"]),
 	});
 }

--- a/packages/open-cloud/src/internal/http/rate-limit-observation.spec.ts
+++ b/packages/open-cloud/src/internal/http/rate-limit-observation.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { ApiError } from "../../errors/api-error.ts";
+import { RateLimitError } from "../../errors/rate-limit.ts";
+import { rateLimitSampleFromResult } from "./rate-limit-observation.ts";
+
+describe(rateLimitSampleFromResult, () => {
+	it("should parse the headers of a successful response", () => {
+		expect.assertions(1);
+
+		const result = rateLimitSampleFromResult({
+			data: {
+				body: undefined,
+				headers: { "x-ratelimit-remaining": "97", "x-ratelimit-reset": "23" },
+				status: 200,
+			},
+			success: true,
+		});
+
+		expect(result).toStrictEqual({ remaining: 97, resetSeconds: 23 });
+	});
+
+	it("should return undefined for a success without rate-limit headers", () => {
+		expect.assertions(1);
+
+		const result = rateLimitSampleFromResult({
+			data: { body: undefined, headers: {}, status: 200 },
+			success: true,
+		});
+
+		expect(result).toBeUndefined();
+	});
+
+	it("should build a sample from a rate-limit error carrying remaining", () => {
+		expect.assertions(1);
+
+		const result = rateLimitSampleFromResult({
+			err: new RateLimitError("Rate limited", { remaining: 0, retryAfterSeconds: 22 }),
+			success: false,
+		});
+
+		expect(result).toStrictEqual({ remaining: 0, resetSeconds: 22 });
+	});
+
+	it("should return undefined for a rate-limit error without remaining", () => {
+		expect.assertions(1);
+
+		const result = rateLimitSampleFromResult({
+			err: new RateLimitError("Rate limited", { retryAfterSeconds: 5 }),
+			success: false,
+		});
+
+		expect(result).toBeUndefined();
+	});
+
+	it("should return undefined for a non-rate-limit error", () => {
+		expect.assertions(1);
+
+		const result = rateLimitSampleFromResult({
+			err: new ApiError("boom", { statusCode: 500 }),
+			success: false,
+		});
+
+		expect(result).toBeUndefined();
+	});
+});

--- a/packages/open-cloud/src/internal/http/rate-limit-observation.ts
+++ b/packages/open-cloud/src/internal/http/rate-limit-observation.ts
@@ -1,0 +1,31 @@
+import type { OpenCloudError } from "../../errors/base.ts";
+import { RateLimitError } from "../../errors/rate-limit.ts";
+import type { Result } from "../../types.ts";
+import type { RateLimitSample } from "./rate-limit-sample.ts";
+import { parseRateLimitHeaders } from "./rate-limit-sample.ts";
+import type { HttpResponse } from "./types.ts";
+
+/**
+ * Extracts a {@link RateLimitSample} from a transport result so the budget gate
+ * can be fed from every attempt. A 2xx carries the budget in its headers; a 429
+ * carries it on the {@link RateLimitError} (the raw headers are dropped before
+ * this point). Any other error, or a response that reported no budget, yields
+ * `undefined` and leaves the gate on static pacing.
+ *
+ * @param result - The classified transport result for one attempt.
+ * @returns The parsed sample, or `undefined` when none was reported.
+ */
+export function rateLimitSampleFromResult(
+	result: Result<HttpResponse, OpenCloudError>,
+): RateLimitSample | undefined {
+	if (result.success) {
+		return parseRateLimitHeaders(result.data.headers);
+	}
+
+	const { err } = result;
+	if (err instanceof RateLimitError && err.remaining !== undefined) {
+		return { remaining: err.remaining, resetSeconds: err.retryAfterSeconds };
+	}
+
+	return undefined;
+}

--- a/packages/open-cloud/src/internal/http/rate-limit-sample.spec.ts
+++ b/packages/open-cloud/src/internal/http/rate-limit-sample.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRateLimitHeaders } from "./rate-limit-sample.ts";
+
+describe(parseRateLimitHeaders, () => {
+	it("should parse single-valued remaining and reset headers", () => {
+		expect.assertions(1);
+
+		expect(
+			parseRateLimitHeaders({
+				"x-ratelimit-remaining": "97",
+				"x-ratelimit-reset": "23",
+			}),
+		).toStrictEqual({ remaining: 97, resetSeconds: 23 });
+	});
+
+	it("should take the smallest remaining and largest reset from comma lists", () => {
+		expect.assertions(1);
+
+		expect(
+			parseRateLimitHeaders({
+				"x-ratelimit-remaining": "0, 70000",
+				"x-ratelimit-reset": "22, 0",
+			}),
+		).toStrictEqual({ remaining: 0, resetSeconds: 22 });
+	});
+
+	it("should reduce regardless of token order", () => {
+		expect.assertions(1);
+
+		expect(
+			parseRateLimitHeaders({
+				"x-ratelimit-remaining": "70000, 0",
+				"x-ratelimit-reset": "0, 22",
+			}),
+		).toStrictEqual({ remaining: 0, resetSeconds: 22 });
+	});
+
+	it("should floor fractional values and clamp negatives to zero", () => {
+		expect.assertions(1);
+
+		expect(
+			parseRateLimitHeaders({
+				"x-ratelimit-remaining": "-5",
+				"x-ratelimit-reset": "22.9",
+			}),
+		).toStrictEqual({ remaining: 0, resetSeconds: 22 });
+	});
+
+	it("should return undefined when the remaining header is absent", () => {
+		expect.assertions(1);
+
+		expect(parseRateLimitHeaders({ "x-ratelimit-reset": "23" })).toBeUndefined();
+	});
+
+	it("should return undefined when the reset header is absent", () => {
+		expect.assertions(1);
+
+		expect(parseRateLimitHeaders({ "x-ratelimit-remaining": "97" })).toBeUndefined();
+	});
+
+	it("should return undefined when a header has no numeric tokens", () => {
+		expect.assertions(1);
+
+		expect(
+			parseRateLimitHeaders({
+				"x-ratelimit-remaining": "abc",
+				"x-ratelimit-reset": "23",
+			}),
+		).toBeUndefined();
+	});
+});

--- a/packages/open-cloud/src/internal/http/rate-limit-sample.spec.ts
+++ b/packages/open-cloud/src/internal/http/rate-limit-sample.spec.ts
@@ -69,4 +69,26 @@ describe(parseRateLimitHeaders, () => {
 			}),
 		).toBeUndefined();
 	});
+
+	it("should drop non-finite tokens such as Infinity", () => {
+		expect.assertions(1);
+
+		expect(
+			parseRateLimitHeaders({
+				"x-ratelimit-remaining": "Infinity",
+				"x-ratelimit-reset": "23",
+			}),
+		).toBeUndefined();
+	});
+
+	it("should trim whitespace and ignore blank tokens", () => {
+		expect.assertions(1);
+
+		expect(
+			parseRateLimitHeaders({
+				"x-ratelimit-remaining": " , 5",
+				"x-ratelimit-reset": "60, ",
+			}),
+		).toStrictEqual({ remaining: 5, resetSeconds: 60 });
+	});
 });

--- a/packages/open-cloud/src/internal/http/rate-limit-sample.ts
+++ b/packages/open-cloud/src/internal/http/rate-limit-sample.ts
@@ -10,38 +10,17 @@ export interface RateLimitSample {
 }
 
 /**
- * Parses the `x-ratelimit-remaining` and `x-ratelimit-reset` response headers
- * into a {@link RateLimitSample}. Each header may carry a comma-separated list
- * of per-window values; `remaining` takes the smallest (most constrained) and
- * `resetSeconds` takes the largest (longest wait) — symmetric to how a 429's
- * retry delay is reduced. Returns `undefined` when either header is missing or
- * has no numeric tokens, so a caller can fall back to static pacing.
- *
- * @param headers - Response headers with lowercased keys.
- * @returns The parsed sample, or `undefined` when the budget cannot be read.
- */
-export function parseRateLimitHeaders(
-	headers: Readonly<Record<string, string>>,
-): RateLimitSample | undefined {
-	const remaining = reduceTokens(headers["x-ratelimit-remaining"], (a, b) => Math.min(a, b));
-	const resetSeconds = reduceTokens(headers["x-ratelimit-reset"], (a, b) => Math.max(a, b));
-	if (remaining === undefined || resetSeconds === undefined) {
-		return undefined;
-	}
-
-	return { remaining, resetSeconds };
-}
-
-/**
  * Reduces a comma-separated rate-limit header value (e.g. `"0, 70000"`) to a
- * single non-negative integer via `combine`. Returns `undefined` when the
- * header is absent or carries no numeric tokens.
+ * single non-negative integer via `combine`. Tokens are trimmed; blank and
+ * non-finite tokens (`""`, `"Infinity"`, `"abc"`) are dropped so a stray value
+ * cannot corrupt the result. Returns `undefined` when the header is absent or
+ * has no finite tokens.
  *
  * @param headerValue - The raw header value, or `undefined` if missing.
  * @param combine - Pairwise reducer, `Math.min` for remaining, `Math.max` for reset.
  * @returns The reduced, floored, clamped value, or `undefined`.
  */
-function reduceTokens(
+export function reduceRateLimitTokens(
 	headerValue: string | undefined,
 	combine: (a: number, b: number) => number,
 ): number | undefined {
@@ -51,11 +30,40 @@ function reduceTokens(
 
 	const tokens = headerValue
 		.split(",")
+		.map((part) => part.trim())
+		.filter((part) => part !== "")
 		.map((part) => Number(part))
-		.filter((value) => !Number.isNaN(value));
+		.filter((value) => Number.isFinite(value));
 	if (tokens.length === 0) {
 		return undefined;
 	}
 
 	return Math.max(0, Math.floor(tokens.reduce(combine)));
+}
+
+/**
+ * Parses the `x-ratelimit-remaining` and `x-ratelimit-reset` response headers
+ * into a {@link RateLimitSample}. Each header may carry a comma-separated list
+ * of per-window values; `remaining` takes the smallest (most constrained) and
+ * `resetSeconds` takes the largest (longest wait), symmetric to how a 429's
+ * retry delay is reduced. Returns `undefined` when either header is missing or
+ * has no finite numeric tokens, so a caller can fall back to static pacing.
+ *
+ * @param headers - Response headers with lowercased keys.
+ * @returns The parsed sample, or `undefined` when the budget cannot be read.
+ */
+export function parseRateLimitHeaders(
+	headers: Readonly<Record<string, string>>,
+): RateLimitSample | undefined {
+	const remaining = reduceRateLimitTokens(headers["x-ratelimit-remaining"], (a, b) =>
+		Math.min(a, b),
+	);
+	const resetSeconds = reduceRateLimitTokens(headers["x-ratelimit-reset"], (a, b) =>
+		Math.max(a, b),
+	);
+	if (remaining === undefined || resetSeconds === undefined) {
+		return undefined;
+	}
+
+	return { remaining, resetSeconds };
 }

--- a/packages/open-cloud/src/internal/http/rate-limit-sample.ts
+++ b/packages/open-cloud/src/internal/http/rate-limit-sample.ts
@@ -1,0 +1,61 @@
+/**
+ * A point-in-time rate-limit budget reading parsed from Roblox Open Cloud
+ * response headers. Both fields are non-negative integers.
+ */
+export interface RateLimitSample {
+	/** Requests still allowed in the current window (the most-constrained one). */
+	readonly remaining: number;
+	/** Seconds until the most-constrained window resets to full. */
+	readonly resetSeconds: number;
+}
+
+/**
+ * Parses the `x-ratelimit-remaining` and `x-ratelimit-reset` response headers
+ * into a {@link RateLimitSample}. Each header may carry a comma-separated list
+ * of per-window values; `remaining` takes the smallest (most constrained) and
+ * `resetSeconds` takes the largest (longest wait) — symmetric to how a 429's
+ * retry delay is reduced. Returns `undefined` when either header is missing or
+ * has no numeric tokens, so a caller can fall back to static pacing.
+ *
+ * @param headers - Response headers with lowercased keys.
+ * @returns The parsed sample, or `undefined` when the budget cannot be read.
+ */
+export function parseRateLimitHeaders(
+	headers: Readonly<Record<string, string>>,
+): RateLimitSample | undefined {
+	const remaining = reduceTokens(headers["x-ratelimit-remaining"], (a, b) => Math.min(a, b));
+	const resetSeconds = reduceTokens(headers["x-ratelimit-reset"], (a, b) => Math.max(a, b));
+	if (remaining === undefined || resetSeconds === undefined) {
+		return undefined;
+	}
+
+	return { remaining, resetSeconds };
+}
+
+/**
+ * Reduces a comma-separated rate-limit header value (e.g. `"0, 70000"`) to a
+ * single non-negative integer via `combine`. Returns `undefined` when the
+ * header is absent or carries no numeric tokens.
+ *
+ * @param headerValue - The raw header value, or `undefined` if missing.
+ * @param combine - Pairwise reducer, `Math.min` for remaining, `Math.max` for reset.
+ * @returns The reduced, floored, clamped value, or `undefined`.
+ */
+function reduceTokens(
+	headerValue: string | undefined,
+	combine: (a: number, b: number) => number,
+): number | undefined {
+	if (headerValue === undefined) {
+		return undefined;
+	}
+
+	const tokens = headerValue
+		.split(",")
+		.map((part) => Number(part))
+		.filter((value) => !Number.isNaN(value));
+	if (tokens.length === 0) {
+		return undefined;
+	}
+
+	return Math.max(0, Math.floor(tokens.reduce(combine)));
+}

--- a/packages/open-cloud/src/internal/resource-client.spec.ts
+++ b/packages/open-cloud/src/internal/resource-client.spec.ts
@@ -785,4 +785,55 @@ describe(ResourceClient, () => {
 			expect(sleep.waits).toStrictEqual([2000]);
 		});
 	});
+
+	describe("adaptive throttling", () => {
+		it("should hold a same-key operation when an earlier response reported zero remaining", async () => {
+			expect.assertions(1);
+
+			const httpClient = createFakeHttpClient({ schemaValidation: "off" })
+				.mockResponse({
+					headers: { "x-ratelimit-remaining": "0", "x-ratelimit-reset": "60" },
+					status: 200,
+				})
+				.mockResponse({ status: 200 });
+			const clock = createFakeClock();
+			const client = new ResourceClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: clock.sleep,
+			});
+
+			const first = await client.execute({ parameters: { id: "1" }, spec: TEST_GET_SPEC });
+			const second = await client.execute({
+				parameters: { id: "2" },
+				spec: TEST_CREATE_SPEC,
+			});
+
+			assert(first.success);
+			assert(second.success);
+
+			// The GET drained the shared per-key window to 0, so the CREATE on
+			// the same key holds for the full reset before its request goes out.
+			expect(clock.waits).toStrictEqual([60_000]);
+		});
+
+		it("should not hold when responses carry no rate-limit headers", async () => {
+			expect.assertions(1);
+
+			const httpClient = createFakeHttpClient({ schemaValidation: "off" })
+				.mockResponse({ status: 200 })
+				.mockResponse({ status: 200 });
+			const clock = createFakeClock();
+			const client = new ResourceClient({
+				apiKey: "test-key",
+				httpClient,
+				sleep: clock.sleep,
+			});
+
+			await client.execute({ parameters: { id: "1" }, spec: TEST_GET_SPEC });
+			await client.execute({ parameters: { id: "2" }, spec: TEST_CREATE_SPEC });
+
+			expect(clock.waits).toStrictEqual([]);
+		});
+	});
 });

--- a/packages/open-cloud/src/internal/resource-client.ts
+++ b/packages/open-cloud/src/internal/resource-client.ts
@@ -14,7 +14,9 @@ import { ApiError } from "../errors/api-error.ts";
 import type { OpenCloudError } from "../errors/base.ts";
 import { PermissionError } from "../errors/permission-error.ts";
 import type { Result } from "../types.ts";
+import { BudgetGate } from "./http/budget-gate.ts";
 import { executeWithRetry } from "./http/execute.ts";
+import { rateLimitSampleFromResult } from "./http/rate-limit-observation.ts";
 import { type OperationLimit, RateLimitQueue } from "./http/rate-limit-queue.ts";
 import { resolveDependencies } from "./http/resolve-dependencies.ts";
 import {
@@ -148,6 +150,7 @@ interface RequestConfigInputs {
  * `src/resources/**` modules in this package.
  */
 export class ResourceClient {
+	readonly #budgets: BudgetGate;
 	readonly #config: Readonly<RetryResolvable>;
 	readonly #hooks: OpenCloudHooks;
 	readonly #httpClient: HttpClient;
@@ -167,6 +170,7 @@ export class ResourceClient {
 		const resolved = resolveDependencies({ httpClient, sleep });
 		this.#httpClient = resolved.httpClient;
 		this.#sleep = resolved.sleep;
+		this.#budgets = new BudgetGate(this.#sleep);
 		this.#hooks = hooks ?? {};
 		this.#config = Object.freeze({
 			...CLIENT_DEFAULTS,
@@ -205,7 +209,7 @@ export class ResourceClient {
 			return executeWithRetry(requestResult.data, {
 				config: merged,
 				hooks: this.#hooks,
-				send: async (toSend) => this.#httpClient.request(toSend, requestConfig),
+				send: this.#gatedSend(merged.apiKey, requestConfig),
 				sleep: this.#sleep,
 			});
 		});
@@ -223,6 +227,28 @@ export class ResourceClient {
 	 */
 	public get sleep(): SleepFunc {
 		return this.#sleep;
+	}
+
+	/**
+	 * Builds the transport callback for one logical call, wrapping the HTTP
+	 * client with the budget gate: each attempt waits on the API key's budget
+	 * before sending, then folds the response's reported budget back in so the
+	 * next attempt (or a sibling operation on the same key) can head off a 429.
+	 *
+	 * @param apiKey - The effective API key to gate on.
+	 * @param requestConfig - The resolved per-request transport config.
+	 * @returns A send callback for {@link executeWithRetry}.
+	 */
+	#gatedSend(
+		apiKey: string,
+		requestConfig: RequestConfig,
+	): (request: HttpRequest) => Promise<Result<HttpResponse, OpenCloudError>> {
+		return async (toSend) => {
+			await this.#budgets.gate(apiKey);
+			const sendResult = await this.#httpClient.request(toSend, requestConfig);
+			this.#budgets.observe(apiKey, rateLimitSampleFromResult(sendResult));
+			return sendResult;
+		};
 	}
 
 	#getQueue(apiKey: string, limit: OperationLimit): RateLimitQueue {


### PR DESCRIPTION
## Summary

The rate limiter paced requests with a **static** per-operation token bucket seeded from the vendored OpenAPI, and only recovered from a 429 reactively. A live probe against the real API showed those constants drift from reality (schema 200/min vs a measured 100/min) and that Roblox returns the live budget (`x-ratelimit-remaining`/`-reset`) on every response — which the SDK was discarding.

This makes pacing **header-primed and adaptive**: a per-API-key budget gate reads the live budget off every response and spaces requests across the window, self-correcting to the server's real rate. The static bucket stays as the cold-start / header-absent fallback, and the reactive 429 retry path stays as defense in depth.

## What changed

- **`parse-multi-window x-ratelimit-reset` fix** — on a 429 the header is a comma list (`"22, 0"`); the old parser ran `Number()` over the whole string, got `NaN`, and silently fell back to exponential backoff. Now reduced with `max` (reset) / `min` (remaining).
- **`RateLimitError.remaining`** — the 429 path built no header record, so the one response that proves exhaustion dropped its budget. It now carries `remaining`.
- **`BudgetTracker` / `BudgetGate`** — header-primed, per-API-key. Gates per *attempt* (the token bucket grants one token for a whole retry loop, so gating at acquisition can't stop retry-loop 429s).
- **Two pacing regimes (A2)** — while budget remains, requests are spaced evenly over the time left in the window (`timeLeft / remaining`) so a burst doesn't spend the window up front and stall; once spent, requests hold until reset. First send in a window goes immediately.

## Design decisions

- **Per-key scope, not per-operation.** Every operation reports the same most-constrained `remaining`, so a per-key tracker drawn down by all operations is always the binding constraint — a per-operation tracker could never independently fire. Per-key is also where a deploy's real 429s live (many operations sharing one key window).
- **Last-writer-wins observation.** Observe time is monotonic (stamped at resolution), so the latest sample is the best estimate; no staleness bookkeeping.
- **Headers are optional.** A missing or non-numeric header parses to `undefined` and leaves that scope on static pacing (404s omit the headers entirely).

## Testing

- TDD throughout, one behaviour per commit; **100% coverage and 100% mutation** on every touched `src/**` file.
- Full package suite green (1600 tests).

## Limitations (documented in the ADR)

- The per-key `remaining` is the *minimum* across Roblox's overlapping windows, so when only a route-specific window is exhausted the gate can briefly over-throttle other operations on that key until the next observation.
- A concurrent burst before the first observation can still overshoot (bounded; the next observation corrects it).
- Multi-client/process-per-key coordination is unchanged from ADR-010.

See the dated amendment in `docs/adr/010-sdk-managed-rate-limiting-and-retry.md` for the full contract and rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Bedrock Code Review: Adaptive Rate Limiter Enhancement

## Architecture Compliance (FCIS Pattern) ✅
- **Core (pure/functional)**
  - `parseRateLimitHeaders`, `reduceRateLimitTokens`: pure parsing with `undefined` fallback when headers are missing/unparseable.
  - `rateLimitSampleFromResult`: pure transformation from request results into an optional budget sample.
  - `BudgetTracker`: pure pacing math (`observe`, `reserve`, `waitMs`) driven by a parsed sample.
- **Shell / orchestration**
  - `BudgetGate`: performs the only timing side effects by injecting `sleep` and gating `gate(scope)` before requests; also handles concurrency by serializing per-scope acquisition via a promise chain.
  - `ResourceClient`: wires the gating into the transport path so each attempt waits (per effective API key) and then observes headers from the attempt result.
- **Ports/adapters**
  - Timing is abstracted via `SleepFunc` injection (no hard-coded timers inside core pacing logic).
  - Rate-limit observation is derived from adapter results and classified errors (`RateLimitError.remaining`) rather than coupling pacing logic to fetch internals.

## Testing Compliance (TDD Required) ✅
- Added/expanded **Vitest** coverage for each new/updated unit:
  - `BudgetTracker`: pacing/waiting across unprimed, primed, evenly-spaced, exhausted, boundary, and re-observation scenarios.
  - `BudgetGate`: no-wait before any sample, correct wait-after-exhaustion, independent per-scope behavior, ignoring `undefined`, even spacing, and **serialized concurrent `gate()` calls** per scope.
  - Header/sample parsing:
    - `parseRateLimitHeaders` and `reduceRateLimitTokens` handle single values, comma-separated multi-window resets, ordering invariance, flooring/clamping, and non-finite/blank tokens.
    - `rateLimitSampleFromResult` derives samples from both **successful responses** and **`RateLimitError.remaining`**.
  - HTTP integration points:
    - `parseRetryAfterSeconds` and 429 handling assert correct behavior for comma-separated `x-ratelimit-reset` and non-numeric reset values, including that `RateLimitError.remaining` is captured only when `x-ratelimit-remaining` is present.
- `RateLimitError` enhancements are covered by dedicated tests for `remaining` presence and `0` handling.

## Code Quality ✅
- **Typed API surface**
  - `RateLimitError` now includes additive `remaining?: number` and is exposed as `public readonly remaining`.
- **Robustness for real header behavior**
  - Multi-window reset parsing uses token reduction semantics (floors, clamps, rejects non-finite, trims/ignores blanks).
  - Fix ensures exhausted-budget signals from **429 error responses** are preserved even when `x-ratelimit-reset` is invalid/non-numeric.
- **Concurrency safety**
  - `BudgetGate.gate()` is serialized per scope so concurrent requests on the same key cannot observe and reserve the same budget slot.

## Security & Constraints ✅
- **Open Cloud only**: changes remain confined to the Open Cloud client’s HTTP rate-limiting/retry machinery.
- **Input validation at adapter boundaries**: all header parsing drops non-finite/blank tokens and clamps negatives before they influence timing calculations.

## Documentation / Release Notes ✅
- Updated package guidance (`packages/open-cloud/CLAUDE.md`) and ADR (`docs/adr/010-sdk-managed-rate-limiting-and-retry.md`) to reflect the new **header-primed, per-API-key budget gate** strategy and multi-window parsing behavior.
- Added a changeset documenting the `RateLimitError.remaining` surface and pacing change.

## Summary
This PR implements adaptive rate limiting by observing live rate-limit budget from `x-ratelimit-remaining`/`x-ratelimit-reset` on every attempt, proactively gating outbound sends to reduce 429s, and pacing requests evenly across the remaining window until reset. It also fixes comma-separated reset parsing for 429 responses and preserves the exhausted-budget signal via `RateLimitError.remaining`. The update is well-covered by focused unit tests (including fake-clock timing and per-scope concurrency serialization) and is documented across ADR/package guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->