### PR TITLE
feat(core): add provision and publish commands

### DIFF
--- a/.changeset/provision-publish-commands.md
+++ b/.changeset/provision-publish-commands.md
@@ -1,0 +1,5 @@
+---
+"@bedrock-rbx/core": minor
+---
+
+Add `provision` and `publish` commands that split the two-phase deploy at its checkpoint seam. `provision` runs the asset stage plus codegen (minting IDs, persisting mutable asset fields, running the emitter, and setting the `pendingRebuild` marker) without building or publishing any place. `publish` is a pure uploader that publishes the on-disk artifact for each `pendingRebuild` place (deduped by file hash), clearing the marker per republished place, with no mint, codegen, or build. Both are exposed programmatically (`provision(options)`, `publish(options)`) and as CLI subcommands (`bedrock provision`, `bedrock publish`), each overridable via `.bedrock/provision.ts` / `.bedrock/publish.ts`. `deploy` behaviour is unchanged.

--- a/.changeset/provision-publish-commands.md
+++ b/.changeset/provision-publish-commands.md
@@ -3,3 +3,7 @@
 ---
 
 Add `provision` and `publish` commands that split the two-phase deploy at its checkpoint seam. `provision` runs the asset stage plus codegen (minting IDs, persisting mutable asset fields, running the emitter, and setting the `pendingRebuild` marker) without building or publishing any place. `publish` is a pure uploader that publishes the on-disk artifact for each `pendingRebuild` place (deduped by file hash), clearing the marker per republished place, with no mint, codegen, or build. Both are exposed programmatically (`provision(options)`, `publish(options)`) and as CLI subcommands (`bedrock provision`, `bedrock publish`), each overridable via `.bedrock/provision.ts` / `.bedrock/publish.ts`. `deploy` behaviour is unchanged.
+
+`provision` reads only asset inputs and `publish` reads only place inputs, so `provision` can run before the place artifact is built and neither stage fails on a file-backed input it does not own (a place `.rbxl` for `provision`, an asset icon for `publish`).
+
+`buildDesired` now takes a single options object (`buildDesired({ resources, readFile, includeKind? })`) instead of positional `(resources, readFile)` arguments, gaining an optional `includeKind` predicate that limits which kinds are read and normalized.

--- a/packages/bedrock/src/cli/commands/deploy.ts
+++ b/packages/bedrock/src/cli/commands/deploy.ts
@@ -1,205 +1,21 @@
-import process from "node:process";
-
-import { createClackProgressAdapter } from "../../adapters/clack-progress-adapter.ts";
-import type { Config } from "../../core/schema.ts";
-import type { ProgressPort } from "../../ports/progress-port.ts";
 import { deploy as defaultDeploy } from "../../shell/deploy.ts";
-import { loadConfig as defaultLoadConfig } from "../../shell/load-config.ts";
-import { buildOverrideInvocation } from "../build-override-invocation.ts";
-import { createClackPort } from "../clack-port.ts";
-import { buildCredentialOverrides } from "../credential-environment-overrides.ts";
-import { createDefaultSpawner } from "../default-spawner.ts";
-import { discoverOverride as defaultDiscoverOverride } from "../discover-override.ts";
-import { dispatchOverride } from "../dispatch-override.ts";
-import { EXIT_ERROR, EXIT_OK } from "../exit-codes.ts";
-import type { ProgDeps as ProgDependencies } from "../index.ts";
-import { type CommonOptions, loadOptionsFor, parseCommonOptions } from "../parse-options.ts";
-import {
-	type ClackPort,
-	renderDeployError,
-	renderOverrideDiscoveryError,
-	renderOverrideError,
-	renderParseError,
-} from "../render.ts";
-import type { Spawner } from "../spawner.ts";
-
-interface ResolvedDeploy {
-	readonly clack: ClackPort;
-	readonly deploy: typeof defaultDeploy;
-	readonly discoverOverride: typeof defaultDiscoverOverride;
-	readonly exit: (code: number) => void;
-	readonly loadConfig: typeof defaultLoadConfig;
-	readonly progressOverride: ProgressPort | undefined;
-	readonly projectRoot: string;
-	readonly spawner: Spawner;
-}
-
-interface DispatchInputs {
-	readonly config: Config;
-	readonly getEnv: (name: string) => string | undefined;
-	readonly overridePath: string | undefined;
-	readonly parsed: CommonOptions;
-	readonly progress: ProgressPort;
-	readonly resolved: ResolvedDeploy;
-}
-
-interface DispatchAndReportInput {
-	readonly loaded: Config;
-	readonly overridePath: string | undefined;
-	readonly parsed: CommonOptions;
-	readonly resolved: ResolvedDeploy;
-}
-
-type OverrideDiscovery =
-	| { readonly kind: "discovered"; readonly overridePath: string | undefined }
-	| { readonly kind: "failed" };
+import type { ProgDeps } from "../index.ts";
+import { createReconcileCommand } from "./reconcile-command.ts";
 
 /**
- * Build the sade action for `bedrock deploy`. The returned function consumes
- * the raw options object sade hands the action callback, parses it via
- * `parseCommonOptions`, loads the project config once, and dispatches
- * `deploy()` for each `--env` value in order. Per-env successes and failures
- * render through clack as a single line each; the aggregated exit code is
- * `EXIT_OK` only when every env succeeded.
- *
- * When a `.bedrock/deploy.ts` override is discovered under the resolved
- * project root, each `--env` is handed to the spawner via
- * {@link dispatchOverride} instead of the in-process `deploy()` call. The
- * aggregation rule is identical: every env still runs and the exit code is
- * `EXIT_OK` only when every spawn returned a zero exit code. Unlike the
- * in-process path, only failures emit a per-env line here; a successful
- * spawn's output comes from the override script's own inherited stdout.
+ * Build the sade action for `bedrock deploy`. Reconciles every `--env` against
+ * the configured environment, dispatching a `.bedrock/deploy.ts` override when
+ * one is discovered. The aggregated exit code is `EXIT_OK` only when every env
+ * succeeded. See {@link createReconcileCommand} for the shared scaffolding.
  * @param deps - Dependency overrides; missing slots are default-constructed
  *   from real implementations.
  * @returns An async sade action that returns once `deps.exit` was invoked.
  */
 export function deployCommand(
-	deps: ProgDependencies,
+	deps: ProgDeps,
 ): (rawOptions: Record<string, unknown>) => Promise<void> {
-	const resolved = resolveDeploy(deps);
-	return async (rawOptions) => {
-		const code = await runDeploy(rawOptions, resolved);
-		resolved.exit(code);
-	};
-}
-
-function resolveDeploy(dependencies: ProgDependencies): ResolvedDeploy {
-	const clack = dependencies.clack ?? createClackPort();
-	return {
-		clack,
-		deploy: dependencies.deploy ?? defaultDeploy,
-		discoverOverride: dependencies.discoverOverride ?? defaultDiscoverOverride,
-		exit: dependencies.exit ?? ((code: number) => process.exit(code)),
-		loadConfig: dependencies.loadConfig ?? defaultLoadConfig,
-		progressOverride: dependencies.progress,
-		projectRoot: dependencies.projectRoot ?? process.cwd(),
-		spawner: dependencies.spawner ?? createDefaultSpawner(),
-	};
-}
-
-function cancelAsFailed(clack: ClackPort): void {
-	clack.cancel("deploy failed");
-}
-
-async function dispatchEnvironments(inputs: DispatchInputs): Promise<ReadonlyArray<string>> {
-	const { config, getEnv, overridePath, parsed, progress, resolved } = inputs;
-	const failed: Array<string> = [];
-	for (const environment of parsed.environments) {
-		if (overridePath !== undefined) {
-			const invocation = buildOverrideInvocation({ environment, overridePath, parsed });
-			const result = await dispatchOverride(invocation, resolved.spawner);
-			if (!result.success) {
-				renderOverrideError({ environment, err: result.err }, resolved.clack);
-				failed.push(environment);
-			}
-
-			continue;
-		}
-
-		const result = await resolved.deploy({
-			config,
-			environment,
-			getEnv,
-			progress,
-		});
-		if (!result.success) {
-			failed.push(environment);
-		}
-	}
-
-	return failed;
-}
-
-function buildGetEnvironment(parsed: CommonOptions): (name: string) => string | undefined {
-	const overrides = buildCredentialOverrides(parsed);
-	return (name) => overrides[name] ?? process.env[name];
-}
-
-async function dispatchAndReport(input: DispatchAndReportInput): Promise<number> {
-	const { loaded, overridePath, parsed, resolved } = input;
-	const progress: ProgressPort =
-		resolved.progressOverride ??
-		createClackProgressAdapter({ clack: resolved.clack, config: loaded });
-
-	const failures = await dispatchEnvironments({
-		config: loaded,
-		getEnv: buildGetEnvironment(parsed),
-		overridePath,
-		parsed,
-		progress,
-		resolved,
-	});
-	if (failures.length > 0) {
-		cancelAsFailed(resolved.clack);
-		return EXIT_ERROR;
-	}
-
-	resolved.clack.outro("deploy succeeded");
-	return EXIT_OK;
-}
-
-function discoverOverridePath(resolved: ResolvedDeploy): OverrideDiscovery {
-	try {
-		return {
-			kind: "discovered",
-			overridePath: resolved.discoverOverride(resolved.projectRoot, "deploy"),
-		};
-	} catch (err) {
-		renderOverrideDiscoveryError(err, resolved.clack);
-		cancelAsFailed(resolved.clack);
-		return { kind: "failed" };
-	}
-}
-
-async function runDeploy(
-	rawOptions: Record<string, unknown>,
-	resolved: ResolvedDeploy,
-): Promise<number> {
-	resolved.clack.intro("bedrock deploy");
-
-	const parsed = parseCommonOptions(rawOptions);
-	if (!parsed.success) {
-		renderParseError(parsed.err, resolved.clack);
-		cancelAsFailed(resolved.clack);
-		return EXIT_ERROR;
-	}
-
-	const loaded = await resolved.loadConfig(loadOptionsFor(parsed.data));
-	if (!loaded.success) {
-		renderDeployError({ cause: loaded.err, kind: "configLoadFailed" }, resolved.clack);
-		cancelAsFailed(resolved.clack);
-		return EXIT_ERROR;
-	}
-
-	const discovery = discoverOverridePath(resolved);
-	if (discovery.kind === "failed") {
-		return EXIT_ERROR;
-	}
-
-	return dispatchAndReport({
-		loaded: loaded.data,
-		overridePath: discovery.overridePath,
-		parsed: parsed.data,
-		resolved,
+	return createReconcileCommand(deps, {
+		command: "deploy",
+		resolveRun: (progDeps) => progDeps.deploy ?? defaultDeploy,
 	});
 }

--- a/packages/bedrock/src/cli/commands/provision.spec.ts
+++ b/packages/bedrock/src/cli/commands/provision.spec.ts
@@ -1,0 +1,82 @@
+import type { Result } from "@bedrock-rbx/ocale";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	type DiscoverOverrideFunc,
+	fakeLoad,
+	makeDeps,
+	okState,
+	sampleConfig,
+} from "#tests/helpers/reconcile-command";
+import type { BedrockState } from "../../core/state.ts";
+import type { DeployError } from "../../shell/deploy.ts";
+import type { ProgDeps } from "../index.ts";
+import type { Spawner, SpawnInvocation } from "../spawner.ts";
+import { provisionCommand } from "./provision.ts";
+
+type ProvisionFunc = NonNullable<ProgDeps["provision"]>;
+
+function fakeProvision(result: Result<BedrockState, DeployError>): ProvisionFunc {
+	return vi.fn<ProvisionFunc>(async () => result);
+}
+
+describe(provisionCommand, () => {
+	it("should intro, dispatch provision, log the succeeded outro, and exit 0", async () => {
+		expect.assertions(4);
+
+		const provision = fakeProvision({ data: okState(), success: true });
+		const deps = makeDeps({ loadConfig: fakeLoad(), provision });
+
+		await provisionCommand(deps)({ env: "production" });
+
+		expect(deps.clack?.intro).toHaveBeenCalledExactlyOnceWith("bedrock provision");
+		expect(provision).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({ config: sampleConfig, environment: "production" }),
+		);
+		expect(deps.clack?.outro).toHaveBeenCalledExactlyOnceWith("provision succeeded");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(0);
+	});
+
+	it("should cancel with 'provision failed' and exit 1 when provision returns Err", async () => {
+		expect.assertions(2);
+
+		const provision = fakeProvision({
+			err: { environment: "production", kind: "stateNotConfigured" },
+			success: false,
+		});
+		const deps = makeDeps({ loadConfig: fakeLoad(), provision });
+
+		await provisionCommand(deps)({ env: "production" });
+
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("provision failed");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should discover a .bedrock/provision.ts override and spawn it instead of provision()", async () => {
+		expect.assertions(3);
+
+		const invocations: Array<SpawnInvocation> = [];
+		const spawner: Spawner = {
+			async spawn(invocation) {
+				invocations.push(invocation);
+				return { data: 0, success: true };
+			},
+		};
+		const discoverOverride = vi.fn<DiscoverOverrideFunc>(() => "/abs/.bedrock/provision.ts");
+		const provision = vi.fn<ProvisionFunc>();
+		const deps = makeDeps({
+			discoverOverride,
+			loadConfig: fakeLoad(),
+			projectRoot: "/abs",
+			provision,
+			spawner,
+		});
+
+		await provisionCommand(deps)({ env: "production" });
+
+		expect(discoverOverride).toHaveBeenCalledExactlyOnceWith("/abs", "provision");
+		expect(provision).not.toHaveBeenCalled();
+		expect(invocations[0]?.args[0]).toBe("/abs/.bedrock/provision.ts");
+	});
+});

--- a/packages/bedrock/src/cli/commands/provision.ts
+++ b/packages/bedrock/src/cli/commands/provision.ts
@@ -1,0 +1,22 @@
+import { provision as defaultProvision } from "../../shell/deploy.ts";
+import type { ProgDeps } from "../index.ts";
+import { createReconcileCommand } from "./reconcile-command.ts";
+
+/**
+ * Build the sade action for `bedrock provision`. Runs the asset stage plus
+ * codegen for every `--env` (minting IDs and setting the pending-rebuild
+ * marker) without building or publishing any place, dispatching a
+ * `.bedrock/provision.ts` override when one is discovered. The aggregated exit
+ * code is `EXIT_OK` only when every env succeeded.
+ * @param deps - Dependency overrides; missing slots are default-constructed
+ *   from real implementations.
+ * @returns An async sade action that returns once `deps.exit` was invoked.
+ */
+export function provisionCommand(
+	deps: ProgDeps,
+): (rawOptions: Record<string, unknown>) => Promise<void> {
+	return createReconcileCommand(deps, {
+		command: "provision",
+		resolveRun: (progDeps) => progDeps.provision ?? defaultProvision,
+	});
+}

--- a/packages/bedrock/src/cli/commands/publish.spec.ts
+++ b/packages/bedrock/src/cli/commands/publish.spec.ts
@@ -1,0 +1,82 @@
+import type { Result } from "@bedrock-rbx/ocale";
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+	type DiscoverOverrideFunc,
+	fakeLoad,
+	makeDeps,
+	okState,
+	sampleConfig,
+} from "#tests/helpers/reconcile-command";
+import type { BedrockState } from "../../core/state.ts";
+import type { DeployError } from "../../shell/deploy.ts";
+import type { ProgDeps } from "../index.ts";
+import type { Spawner, SpawnInvocation } from "../spawner.ts";
+import { publishCommand } from "./publish.ts";
+
+type PublishFunc = NonNullable<ProgDeps["publish"]>;
+
+function fakePublish(result: Result<BedrockState, DeployError>): PublishFunc {
+	return vi.fn<PublishFunc>(async () => result);
+}
+
+describe(publishCommand, () => {
+	it("should intro, dispatch publish, log the succeeded outro, and exit 0", async () => {
+		expect.assertions(4);
+
+		const publish = fakePublish({ data: okState(), success: true });
+		const deps = makeDeps({ loadConfig: fakeLoad(), publish });
+
+		await publishCommand(deps)({ env: "production" });
+
+		expect(deps.clack?.intro).toHaveBeenCalledExactlyOnceWith("bedrock publish");
+		expect(publish).toHaveBeenCalledExactlyOnceWith(
+			expect.objectContaining({ config: sampleConfig, environment: "production" }),
+		);
+		expect(deps.clack?.outro).toHaveBeenCalledExactlyOnceWith("publish succeeded");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(0);
+	});
+
+	it("should cancel with 'publish failed' and exit 1 when publish returns Err", async () => {
+		expect.assertions(2);
+
+		const publish = fakePublish({
+			err: { environment: "production", kind: "stateNotConfigured" },
+			success: false,
+		});
+		const deps = makeDeps({ loadConfig: fakeLoad(), publish });
+
+		await publishCommand(deps)({ env: "production" });
+
+		expect(deps.clack?.cancel).toHaveBeenCalledExactlyOnceWith("publish failed");
+		expect(deps.exit).toHaveBeenCalledExactlyOnceWith(1);
+	});
+
+	it("should discover a .bedrock/publish.ts override and spawn it instead of publish()", async () => {
+		expect.assertions(3);
+
+		const invocations: Array<SpawnInvocation> = [];
+		const spawner: Spawner = {
+			async spawn(invocation) {
+				invocations.push(invocation);
+				return { data: 0, success: true };
+			},
+		};
+		const discoverOverride = vi.fn<DiscoverOverrideFunc>(() => "/abs/.bedrock/publish.ts");
+		const publish = vi.fn<PublishFunc>();
+		const deps = makeDeps({
+			discoverOverride,
+			loadConfig: fakeLoad(),
+			projectRoot: "/abs",
+			publish,
+			spawner,
+		});
+
+		await publishCommand(deps)({ env: "production" });
+
+		expect(discoverOverride).toHaveBeenCalledExactlyOnceWith("/abs", "publish");
+		expect(publish).not.toHaveBeenCalled();
+		expect(invocations[0]?.args[0]).toBe("/abs/.bedrock/publish.ts");
+	});
+});

--- a/packages/bedrock/src/cli/commands/publish.ts
+++ b/packages/bedrock/src/cli/commands/publish.ts
@@ -1,0 +1,22 @@
+import { publish as defaultPublish } from "../../shell/deploy.ts";
+import type { ProgDeps } from "../index.ts";
+import { createReconcileCommand } from "./reconcile-command.ts";
+
+/**
+ * Build the sade action for `bedrock publish`. Uploads the on-disk artifact for
+ * every place under a pending-rebuild marker in each `--env` (deduplicated by
+ * file hash, clearing the marker per republished place) without minting, codegen, or
+ * building, dispatching a `.bedrock/publish.ts` override when one is discovered.
+ * The aggregated exit code is `EXIT_OK` only when every env succeeded.
+ * @param deps - Dependency overrides; missing slots are default-constructed
+ *   from real implementations.
+ * @returns An async sade action that returns once `deps.exit` was invoked.
+ */
+export function publishCommand(
+	deps: ProgDeps,
+): (rawOptions: Record<string, unknown>) => Promise<void> {
+	return createReconcileCommand(deps, {
+		command: "publish",
+		resolveRun: (progDeps) => progDeps.publish ?? defaultPublish,
+	});
+}

--- a/packages/bedrock/src/cli/commands/reconcile-command.ts
+++ b/packages/bedrock/src/cli/commands/reconcile-command.ts
@@ -1,0 +1,225 @@
+import type { Result } from "@bedrock-rbx/ocale";
+
+import process from "node:process";
+
+import { createClackProgressAdapter } from "../../adapters/clack-progress-adapter.ts";
+import type { Config } from "../../core/schema.ts";
+import type { BedrockState } from "../../core/state.ts";
+import type { ProgressPort } from "../../ports/progress-port.ts";
+import type { DeployError } from "../../shell/deploy.ts";
+import {
+	loadConfig as defaultLoadConfig,
+	type LoadConfigOptions,
+} from "../../shell/load-config.ts";
+import { buildOverrideInvocation } from "../build-override-invocation.ts";
+import { createClackPort } from "../clack-port.ts";
+import { buildCredentialOverrides } from "../credential-environment-overrides.ts";
+import { createDefaultSpawner } from "../default-spawner.ts";
+import { discoverOverride as defaultDiscoverOverride } from "../discover-override.ts";
+import { dispatchOverride } from "../dispatch-override.ts";
+import { EXIT_ERROR, EXIT_OK } from "../exit-codes.ts";
+import type { ProgDeps } from "../index.ts";
+import { type CommonOptions, parseCommonOptions } from "../parse-options.ts";
+import {
+	type ClackPort,
+	renderDeployError,
+	renderOverrideDiscoveryError,
+	renderOverrideError,
+	renderParseError,
+} from "../render.ts";
+import type { Spawner } from "../spawner.ts";
+
+/**
+ * Static identity of a reconcile command: the subcommand name (used for
+ * override discovery and the `bedrock <name>` / `<name> failed|succeeded`
+ * labels) and a resolver that picks the pipeline from the injected deps.
+ */
+export interface ReconcileCommandSpec {
+	/** Subcommand name, used for override discovery and the clack labels. */
+	readonly command: string;
+	/** Picks the reconcile pipeline from the injected deps. */
+	readonly resolveRun: (deps: ProgDeps) => ReconcileRun;
+}
+
+/**
+ * A reconcile pipeline invoked once per `--env`. `deploy`, `provision`, and
+ * `publish` each supply one; the command scaffolding (parse, load, override
+ * discovery, per-env dispatch, exit-code aggregation) is identical around it.
+ */
+type ReconcileRun = (options: {
+	readonly config: Config;
+	readonly environment: string;
+	readonly getEnv: (name: string) => string | undefined;
+	readonly progress: ProgressPort;
+}) => Promise<Result<BedrockState, DeployError>>;
+
+interface Resolved {
+	readonly clack: ClackPort;
+	readonly command: string;
+	readonly discoverOverride: typeof defaultDiscoverOverride;
+	readonly exit: (code: number) => void;
+	readonly loadConfig: typeof defaultLoadConfig;
+	readonly progressOverride: ProgressPort | undefined;
+	readonly projectRoot: string;
+	readonly run: ReconcileRun;
+	readonly spawner: Spawner;
+}
+
+interface DispatchInputs {
+	readonly config: Config;
+	readonly getEnv: (name: string) => string | undefined;
+	readonly overridePath: string | undefined;
+	readonly parsed: CommonOptions;
+	readonly progress: ProgressPort;
+	readonly resolved: Resolved;
+}
+
+interface DispatchAndReportInput {
+	readonly loaded: Config;
+	readonly overridePath: string | undefined;
+	readonly parsed: CommonOptions;
+	readonly resolved: Resolved;
+}
+
+type OverrideDiscovery =
+	| { readonly kind: "discovered"; readonly overridePath: string | undefined }
+	| { readonly kind: "failed" };
+
+/**
+ * Build the sade action for a reconcile subcommand. The returned function
+ * parses the raw options via `parseCommonOptions`, loads the project config
+ * once, discovers a `.bedrock/<command>.ts` override, and dispatches the
+ * pipeline (or the override spawn) for each `--env` value in order. The
+ * aggregated exit code is `EXIT_OK` only when every env succeeded.
+ * @param deps - Dependency overrides; missing slots are default-constructed.
+ * @param spec - The subcommand's name and pipeline resolver.
+ * @returns An async sade action that returns once `deps.exit` was invoked.
+ */
+export function createReconcileCommand(
+	deps: ProgDeps,
+	spec: ReconcileCommandSpec,
+): (rawOptions: Record<string, unknown>) => Promise<void> {
+	const resolved = resolveDeps(deps, spec);
+	return async (rawOptions) => {
+		const code = await run(rawOptions, resolved);
+		resolved.exit(code);
+	};
+}
+
+function resolveDeps(deps: ProgDeps, spec: ReconcileCommandSpec): Resolved {
+	const clack = deps.clack ?? createClackPort();
+	return {
+		clack,
+		command: spec.command,
+		discoverOverride: deps.discoverOverride ?? defaultDiscoverOverride,
+		exit: deps.exit ?? ((code: number) => process.exit(code)),
+		loadConfig: deps.loadConfig ?? defaultLoadConfig,
+		progressOverride: deps.progress,
+		projectRoot: deps.projectRoot ?? process.cwd(),
+		run: spec.resolveRun(deps),
+		spawner: deps.spawner ?? createDefaultSpawner(),
+	};
+}
+
+function loadOptionsFor(parsed: CommonOptions): LoadConfigOptions | undefined {
+	return parsed.configFile === undefined ? undefined : { configFile: parsed.configFile };
+}
+
+function cancelAsFailed(resolved: Resolved): void {
+	resolved.clack.cancel(`${resolved.command} failed`);
+}
+
+async function dispatchEnvironments(inputs: DispatchInputs): Promise<ReadonlyArray<string>> {
+	const { config, getEnv, overridePath, parsed, progress, resolved } = inputs;
+	const failed: Array<string> = [];
+	for (const environment of parsed.environments) {
+		if (overridePath !== undefined) {
+			const invocation = buildOverrideInvocation({ environment, overridePath, parsed });
+			const result = await dispatchOverride(invocation, resolved.spawner);
+			if (!result.success) {
+				renderOverrideError({ environment, err: result.err }, resolved.clack);
+				failed.push(environment);
+			}
+
+			continue;
+		}
+
+		const result = await resolved.run({ config, environment, getEnv, progress });
+		if (!result.success) {
+			failed.push(environment);
+		}
+	}
+
+	return failed;
+}
+
+function buildGetEnvironment(parsed: CommonOptions): (name: string) => string | undefined {
+	const overrides = buildCredentialOverrides(parsed);
+	return (name) => overrides[name] ?? process.env[name];
+}
+
+async function dispatchAndReport(input: DispatchAndReportInput): Promise<number> {
+	const { loaded, overridePath, parsed, resolved } = input;
+	const progress: ProgressPort =
+		resolved.progressOverride ??
+		createClackProgressAdapter({ clack: resolved.clack, config: loaded });
+
+	const failures = await dispatchEnvironments({
+		config: loaded,
+		getEnv: buildGetEnvironment(parsed),
+		overridePath,
+		parsed,
+		progress,
+		resolved,
+	});
+	if (failures.length > 0) {
+		cancelAsFailed(resolved);
+		return EXIT_ERROR;
+	}
+
+	resolved.clack.outro(`${resolved.command} succeeded`);
+	return EXIT_OK;
+}
+
+function discoverOverridePath(resolved: Resolved): OverrideDiscovery {
+	try {
+		return {
+			kind: "discovered",
+			overridePath: resolved.discoverOverride(resolved.projectRoot, resolved.command),
+		};
+	} catch (err) {
+		renderOverrideDiscoveryError(err, resolved.clack);
+		cancelAsFailed(resolved);
+		return { kind: "failed" };
+	}
+}
+
+async function run(rawOptions: Record<string, unknown>, resolved: Resolved): Promise<number> {
+	resolved.clack.intro(`bedrock ${resolved.command}`);
+
+	const parsed = parseCommonOptions(rawOptions);
+	if (!parsed.success) {
+		renderParseError(parsed.err, resolved.clack);
+		cancelAsFailed(resolved);
+		return EXIT_ERROR;
+	}
+
+	const loaded = await resolved.loadConfig(loadOptionsFor(parsed.data));
+	if (!loaded.success) {
+		renderDeployError({ cause: loaded.err, kind: "configLoadFailed" }, resolved.clack);
+		cancelAsFailed(resolved);
+		return EXIT_ERROR;
+	}
+
+	const discovery = discoverOverridePath(resolved);
+	if (discovery.kind === "failed") {
+		return EXIT_ERROR;
+	}
+
+	return dispatchAndReport({
+		loaded: loaded.data,
+		overridePath: discovery.overridePath,
+		parsed: parsed.data,
+		resolved,
+	});
+}

--- a/packages/bedrock/src/cli/index.spec-d.ts
+++ b/packages/bedrock/src/cli/index.spec-d.ts
@@ -3,7 +3,7 @@ import { describe, expectTypeOf, it } from "vitest";
 
 import type { ProgressPort } from "../ports/progress-port.ts";
 import type { buildStatePort } from "../shell/build-state-port.ts";
-import type { deploy } from "../shell/deploy.ts";
+import type { deploy, provision, publish } from "../shell/deploy.ts";
 import type { loadConfig } from "../shell/load-config.ts";
 import type { migrateMantleState } from "../shell/migrate-mantle-state.ts";
 import type { previewDiff } from "../shell/preview-diff.ts";
@@ -29,6 +29,8 @@ describe("ProgDeps shape", () => {
 			| "previewDiff"
 			| "progress"
 			| "projectRoot"
+			| "provision"
+			| "publish"
 			| "spawner"
 			| "writeFile"
 		>();
@@ -54,6 +56,16 @@ describe("ProgDeps deploy/diff slots", () => {
 		expectTypeOf<NonNullable<ProgDependencies["loadConfig"]>>().toEqualTypeOf<
 			typeof loadConfig
 		>();
+	});
+
+	it("should accept the real provision signature in the provision slot", () => {
+		expectTypeOf<NonNullable<ProgDependencies["provision"]>>().toEqualTypeOf<
+			typeof provision
+		>();
+	});
+
+	it("should accept the real publish signature in the publish slot", () => {
+		expectTypeOf<NonNullable<ProgDependencies["publish"]>>().toEqualTypeOf<typeof publish>();
 	});
 });
 

--- a/packages/bedrock/src/cli/index.ts
+++ b/packages/bedrock/src/cli/index.ts
@@ -4,7 +4,11 @@ import type { Sade } from "sade";
 import manifest from "../../package.json" with { type: "json" };
 import type { ProgressPort } from "../ports/progress-port.ts";
 import type { buildStatePort as defaultBuildStatePort } from "../shell/build-state-port.ts";
-import type { deploy as defaultDeploy } from "../shell/deploy.ts";
+import type {
+	deploy as defaultDeploy,
+	provision as defaultProvision,
+	publish as defaultPublish,
+} from "../shell/deploy.ts";
 import type { loadConfig as defaultLoadConfig } from "../shell/load-config.ts";
 import type { migrateMantleState as defaultMigrateMantleState } from "../shell/migrate-mantle-state.ts";
 import type { previewDiff as defaultPreviewDiff } from "../shell/preview-diff.ts";
@@ -12,6 +16,8 @@ import { buildCommand } from "./commands/build.ts";
 import { deployCommand } from "./commands/deploy.ts";
 import { diffCommand } from "./commands/diff.ts";
 import { migrateCommand } from "./commands/migrate.ts";
+import { provisionCommand } from "./commands/provision.ts";
+import { publishCommand } from "./commands/publish.ts";
 import type { discoverOverride as defaultDiscoverOverride } from "./discover-override.ts";
 import type { MigratePromptPort } from "./migrate-prompt-port.ts";
 import type { ClackPort } from "./render.ts";
@@ -51,11 +57,48 @@ export interface ProgDeps {
 	readonly progress?: ProgressPort;
 	/** Project root passed to override discovery; defaults to `process.cwd()`. */
 	readonly projectRoot?: string;
+	/** Runs the asset stage plus codegen; defaults to the public `provision`. */
+	readonly provision?: typeof defaultProvision;
+	/** Publishes on-disk artifacts for pending-rebuild places; defaults to the public `publish`. */
+	readonly publish?: typeof defaultPublish;
 	/** Child-process spawner used to launch override scripts; defaults to `createDefaultSpawner()`. */
 	readonly spawner?: Spawner;
 	/** File-write seam used by the migrate command to emit the bedrock config file; defaults to `node:fs/promises.writeFile`. */
 	readonly writeFile?: (path: string, contents: string) => Promise<void>;
 }
+
+/**
+ * The reconcile-style subcommands, each sharing the `withCommonOptions` flag
+ * surface. `migrate` is registered separately because it takes a positional
+ * argument and its own flags.
+ */
+const RECONCILE_COMMANDS = [
+	{
+		name: "deploy",
+		action: deployCommand,
+		describe: "Reconcile a project's resources against the configured environment(s)",
+	},
+	{
+		name: "build",
+		action: buildCommand,
+		describe: "Run the project's .bedrock/build.ts override to produce place artifacts",
+	},
+	{
+		name: "diff",
+		action: diffCommand,
+		describe: "Preview the operations a deploy would apply, without writing state",
+	},
+	{
+		name: "provision",
+		action: provisionCommand,
+		describe: "Mint assets and run codegen without building or publishing a place",
+	},
+	{
+		name: "publish",
+		action: publishCommand,
+		describe: "Upload on-disk place artifacts pending a rebuild, without minting or codegen",
+	},
+] as const;
 
 /**
  * Construct the bedrock CLI program. Pure factory: no `process.argv` parsing,
@@ -65,28 +108,14 @@ export interface ProgDeps {
  *   resolves its own defaults from any omitted slots.
  * @returns A configured sade program with the bedrock name, description, and
  *   the currently installed `@bedrock-rbx/core` version, plus the registered
- *   `build`, `deploy`, `diff`, and `migrate` commands.
+ *   `build`, `deploy`, `diff`, `provision`, `publish`, and `migrate` commands.
  */
 export function createProg(deps: ProgDeps = {}): Sade {
 	const prog = sade(PROGRAM_NAME).describe(PROGRAM_DESCRIBE).version(manifest.version);
 
-	withCommonOptions(
-		prog
-			.command("deploy")
-			.describe("Reconcile a project's resources against the configured environment(s)"),
-	).action(deployCommand(deps));
-
-	withCommonOptions(
-		prog
-			.command("build")
-			.describe("Run the project's .bedrock/build.ts override to produce place artifacts"),
-	).action(buildCommand(deps));
-
-	withCommonOptions(
-		prog
-			.command("diff")
-			.describe("Preview the operations a deploy would apply, without writing state"),
-	).action(diffCommand(deps));
+	for (const { name, action, describe } of RECONCILE_COMMANDS) {
+		withCommonOptions(prog.command(name).describe(describe)).action(action(deps));
+	}
 
 	prog.command("migrate [stateFilePath]")
 		.describe("Translate a state file from another tool into a bedrock project")
@@ -98,11 +127,11 @@ export function createProg(deps: ProgDeps = {}): Sade {
 
 /**
  * Register the environment/config/credential flags shared by every
- * reconcile-style subcommand (`deploy`, `build`, `diff`) onto the sade command
- * the caller has just opened via `prog.command(...).describe(...)`. Keeping the
- * flag names and descriptions in one place stops the three registrations from
- * drifting apart. `migrate` has its own flag surface and is registered without
- * this helper.
+ * reconcile-style subcommand (`deploy`, `build`, `diff`, `provision`,
+ * `publish`) onto the sade command the caller has just opened via
+ * `prog.command(...).describe(...)`. Keeping the flag names and descriptions in
+ * one place stops the registrations from drifting apart. `migrate` has its own
+ * flag surface and is registered without this helper.
  * @param command - The sade instance positioned on the command being defined.
  * @returns The same sade instance so the caller can chain `.action(...)`.
  */

--- a/packages/bedrock/src/index.spec-d.ts
+++ b/packages/bedrock/src/index.spec-d.ts
@@ -17,6 +17,8 @@ import {
 	isRobloxAssetId,
 	isSha256Hex,
 	loadConfig,
+	provision,
+	publish,
 } from "./index.ts";
 import type {
 	AggregateApplyError,
@@ -35,6 +37,8 @@ import type {
 	PlaceDriverDeps as PlaceDriverDependencies,
 	PlaceEntry,
 	PlaceOutputs,
+	ProvisionOptions,
+	PublishOptions,
 	ResolvedConfig,
 	ResolvedPlaceEntry,
 	ResourceCurrentState,
@@ -170,12 +174,14 @@ type ExpectedDeployErrorKind =
 	| "unknownEnvironment"
 	| "unsupportedBackend";
 
+const RESOLVES_RESULT = "should resolve to a Result of BedrockState or DeployError";
+
 describe(deploy, () => {
 	it("should accept a single DeployOptions argument", () => {
 		expectTypeOf(deploy).parameter(0).toEqualTypeOf<DeployOptions>();
 	});
 
-	it("should resolve to a Result of BedrockState or DeployError", () => {
+	it(RESOLVES_RESULT, () => {
 		expectTypeOf<Awaited<ReturnType<typeof deploy>>>().toEqualTypeOf<
 			Result<BedrockState, DeployError>
 		>();
@@ -189,6 +195,30 @@ describe(deploy, () => {
 		expectTypeOf<
 			Extract<DeployError, { kind: "stateWriteFailed" }>["unsavedState"]
 		>().toEqualTypeOf<BedrockState>();
+	});
+});
+
+describe(provision, () => {
+	it("should accept a single ProvisionOptions argument", () => {
+		expectTypeOf(provision).parameter(0).toEqualTypeOf<ProvisionOptions>();
+	});
+
+	it(RESOLVES_RESULT, () => {
+		expectTypeOf<Awaited<ReturnType<typeof provision>>>().toEqualTypeOf<
+			Result<BedrockState, DeployError>
+		>();
+	});
+});
+
+describe(publish, () => {
+	it("should accept a single PublishOptions argument", () => {
+		expectTypeOf(publish).parameter(0).toEqualTypeOf<PublishOptions>();
+	});
+
+	it(RESOLVES_RESULT, () => {
+		expectTypeOf<Awaited<ReturnType<typeof publish>>>().toEqualTypeOf<
+			Result<BedrockState, DeployError>
+		>();
 	});
 });
 

--- a/packages/bedrock/src/index.ts
+++ b/packages/bedrock/src/index.ts
@@ -168,7 +168,15 @@ export {
 	type UnsupportedBackendError,
 } from "./shell/build-state-port.ts";
 export { defineConfig, type ConfigContext, type ConfigInput } from "./shell/define-config.ts";
-export { deploy, type DeployError, type DeployOptions } from "./shell/deploy.ts";
+export {
+	deploy,
+	type DeployError,
+	type DeployOptions,
+	provision,
+	type ProvisionOptions,
+	publish,
+	type PublishOptions,
+} from "./shell/deploy.ts";
 export { loadConfig, type LoadConfigOptions } from "./shell/load-config.ts";
 export { migrateMantleState, type MigrateMantleStateDeps } from "./shell/migrate-mantle-state.ts";
 export type { CodegenError } from "./shell/run-codegen.ts";

--- a/packages/bedrock/src/shell/build-desired.example.spec.ts
+++ b/packages/bedrock/src/shell/build-desired.example.spec.ts
@@ -6,8 +6,9 @@ it('Example 1', () => {
   async function readFile(): Promise<Uint8Array> {
     return new Uint8Array([1, 2, 3])
   }
-  return buildDesired(
-    [
+  return buildDesired({
+    readFile,
+    resources: [
       {
         description: 'Grants VIP perks.',
         icon: { 'en-us': 'assets/vip-icon.png' },
@@ -17,8 +18,7 @@ it('Example 1', () => {
         price: 500,
       },
     ],
-    readFile,
-  ).then((result) => {
+  }).then((result) => {
     expect(result.success).toBeTrue()
     if (result.success) {
       expect(result.data).toHaveLength(1)

--- a/packages/bedrock/src/shell/build-desired.spec.ts
+++ b/packages/bedrock/src/shell/build-desired.spec.ts
@@ -24,7 +24,7 @@ describe(buildDesired, () => {
 
 		const readFile = vi.fn<(path: string) => Promise<Uint8Array>>();
 
-		const result = await buildDesired([], readFile);
+		const result = await buildDesired({ readFile, resources: [] });
 
 		expect(result).toStrictEqual({ data: [], success: true });
 		expect(readFile).not.toHaveBeenCalled();
@@ -37,7 +37,7 @@ describe(buildDesired, () => {
 			.fn<(path: string) => Promise<Uint8Array>>()
 			.mockResolvedValue(new Uint8Array([1, 2, 3]));
 
-		const result = await buildDesired([gamePassInput()], readFile);
+		const result = await buildDesired({ readFile, resources: [gamePassInput()] });
 
 		expect(result).toStrictEqual({
 			data: [
@@ -64,7 +64,7 @@ describe(buildDesired, () => {
 			.fn<(path: string) => Promise<Uint8Array>>()
 			.mockResolvedValue(new Uint8Array([0]));
 
-		const result = await buildDesired([gamePassInput()], readFile);
+		const result = await buildDesired({ readFile, resources: [gamePassInput()] });
 
 		assert(result.success);
 
@@ -83,13 +83,13 @@ describe(buildDesired, () => {
 			.fn<(path: string) => Promise<Uint8Array>>()
 			.mockResolvedValue(new Uint8Array([1, 2, 3]));
 
-		const result = await buildDesired(
-			[
+		const result = await buildDesired({
+			readFile,
+			resources: [
 				gamePassInput({ key: asResourceKey("first-pass") }),
 				gamePassInput({ key: asResourceKey("second-pass") }),
 			],
-			readFile,
-		);
+		});
 
 		assert(result.success);
 
@@ -108,7 +108,7 @@ describe(buildDesired, () => {
 				.fn<(path: string) => Promise<Uint8Array>>()
 				.mockRejectedValueOnce(rejection);
 
-			const result = await buildDesired([gamePassInput()], readFile);
+			const result = await buildDesired({ readFile, resources: [gamePassInput()] });
 
 			expect(result).toStrictEqual({
 				err: {
@@ -129,8 +129,9 @@ describe(buildDesired, () => {
 			.fn<(path: string) => Promise<Uint8Array>>()
 			.mockResolvedValue(new Uint8Array([1, 2, 3]));
 
-		const result = await buildDesired(
-			[
+		const result = await buildDesired({
+			readFile,
+			resources: [
 				{
 					key: asResourceKey("start-place"),
 					description: undefined,
@@ -141,8 +142,7 @@ describe(buildDesired, () => {
 					serverSize: undefined,
 				},
 			],
-			readFile,
-		);
+		});
 
 		expect(result).toStrictEqual({
 			data: [
@@ -168,8 +168,9 @@ describe(buildDesired, () => {
 			.fn<(path: string) => Promise<Uint8Array>>()
 			.mockRejectedValueOnce(new Error("ENOENT"));
 
-		const result = await buildDesired(
-			[
+		const result = await buildDesired({
+			readFile,
+			resources: [
 				{
 					key: asResourceKey("start-place"),
 					description: undefined,
@@ -180,8 +181,7 @@ describe(buildDesired, () => {
 					serverSize: undefined,
 				},
 			],
-			readFile,
-		);
+		});
 
 		expect(result).toStrictEqual({
 			err: {
@@ -201,8 +201,9 @@ describe(buildDesired, () => {
 			.fn<(path: string) => Promise<Uint8Array>>()
 			.mockResolvedValue(new Uint8Array([1, 2, 3]));
 
-		const result = await buildDesired(
-			[
+		const result = await buildDesired({
+			readFile,
+			resources: [
 				gamePassInput(),
 				{
 					key: asResourceKey("start-place"),
@@ -214,12 +215,41 @@ describe(buildDesired, () => {
 					serverSize: undefined,
 				},
 			],
-			readFile,
-		);
+		});
 
 		assert(result.success);
 
 		expect(result.data.map((entry) => entry.kind)).toStrictEqual(["gamePass", "place"]);
+	});
+
+	it("should skip inputs the includeKind predicate rejects and read no file for them", async () => {
+		expect.assertions(2);
+
+		const readFile = vi
+			.fn<(path: string) => Promise<Uint8Array>>()
+			.mockResolvedValue(new Uint8Array([1, 2, 3]));
+
+		const result = await buildDesired({
+			includeKind: (kind) => kind !== "place",
+			readFile,
+			resources: [
+				gamePassInput(),
+				{
+					key: asResourceKey("start-place"),
+					description: undefined,
+					displayName: undefined,
+					filePath: "places/start.rbxl",
+					kind: "place",
+					placeId: asRobloxAssetId("4711"),
+					serverSize: undefined,
+				},
+			],
+		});
+
+		assert(result.success);
+
+		expect(result.data.map((entry) => entry.kind)).toStrictEqual(["gamePass"]);
+		expect(readFile).not.toHaveBeenCalledWith("places/start.rbxl");
 	});
 
 	it("should pass a universe input straight through without calling readFile", async () => {
@@ -227,8 +257,9 @@ describe(buildDesired, () => {
 
 		const readFile = vi.fn<(path: string) => Promise<Uint8Array>>();
 
-		const result = await buildDesired(
-			[
+		const result = await buildDesired({
+			readFile,
+			resources: [
 				{
 					key: UNIVERSE_SINGLETON_KEY,
 					consoleEnabled: undefined,
@@ -242,8 +273,7 @@ describe(buildDesired, () => {
 					vrEnabled: undefined,
 				},
 			],
-			readFile,
-		);
+		});
 
 		expect(result).toStrictEqual({
 			data: [
@@ -270,8 +300,9 @@ describe(buildDesired, () => {
 
 		const readFile = vi.fn<(path: string) => Promise<Uint8Array>>();
 
-		const result = await buildDesired(
-			[
+		const result = await buildDesired({
+			readFile,
+			resources: [
 				{
 					key: UNIVERSE_SINGLETON_KEY,
 					consoleEnabled: undefined,
@@ -285,8 +316,7 @@ describe(buildDesired, () => {
 					vrEnabled: undefined,
 				},
 			],
-			readFile,
-		);
+		});
 
 		assert(result.success);
 		assert(result.data[0]!.kind === "universe");
@@ -313,7 +343,10 @@ describe(buildDesired, () => {
 				voiceChatEnabled: undefined,
 				vrEnabled: undefined,
 			};
-			const result = await buildDesired([{ ...baseInput, [flag]: true }], readFile);
+			const result = await buildDesired({
+				readFile,
+				resources: [{ ...baseInput, [flag]: true }],
+			});
 
 			assert(result.success);
 			assert(result.data[0]!.kind === "universe");
@@ -327,8 +360,9 @@ describe(buildDesired, () => {
 
 		const readFile = vi.fn<(path: string) => Promise<Uint8Array>>();
 
-		const result = await buildDesired(
-			[
+		const result = await buildDesired({
+			readFile,
+			resources: [
 				{
 					key: UNIVERSE_SINGLETON_KEY,
 					consoleEnabled: undefined,
@@ -343,8 +377,7 @@ describe(buildDesired, () => {
 					vrEnabled: undefined,
 				},
 			],
-			readFile,
-		);
+		});
 
 		assert(result.success);
 		assert(result.data[0]!.kind === "universe");
@@ -358,8 +391,9 @@ describe(buildDesired, () => {
 
 		const readFile = vi.fn<(path: string) => Promise<Uint8Array>>();
 
-		const result = await buildDesired(
-			[
+		const result = await buildDesired({
+			readFile,
+			resources: [
 				{
 					key: UNIVERSE_SINGLETON_KEY,
 					consoleEnabled: undefined,
@@ -373,8 +407,7 @@ describe(buildDesired, () => {
 					vrEnabled: undefined,
 				},
 			],
-			readFile,
-		);
+		});
 
 		assert(result.success);
 		assert(result.data[0]!.kind === "universe");

--- a/packages/bedrock/src/shell/build-desired.ts
+++ b/packages/bedrock/src/shell/build-desired.ts
@@ -7,6 +7,20 @@ import type { ResourceDesiredState, ResourceKind } from "../core/resources.ts";
 
 export type { BuildDesiredError } from "../core/kinds/module.ts";
 
+interface BuildDesiredInputs {
+	/**
+	 * Restricts processing to inputs whose kind satisfies the predicate. A
+	 * skipped input is neither read nor included, so a caller reconciling only a
+	 * subset of kinds (an asset-only provision, a place-only publish) does no
+	 * file I/O for the kinds it does not own. Omit to process every input.
+	 */
+	readonly includeKind?: ((kind: ResourceKind) => boolean) | undefined;
+	/** Reads file bytes for a given path; rejection becomes a `fileReadFailed` Err. */
+	readonly readFile: (path: string) => Promise<Uint8Array>;
+	/** Flat tagged resource inputs from `flattenConfig`. */
+	readonly resources: ReadonlyArray<ResourceDesiredInput>;
+}
+
 /**
  * Layer file I/O onto a flat tagged list of resource inputs to produce
  * `ResourceDesiredState`.
@@ -18,11 +32,10 @@ export type { BuildDesiredError } from "../core/kinds/module.ts";
  *
  * @since 0.1.0
  *
- * @param inputs - Flat tagged resource inputs from `flattenConfig`.
- * @param readFile - Reads file bytes for a given path; rejection becomes a
- * `fileReadFailed` Err.
- * @returns `Ok` with the desired-state array (same length and order as
- * `inputs`), or `Err` with the first I/O failure.
+ * @param inputs - The resource inputs, file reader, and optional `includeKind`
+ * filter. See {@link BuildDesiredInputs}.
+ * @returns `Ok` with the desired-state array (in input order, limited to the
+ * kinds `includeKind` admits), or `Err` with the first I/O failure.
  * @example
  *
  * ```ts
@@ -32,8 +45,9 @@ export type { BuildDesiredError } from "../core/kinds/module.ts";
  *     return new Uint8Array([1, 2, 3]);
  * }
  *
- * return buildDesired(
- *     [
+ * return buildDesired({
+ *     readFile,
+ *     resources: [
  *         {
  *             description: "Grants VIP perks.",
  *             icon: { "en-us": "assets/vip-icon.png" },
@@ -43,8 +57,7 @@ export type { BuildDesiredError } from "../core/kinds/module.ts";
  *             price: 500,
  *         },
  *     ],
- *     readFile,
- * ).then((result) => {
+ * }).then((result) => {
  *     expect(result.success).toBeTrue();
  *     if (result.success) {
  *         expect(result.data).toHaveLength(1);
@@ -54,12 +67,16 @@ export type { BuildDesiredError } from "../core/kinds/module.ts";
  * ```
  */
 export async function buildDesired(
-	inputs: ReadonlyArray<ResourceDesiredInput>,
-	readFile: (path: string) => Promise<Uint8Array>,
+	inputs: BuildDesiredInputs,
 ): Promise<Result<ReadonlyArray<ResourceDesiredState>, BuildDesiredError>> {
+	const { includeKind, readFile, resources } = inputs;
 	const desired: Array<ResourceDesiredState> = [];
 	const io = { readFile };
-	for (const input of inputs) {
+	for (const input of resources) {
+		if (includeKind !== undefined && !includeKind(input.kind)) {
+			continue;
+		}
+
 		// Registry index returns a union of per-kind modules; widening its
 		// type parameter lets us call normalize without per-kind
 		// discriminator narrowing. Safe because input.kind pins which

--- a/packages/bedrock/src/shell/deploy.example.spec.ts
+++ b/packages/bedrock/src/shell/deploy.example.spec.ts
@@ -5,6 +5,8 @@ import {
   type BedrockState,
   type DriverRegistry,
   type StatePort,
+  provision,
+  publish,
 } from '@bedrock-rbx/core'
 
 it('Example 1', () => {
@@ -65,6 +67,28 @@ it('Example 2', () => {
     if (result.success) {
       expect(result.data.environment).toBe('production')
       expect(result.data.resources).toBeEmpty()
+    }
+  })
+})
+
+it('Example 3', () => {
+  return provision({ environment: 'production' }).then((result) => {
+    expect(result.success).toBeFalse()
+    if (!result.success) {
+      expect(['configLoadFailed', 'stateNotConfigured']).toContain(
+        result.err.kind,
+      )
+    }
+  })
+})
+
+it('Example 4', () => {
+  return publish({ environment: 'production' }).then((result) => {
+    expect(result.success).toBeFalse()
+    if (!result.success) {
+      expect(['configLoadFailed', 'stateNotConfigured']).toContain(
+        result.err.kind,
+      )
     }
   })
 })

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -23,6 +23,7 @@ import type {
 	PlaceDesiredState,
 	ResourceCurrentState,
 	ResourceDesiredState,
+	ResourceKind,
 	ResourceRealDisplay,
 } from "../core/resources.ts";
 import type { Config, ResolvedConfig } from "../core/schema.ts";
@@ -947,13 +948,31 @@ async function runTwoPhase(inputs: TwoPhaseInputs): Promise<Result<BedrockState,
 	return completeTwoPhase({ ...inputs, assetPass, codegen });
 }
 
-async function loadReconcileInputs(
-	environment: string,
+async function resolveDesiredState(
 	dependencies: ResolvedDependencies,
-): Promise<Result<ReconcileInputs, DeployError>> {
-	const desired = await buildDesired(flattenConfig(dependencies.config), dependencies.readFile);
+	includeKind?: (kind: ResourceKind) => boolean,
+): Promise<Result<ReadonlyArray<ResourceDesiredState>, DeployError>> {
+	const desired = await buildDesired({
+		includeKind,
+		readFile: dependencies.readFile,
+		resources: flattenConfig(dependencies.config),
+	});
 	if (!desired.success) {
 		return { err: { cause: desired.err, kind: "buildDesiredFailed" }, success: false };
+	}
+
+	return desired;
+}
+
+async function loadReconcileInputs(inputs: {
+	readonly dependencies: ResolvedDependencies;
+	readonly environment: string;
+	readonly includeKind?: (kind: ResourceKind) => boolean;
+}): Promise<Result<ReconcileInputs, DeployError>> {
+	const { dependencies, environment, includeKind } = inputs;
+	const desired = await resolveDesiredState(dependencies, includeKind);
+	if (!desired.success) {
+		return desired;
 	}
 
 	const prior = await dependencies.statePort.read(environment);
@@ -999,7 +1018,7 @@ async function runReconcile(
 	environment: string,
 	dependencies: ResolvedDependencies,
 ): Promise<Result<BedrockState, DeployError>> {
-	const loaded = await loadReconcileInputs(environment, dependencies);
+	const loaded = await loadReconcileInputs({ dependencies, environment });
 	if (!loaded.success) {
 		return loaded;
 	}
@@ -1034,24 +1053,34 @@ async function runReconcile(
 	});
 }
 
+function declaredPlaceKeys(config: ResolvedConfig): ReadonlyArray<ResourceKey> {
+	return flattenConfig(config)
+		.filter((input) => input.kind === "place")
+		.map((input) => input.key);
+}
+
 async function runProvision(
 	environment: string,
 	deps: ResolvedDependencies,
 ): Promise<Result<BedrockState, DeployError>> {
-	const loaded = await loadReconcileInputs(environment, deps);
+	// Reconcile assets only: provision never reads the place artifact, so it can
+	// run before the place is built. Every declared place is marked for a later
+	// publish, its key taken from config rather than a diffed op.
+	const loaded = await loadReconcileInputs({
+		dependencies: deps,
+		environment,
+		includeKind: (kind) => kind !== "place",
+	});
 	if (!loaded.success) {
 		return loaded;
 	}
 
 	const { ops, priorResources, storedHash } = loaded.data;
-	// Withhold place ops and mark every declared place: provision mints the
-	// assets and sets the marker, leaving the places for a later publish.
-	const plan = planTwoPhase(ops);
 	const { outcome } = await runProvisionStage({
 		deps,
 		environment,
-		markPlaces: plan.markPlaces,
-		ops: plan.assetOps,
+		markPlaces: declaredPlaceKeys(deps.config),
+		ops,
 		priorResources,
 		storedHash,
 	});
@@ -1073,17 +1102,22 @@ async function runPublish(
 	environment: string,
 	deps: ResolvedDependencies,
 ): Promise<Result<BedrockState, DeployError>> {
-	const loaded = await loadReconcileInputs(environment, deps);
+	// Reconcile places only: publish never reads asset files. Publish just the
+	// places owing a rebuild; the diff already noop's a place whose on-disk
+	// artifact hash matches state, so an unchanged artifact is not dispatched (no
+	// upload). The stored hash threads through unchanged: publish runs no
+	// codegen.
+	const loaded = await loadReconcileInputs({
+		dependencies: deps,
+		environment,
+		includeKind: (kind) => kind === "place",
+	});
 	if (!loaded.success) {
 		return loaded;
 	}
 
 	const { ops, owedRebuild, priorResources, storedHash } = loaded.data;
-	// Publish only the places owing a rebuild; the diff already noop's a place
-	// whose on-disk artifact hash matches state, so an unchanged artifact is not
-	// dispatched (no upload). The stored hash threads through unchanged: publish
-	// runs no codegen.
-	const placeOps = planTwoPhase(ops).placeOps.filter((op) => owedRebuild.has(op.key));
+	const placeOps = ops.filter((op) => owedRebuild.has(op.key));
 	const pass = await applyAndPersist({
 		codegenHash: storedHash,
 		environment,

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -662,16 +662,6 @@ async function resolveDependencies(
 	};
 }
 
-async function runDeploy(context: RunContext): Promise<Result<BedrockState, DeployError>> {
-	const { options, progress, runner } = context;
-	const resolved = await resolveDependencies(options);
-	if (!resolved.success) {
-		return resolved;
-	}
-
-	return runner(options.environment, { ...resolved.data, progress });
-}
-
 function emitTerminalEvent(inputs: EmitTerminalEventInputs): void {
 	const { environment, progress, result } = inputs;
 	if (result.success) {
@@ -687,12 +677,15 @@ function emitTerminalEvent(inputs: EmitTerminalEventInputs): void {
 }
 
 async function runAndEmit(context: RunContext): Promise<Result<BedrockState, DeployError>> {
-	const result = await runDeploy(context);
-	emitTerminalEvent({
-		environment: context.options.environment,
-		progress: context.progress,
-		result,
-	});
+	const { options, progress, runner } = context;
+	const resolved = await resolveDependencies(options);
+	if (!resolved.success) {
+		emitTerminalEvent({ environment: options.environment, progress, result: resolved });
+		return resolved;
+	}
+
+	const result = await runner(options.environment, { ...resolved.data, progress });
+	emitTerminalEvent({ environment: options.environment, progress, result });
 	return result;
 }
 

--- a/packages/bedrock/src/shell/deploy.ts
+++ b/packages/bedrock/src/shell/deploy.ts
@@ -119,6 +119,75 @@ export interface DeployOptions {
 }
 
 /**
+ * Inputs for `provision`, the asset half of a decomposed deploy. Mirrors the
+ * relevant slice of {@link DeployOptions} minus the place-stage hooks: there is
+ * no `rebuild` (provision never republishes a place) and no
+ * `clearPendingRebuild` (provision always re-marks every declared place). The
+ * codegen `emit`/`codegenWriter` seams remain because provision runs the
+ * emitter.
+ *
+ * @since 0.1.0
+ */
+export interface ProvisionOptions {
+	/**
+	 * Writer for codegen output; defaults to a node-fs writer rooted at
+	 * `config.codegen.output`. Only consulted when codegen is enabled.
+	 */
+	readonly codegenWriter?: CodegenWriterPort;
+	/** Pre-loaded, optionally-mutated project config. Omit to call `loadConfig()` automatically. */
+	readonly config?: Config;
+	/**
+	 * Codegen emitter. Supplied programmatically. When codegen is enabled in
+	 * config, `provision` runs it after the checkpoint write.
+	 */
+	readonly emit?: Emitter;
+	/** Environment name; threaded into `StatePort.read` and the persisted snapshot. */
+	readonly environment: string;
+	/** `fetch` override plumbed into the default-constructed gist adapter when `statePort` is omitted. */
+	readonly fetch?: GistFetch;
+	/** Reads an environment variable; defaults to `(name) => process.env[name]`. */
+	readonly getEnv?: (name: string) => string | undefined;
+	/** Loader invoked when `config` is omitted; defaults to `loadConfig` from this package. */
+	readonly loadConfig?: (options?: LoadConfigOptions) => Promise<Result<Config, ConfigError>>;
+	/** Optional sink for per-resource and aggregate progress events. Omit to run silently. */
+	readonly progress?: ProgressPort;
+	/** Reads file bytes for resources that have file-backed inputs. Defaults to `node:fs/promises.readFile`. */
+	readonly readFile?: (path: string) => Promise<Uint8Array>;
+	/** Per-kind driver table consulted for create / update dispatch. Default-constructed from `BEDROCK_API_KEY` when omitted. */
+	readonly registry?: DriverRegistry;
+	/** Backend used to read the prior snapshot and persist the new one. Default-constructed from `config.state` and `BEDROCK_GITHUB_TOKEN` when omitted. */
+	readonly statePort?: StatePort;
+}
+
+/**
+ * Inputs for `publish`, the place-uploader half of a decomposed deploy. A pure
+ * uploader: it mints nothing, runs no codegen, and builds no place, so it omits
+ * every asset- and codegen-related seam of {@link DeployOptions}.
+ *
+ * @since 0.1.0
+ */
+export interface PublishOptions {
+	/** Pre-loaded, optionally-mutated project config. Omit to call `loadConfig()` automatically. */
+	readonly config?: Config;
+	/** Environment name; threaded into `StatePort.read` and the persisted snapshot. */
+	readonly environment: string;
+	/** `fetch` override plumbed into the default-constructed gist adapter when `statePort` is omitted. */
+	readonly fetch?: GistFetch;
+	/** Reads an environment variable; defaults to `(name) => process.env[name]`. */
+	readonly getEnv?: (name: string) => string | undefined;
+	/** Loader invoked when `config` is omitted; defaults to `loadConfig` from this package. */
+	readonly loadConfig?: (options?: LoadConfigOptions) => Promise<Result<Config, ConfigError>>;
+	/** Optional sink for per-resource and aggregate progress events. Omit to run silently. */
+	readonly progress?: ProgressPort;
+	/** Reads on-disk place artifacts to publish. Defaults to `node:fs/promises.readFile`. */
+	readonly readFile?: (path: string) => Promise<Uint8Array>;
+	/** Per-kind driver table consulted for create / update dispatch. Default-constructed from `BEDROCK_API_KEY` when omitted. */
+	readonly registry?: DriverRegistry;
+	/** Backend used to read the prior snapshot and persist the new one. Default-constructed from `config.state` and `BEDROCK_GITHUB_TOKEN` when omitted. */
+	readonly statePort?: StatePort;
+}
+
+/**
  * Failure surfaced by `deploy`. Stage-tagged so callers can branch on
  * `kind` to distinguish reconciliation failures (`stateReadFailed`,
  * `applyFailed`, `codegenFailed`, `rebuildHookThrew`,
@@ -191,6 +260,22 @@ interface EmitTerminalEventInputs {
 	readonly result: Result<BedrockState, DeployError>;
 }
 
+/**
+ * A reconcile pipeline over resolved deps for one environment. `deploy`,
+ * `provision`, and `publish` each supply one, sharing the dep-resolution and
+ * progress-emission scaffolding around it.
+ */
+type ReconcileRunner = (
+	environment: string,
+	deps: ResolvedDependencies,
+) => Promise<Result<BedrockState, DeployError>>;
+
+interface RunContext {
+	readonly options: DeployOptions;
+	readonly progress: ProgressPort;
+	readonly runner: ReconcileRunner;
+}
+
 interface SinglePassInputs {
 	readonly deps: ResolvedDependencies;
 	readonly environment: string;
@@ -213,6 +298,17 @@ interface TwoPhaseInputs {
 interface CompleteTwoPhaseInputs extends TwoPhaseInputs {
 	readonly assetPass: ReconcilePass;
 	readonly codegen: Result<Sha256Hex, CodegenError> | undefined;
+}
+
+/**
+ * Outcome of the provision stage (asset stage + codegen + checkpoint). `outcome`
+ * is the caller-facing result: non-success aborts any following place stage,
+ * while `assetPass` and `codegen` let a two-phase deploy continue to republish.
+ */
+interface ProvisionStage {
+	readonly assetPass: ReconcilePass;
+	readonly codegen: Result<Sha256Hex, CodegenError> | undefined;
+	readonly outcome: Result<BedrockState, DeployError>;
 }
 
 interface AssetStageInputs {
@@ -341,15 +437,71 @@ export function isCliEnvironmentFlagSet(value: string | undefined): boolean {
  * ```
  */
 export async function deploy(options: DeployOptions): Promise<Result<BedrockState, DeployError>> {
-	if (options.progress !== undefined) {
-		return runAndEmit(options, options.progress);
-	}
+	return execute(options, runReconcile);
+}
 
-	if (!isCliEnvironmentFlagSet(getEnvironmentOf(options)("BEDROCK_CLI"))) {
-		return runAndEmit(options, createNoOpProgressAdapter());
-	}
+/**
+ * Run the asset half of a deploy: apply non-place ops (minting IDs), persist
+ * mutable asset fields, run codegen, and set the `pendingRebuild` marker at the
+ * checkpoint. Builds and publishes no place. The minted-but-unpublished state it
+ * leaves is exactly the one the marker models, so a later `publish` (or the next
+ * `deploy`) republishes the affected places. Default-constructs missing deps and
+ * resolves the progress port exactly as {@link deploy} does.
+ *
+ * @since 0.1.0
+ *
+ * @param options - Target environment plus optional overrides.
+ * @returns The checkpoint `BedrockState` on success, or a stage-tagged
+ *   `DeployError` on failure (a partial asset failure returns `applyFailed` with
+ *   survivors and the marker persisted).
+ * @example
+ *
+ * ```ts
+ * import { provision } from "@bedrock-rbx/core";
+ *
+ * return provision({ environment: "production" }).then((result) => {
+ *     expect(result.success).toBeFalse();
+ *     if (!result.success) {
+ *         expect(["configLoadFailed", "stateNotConfigured"]).toContain(result.err.kind);
+ *     }
+ * });
+ * ```
+ */
+export async function provision(
+	options: ProvisionOptions,
+): Promise<Result<BedrockState, DeployError>> {
+	return execute(options, runProvision);
+}
 
-	return runWithDeferredClackProgress(options);
+/**
+ * Publish the on-disk artifact for every place under a `pendingRebuild` marker,
+ * clearing the marker for each place actually republished. A pure uploader: it
+ * mints nothing, runs no codegen, and builds no place. An unchanged artifact
+ * (its file hash already matches state) is a no-op upload that keeps its marker,
+ * so the place still shows as owing a rebuild until its artifact changes.
+ * Default-constructs missing deps and resolves the progress port exactly as
+ * {@link deploy} does.
+ *
+ * @since 0.1.0
+ *
+ * @param options - Target environment plus optional overrides.
+ * @returns The persisted `BedrockState` on success, or a stage-tagged
+ *   `DeployError` on failure.
+ * @example
+ *
+ * ```ts
+ * import { publish } from "@bedrock-rbx/core";
+ *
+ * return publish({ environment: "production" }).then((result) => {
+ *     expect(result.success).toBeFalse();
+ *     if (!result.success) {
+ *         expect(["configLoadFailed", "stateNotConfigured"]).toContain(result.err.kind);
+ *     }
+ * });
+ * ```
+ */
+export async function publish(options: PublishOptions): Promise<Result<BedrockState, DeployError>> {
+	return execute(options, runPublish);
 }
 
 function readProcessEnvironment(name: string): string | undefined {
@@ -510,6 +662,76 @@ async function resolveDependencies(
 	};
 }
 
+async function runDeploy(context: RunContext): Promise<Result<BedrockState, DeployError>> {
+	const { options, progress, runner } = context;
+	const resolved = await resolveDependencies(options);
+	if (!resolved.success) {
+		return resolved;
+	}
+
+	return runner(options.environment, { ...resolved.data, progress });
+}
+
+function emitTerminalEvent(inputs: EmitTerminalEventInputs): void {
+	const { environment, progress, result } = inputs;
+	if (result.success) {
+		progress.emit({
+			environment,
+			kind: "deploySuccess",
+			resourceCount: result.data.resources.length,
+		});
+		return;
+	}
+
+	progress.emit({ environment, error: result.err, kind: "deployFailure" });
+}
+
+async function runAndEmit(context: RunContext): Promise<Result<BedrockState, DeployError>> {
+	const result = await runDeploy(context);
+	emitTerminalEvent({
+		environment: context.options.environment,
+		progress: context.progress,
+		result,
+	});
+	return result;
+}
+
+async function runWithDeferredClackProgress(
+	options: DeployOptions,
+	runner: ReconcileRunner,
+): Promise<Result<BedrockState, DeployError>> {
+	const resolved = await resolveDependencies(options);
+	const labelConfig = resolved.success ? resolved.data.config : options.config;
+	const progress = createDefaultProgressAdapter(labelConfig);
+
+	if (!resolved.success) {
+		emitTerminalEvent({ environment: options.environment, progress, result: resolved });
+		return resolved;
+	}
+
+	const result = await runner(options.environment, { ...resolved.data, progress });
+	emitTerminalEvent({ environment: options.environment, progress, result });
+	return result;
+}
+
+async function execute(
+	options: DeployOptions,
+	runner: ReconcileRunner,
+): Promise<Result<BedrockState, DeployError>> {
+	if (options.progress !== undefined) {
+		return runAndEmit({ options, progress: options.progress, runner });
+	}
+
+	// A non-empty `BEDROCK_CLI` selects the clack-backed adapter (resolved after
+	// the config loads, for its state-backend label); every other reading runs
+	// silently through the no-op adapter.
+	if (isCliEnvironmentFlagSet(getEnvironmentOf(options)("BEDROCK_CLI"))) {
+		return runWithDeferredClackProgress(options, runner);
+	}
+
+	return runAndEmit({ options, progress: createNoOpProgressAdapter(), runner });
+}
+
 function finalize(
 	pass: ReconcilePass,
 	codegen: Result<Sha256Hex, CodegenError> | undefined,
@@ -574,24 +796,6 @@ async function runSinglePass(inputs: SinglePassInputs): Promise<Result<BedrockSt
 
 	const codegen = await runCodegenStage(deps, pass);
 	return finalize(pass, codegen);
-}
-
-async function runAssetStage(inputs: AssetStageInputs): Promise<ReconcilePass> {
-	const { deps, environment, markPlaces, ops, priorResources, storedHash } = inputs;
-	// The checkpoint preserves the stored hash: only the write that completes a
-	// successful republish (or pre-built publish) advances it, so an aborted
-	// rebuild retains the stale hash and the next deploy retries.
-	return applyAndPersist({
-		codegenHash: storedHash,
-		environment,
-		ops,
-		pendingRebuild: new Set(markPlaces),
-		priorResources,
-		progress: deps.progress,
-		realDisplay: deps.realDisplay,
-		registry: deps.registry,
-		statePort: deps.statePort,
-	});
 }
 
 async function runRepublishStage(inputs: RepublishStageInputs): Promise<ReconcilePass> {
@@ -702,9 +906,39 @@ async function completeTwoPhase(
 	return finalize(republishPass, codegen);
 }
 
+async function runAssetStage(inputs: AssetStageInputs): Promise<ReconcilePass> {
+	const { deps, environment, markPlaces, ops, priorResources, storedHash } = inputs;
+	// The checkpoint preserves the stored hash: only the write that completes a
+	// successful republish (or pre-built publish) advances it, so an aborted
+	// rebuild retains the stale hash and the next deploy retries.
+	return applyAndPersist({
+		codegenHash: storedHash,
+		environment,
+		ops,
+		pendingRebuild: new Set(markPlaces),
+		priorResources,
+		progress: deps.progress,
+		realDisplay: deps.realDisplay,
+		registry: deps.registry,
+		statePort: deps.statePort,
+	});
+}
+
+async function runProvisionStage(inputs: AssetStageInputs): Promise<ProvisionStage> {
+	const assetPass = await runAssetStage(inputs);
+	const codegen = await runCodegenStage(inputs.deps, assetPass);
+	// `finalize` returns a non-success outcome exactly when the stage must abort:
+	// a partial asset failure (or failed checkpoint write) leaves survivors and
+	// the marker persisted, and a codegen failure after the checkpoint retains
+	// the stale hash; in every case the next run retries via the marker rather
+	// than building against missing IDs. A success outcome means the checkpoint
+	// is clean and a caller may proceed to a place stage.
+	return { assetPass, codegen, outcome: finalize(assetPass, codegen) };
+}
+
 async function runTwoPhase(inputs: TwoPhaseInputs): Promise<Result<BedrockState, DeployError>> {
 	const { deps, environment, plan, priorResources, storedHash } = inputs;
-	const assetPass = await runAssetStage({
+	const { assetPass, codegen, outcome } = await runProvisionStage({
 		deps,
 		environment,
 		markPlaces: plan.markPlaces,
@@ -713,20 +947,8 @@ async function runTwoPhase(inputs: TwoPhaseInputs): Promise<Result<BedrockState,
 		storedHash,
 	});
 
-	const codegen = await runCodegenStage(deps, assetPass);
-
-	// A partial asset failure (or a failed checkpoint write) aborts the rebuild:
-	// survivors and the marker are already persisted, codegen has emitted the
-	// resolved keys, and the asset-stage error stands so the next run retries
-	// via the marker instead of rebuilding against missing IDs. A codegen failure
-	// after the checkpoint aborts too: with no fresh hash the rebuild decision
-	// cannot be made, so the marker and the stale hash are retained.
-	if (!assetPass.written.success || !assetPass.applied.success) {
-		return finalize(assetPass, codegen);
-	}
-
-	if (codegen !== undefined && !codegen.success) {
-		return finalize(assetPass, codegen);
+	if (!outcome.success) {
+		return outcome;
 	}
 
 	return completeTwoPhase({ ...inputs, assetPass, codegen });
@@ -819,54 +1041,66 @@ async function runReconcile(
 	});
 }
 
-async function runDeploy(
-	options: DeployOptions,
-	progress: ProgressPort,
+async function runProvision(
+	environment: string,
+	deps: ResolvedDependencies,
 ): Promise<Result<BedrockState, DeployError>> {
-	const resolved = await resolveDependencies(options);
-	if (!resolved.success) {
-		return resolved;
+	const loaded = await loadReconcileInputs(environment, deps);
+	if (!loaded.success) {
+		return loaded;
 	}
 
-	return runReconcile(options.environment, { ...resolved.data, progress });
+	const { ops, priorResources, storedHash } = loaded.data;
+	// Withhold place ops and mark every declared place: provision mints the
+	// assets and sets the marker, leaving the places for a later publish.
+	const plan = planTwoPhase(ops);
+	const { outcome } = await runProvisionStage({
+		deps,
+		environment,
+		markPlaces: plan.markPlaces,
+		ops: plan.assetOps,
+		priorResources,
+		storedHash,
+	});
+	return outcome;
 }
 
-function emitTerminalEvent(inputs: EmitTerminalEventInputs): void {
-	const { environment, progress, result } = inputs;
-	if (result.success) {
-		progress.emit({
-			environment,
-			kind: "deploySuccess",
-			resourceCount: result.data.resources.length,
-		});
-		return;
+function remainingOwed(
+	owedRebuild: ReadonlySet<ResourceKey>,
+	survivors: ReadonlyArray<ResourceCurrentState>,
+): ReadonlySet<ResourceKey> {
+	// A survivor is a place that actually republished; clear its marker. A place
+	// whose op noop'd (unchanged artifact) or failed is absent and keeps its
+	// marker, so it still shows as owing a rebuild.
+	const republished = new Set(survivors.map((resource) => resource.key));
+	return new Set([...owedRebuild].filter((key) => !republished.has(key)));
+}
+
+async function runPublish(
+	environment: string,
+	deps: ResolvedDependencies,
+): Promise<Result<BedrockState, DeployError>> {
+	const loaded = await loadReconcileInputs(environment, deps);
+	if (!loaded.success) {
+		return loaded;
 	}
 
-	progress.emit({ environment, error: result.err, kind: "deployFailure" });
-}
-
-async function runAndEmit(
-	options: DeployOptions,
-	progress: ProgressPort,
-): Promise<Result<BedrockState, DeployError>> {
-	const result = await runDeploy(options, progress);
-	emitTerminalEvent({ environment: options.environment, progress, result });
-	return result;
-}
-
-async function runWithDeferredClackProgress(
-	options: DeployOptions,
-): Promise<Result<BedrockState, DeployError>> {
-	const resolved = await resolveDependencies(options);
-	const labelConfig = resolved.success ? resolved.data.config : options.config;
-	const progress = createDefaultProgressAdapter(labelConfig);
-
-	if (!resolved.success) {
-		emitTerminalEvent({ environment: options.environment, progress, result: resolved });
-		return resolved;
-	}
-
-	const result = await runReconcile(options.environment, { ...resolved.data, progress });
-	emitTerminalEvent({ environment: options.environment, progress, result });
-	return result;
+	const { ops, owedRebuild, priorResources, storedHash } = loaded.data;
+	// Publish only the places owing a rebuild; the diff already noop's a place
+	// whose on-disk artifact hash matches state, so an unchanged artifact is not
+	// dispatched (no upload). The stored hash threads through unchanged: publish
+	// runs no codegen.
+	const placeOps = planTwoPhase(ops).placeOps.filter((op) => owedRebuild.has(op.key));
+	const pass = await applyAndPersist({
+		codegenHash: storedHash,
+		environment,
+		ops: placeOps,
+		pendingRebuild: (survivors) => remainingOwed(owedRebuild, survivors),
+		priorResources,
+		progress: deps.progress,
+		realDisplay: deps.realDisplay,
+		registry: deps.registry,
+		statePort: deps.statePort,
+	});
+	return finalize(pass, undefined);
 }

--- a/packages/bedrock/src/shell/preview-diff.ts
+++ b/packages/bedrock/src/shell/preview-diff.ts
@@ -213,7 +213,10 @@ async function runPreview(
 	environment: string,
 	dependencies: ResolvedDependencies,
 ): Promise<Result<DiffPreview, PreviewDiffError>> {
-	const desired = await buildDesired(flattenConfig(dependencies.config), dependencies.readFile);
+	const desired = await buildDesired({
+		readFile: dependencies.readFile,
+		resources: flattenConfig(dependencies.config),
+	});
 	if (!desired.success) {
 		return { err: { cause: desired.err, kind: "buildDesiredFailed" }, success: false };
 	}

--- a/packages/bedrock/src/shell/provision.spec.ts
+++ b/packages/bedrock/src/shell/provision.spec.ts
@@ -218,6 +218,32 @@ describe(provision, () => {
 		expect(inputs[0]!.environments["production"]!.resources).toStrictEqual([alpha]);
 	});
 
+	it("should not read the place artifact file so it can run before the place is built", async () => {
+		expect.assertions(2);
+
+		const { port, writes } = inMemoryStatePort();
+		const readFile = vi.fn<(path: string) => Promise<Uint8Array>>(async (path) => {
+			if (path === "places/start.rbxl") {
+				throw new Error("place artifact must not be read during provision");
+			}
+
+			return ICON_BYTES;
+		});
+
+		const result = await provision({
+			config: provisionConfig(),
+			environment: "production",
+			readFile,
+			registry: vipCreateRegistry(),
+			statePort: port,
+		});
+
+		assert(result.success);
+
+		expect(writes[0]!.pendingRebuild).toStrictEqual(new Set([startPlace]));
+		expect(readFile).not.toHaveBeenCalledWith("places/start.rbxl");
+	});
+
 	it("should surface stateReadFailed without dispatching drivers when StatePort.read returns Err", async () => {
 		expect.assertions(1);
 

--- a/packages/bedrock/src/shell/provision.spec.ts
+++ b/packages/bedrock/src/shell/provision.spec.ts
@@ -1,0 +1,251 @@
+import { OpenCloudError } from "@bedrock-rbx/ocale";
+
+import { assert, describe, expect, it, vi } from "vitest";
+
+import { gamePassCurrent } from "#tests/helpers/resources";
+import type { CodegenFile, EmitInput, Emitter } from "../core/codegen.ts";
+import type { ResourceCurrentState } from "../core/resources.ts";
+import type { Config } from "../core/schema.ts";
+import type { BedrockState } from "../core/state.ts";
+import type { CodegenWriterPort } from "../ports/codegen-writer.ts";
+import type { DriverRegistry, ResourceDriver } from "../ports/resource-driver.ts";
+import type { StatePort } from "../ports/state-port.ts";
+import { asResourceKey, asRobloxAssetId } from "../types/ids.ts";
+import { provision } from "./deploy.ts";
+
+const ICON_BYTES = new Uint8Array();
+
+async function readIcon(): Promise<Uint8Array> {
+	return ICON_BYTES;
+}
+
+const startPlace = asResourceKey("start-place");
+const CODEGEN_FILE: CodegenFile = { content: "return {}\n", path: "ids.luau" };
+
+const developerProductStub: ResourceDriver<"developerProduct"> = {
+	async create() {
+		throw new Error("developerProduct driver must not run for this fixture");
+	},
+};
+
+const placeStub: ResourceDriver<"place"> = {
+	async create() {
+		throw new Error("place driver must not run: provision withholds place ops");
+	},
+	async update() {
+		throw new Error("place driver must not run: provision withholds place ops");
+	},
+};
+
+const universeStub: ResourceDriver<"universe"> = {
+	async create() {
+		throw new Error("universe driver must not run for this fixture");
+	},
+};
+
+function inMemoryStatePort(initial?: BedrockState): {
+	port: StatePort;
+	writes: Array<BedrockState>;
+} {
+	let current = initial;
+	const writes: Array<BedrockState> = [];
+	return {
+		port: {
+			async read() {
+				return { data: current, success: true };
+			},
+			async write(state) {
+				writes.push(state);
+				current = state;
+				return { data: undefined, success: true };
+			},
+		},
+		writes,
+	};
+}
+
+function inMemoryCodegenWriter(): { port: CodegenWriterPort; writes: Array<CodegenFile> } {
+	const writes: Array<CodegenFile> = [];
+	return {
+		port: {
+			async write(file) {
+				writes.push(file);
+				return { data: undefined, success: true };
+			},
+		},
+		writes,
+	};
+}
+
+const VipPassEntry = {
+	name: "VIP Pass",
+	description: "Grants VIP perks.",
+	icon: { "en-us": "assets/vip-icon.png" },
+	price: 500,
+} as const;
+
+const AlphaPassEntry = {
+	name: "Alpha Pass",
+	description: "Grants alpha perks.",
+	icon: { "en-us": "assets/alpha-icon.png" },
+	price: 250,
+} as const;
+
+function provisionConfig(): Config {
+	return {
+		environments: { production: { places: { "start-place": { placeId: "4711" } } } },
+		passes: { "vip-pass": VipPassEntry },
+		places: { "start-place": { filePath: "places/start.rbxl" } },
+	};
+}
+
+function withCodegen(config: Config): Config {
+	return { ...config, codegen: { enabled: true, output: "src/generated" } };
+}
+
+function vipCreateRegistry(): DriverRegistry {
+	return {
+		developerProduct: developerProductStub,
+		gamePass: {
+			async create() {
+				return { data: gamePassCurrent(), success: true };
+			},
+		},
+		place: placeStub,
+		universe: universeStub,
+	};
+}
+
+function alphaPassCurrent(): ResourceCurrentState<"gamePass"> {
+	return gamePassCurrent({
+		key: asResourceKey("alpha-pass"),
+		name: "Alpha Pass",
+		description: "Grants alpha perks.",
+		icon: { "en-us": "assets/alpha-icon.png" },
+		outputs: {
+			assetId: asRobloxAssetId("1111111111"),
+			iconAssetIds: { "en-us": asRobloxAssetId("2222222222") },
+		},
+		price: 250,
+	});
+}
+
+describe(provision, () => {
+	it("should mint non-place ops and mark every declared place pending without dispatching the place driver", async () => {
+		expect.assertions(2);
+
+		const { port, writes } = inMemoryStatePort();
+
+		const result = await provision({
+			config: provisionConfig(),
+			environment: "production",
+			readFile: readIcon,
+			registry: vipCreateRegistry(),
+			statePort: port,
+		});
+
+		assert(result.success);
+
+		expect(writes[0]!.resources).toStrictEqual([gamePassCurrent()]);
+		expect(writes[0]!.pendingRebuild).toStrictEqual(new Set([startPlace]));
+	});
+
+	it("should run the emitter and write codegen after the checkpoint", async () => {
+		expect.assertions(1);
+
+		const writer = inMemoryCodegenWriter();
+		const emit = vi.fn<Emitter>().mockResolvedValue([CODEGEN_FILE]);
+
+		const result = await provision({
+			codegenWriter: writer.port,
+			config: withCodegen(provisionConfig()),
+			emit,
+			environment: "production",
+			readFile: readIcon,
+			registry: vipCreateRegistry(),
+			statePort: inMemoryStatePort().port,
+		});
+
+		assert(result.success);
+
+		// The emitter's output reached the writer: proof codegen fired.
+		expect(writer.writes).toStrictEqual([CODEGEN_FILE]);
+	});
+
+	it("should persist survivors and the marker and emit only resolved keys on a partial asset failure", async () => {
+		expect.assertions(4);
+
+		const alpha = alphaPassCurrent();
+		const cause = new OpenCloudError("create vip-pass: 503");
+		const create = vi
+			.fn<ResourceDriver<"gamePass">["create"]>()
+			.mockImplementation(async (desired) => {
+				return desired.key === "alpha-pass"
+					? { data: alpha, success: true }
+					: { err: cause, success: false };
+			});
+		const inputs: Array<EmitInput> = [];
+		const emit = vi.fn<Emitter>(async (input) => {
+			inputs.push(input);
+			return [CODEGEN_FILE];
+		});
+		const { port, writes } = inMemoryStatePort();
+
+		const result = await provision({
+			codegenWriter: inMemoryCodegenWriter().port,
+			config: withCodegen({
+				environments: { production: { places: { "start-place": { placeId: "4711" } } } },
+				passes: { "alpha-pass": AlphaPassEntry, "vip-pass": VipPassEntry },
+				places: { "start-place": { filePath: "places/start.rbxl" } },
+			}),
+			emit,
+			environment: "production",
+			readFile: readIcon,
+			registry: {
+				developerProduct: developerProductStub,
+				gamePass: { create },
+				place: placeStub,
+				universe: universeStub,
+			},
+			statePort: port,
+		});
+
+		assert(!result.success);
+
+		expect(result.err.kind).toBe("applyFailed");
+		expect(writes[0]!.resources).toStrictEqual([alpha]);
+		expect(writes[0]!.pendingRebuild).toStrictEqual(new Set([startPlace]));
+		expect(inputs[0]!.environments["production"]!.resources).toStrictEqual([alpha]);
+	});
+
+	it("should surface stateReadFailed without dispatching drivers when StatePort.read returns Err", async () => {
+		expect.assertions(1);
+
+		const stateError = {
+			file: ".bedrock/state/production.json",
+			kind: "stateError" as const,
+			reason: "Corrupt JSON",
+		};
+		const port: StatePort = {
+			async read() {
+				return { err: stateError, success: false };
+			},
+			async write() {
+				return { data: undefined, success: true };
+			},
+		};
+
+		const result = await provision({
+			config: provisionConfig(),
+			environment: "production",
+			readFile: readIcon,
+			registry: vipCreateRegistry(),
+			statePort: port,
+		});
+
+		expect(result).toStrictEqual({
+			err: { cause: stateError, kind: "stateReadFailed" },
+			success: false,
+		});
+	});
+});

--- a/packages/bedrock/src/shell/publish.spec.ts
+++ b/packages/bedrock/src/shell/publish.spec.ts
@@ -136,6 +136,46 @@ describe(publish, () => {
 		expect(writes.at(-1)!.pendingRebuild).toBeUndefined();
 	});
 
+	it("should not read asset icon files because it reconciles only places", async () => {
+		expect.assertions(2);
+
+		const { placeCalls, registry } = recordingPlaceRegistry();
+		const { port } = inMemoryStatePort(
+			priorWith(placeCurrent({ fileHash: STALE_HASH }), new Set([startPlace])),
+		);
+		const readFile = vi.fn<(path: string) => Promise<Uint8Array>>(async (path) => {
+			if (path === "places/start.rbxl") {
+				return PLACE_BYTES;
+			}
+
+			throw new Error(`publish must not read non-place file: ${path}`);
+		});
+
+		const result = await publish({
+			config: {
+				environments: { production: { places: { "start-place": { placeId: "4711" } } } },
+				passes: {
+					"vip-pass": {
+						name: "VIP Pass",
+						description: "Grants VIP perks.",
+						icon: { "en-us": "assets/vip-icon.png" },
+						price: 500,
+					},
+				},
+				places: { "start-place": { filePath: "places/start.rbxl" } },
+			},
+			environment: "production",
+			readFile,
+			registry,
+			statePort: port,
+		});
+
+		assert(result.success);
+
+		expect(placeCalls).toStrictEqual([{ key: "start-place", type: "update" }]);
+		expect(readFile).not.toHaveBeenCalledWith("assets/vip-icon.png");
+	});
+
 	it("should keep the marker and skip the upload when a pending place's artifact is unchanged", async () => {
 		expect.assertions(2);
 

--- a/packages/bedrock/src/shell/publish.spec.ts
+++ b/packages/bedrock/src/shell/publish.spec.ts
@@ -1,0 +1,269 @@
+import { OpenCloudError } from "@bedrock-rbx/ocale";
+
+import { assert, describe, expect, it, vi } from "vitest";
+
+import { placeCurrent } from "#tests/helpers/resources";
+import type { ResourceCurrentState } from "../core/resources.ts";
+import type { Config } from "../core/schema.ts";
+import type { BedrockState } from "../core/state.ts";
+import type { DriverRegistry, ResourceDriver } from "../ports/resource-driver.ts";
+import type { StatePort } from "../ports/state-port.ts";
+import { asResourceKey, asSha256Hex } from "../types/ids.ts";
+import { publish } from "./deploy.ts";
+
+// `readPlace` returns bytes [1,2,3], which hash to PLACE_HASH — the default
+// `fileHash` on the place fixtures. A current place carrying PLACE_HASH is
+// therefore a noop (unchanged artifact); one carrying STALE_HASH drifts.
+const PLACE_BYTES = new Uint8Array([1, 2, 3]);
+const STALE_HASH = asSha256Hex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+const startPlace = asResourceKey("start-place");
+
+async function readPlace(): Promise<Uint8Array> {
+	return PLACE_BYTES;
+}
+
+const developerProductStub: ResourceDriver<"developerProduct"> = {
+	async create() {
+		throw new Error("developerProduct driver must not run for this fixture");
+	},
+};
+
+const universeStub: ResourceDriver<"universe"> = {
+	async create() {
+		throw new Error("universe driver must not run for this fixture");
+	},
+};
+
+const gamePassStub: ResourceDriver<"gamePass"> = {
+	async create() {
+		throw new Error("gamePass driver must not run for this fixture");
+	},
+};
+
+interface PlaceCall {
+	readonly key: string;
+	readonly type: "create" | "update";
+}
+
+function inMemoryStatePort(initial?: BedrockState): {
+	port: StatePort;
+	writes: Array<BedrockState>;
+} {
+	let current = initial;
+	const writes: Array<BedrockState> = [];
+	return {
+		port: {
+			async read() {
+				return { data: current, success: true };
+			},
+			async write(state) {
+				writes.push(state);
+				current = state;
+				return { data: undefined, success: true };
+			},
+		},
+		writes,
+	};
+}
+
+function recordingPlaceRegistry(placeDriver?: Partial<ResourceDriver<"place">>): {
+	placeCalls: Array<PlaceCall>;
+	registry: DriverRegistry;
+} {
+	const placeCalls: Array<PlaceCall> = [];
+	const place: ResourceDriver<"place"> = {
+		async create(desired) {
+			placeCalls.push({ key: desired.key, type: "create" });
+			return { data: placeCurrent(), success: true };
+		},
+
+		async update(_current, desired) {
+			placeCalls.push({ key: desired.key, type: "update" });
+			return { data: { ...placeCurrent(), outputs: { versionNumber: 2 } }, success: true };
+		},
+		...placeDriver,
+	};
+	return {
+		placeCalls,
+		registry: {
+			developerProduct: developerProductStub,
+			gamePass: gamePassStub,
+			place,
+			universe: universeStub,
+		},
+	};
+}
+
+function publishConfig(): Config {
+	return {
+		environments: { production: { places: { "start-place": { placeId: "4711" } } } },
+		places: { "start-place": { filePath: "places/start.rbxl" } },
+	};
+}
+
+function priorWith(
+	place: ResourceCurrentState<"place">,
+	pendingRebuild?: ReadonlySet<ReturnType<typeof asResourceKey>>,
+): BedrockState {
+	return {
+		environment: "production",
+		resources: [place],
+		version: 1,
+		...(pendingRebuild === undefined ? {} : { pendingRebuild }),
+	};
+}
+
+describe(publish, () => {
+	it("should republish a pending place whose artifact changed and clear its marker", async () => {
+		expect.assertions(2);
+
+		const { placeCalls, registry } = recordingPlaceRegistry();
+		const { port, writes } = inMemoryStatePort(
+			priorWith(placeCurrent({ fileHash: STALE_HASH }), new Set([startPlace])),
+		);
+
+		const result = await publish({
+			config: publishConfig(),
+			environment: "production",
+			readFile: readPlace,
+			registry,
+			statePort: port,
+		});
+
+		assert(result.success);
+
+		expect(placeCalls).toStrictEqual([{ key: "start-place", type: "update" }]);
+		expect(writes.at(-1)!.pendingRebuild).toBeUndefined();
+	});
+
+	it("should keep the marker and skip the upload when a pending place's artifact is unchanged", async () => {
+		expect.assertions(2);
+
+		const { placeCalls, registry } = recordingPlaceRegistry();
+		const { port, writes } = inMemoryStatePort(
+			priorWith(placeCurrent(), new Set([startPlace])),
+		);
+
+		const result = await publish({
+			config: publishConfig(),
+			environment: "production",
+			readFile: readPlace,
+			registry,
+			statePort: port,
+		});
+
+		assert(result.success);
+
+		expect(placeCalls).toBeEmpty();
+		expect(writes.at(-1)!.pendingRebuild).toStrictEqual(new Set([startPlace]));
+	});
+
+	it("should keep the marker when republishing a pending place fails", async () => {
+		expect.assertions(2);
+
+		const cause = new OpenCloudError("publish start-place: 503");
+		const { registry } = recordingPlaceRegistry({
+			async update() {
+				return { err: cause, success: false };
+			},
+		});
+		const { port, writes } = inMemoryStatePort(
+			priorWith(placeCurrent({ fileHash: STALE_HASH }), new Set([startPlace])),
+		);
+
+		const result = await publish({
+			config: publishConfig(),
+			environment: "production",
+			readFile: readPlace,
+			registry,
+			statePort: port,
+		});
+
+		assert(!result.success);
+
+		expect(result.err.kind).toBe("applyFailed");
+		expect(writes.at(-1)!.pendingRebuild).toStrictEqual(new Set([startPlace]));
+	});
+
+	it("should not mint a non-place resource that drifts in config", async () => {
+		expect.assertions(2);
+
+		const productCreate = vi.fn<ResourceDriver<"developerProduct">["create"]>();
+		const { placeCalls, registry } = recordingPlaceRegistry();
+		const { port } = inMemoryStatePort(
+			priorWith(placeCurrent({ fileHash: STALE_HASH }), new Set([startPlace])),
+		);
+
+		const result = await publish({
+			config: {
+				environments: { production: { places: { "start-place": { placeId: "4711" } } } },
+				places: { "start-place": { filePath: "places/start.rbxl" } },
+				products: { "gem-pack": { name: "Gem Pack", description: "1,000 gems." } },
+			},
+			environment: "production",
+			readFile: readPlace,
+			registry: { ...registry, developerProduct: { create: productCreate } },
+			statePort: port,
+		});
+
+		assert(result.success);
+
+		expect(productCreate).not.toHaveBeenCalled();
+		expect(placeCalls).toStrictEqual([{ key: "start-place", type: "update" }]);
+	});
+
+	it("should be a no-op success that dispatches nothing when no place owes a rebuild", async () => {
+		expect.assertions(3);
+
+		const { placeCalls, registry } = recordingPlaceRegistry();
+		const { port, writes } = inMemoryStatePort(
+			priorWith(placeCurrent({ fileHash: STALE_HASH })),
+		);
+
+		const result = await publish({
+			config: publishConfig(),
+			environment: "production",
+			readFile: readPlace,
+			registry,
+			statePort: port,
+		});
+
+		assert(result.success);
+
+		expect(placeCalls).toBeEmpty();
+		expect(writes.at(-1)!.pendingRebuild).toBeUndefined();
+		expect(result.data.resources).toStrictEqual([placeCurrent({ fileHash: STALE_HASH })]);
+	});
+
+	it("should surface stateReadFailed without dispatching drivers when StatePort.read returns Err", async () => {
+		expect.assertions(1);
+
+		const stateError = {
+			file: ".bedrock/state/production.json",
+			kind: "stateError" as const,
+			reason: "Corrupt JSON",
+		};
+		const { registry } = recordingPlaceRegistry();
+		const port: StatePort = {
+			async read() {
+				return { err: stateError, success: false };
+			},
+			async write() {
+				return { data: undefined, success: true };
+			},
+		};
+
+		const result = await publish({
+			config: publishConfig(),
+			environment: "production",
+			readFile: readPlace,
+			registry,
+			statePort: port,
+		});
+
+		expect(result).toStrictEqual({
+			err: { cause: stateError, kind: "stateReadFailed" },
+			success: false,
+		});
+	});
+});

--- a/packages/bedrock/src/shell/reconcile-pass.spec.ts
+++ b/packages/bedrock/src/shell/reconcile-pass.spec.ts
@@ -259,6 +259,65 @@ describe(applyAndPersist, () => {
 		expect(states[0]!.pendingRebuild).toStrictEqual(marker);
 	});
 
+	it("should resolve the pendingRebuild marker from the applied survivors when given a function", async () => {
+		expect.assertions(2);
+
+		let received: ReadonlyArray<ResourceCurrentState> | undefined;
+
+		const pass = await applyAndPersist({
+			environment: "production",
+			ops: [createGamePassOp(asResourceKey("vip-pass"))],
+			pendingRebuild: (survivors) => {
+				received = survivors;
+				return new Set(survivors.map((resource) => asResourceKey(resource.key)));
+			},
+			priorResources: [],
+			progress: recordingProgress().port,
+			registry: gamePassRegistry({ "vip-pass": vip }),
+			statePort: inMemoryStatePort().port,
+		});
+
+		expect(received).toStrictEqual([vip]);
+		expect(pass.merged.pendingRebuild).toStrictEqual(new Set([asResourceKey("vip-pass")]));
+	});
+
+	it("should pass only the succeeding survivors to the pendingRebuild resolver when an op fails", async () => {
+		expect.assertions(1);
+
+		const failure = new OpenCloudError("create vip-pass: 503");
+		const registry: DriverRegistry = {
+			developerProduct: developerProductStub,
+			gamePass: {
+				async create(desired) {
+					return desired.key === "alpha-pass"
+						? { data: alpha, success: true }
+						: { err: failure, success: false };
+				},
+			},
+			place: placeStub,
+			universe: universeStub,
+		};
+		let received: ReadonlyArray<ResourceCurrentState> | undefined;
+
+		await applyAndPersist({
+			environment: "production",
+			ops: [
+				createGamePassOp(asResourceKey("alpha-pass")),
+				createGamePassOp(asResourceKey("vip-pass")),
+			],
+			pendingRebuild: (survivors) => {
+				received = survivors;
+				return new Set();
+			},
+			priorResources: [],
+			progress: recordingProgress().port,
+			registry,
+			statePort: inMemoryStatePort().port,
+		});
+
+		expect(received).toStrictEqual([alpha]);
+	});
+
 	it("should omit the pendingRebuild marker when the supplied set is empty", async () => {
 		expect.assertions(1);
 

--- a/packages/bedrock/src/shell/reconcile-pass.ts
+++ b/packages/bedrock/src/shell/reconcile-pass.ts
@@ -25,6 +25,16 @@ export interface ReconcilePass {
 }
 
 /**
+ * Place keys to record as owing a rebuild, or a resolver computing them from the
+ * pass's survivors. The resolver form runs after `applyOps`, so a caller can
+ * clear the marker only for the places that actually applied; a failed or
+ * withheld (noop) place is absent from the survivors and keeps its marker.
+ */
+type PendingRebuildInput =
+	| ((survivors: ReadonlyArray<ResourceCurrentState>) => ReadonlySet<ResourceKey>)
+	| ReadonlySet<ResourceKey>;
+
+/**
  * Inputs for a single {@link applyAndPersist} pass. `priorResources` is the
  * cumulative baseline the pass folds its survivors into before writing, so a
  * later pass receives the previous pass's `merged.resources` here.
@@ -45,10 +55,11 @@ interface ApplyAndPersistInputs {
 	/** Subset of reconcile ops applied in this pass, in declaration order. */
 	readonly ops: ReadonlyArray<Operation>;
 	/**
-	 * Place keys to record as owing a rebuild. Stamped onto the persisted
-	 * snapshot when non-empty; an empty or absent set leaves the marker off.
+	 * Place keys to record as owing a rebuild, or a resolver computing them from
+	 * the pass's survivors. Stamped onto the persisted snapshot when non-empty;
+	 * an empty or absent set leaves the marker off.
 	 */
-	readonly pendingRebuild?: ReadonlySet<ResourceKey>;
+	readonly pendingRebuild?: PendingRebuildInput;
 	/** Resources already persisted; survivors merge on top, none are dropped. */
 	readonly priorResources: ReadonlyArray<ResourceCurrentState>;
 	/** Sink for per-resource, summary, and `stateWritten` progress events. */
@@ -107,7 +118,7 @@ export async function applyAndPersist(inputs: ApplyAndPersistInputs): Promise<Re
 		applied,
 		codegenHash,
 		environment,
-		pendingRebuild,
+		pendingRebuild: resolvePendingRebuild(pendingRebuild, applied),
 		priorResources,
 		realDisplay,
 	});
@@ -118,6 +129,19 @@ export async function applyAndPersist(inputs: ApplyAndPersistInputs): Promise<Re
 	}
 
 	return { applied, merged, written };
+}
+
+function resolvePendingRebuild(
+	pendingRebuild: PendingRebuildInput | undefined,
+	applied: Result<ReadonlyArray<ResourceCurrentState>, AggregateApplyError>,
+): ReadonlySet<ResourceKey> | undefined {
+	if (typeof pendingRebuild !== "function") {
+		return pendingRebuild;
+	}
+
+	// Resolve from the survivors so a caller clears the marker only for places
+	// that actually applied; failed and withheld places are absent and keep it.
+	return pendingRebuild(applied.success ? applied.data : applied.err.applied);
 }
 
 function mergeResources(

--- a/packages/bedrock/tests/helpers/reconcile-command.ts
+++ b/packages/bedrock/tests/helpers/reconcile-command.ts
@@ -1,0 +1,46 @@
+import { vi } from "vitest";
+
+import type { ProgDeps } from "#src/cli/index";
+import type { Config } from "#src/core/schema";
+import type { BedrockState } from "#src/core/state";
+import { fakeClackPort } from "#tests/helpers/clack";
+
+/** Type of the `discoverOverride` dep slot, for stubbing override discovery. */
+export type DiscoverOverrideFunc = NonNullable<ProgDeps["discoverOverride"]>;
+
+type ExitFunc = NonNullable<ProgDeps["exit"]>;
+
+type LoadConfigFunc = NonNullable<ProgDeps["loadConfig"]>;
+
+/** Minimal config every reconcile-command spec loads through `fakeLoad`. */
+export const sampleConfig: Config = { environments: { production: {} } };
+
+/**
+ * Build a `ProgDeps` wired for a reconcile-command action: a spy clack port and
+ * a spy `exit`, with any slot overridable. Shared by the `deploy`/`provision`/
+ * `publish` command specs so the fixture cannot drift between them.
+ *
+ * @param overrides - Dep slots to replace on the returned object.
+ * @returns A `ProgDeps` whose `clack` and `exit` are fresh spies.
+ */
+export function makeDeps(overrides: Partial<ProgDeps> = {}): ProgDeps {
+	return { clack: fakeClackPort(), exit: vi.fn<ExitFunc>(), ...overrides };
+}
+
+/**
+ * A `loadConfig` spy resolving to {@link sampleConfig}.
+ *
+ * @returns A `vi.fn()` that resolves to an `Ok` wrapping {@link sampleConfig}.
+ */
+export function fakeLoad(): LoadConfigFunc {
+	return vi.fn<LoadConfigFunc>(async () => ({ data: sampleConfig, success: true }));
+}
+
+/**
+ * A trivial successful `BedrockState` for a command that reconciled nothing.
+ *
+ * @returns A `BedrockState` for `production` with no resources.
+ */
+export function okState(): BedrockState {
+	return { environment: "production", resources: [], version: 1 };
+}

--- a/packages/bedrock/tests/integration/cli/index.spec.ts
+++ b/packages/bedrock/tests/integration/cli/index.spec.ts
@@ -191,6 +191,46 @@ describe("cli program factory", () => {
 		}
 	});
 
+	it("should describe the provision subcommand and each of its flags in 'provision --help' output", () => {
+		expect.assertions(5);
+
+		const prog = createProg();
+
+		const collect = startCapture();
+		try {
+			prog.parse(["node", "bedrock", "provision", "--help"]);
+		} finally {
+			const { stdout } = collect();
+			const captured = stdout.join("");
+
+			expect(captured).toContain("Mint assets and run codegen");
+			expect(captured).toContain("Target environment");
+			expect(captured).toContain("Config file path");
+			expect(captured).toContain("BEDROCK_API_KEY");
+			expect(captured).toContain("BEDROCK_GITHUB_TOKEN");
+		}
+	});
+
+	it("should describe the publish subcommand and each of its flags in 'publish --help' output", () => {
+		expect.assertions(5);
+
+		const prog = createProg();
+
+		const collect = startCapture();
+		try {
+			prog.parse(["node", "bedrock", "publish", "--help"]);
+		} finally {
+			const { stdout } = collect();
+			const captured = stdout.join("");
+
+			expect(captured).toContain("Upload on-disk place artifacts");
+			expect(captured).toContain("Target environment");
+			expect(captured).toContain("Config file path");
+			expect(captured).toContain("BEDROCK_API_KEY");
+			expect(captured).toContain("BEDROCK_GITHUB_TOKEN");
+		}
+	});
+
 	it("should describe the migrate subcommand and its --from flag in 'migrate --help' output", () => {
 		expect.assertions(3);
 

--- a/packages/bedrock/tests/integration/config-pipeline.spec.ts
+++ b/packages/bedrock/tests/integration/config-pipeline.spec.ts
@@ -116,7 +116,10 @@ async function runPipelineFromFixture(cwd: string): Promise<CreateFlowResult> {
 	const resolved = selectEnvironment(loaded.data, "production");
 	assert(resolved.success);
 
-	const desiredResult = await buildDesired(flattenConfig(resolved.data), readIcon);
+	const desiredResult = await buildDesired({
+		readFile: readIcon,
+		resources: flattenConfig(resolved.data),
+	});
 	assert(desiredResult.success);
 
 	const httpClient = createFakeHttpClient().mockResponse({
@@ -193,7 +196,10 @@ describe("config pipeline end-to-end", () => {
 		const resolved = selectEnvironment(loaded.data, "production");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readIcon);
+		const desiredResult = await buildDesired({
+			readFile: readIcon,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const ops = diff(desiredResult.data, [await buildExistingPass()]);

--- a/packages/bedrock/tests/integration/developer-products.spec.ts
+++ b/packages/bedrock/tests/integration/developer-products.spec.ts
@@ -80,7 +80,10 @@ describe("developer-products pipeline end-to-end", () => {
 		const resolved = selectEnvironment(loaded.data, "production");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFileNever);
+		const desiredResult = await buildDesired({
+			readFile: readFileNever,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient().mockResponse({
@@ -141,7 +144,10 @@ describe("developer-products pipeline end-to-end", () => {
 		const resolved = selectEnvironment(loaded.data, "production");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFileNever);
+		const desiredResult = await buildDesired({
+			readFile: readFileNever,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient();
@@ -191,7 +197,10 @@ describe("developer-products pipeline end-to-end", () => {
 		const resolved = selectEnvironment(loaded.data, "production");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFileNever);
+		const desiredResult = await buildDesired({
+			readFile: readFileNever,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient().mockResponse({
@@ -260,7 +269,10 @@ describe("developer-products pipeline end-to-end", () => {
 		const resolved = selectEnvironment(config, "production");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFileNever);
+		const desiredResult = await buildDesired({
+			readFile: readFileNever,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		// First deploy: POST persists the product, PATCH fails. The driver

--- a/packages/bedrock/tests/integration/passes-redacted.spec.ts
+++ b/packages/bedrock/tests/integration/passes-redacted.spec.ts
@@ -135,7 +135,10 @@ describe("passes-redacted pipeline end-to-end", () => {
 		assert(resolved.success);
 
 		const readFile = panicOnRealPath;
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		const desiredResult = await buildDesired({
+			readFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient().mockResponse({
@@ -202,7 +205,10 @@ describe("passes-redacted pipeline end-to-end", () => {
 		assert(resolved.success);
 
 		const readFile = panicOnRealPath;
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		const desiredResult = await buildDesired({
+			readFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient().mockResponse({
@@ -259,7 +265,10 @@ describe("passes-redacted pipeline end-to-end", () => {
 		assert(resolved.success);
 
 		const readFile = panicOnRealPath;
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		const desiredResult = await buildDesired({
+			readFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient().mockResponse({
@@ -307,7 +316,10 @@ describe("passes-redacted pipeline end-to-end", () => {
 		assert(resolved.success);
 
 		const readFile = panicOnRealPath;
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		const desiredResult = await buildDesired({
+			readFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient();
@@ -357,7 +369,10 @@ describe("passes-redacted pipeline end-to-end", () => {
 		assert(resolved.success);
 
 		const readFile = panicOnRealPath;
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		const desiredResult = await buildDesired({
+			readFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const ops = diff(desiredResult.data, [persistedPass(desiredResult.data), UNIVERSE_ADOPTED]);
@@ -396,7 +411,10 @@ describe("passes-redacted pipeline end-to-end", () => {
 			throw new Error(`readFile must not run for path: ${path}`);
 		}
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readOverrideIcon);
+		const desiredResult = await buildDesired({
+			readFile: readOverrideIcon,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient().mockResponse({
@@ -457,7 +475,10 @@ describe("passes-redacted pipeline end-to-end", () => {
 		assert(resolved.success);
 
 		const readFile = panicOnRealPath;
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		const desiredResult = await buildDesired({
+			readFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient().mockResponse({
@@ -518,7 +539,10 @@ describe("passes-redacted pipeline end-to-end", () => {
 		assert(resolved.success);
 
 		const readFile = readRealIcon;
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		const desiredResult = await buildDesired({
+			readFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient()
@@ -642,7 +666,10 @@ async function hashPlaceholderIcon(): Promise<
 	});
 	const resolved = selectEnvironment(probe, "production");
 	assert(resolved.success);
-	const desired = await buildDesired(flattenConfig(resolved.data), panicOnRealPath);
+	const desired = await buildDesired({
+		readFile: panicOnRealPath,
+		resources: flattenConfig(resolved.data),
+	});
 	assert(desired.success);
 	const entry = findGamePassDesired(desired.data);
 	return entry.iconFileHashes["en-us"];

--- a/packages/bedrock/tests/integration/places-redacted.spec.ts
+++ b/packages/bedrock/tests/integration/places-redacted.spec.ts
@@ -86,7 +86,10 @@ describe("places-redacted pipeline end-to-end", () => {
 		const resolved = selectEnvironment(config, "production");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readPlaceFile);
+		const desiredResult = await buildDesired({
+			readFile: readPlaceFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient()
@@ -154,7 +157,10 @@ describe("places-redacted pipeline end-to-end", () => {
 		const resolved = selectEnvironment(config, "staging");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readPlaceFile);
+		const desiredResult = await buildDesired({
+			readFile: readPlaceFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient()
@@ -254,7 +260,10 @@ describe("places-redacted pipeline end-to-end", () => {
 		const resolved = selectEnvironment(config, "production");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readPlaceFile);
+		const desiredResult = await buildDesired({
+			readFile: readPlaceFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const ops = diff(desiredResult.data, [persistedPlace(desiredResult.data)]);

--- a/packages/bedrock/tests/integration/places.spec.ts
+++ b/packages/bedrock/tests/integration/places.spec.ts
@@ -58,7 +58,10 @@ describe("places pipeline end-to-end", () => {
 		const resolved = selectEnvironment(loaded.data, "production");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readPlaceFile);
+		const desiredResult = await buildDesired({
+			readFile: readPlaceFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient().mockResponse({
@@ -107,7 +110,10 @@ describe("places pipeline end-to-end", () => {
 		const resolved = selectEnvironment(loaded.data, "production");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readPlaceFile);
+		const desiredResult = await buildDesired({
+			readFile: readPlaceFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient()

--- a/packages/bedrock/tests/integration/products-redacted.spec.ts
+++ b/packages/bedrock/tests/integration/products-redacted.spec.ts
@@ -134,7 +134,10 @@ describe("products-redacted pipeline end-to-end", () => {
 		assert(resolved.success);
 
 		const readFile = panicOnRealPath;
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		const desiredResult = await buildDesired({
+			readFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const expectedName = defaultRedactedProductName("gem-pack");
@@ -202,7 +205,10 @@ describe("products-redacted pipeline end-to-end", () => {
 		assert(resolved.success);
 
 		const readFile = panicOnRealPath;
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		const desiredResult = await buildDesired({
+			readFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const expectedName = defaultRedactedProductName("gem-pack");
@@ -260,7 +266,10 @@ describe("products-redacted pipeline end-to-end", () => {
 		assert(resolved.success);
 
 		const readFile = panicOnRealPath;
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		const desiredResult = await buildDesired({
+			readFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const expectedName = defaultRedactedProductName("soon-pack");
@@ -309,7 +318,10 @@ describe("products-redacted pipeline end-to-end", () => {
 		assert(resolved.success);
 
 		const readFile = panicOnRealPath;
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		const desiredResult = await buildDesired({
+			readFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient();
@@ -360,7 +372,10 @@ describe("products-redacted pipeline end-to-end", () => {
 		assert(resolved.success);
 
 		const readFile = panicOnRealPath;
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		const desiredResult = await buildDesired({
+			readFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const gemPack = findProductDesired(desiredResult.data, "gem-pack");
@@ -400,7 +415,10 @@ describe("products-redacted pipeline end-to-end", () => {
 			throw new Error(`readFile must not run for path: ${path}`);
 		}
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readOverrideIcon);
+		const desiredResult = await buildDesired({
+			readFile: readOverrideIcon,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const expectedName = defaultRedactedProductName("gem-pack");
@@ -462,7 +480,10 @@ describe("products-redacted pipeline end-to-end", () => {
 		assert(resolved.success);
 
 		const readFile = panicOnRealPath;
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		const desiredResult = await buildDesired({
+			readFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient().mockResponse({
@@ -523,7 +544,10 @@ describe("products-redacted pipeline end-to-end", () => {
 		assert(resolved.success);
 
 		const readFile = readRealIcon;
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		const desiredResult = await buildDesired({
+			readFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient().mockResponse({
@@ -594,7 +618,10 @@ describe("products-redacted pipeline end-to-end", () => {
 		assert(resolved.success);
 
 		const readFile = panicOnRealPath;
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFile);
+		const desiredResult = await buildDesired({
+			readFile,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const reconcilable = assertAllReconcilable(desiredResult.data, []);
@@ -679,7 +706,10 @@ describe("products-redacted pipeline end-to-end", () => {
 		const resolved = selectEnvironment(config, "production");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), panicOnRealPath);
+		const desiredResult = await buildDesired({
+			readFile: panicOnRealPath,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const reconcilable = assertAllReconcilable(desiredResult.data, []);
@@ -760,7 +790,10 @@ async function hashPlaceholderIcon(): Promise<
 	});
 	const resolved = selectEnvironment(probe, "production");
 	assert(resolved.success);
-	const desired = await buildDesired(flattenConfig(resolved.data), panicOnRealPath);
+	const desired = await buildDesired({
+		readFile: panicOnRealPath,
+		resources: flattenConfig(resolved.data),
+	});
 	assert(desired.success);
 	const entry = findProductDesired(desired.data, "probe");
 	assert(entry.iconFileHashes !== undefined);

--- a/packages/bedrock/tests/integration/universe.spec.ts
+++ b/packages/bedrock/tests/integration/universe.spec.ts
@@ -81,7 +81,10 @@ describe("universe pipeline end-to-end", () => {
 		const resolved = selectEnvironment(loaded.data, "production");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFileNever);
+		const desiredResult = await buildDesired({
+			readFile: readFileNever,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		// `twitterSocialLink: undefined` in the fixture flows through as a
@@ -133,7 +136,10 @@ describe("universe pipeline end-to-end", () => {
 		const resolved = selectEnvironment(loaded.data, "production");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFileNever);
+		const desiredResult = await buildDesired({
+			readFile: readFileNever,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient({ schemaValidation: "off" }).mockResponse({
@@ -172,7 +178,10 @@ describe("universe pipeline end-to-end", () => {
 		const resolved = selectEnvironment(loaded.data, "production");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFileNever);
+		const desiredResult = await buildDesired({
+			readFile: readFileNever,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const httpClient = createFakeHttpClient({ schemaValidation: "off" }).mockResponse({
@@ -214,7 +223,10 @@ describe("universe pipeline end-to-end", () => {
 		const resolved = selectEnvironment(loaded.data, "production");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFileNever);
+		const desiredResult = await buildDesired({
+			readFile: readFileNever,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const ops = diff(desiredResult.data, [
@@ -265,7 +277,10 @@ describe("universe pipeline end-to-end", () => {
 		const resolved = selectEnvironment(loaded.data, "production");
 		assert(resolved.success);
 
-		const desiredResult = await buildDesired(flattenConfig(resolved.data), readFileNever);
+		const desiredResult = await buildDesired({
+			readFile: readFileNever,
+			resources: flattenConfig(resolved.data),
+		});
 		assert(desiredResult.success);
 
 		const ops = diff(desiredResult.data, [


### PR DESCRIPTION
## Summary

Splits the internal two-phase deploy checkpoint into two composable commands (the `provision`/`publish` half of the ADR-026 lifecycle-decomposition amendment, #511), so CI can build and test the final artifact *between* minting asset IDs and publishing a place.

- **`provision`** runs the asset stage plus codegen: it mints non-place ops, persists mutable asset fields, runs the emitter, and sets the `pendingRebuild` marker at the checkpoint, building and publishing **no** place.
- **`publish`** is a pure uploader: it publishes the on-disk artifact for each `pendingRebuild` place (deduped by file hash per ADR-021) and clears the marker **per republished place**, with no mint, codegen, or build.

Both are exposed programmatically (`provision()` / `publish()`) and as CLI subcommands (`bedrock provision`, `bedrock publish`), each overridable via `.bedrock/<command>.ts` through the existing spawn model. A behaviour-preserving prefactor extracts `runProvisionStage` from the two-phase path, adds a resolver form to `applyAndPersist`'s `pendingRebuild`, and factors the shared per-command CLI scaffolding into a `reconcile-command` factory that `deploy` now also uses. **`deploy()` behaviour is unchanged.** The amendment's `build` stage and rebuild-hook removal are out of scope (tracked separately).

**Design note:** `publish` clears the marker only for places *actually republished*; a no-op (unchanged artifact) or a failed upload keeps its marker, preserving ADR-026's self-heal invariant.

## References

Closes #508
Related: #511 (ADR-026 lifecycle-decomposition amendment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Overall, this PR aligns well with the FCIS split: `provision` and `publish` stay in shell/orchestration, the shared CLI scaffold is factored cleanly, and the test coverage added for the new lifecycle paths is strong.

Inline comments:
- The new `provision`/`publish` public APIs should be called out prominently in the package changelog/release notes as semver-bearing surface area; the changeset is present, but this is a user-facing API expansion worth explicitly highlighting.
- The new CLI wrapper tests are good, but they only verify the override path is spawned; consider adding one assertion that the default reconcile path is *not* invoked when an override exists, to make the shell/override contract more explicit.

I didn’t find any clear architecture violations or missing test coverage blockers in the touched code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->