### PR TITLE
perf(core): cut gist api usage with conditional visibility polls

### DIFF
--- a/.changeset/conditional-visibility-poll.md
+++ b/.changeset/conditional-visibility-poll.md
@@ -1,0 +1,5 @@
+---
+"@bedrock-rbx/core": patch
+---
+
+Cut the gist state adapter's GitHub API usage on writes. After a state write, the read-your-write visibility poll now issues conditional GETs (`If-None-Match`) once a stale replica reveals its ETag: a replica still serving the prior body answers `304 Not Modified`, which GitHub does not count against the primary REST rate limit. A slow-to-propagate write now costs roughly one charged GET instead of one per poll attempt, lowering the chance of a `403` rate-limit exhaustion under frequent deploys.

--- a/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.spec.ts
@@ -1179,6 +1179,55 @@ describe(createGistStateAdapter, () => {
 				expect(sleepFake.calls).toStrictEqual([250, 500, 1000, 2000]);
 			});
 
+			it("should replay a stale replica's ETag on later polls so 304s and missing-etag GETs stay conditional", async () => {
+				expect.assertions(5);
+
+				const written: BedrockState = {
+					environment: "production",
+					resources: [],
+					version: 1,
+				};
+				const staleEtag = 'W/"stale-replica-etag"';
+				function staleFile(etag?: string): Response {
+					return new Response(
+						JSON.stringify({
+							files: { "state.production.json": { content: "stale prior content" } },
+						}),
+						etag === undefined ? { status: 200 } : { headers: { etag }, status: 200 },
+					);
+				}
+
+				const { calls, fetchFn } = fakeFetchSequence([
+					emptyResponse(200),
+					staleFile(staleEtag),
+					new Response(undefined, { status: 304 }),
+					staleFile(),
+					okJson({
+						files: {
+							"state.production.json": { content: serializeStateFile(written) },
+						},
+					}),
+				]);
+				const sleepFake = fakeSleep();
+				const port = createGistStateAdapter({
+					fetch: fetchFn,
+					gistId: GIST_ID,
+					sleep: sleepFake.sleep,
+					token: TOKEN,
+				});
+
+				const result = await port.write(written);
+
+				expect(result.success).toBeTrue();
+				expect(calls).toHaveLength(5);
+				// First poll has no baseline ETag, so it is unconditional.
+				expect(calls[1]!.headers.get("if-none-match")).toBeNull();
+				// Captured ETag is replayed so a still-stale replica answers 304.
+				expect(calls[2]!.headers.get("if-none-match")).toBe(staleEtag);
+				// Retained across the 304 and a later etag-less stale 200.
+				expect(calls[4]!.headers.get("if-none-match")).toBe(staleEtag);
+			});
+
 			it("should keep polling when a present file's value is malformed (non-object)", async () => {
 				expect.assertions(3);
 

--- a/packages/bedrock/src/adapters/gist-state-adapter.ts
+++ b/packages/bedrock/src/adapters/gist-state-adapter.ts
@@ -218,9 +218,16 @@ function buildHeaders(token: string): Headers {
 	return headers;
 }
 
-async function sendGet(ctx: AdapterContext): Promise<Response> {
+async function sendGet(ctx: AdapterContext, etag?: string): Promise<Response> {
+	const headers = buildHeaders(ctx.token);
+	if (etag !== undefined) {
+		// Conditional GET: a replica still serving the prior body answers 304,
+		// which GitHub does not count against the primary REST rate limit.
+		headers.set("If-None-Match", etag);
+	}
+
 	return ctx.fetchFn(`${GITHUB_API_BASE}/gists/${ctx.gistId}`, {
-		headers: buildHeaders(ctx.token),
+		headers,
 		method: "GET",
 	});
 }
@@ -338,27 +345,6 @@ async function sendPatch(ctx: AdapterContext, body: string): Promise<Response> {
 	});
 }
 
-async function isContentVisible(ctx: AdapterContext, want: VisibilityTarget): Promise<boolean> {
-	const target = fileName(want.environment);
-	try {
-		// Compare the written body, not just the filename. The name is fixed
-		// per environment and unchanged by an overwrite, so presence alone
-		// never proves the new write propagated. Any absent or malformed shape
-		// (missing files map, missing file entry, missing content) surfaces as
-		// undefined or a thrown Reflect.get and is funnelled through the catch
-		// below, counting as "not yet visible" so the poll keeps trying rather
-		// than accepting a stale replica.
-		const response = await sendGet(ctx);
-		const body = JSON.parse(await response.text());
-		const files = Reflect.get(body, "files");
-		const entry = Reflect.get(files, target);
-		const content = Reflect.get(entry, "content");
-		return content === want.content;
-	} catch {
-		return false;
-	}
-}
-
 /**
  * Polls the gist until the just-written file is visible on a GET carrying the
  * content just written, with bounded retries. GitHub's gist API does not
@@ -372,6 +358,12 @@ async function isContentVisible(ctx: AdapterContext, want: VisibilityTarget): Pr
  * whether the content became visible. The PATCH already committed; the poll
  * only narrows the window in which subsequent reads can lag.
  *
+ * Once a stale replica reveals its ETag, later polls replay it via
+ * `If-None-Match`: a replica still serving the prior body answers `304 Not
+ * Modified`, which GitHub does not bill against the primary REST rate limit,
+ * so a slow-propagating write costs roughly one charged GET instead of one per
+ * attempt.
+ *
  * @param ctx - Adapter context carrying the injected fetch and sleep seams.
  * @param want - Environment file and serialized body the PATCH just wrote.
  */
@@ -379,9 +371,26 @@ async function waitForContentVisibility(
 	ctx: AdapterContext,
 	want: VisibilityTarget,
 ): Promise<void> {
+	const target = fileName(want.environment);
+	let etag: string | undefined;
 	for (let attempt = 0; attempt < MAX_VISIBILITY_ATTEMPTS; attempt += 1) {
-		if (await isContentVisible(ctx, want)) {
-			return;
+		try {
+			const response = await sendGet(ctx, etag);
+			// Carry the replica's ETag forward (keeping the prior one when the
+			// response omits it) so later polls stay conditional. Compare the
+			// written body, not the filename: the name is stable across an
+			// overwrite, so presence alone never proves propagation. Any absent
+			// or malformed shape, or an empty 304 body, throws and drops to the
+			// catch as "not yet visible" rather than accepting a stale replica.
+			etag = response.headers.get("etag") ?? etag;
+			const body = JSON.parse(await response.text());
+			const files = Reflect.get(body, "files");
+			const entry = Reflect.get(files, target);
+			if (Reflect.get(entry, "content") === want.content) {
+				return;
+			}
+		} catch {
+			/* not yet visible; keep polling with the retained ETag. */
 		}
 
 		if (attempt < MAX_VISIBILITY_ATTEMPTS - 1) {


### PR DESCRIPTION
## What

After a gist state write, the read-your-write visibility poll now issues **conditional GETs** (`If-None-Match`) once a stale replica reveals its `ETag`. A replica still serving the prior body answers `304 Not Modified`, which GitHub does **not** count against the primary REST rate limit — so a slow-to-propagate write costs roughly one charged GET instead of one per poll attempt (up to 5).

Responses without an `ETag` (every prior code path and all existing fixtures) behave byte-for-byte as before — this is purely additive.

## Why

Smoke CI was failing with `403 rate limited` on gist writes. The bare reason (no `retry-after`) pins it to the **primary** per-token hourly limit (5,000 req/hr), exhausted by aggregate gist traffic across concurrent PR + push runs sharing one token. The visibility poll was the dominant multiplier (up to 5 GETs per write); conditional requests make the repeat polls free, cutting that pressure.

## Notes

- The explicit `304` branch was dropped as redundant: a null-body `304` fails `JSON.parse` and already funnels through the existing "not yet visible" catch, which retains the prior `ETag` for the next conditional poll. (Removing it also cleared two equivalent-mutant survivors rather than contriving a test.)
- New test asserts conditional replay across a `304` and a later etag-less stale `200`.

## Verification

- Package suite: 2381 passed · typecheck clean · lint clean · build + publint clean
- `mutate:changed`: **100%**, 0 survivors
- Changeset: `patch` (`@bedrock-rbx/core`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)